### PR TITLE
[BUGFIX] site:import throws Unexpected element exception

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -512,6 +512,8 @@ class NodeImportService {
 	 */
 	protected function parseEndElement(\XMLReader $reader) {
 		switch ($reader->name) {
+			case 'hiddenBeforeDateTime':
+			case 'hiddenAfterDateTime':
 			case 'creationDateTime':
 			case 'lastModificationDateTime':
 			case 'lastPublicationDateTime':


### PR DESCRIPTION
While importing site-exports containing documents having the hiddenBeforeDateTime attribute set, `site:import` fails with this error:

```
Error: During the import of the file "Site.xml" an exception occurred:
Unexpected element <hiddenBeforeDateTime>
```

Releases: master, 2.0