### PR TITLE
[TASK] Add trait to avoid duplicate code in ViewHelpers

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -18,7 +18,7 @@ use TYPO3\Fluid\Core\ViewHelper\Exception as ViewHelperException;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Service\AuthorizationService;
-use TYPO3\TypoScript\TypoScriptObjects\Helpers\TypoScriptAwareViewInterface;
+use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
 
 /**
  * Renders a wrapper around the inner contents of the tag to enable frontend editing.
@@ -34,6 +34,8 @@ use TYPO3\TypoScript\TypoScriptObjects\Helpers\TypoScriptAwareViewInterface;
  */
 class EditableViewHelper extends AbstractTagBasedViewHelper
 {
+    use TypoScriptContextTrait;
+
     /**
      * @Flow\Inject
      * @var PrivilegeManagerInterface
@@ -108,13 +110,11 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
      */
     protected function getNodeFromTypoScriptContext()
     {
-        $view = $this->viewHelperVariableContainer->getView();
-        if (!$view instanceof TypoScriptAwareViewInterface) {
+        $node = $this->getContextVariable('node');
+        if ($node === null) {
             throw new ViewHelperException('This ViewHelper can only be used in a TypoScript content element. You have to specify the "node" argument if it cannot be resolved from the TypoScript context.', 1385737102);
         }
-        $typoScriptObject = $view->getTypoScriptObject();
-        $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
 
-        return $currentContext['node'];
+        return $node;
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
@@ -16,10 +16,9 @@ use TYPO3\Flow\Mvc\Exception\NoMatchingRouteException;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\Neos\Service\LinkingService;
-use TYPO3\TypoScript\TypoScriptObjects\Helpers\TypoScriptAwareViewInterface;
 use TYPO3\Fluid\Core\ViewHelper\Exception as ViewHelperException;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
-use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
+use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
 
 /**
  * A view helper for creating links with URIs pointing to nodes.
@@ -100,6 +99,8 @@ use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
  */
 class NodeViewHelper extends AbstractTagBasedViewHelper
 {
+    use TypoScriptContextTrait;
+
     /**
      * @var string
      */
@@ -145,14 +146,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
     {
         $baseNode = null;
         if (!$node instanceof NodeInterface) {
-            $view = $this->viewHelperVariableContainer->getView();
-            if ($view instanceof TypoScriptAwareViewInterface) {
-                $typoScriptObject = $view->getTypoScriptObject();
-                $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
-                if (isset($currentContext[$baseNodeName])) {
-                    $baseNode = $currentContext[$baseNodeName];
-                }
-            }
+            $baseNode = $this->getContextVariable($baseNodeName);
         }
 
         try {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
@@ -16,10 +16,9 @@ use TYPO3\Flow\Mvc\Exception\NoMatchingRouteException;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Neos\Service\LinkingService;
-use TYPO3\TypoScript\TypoScriptObjects\Helpers\TypoScriptAwareViewInterface;
 use TYPO3\Fluid\Core\ViewHelper\Exception as ViewHelperException;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
-use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
+use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
 
 /**
  * A view helper for creating URIs pointing to nodes.
@@ -83,6 +82,8 @@ use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
  */
 class NodeViewHelper extends AbstractViewHelper
 {
+    use TypoScriptContextTrait;
+
     /**
      * @Flow\Inject
      * @var LinkingService
@@ -108,15 +109,7 @@ class NodeViewHelper extends AbstractViewHelper
     {
         $baseNode = null;
         if (!$node instanceof NodeInterface) {
-            $view = $this->viewHelperVariableContainer->getView();
-            if ($view instanceof TypoScriptAwareViewInterface) {
-                /** @var TemplateImplementation $typoScriptObject */
-                $typoScriptObject = $view->getTypoScriptObject();
-                $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
-                if (isset($currentContext[$baseNodeName])) {
-                    $baseNode = $currentContext[$baseNodeName];
-                }
-            }
+            $baseNode = $this->getContextVariable($baseNodeName);
         }
 
         try {

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/AbstractTypoScriptObject.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/AbstractTypoScriptObject.php
@@ -12,6 +12,7 @@ namespace TYPO3\TypoScript\TypoScriptObjects;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TypoScript\Core\Runtime;
 
 /**
  * Base class for all TypoScript objects
@@ -19,7 +20,7 @@ use TYPO3\Flow\Annotations as Flow;
 abstract class AbstractTypoScriptObject implements \ArrayAccess
 {
     /**
-     * @var \TYPO3\TypoScript\Core\Runtime
+     * @var Runtime
      */
     protected $tsRuntime;
 
@@ -40,16 +41,16 @@ abstract class AbstractTypoScriptObject implements \ArrayAccess
     /**
      * @var array
      */
-    protected $tsValueCache = array();
+    protected $tsValueCache = [];
 
     /**
      * Constructor
      *
-     * @param \TYPO3\TypoScript\Core\Runtime $tsRuntime
+     * @param Runtime $tsRuntime
      * @param string $path
      * @param string $typoScriptObjectName
      */
-    public function __construct(\TYPO3\TypoScript\Core\Runtime $tsRuntime, $path, $typoScriptObjectName)
+    public function __construct(Runtime $tsRuntime, $path, $typoScriptObjectName)
     {
         $this->tsRuntime = $tsRuntime;
         $this->path = $path;
@@ -62,6 +63,16 @@ abstract class AbstractTypoScriptObject implements \ArrayAccess
      * @return mixed
      */
     abstract public function evaluate();
+
+    /**
+     * Get the TypoScript runtime this object was created in.
+     *
+     * @return Runtime
+     */
+    public function getTsRuntime()
+    {
+        return $this->tsRuntime;
+    }
 
     /**
      * Return the TypoScript value relative to this TypoScript object (with processors etc applied).

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/TemplateImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/TemplateImplementation.php
@@ -72,15 +72,6 @@ class TemplateImplementation extends AbstractArrayTypoScriptObject
     }
 
     /**
-     * @return \TYPO3\TypoScript\Core\Runtime
-     * @internal
-     */
-    public function getTsRuntime()
-    {
-        return $this->tsRuntime;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return string

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/ViewHelpers/TypoScriptContextTrait.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/ViewHelpers/TypoScriptContextTrait.php
@@ -1,0 +1,67 @@
+<?php
+namespace TYPO3\TypoScript\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3.TypoScript package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\TypoScript\TypoScriptObjects\Helpers\TypoScriptAwareViewInterface;
+
+/**
+ * This trait is to be used in ViewHelpers that need to get information from the TypoScript runtime context.
+ * It will only work when the ViewHelper in question is used in a TypoScriptAwareViewInterface.
+ *
+ * A property "viewHelperVariableContainer" is expected in classes that use this, which will be the case for any Fluid ViewHelper.
+ */
+trait TypoScriptContextTrait
+{
+
+    /**
+     * Get a variable value from the TypoScript runtime context.
+     *
+     * Note: This will return NULL if the variable didn't exist.
+     *
+     * @see hasContextVariable()
+     *
+     * @param string $variableName
+     * @return mixed
+     */
+    protected function getContextVariable($variableName)
+    {
+        $value = null;
+
+        $view = $this->viewHelperVariableContainer->getView();
+        if ($view instanceof TypoScriptAwareViewInterface) {
+            $typoScriptObject = $view->getTypoScriptObject();
+            $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+            if (isset($currentContext[$variableName])) {
+                $value = $currentContext[$variableName];
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $variableName
+     * @return boolean
+     */
+    protected function hasContextVariable($variableName)
+    {
+        $view = $this->viewHelperVariableContainer->getView();
+        if (!$view instanceof TypoScriptAwareViewInterface) {
+            return false;
+        }
+
+        $typoScriptObject = $view->getTypoScriptObject();
+        $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+
+        return array_key_exists($variableName, $currentContext);
+    }
+}


### PR DESCRIPTION
The new ``TypoScriptContextTrait`` can be used to get
variables from the TypoScript runtime context inside a
ViewHelper as long as it's used inside a
``TypoScriptAwareView``. This helps to avoid code duplication
while avoiding long inheritance chains.
