### PR TITLE
[BUGFIX] Add inversedBy attribute to association

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
@@ -37,7 +37,7 @@ class AssetCollection {
 
 	/**
 	 * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\Tag>
-	 * @ORM\ManyToMany
+	 * @ORM\ManyToMany(inversedBy="assetCollections")
 	 * @ORM\OrderBy({"label"="ASC"})
 	 * @Flow\Lazy
 	 */


### PR DESCRIPTION
When running a doctrine:validate an error is shown for the Tag model
since it does not contain the required inversedBy attribute. This
change fixes that by adding it.

Fixes: NEOS-1507
Releases: master, 2.0