### PR TITLE
[TASK] Adapt Neos composer.json to new installer script

### DIFF
--- a/TYPO3.Neos/composer.json
+++ b/TYPO3.Neos/composer.json
@@ -23,6 +23,9 @@
     "extra": {
         "typo3/flow": {
             "manage-resources" : true
+        },
+        "neos": {
+            "installer-resource-folders": ["Resources/Private/Installer/"]
         }
     }
 }


### PR DESCRIPTION
Adapts the Neos composer.json to the new configuration for
installer resources that works with joined repositories.
The old configuration (which won't be used anymore) is
kept for backwards compatibility reasons but should be removed
soon.

Releases: master, 2.0, 1.2