### PR TITLE
[BUGFIX] Service\NodesController should stick to interfaces

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
@@ -20,7 +20,7 @@ use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\Domain\Service\ContentContextFactory;
-use TYPO3\Neos\Domain\Service\NodeSearchService;
+use TYPO3\Neos\Domain\Service\NodeSearchServiceInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TYPO3CR\Domain\Service\Context;
@@ -61,7 +61,7 @@ class NodesController extends ActionController {
 
 	/**
 	 * @Flow\Inject
-	 * @var NodeSearchService
+	 * @var NodeSearchServiceInterface
 	 */
 	protected $nodeSearchService;
 


### PR DESCRIPTION


The ``Service\NodesController`` should refer to the
``NodeSearchServiceInterface`` instead of the implementation class
to avoid hard dependencies and allow overwriting the implementation
from the outside.

Change-Id: I4ae7222e195d3fdfa4fd1b5b21ef17b878538e6d
Releases: master, 2.0
