### PR TITLE
[TASK] Add missing typo3/party requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "typo3/setup": "*",
     "typo3/twitter-bootstrap": "*",
     "gedmo/doctrine-extensions": "2.3.*",
+    "typo3/party": "*",
     "typo3/imagine": "*"
   },
   "replace": {


### PR DESCRIPTION
This change adds typo3/party to the collections requirements
as it is not installed automatically but is a requirement
for Neos.

Releases: master