### PR TITLE
TASK: New FlowQuery filter operation!instanceof

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
@@ -130,14 +130,7 @@ class FilterOperation extends \TYPO3\Eel\FlowQuery\Operations\Object\FilterOpera
 				return $operand[0] === '!' ? $isOfType === FALSE : $isOfType;
 			}
 		} else if ($operator === '!instanceof' && $value instanceof \TYPO3\TYPO3CR\Domain\Model\NodeInterface) {
-			if ($this->operandIsSimpleType($operand)) {
-				return !$this->handleSimpleTypeOperand($operand, $value);
-			} elseif ($operand === 'TYPO3\TYPO3CR\Domain\Model\NodeInterface' || $operand === 'TYPO3\TYPO3CR\Domain\Model\Node') {
-				return FALSE;
-			} else {
-				$isOfType = $value->getNodeType()->isOfType($operand[0] === '!' ? substr($operand, 1) : $operand);
-				return $operand[0] === '!' ? $isOfType : $isOfType === FALSE;
-			}
+			return !$this->evaluateOperator($value, 'instanceof', $operand);
 		}
 		return parent::evaluateOperator($value, $operator, $operand);
 	}

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
@@ -129,7 +129,17 @@ class FilterOperation extends \TYPO3\Eel\FlowQuery\Operations\Object\FilterOpera
 				$isOfType = $value->getNodeType()->isOfType($operand[0] === '!' ? substr($operand, 1) : $operand);
 				return $operand[0] === '!' ? $isOfType === FALSE : $isOfType;
 			}
+		} else if ($operator === '!instanceof' && $value instanceof \TYPO3\TYPO3CR\Domain\Model\NodeInterface) {
+			if ($this->operandIsSimpleType($operand)) {
+				return !$this->handleSimpleTypeOperand($operand, $value);
+			} elseif ($operand === 'TYPO3\TYPO3CR\Domain\Model\NodeInterface' || $operand === 'TYPO3\TYPO3CR\Domain\Model\Node') {
+				return FALSE;
+			} else {
+				$isOfType = $value->getNodeType()->isOfType($operand[0] === '!' ? substr($operand, 1) : $operand);
+				return $operand[0] === '!' ? $isOfType : $isOfType === FALSE;
+			}
 		}
 		return parent::evaluateOperator($value, $operator, $operand);
 	}
+
 }

--- a/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
@@ -152,6 +152,30 @@ class FilterOperationTest extends AbstractNodeTest {
 	/**
 	 * @test
 	 */
+	public function notInstanceofFilterUsingNodeTypeIsSupported() {
+		$productsNode = $this->node->getNode('products');
+		$teaserNode = $this->node->getNode('teaser');
+		$sidebarNode = $this->node->getNode('sidebar');
+		$dummy = $sidebarNode->getNode('dummy43');
+		$q = new FlowQuery(array($this->node, $dummy, $productsNode, $teaserNode, $sidebarNode));
+		$foundNodes = $q->filter('[!instanceof TYPO3.TYPO3CR.Testing:Html]')->get();
+		$this->assertSame($this->node, $foundNodes[0]);
+		$this->assertSame($productsNode, $foundNodes[1]);
+		$this->assertSame($teaserNode, $foundNodes[2]);
+		$this->assertSame($sidebarNode, $foundNodes[3]);
+		$this->assertEquals(4, count($foundNodes));
+		$foundNodes = $q->filter('[!instanceof TYPO3.TYPO3CR.Testing:ContentCollection]')->get();
+		$this->assertSame($this->node, $foundNodes[0]);
+		$this->assertSame($dummy, $foundNodes[1]);
+		$this->assertSame($productsNode, $foundNodes[2]);
+		$this->assertEquals(3, count($foundNodes));
+		$foundNodes = $q->filter('[!instanceof X]')->get();
+		$this->assertEquals(5, count($foundNodes));
+	}
+
+	/**
+	 * @test
+	 */
 	public function twoInstanceofFiltersUsingNodeTypeIsSupported() {
 		$productsNode = $this->node->getNode('products');
 		$teaserNode = $this->node->getNode('teaser');
@@ -201,4 +225,23 @@ class FilterOperationTest extends AbstractNodeTest {
 		$this->assertEquals(4, count($foundNodes));
 	}
 
+	/**
+	 * @test
+	 */
+	public function doubleNegatedInstanceofFilterUsingNodeTypeIsSupported() {
+		$productsNode = $this->node->getNode('products');
+		$teaserNode = $this->node->getNode('teaser');
+		$sidebarNode = $this->node->getNode('sidebar');
+		$q = new FlowQuery(array($this->node, $productsNode, $teaserNode, $sidebarNode));
+		$foundNodes = $q->filter('[!instanceof !TYPO3.TYPO3CR.Testing:Page]')->get();
+		$this->assertSame($this->node, $foundNodes[0]);
+		$this->assertSame($productsNode, $foundNodes[1]);
+		$this->assertEquals(2, count($foundNodes));
+		$foundNodes = $q->filter('[!instanceof !TYPO3.TYPO3CR.Testing:ContentCollection]')->get();
+		$this->assertSame($teaserNode, $foundNodes[0]);
+		$this->assertSame($sidebarNode, $foundNodes[1]);
+		$this->assertEquals(2, count($foundNodes));
+		$foundNodes = $q->filter('[!instanceof !X]')->get();
+		$this->assertEquals(0, count($foundNodes));
+	}
 }


### PR DESCRIPTION
Checks if the value is not an instance of the operand.

Example of usage:

  node = ${q(node).filter('[!instanceof Acme:Node]')}

NEOS-1321 #close
