### PR TITLE
[FEATURE] Contextual help messages for node types and node properties

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -369,9 +369,37 @@ class NodeTypeConfigurationEnrichmentAspect
 
             if ($helpMessage !== '') {
                 $helpMessage = $this->markdownConverter->convertToHtml($helpMessage);
+                $helpMessage = $this->addTargetAttribute($helpMessage);
             }
         }
         $configuration['ui']['help']['message'] = $helpMessage;
+    }
+
+    /**
+     * Adds _blank as target to all a tags not having a target attribute.
+     *
+     * @param string $htmlString
+     * @return string
+     */
+    protected function addTargetAttribute($htmlString)
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML($htmlString);
+        $links = $document->getElementsByTagName('a');
+        /** @var \DOMElement $item */
+        foreach ($links as $item) {
+            if (!$item->hasAttribute('target')) {
+                $item->setAttribute('target', '_blank');
+            }
+        }
+
+        $output = '';
+        $body = $document->getElementsByTagName('body')->item(0);
+        foreach ($body->childNodes as $node) {
+            $output .= $document->saveHTML($node);
+        }
+
+        return $output;
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -148,7 +148,7 @@ class NodeTypeConfigurationEnrichmentAspect
                 continue;
             }
 
-            if ($this->shouldGenerateLabel($propertyConfiguration['ui'])) {
+            if ($this->shouldFetchTranslation($propertyConfiguration['ui'])) {
                 $propertyConfiguration['ui']['label'] = $this->getPropertyLabelTranslationId($nodeTypeLabelIdPrefix, $propertyName);
             }
 
@@ -156,7 +156,7 @@ class NodeTypeConfigurationEnrichmentAspect
                 $this->applyInspectorEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $propertyConfiguration);
             }
 
-            if (isset($propertyConfiguration['ui']['aloha']) && $this->shouldGenerateLabel($propertyConfiguration['ui']['aloha'], 'placeholder')) {
+            if (isset($propertyConfiguration['ui']['aloha']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['aloha'], 'placeholder')) {
                 $propertyConfiguration['ui']['aloha']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'aloha.placeholder');
             }
         }
@@ -174,7 +174,7 @@ class NodeTypeConfigurationEnrichmentAspect
 
         switch ($editorName) {
             case 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor':
-                if (isset($propertyConfiguration['ui']['inspector']['editorOptions']) && $this->shouldGenerateLabel($propertyConfiguration['ui']['inspector']['editorOptions'], 'placeholder')) {
+                if (isset($propertyConfiguration['ui']['inspector']['editorOptions']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['inspector']['editorOptions'], 'placeholder')) {
                     $propertyConfiguration['ui']['inspector']['editorOptions']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'selectBoxEditor.placeholder');
                 }
 
@@ -185,13 +185,13 @@ class NodeTypeConfigurationEnrichmentAspect
                     if ($optionConfiguration === null) {
                         continue;
                     }
-                    if ($this->shouldGenerateLabel($optionConfiguration)) {
+                    if ($this->shouldFetchTranslation($optionConfiguration)) {
                         $optionConfiguration['label'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'selectBoxEditor.values.' . $value);
                     }
                 }
                 break;
             case 'TYPO3.Neos/Inspector/Editors/CodeEditor':
-                if ($this->shouldGenerateLabel($propertyConfiguration['ui']['inspector']['editorOptions'], 'buttonLabel')) {
+                if ($this->shouldFetchTranslation($propertyConfiguration['ui']['inspector']['editorOptions'], 'buttonLabel')) {
                     $propertyConfiguration['ui']['inspector']['editorOptions']['buttonLabel'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'codeEditor.buttonLabel');
                 }
                 break;
@@ -207,7 +207,7 @@ class NodeTypeConfigurationEnrichmentAspect
      */
     protected function setGlobalUiElementLabels($nodeTypeLabelIdPrefix, &$configuration)
     {
-        if ($this->shouldGenerateLabel($configuration['ui'])) {
+        if ($this->shouldFetchTranslation($configuration['ui'])) {
             $configuration['ui']['label'] = $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'ui', 'label');
         }
 
@@ -215,7 +215,7 @@ class NodeTypeConfigurationEnrichmentAspect
         if (is_array($inspectorConfiguration)) {
             foreach ($inspectorConfiguration as $elementTypeName => $elementTypeItems) {
                 foreach ($elementTypeItems as $elementName => $elementConfiguration) {
-                    if (!$this->shouldGenerateLabel($elementConfiguration)) {
+                    if (!$this->shouldFetchTranslation($elementConfiguration)) {
                         continue;
                     }
 
@@ -233,7 +233,7 @@ class NodeTypeConfigurationEnrichmentAspect
      * @param string $fieldName Name of the possibly existing subfield
      * @return boolean
      */
-    protected function shouldGenerateLabel($parentConfiguration, $fieldName = 'label')
+    protected function shouldFetchTranslation($parentConfiguration, $fieldName = 'label')
     {
         $fieldValue = array_key_exists($fieldName, $parentConfiguration) ? $parentConfiguration[$fieldName] : '';
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeTypeSchemaBuilder.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeTypeSchemaBuilder.php
@@ -13,7 +13,6 @@ namespace TYPO3\Neos\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
-use League\CommonMark\CommonMarkConverter;
 
 /**
  * Renders the Node Type Schema in a format the User Interface understands; additionally pre-calculating node constraints
@@ -27,12 +26,6 @@ class NodeTypeSchemaBuilder
      * @var \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
      */
     protected $nodeTypeManager;
-
-    /**
-     * @var CommonMarkConverter
-     * @Flow\Inject
-     */
-    protected $markdownConverter;
 
     /**
      * The preprocessed node type schema contains everything we need for the UI:
@@ -66,7 +59,6 @@ class NodeTypeSchemaBuilder
         foreach ($nodeTypes as $nodeTypeName => $nodeType) {
             if ($nodeType->isAbstract() === false) {
                 $configuration = $nodeType->getFullConfiguration();
-                $this->parseMarkdown($configuration);
                 $this->flattenAlohaFormatOptions($configuration);
                 $schema['nodeTypes'][$nodeTypeName] = $configuration;
                 $schema['nodeTypes'][$nodeTypeName]['label'] = $nodeType->getLabel();
@@ -80,26 +72,6 @@ class NodeTypeSchemaBuilder
         }
 
         return $schema;
-    }
-
-    /**
-     * Process markdown syntax for help message properties
-     *
-     * @param array $options The options array, passed by reference
-     * @return void
-     */
-    protected function parseMarkdown(array &$options)
-    {
-        if (isset($options['ui']['help']['message'])) {
-            $options['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['ui']['help']['message']);
-        }
-        if (isset($options['properties'])) {
-            foreach (array_keys($options['properties']) as $propertyName) {
-                if (isset($options['properties'][$propertyName]['ui']['help']['message'])) {
-                    $options['properties'][$propertyName]['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['properties'][$propertyName]['ui']['help']['message']);
-                }
-            }
-        }
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
@@ -13,7 +13,6 @@ namespace TYPO3\Neos\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
-use League\CommonMark\CommonMarkConverter;
 
 /**
  * Generate a schema in JSON format for the VIE dataTypes validation, necessary
@@ -30,12 +29,6 @@ class VieSchemaBuilder
      * @Flow\Inject
      */
     protected $nodeTypeManager;
-
-    /**
-     * @var CommonMarkConverter
-     * @Flow\Inject
-     */
-    protected $markdownConverter;
 
     /**
      * @var array
@@ -119,8 +112,8 @@ class VieSchemaBuilder
     protected function readNodeTypeConfiguration($nodeTypeName, NodeType $nodeType)
     {
         $nodeTypeConfiguration = $nodeType->getFullConfiguration();
-        $this->parseMarkdown($nodeTypeConfiguration);
         $this->superTypeConfiguration['typo3:' . $nodeTypeName] = array();
+        /** @var NodeType $superType */
         foreach ($nodeType->getDeclaredSuperTypes() as $superType) {
             $this->superTypeConfiguration['typo3:' . $nodeTypeName][] = 'typo3:' . $superType->getName();
         }
@@ -159,26 +152,6 @@ class VieSchemaBuilder
             'comment' => '',
             'comment_plain' => ''
         );
-    }
-
-    /**
-     * Process markdown syntax for help message properties
-     *
-     * @param array $options The options array, passed by reference
-     * @return void
-     */
-    protected function parseMarkdown(array &$options)
-    {
-        if (isset($options['ui']['help']['message'])) {
-            $options['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['ui']['help']['message']);
-        }
-        if (isset($options['properties'])) {
-            foreach (array_keys($options['properties']) as $propertyName) {
-                if (isset($options['properties'][$propertyName]['ui']['help']['message'])) {
-                    $options['properties'][$propertyName]['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['properties'][$propertyName]['ui']['help']['message']);
-                }
-            }
-        }
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * Generate a schema in JSON format for the VIE dataTypes validation, necessary
@@ -29,6 +30,12 @@ class VieSchemaBuilder
      * @Flow\Inject
      */
     protected $nodeTypeManager;
+
+    /**
+     * @var CommonMarkConverter
+     * @Flow\Inject
+     */
+    protected $markdownConverter;
 
     /**
      * @var array
@@ -112,6 +119,7 @@ class VieSchemaBuilder
     protected function readNodeTypeConfiguration($nodeTypeName, NodeType $nodeType)
     {
         $nodeTypeConfiguration = $nodeType->getFullConfiguration();
+        $this->parseMarkdown($nodeTypeConfiguration);
         $this->superTypeConfiguration['typo3:' . $nodeTypeName] = array();
         foreach ($nodeType->getDeclaredSuperTypes() as $superType) {
             $this->superTypeConfiguration['typo3:' . $nodeTypeName][] = 'typo3:' . $superType->getName();
@@ -151,6 +159,26 @@ class VieSchemaBuilder
             'comment' => '',
             'comment_plain' => ''
         );
+    }
+
+    /**
+     * Process markdown syntax for help message properties
+     *
+     * @param array $options The options array, passed by reference
+     * @return void
+     */
+    protected function parseMarkdown(array &$options)
+    {
+        if (isset($options['ui']['help']['message'])) {
+            $options['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['ui']['help']['message']);
+        }
+        if (isset($options['properties'])) {
+            foreach (array_keys($options['properties']) as $propertyName) {
+                if (isset($options['properties'][$propertyName]['ui']['help']['message'])) {
+                    $options['properties'][$propertyName]['ui']['help']['message'] = $this->markdownConverter->convertToHtml($options['properties'][$propertyName]['ui']['help']['message']);
+                }
+            }
+        }
     }
 
     /**

--- a/TYPO3.Neos/Configuration/Objects.yaml
+++ b/TYPO3.Neos/Configuration/Objects.yaml
@@ -57,3 +57,6 @@ TYPO3\Neos\Service\XliffService:
         arguments:
           1:
             value: TYPO3_Neos_XliffToJsonTranslations
+
+League\CommonMark\CommonMarkConverter:
+  className: League\CommonMark\CommonMarkConverter

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -96,6 +96,24 @@ The following options are allowed:
       Help text for the node type. It supports markdown to format the help text and can
       be translated (see :ref:`translate-nodetypes`).
 
+    ``thumbnail``
+      This is shown in the popover and can be supplied in two ways:
+
+      - as an absolute URL to an image (``http://static/acme.com/thumbnails/bar.png``)
+      - as a resource URI (``resource://AcmeCom.Website/NodeTypes/Thumbnails/foo.png``)
+
+      If the ``thumbnail`` setting is undefined but an image matching the nodetype name
+       is found, it will be used automatically. It will be looked for in
+       ``<packageKey>/Resources/Public/Images/NodeTypes/<nodeTypeName>.png`` with
+       ``packageKey`` and ``nodeTypeName`` being extracted from the full nodetype name
+       like this:
+
+       ``AcmeCom.Website:FooWithBar`` -> ``AcmeCom.Website`` and ``FooWithBar``
+
+       The image will be downscaled to a width of 342 pixels, so it should either be that
+       size to be placed above any further help text (if supplied) or be half that size for
+       the help text to flow around it.
+
   ``inlineEditable``
     If TRUE, it is possible to interact with this Node directly in the content view.
     If FALSE, an overlay is shown preventing any interaction with the node.

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -89,11 +89,12 @@ The following options are allowed:
     are available in Font Awesome http://fortawesome.github.io/Font-Awesome/3.2.1/icons/.
 
   ``help``
-    Configuration of contextual help. For now only ``message`` that is rendered as popover
-    is supported.
+    Configuration of contextual help. Displays a message that is rendered as popover
+    when the user clicks the help icon in an insert node dialog.
 
     ``message``
-      Help text for the node type. Supports markdown.
+      Help text for the node type. It supports markdown to format the help text and can
+      be translated (see :ref:`translate-nodetypes`).
 
   ``inlineEditable``
     If TRUE, it is possible to interact with this Node directly in the content view.
@@ -152,11 +153,12 @@ The following options are allowed:
       The human-readable label of the property
 
     ``help``
-      Configuration of contextual help. For now only ``message`` that is rendered as popover
-      is supported.
+      Configuration of contextual help. Displays a message that is rendered as popover
+      when the user clicks the help icon in the inspector.
 
       ``message``
-        Help text for this property. Supports markdown.
+        Help text for this property. It supports markdown to format the help text and can
+        be translated (see :ref:`translate-nodetypes`).
 
     ``reloadIfChanged``
       If TRUE, the whole content element needs to be re-rendered on the server side if the value

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -88,6 +88,13 @@ The following options are allowed:
     Currently it's only possible to use a predefined selection of icons, which
     are available in Font Awesome http://fortawesome.github.io/Font-Awesome/3.2.1/icons/.
 
+  ``help``
+    Configuration of contextual help. For now only ``message`` that is rendered as popover
+    is supported.
+
+    ``message``
+      Help text for the node type. Supports markdown.
+
   ``inlineEditable``
     If TRUE, it is possible to interact with this Node directly in the content view.
     If FALSE, an overlay is shown preventing any interaction with the node.
@@ -143,6 +150,13 @@ The following options are allowed:
 
     ``label``
       The human-readable label of the property
+
+    ``help``
+      Configuration of contextual help. For now only ``message`` that is rendered as popover
+      is supported.
+
+      ``message``
+        Help text for this property. Supports markdown.
 
     ``reloadIfChanged``
       If TRUE, the whole content element needs to be re-rendered on the server side if the value

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
@@ -1,8 +1,10 @@
+.. _translate-nodetypes:
+
 Translate NodeTypes
 ===================
 
-To use the translations for NodeType labels you have to enable it for each label by
-setting the label to the predefined value "i18n".
+To use the translations for NodeType labels or help messages you have to enable it for each label
+or message by setting the value to the predefined value "i18n".
 
 *NodeTypes.yaml*
 
@@ -10,6 +12,8 @@ setting the label to the predefined value "i18n".
 
   Vendor.Site:YourContentElementName:
     ui:
+      help:
+        message: 'i18n'
       inspector:
         tabs:
           yourTab:
@@ -22,6 +26,8 @@ setting the label to the predefined value "i18n".
         type: string
           ui:
             label: 'i18n'
+            help:
+              message: 'i18n'
 
 That will instruct Neos to look for translations of these labels. To register an xliff file
 for this NodeTypes you have to add the following configuration to the Settings.yaml of your package:
@@ -37,7 +43,8 @@ for this NodeTypes you have to add the following configuration to the Settings.y
 
 
 Inside of the xliff file **Resources/Private/Translations/en/NodeTypes/YourContentElementName.xliff** the
-translated labels for ``properties``, ``groups``, ``tabs`` and ``views`` are defined in the xliff like as follows.
+translated labels for ``help``, ``properties``, ``groups``, ``tabs`` and ``views`` are defined in the xliff
+as follows:
 
 .. code-block:: xml
 
@@ -45,6 +52,9 @@ translated labels for ``properties``, ``groups``, ``tabs`` and ``views`` are def
 	<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 		<file original="" product-name="Vendor.Site" source-language="en" datatype="plaintext">
 			<body>
+				<trans-unit id="ui.help.message" xml:space="preserve">
+					<source>Your help message here</source>
+				</trans-uni>
 				<trans-unit id="tabs.myTab" xml:space="preserve">
 					<source>Your Tab Title</source>
 				</trans-unit>
@@ -54,6 +64,9 @@ translated labels for ``properties``, ``groups``, ``tabs`` and ``views`` are def
 				<trans-unit id="properties.myProperty" xml:space="preserve">
 					<source>Your Property Title</source>
 				</trans-unit>
+				<trans-unit id="properties.myProperty.ui.help.message" xml:space="preserve">
+					<source>Your help message here</source>
+				</trans-uni>
 			</body>
 		</file>
 	</xliff>

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -18,6 +18,12 @@ additionalProperties:
 
               'label': { type: string, description: "Human-readable label for this property." }
 
+              'help':
+                type: dictionary
+                additionalProperties: FALSE
+                properties:
+                  'message': { type: string, description: "Help text for this property. Supports markdown." }
+
               'reloadIfChanged': { type: boolean, description: "If this property changes, should a element refresh occur?" }
 
               'reloadPageIfChanged': { type: boolean, description: "If this property changes, should a page reload occur?" }
@@ -112,6 +118,12 @@ additionalProperties:
       properties:
 
         'label': { type: string, description: "Human-readable label for this Node Type." }
+
+        'help':
+          type: dictionary
+          additionalProperties: FALSE
+          properties:
+            'message': { type: string, description: "Help text for this Node Type. Supports markdown." }
 
         'icon': { type: string, description: "Icon class" }
 

--- a/TYPO3.Neos/Resources/Private/Styles/Components/_HelpMessage.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Components/_HelpMessage.scss
@@ -6,7 +6,8 @@
 .neos-help-message-icon {
 	color: $textOnGray;
 	font-size: 1rem;
-	vertical-align: middle; // align the icon inside
+	position: relative;
+	top: 4px;
 	cursor: pointer;
 	text-decoration: none;
 }

--- a/TYPO3.Neos/Resources/Private/Styles/Components/_HelpMessage.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Components/_HelpMessage.scss
@@ -1,0 +1,12 @@
+.neos-help-message-button {
+	&:active, &:focus {
+		outline: none; // we really don't need that outline for the tiny [?] icon, do we?
+	}
+}
+.neos-help-message-icon {
+	color: $textOnGray;
+	font-size: 1rem;
+	vertical-align: middle; // align the icon inside
+	cursor: pointer;
+	text-decoration: none;
+}

--- a/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
@@ -15,11 +15,8 @@
 		overflow-y: auto;
 	}
 
-	ul {
-		font-size: 0;
-	}
-
 	.neos-content-new-selecttype-button {
+		position: relative;
 		float: left;
 		margin: 0;
 		width: 100 / 3 * 1%;
@@ -36,16 +33,6 @@
 			text-overflow: ellipsis;
 			white-space: nowrap;
 
-			&:focus,
-			&:hover {
-				background-color: $blue;
-				outline: none;
-
-				i {
-					color: #fff;
-				}
-			}
-
 			i {
 				width: 14px;
 				padding-right: $relatedMargin;
@@ -54,5 +41,34 @@
 				vertical-align: baseline;
 			}
 		}
+		&:focus, &:hover {
+			background-color: $blue;
+			button {
+				outline: none;
+			}
+			i {
+				color: #fff;
+			}
+
+			.neos-help-message-button {
+				display: inline-block;
+			}
+		}
+
+		.neos-help-message-button {
+			display: none;
+			position: absolute;
+			top: 0;
+			right: 0;
+			padding: 9px;
+			cursor: pointer;
+			&:focus {
+				display: inline-block; // so when the hover is gone, the popover doesn't disappear
+			}
+		}
+	}
+
+	.neos-popover {
+		width: $popoverSizeForHelpMessages;
 	}
 }

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_popovers.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_popovers.scss
@@ -1,9 +1,12 @@
 //
 // Popovers
 // --------------------------------------------------
+$popoverSizeDefault: 236px;
+$popoverSizeForHelpMessages: 366px;
 
+$popoverBorderColor: $grayLight;
 $popoverBackground: $grayDark;
-$popoverTitleBackground: $grayMedium;
+$popoverTitleBackground: $grayDarker;
 $popoverArrowColor: $grayDark;
 $popoverArrowOuterColor: $grayLight;
 
@@ -13,12 +16,12 @@ $popoverArrowOuterColor: $grayLight;
 	left: 0;
 	z-index: $zindexPopover;
 	display: none;
-	width: 236px;
+	width: $popoverSizeDefault;
 	background-color: $popoverBackground;
 	-webkit-background-clip: padding-box;
 	-moz-background-clip: padding;
 	background-clip: padding-box;
-	border: 1px solid $grayLight;
+	border: 1px solid $popoverBorderColor;
 	@include box-shadow(#{0 5px 10px rgba(0, 0, 0, .2)});
 
 	// Offset the popover to account for the popover arrow
@@ -32,9 +35,11 @@ $popoverArrowOuterColor: $grayLight;
 	margin: 0; // reset heading margin
 	padding: $relatedMargin;
 	font-size: 14px;
-	font-weight: normal;
+	font-weight: bold;
+	color: $textOnGray;
 	line-height: 18px;
 	background-color: $popoverTitleBackground;
+	border-bottom: 1px solid $popoverBorderColor;
 
 	&:empty {
 		display: none;
@@ -43,9 +48,78 @@ $popoverArrowOuterColor: $grayLight;
 
 .neos-popover-content {
 	padding: $relatedMargin;
+	max-height: $popoverSizeDefault;
+	overflow-y: auto;
+	white-space: normal;
 
 	p, ul, ol {
-		margin-bottom: 0;
+		margin-bottom: 0.4rem; // same padding as for content padding inside popover
+		font-size: inherit; // so setting font-size only for parent .neos-popover-content works
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+	// Re-style UL and OL because inside .neos container they have zero-ed margins and no list-style-type.
+	ul, ol {
+		margin-left: 1.1rem;
+		li {
+			list-style-type: inherit; // It's enough to set list-style-type for UL/OL, but it's re-set for whole .neos container, so it needs to be re-defined again
+		}
+	}
+	ul {
+		list-style-type: disc;
+	}
+	ol {
+		list-style-type: decimal;
+	}
+	h1, h2, h3, h4, h5, h6 {
+		color: inherit;
+		font-weight: bold;
+	}
+	h1 {
+		font-size: 1.6em;
+	}
+	h2 {
+		font-size: 1.4em;
+	}
+	h3 {
+		font-size: 1.3em;
+	}
+	h4 {
+		font-size: 1.2em;
+	}
+	h5 {
+		font-size: 1em;
+	}
+	h6 {
+		font-size: 0.9em;
+	}
+	a {
+		color: $blueLight;
+		&:hover, &:focus, &:active { color: $blue }
+	}
+	strong {
+		font-weight: bold;
+	}
+	em {
+		font-style: italic;
+	}
+	code { // inline code using single `` backticks.
+		color: inherit;
+		background-color: $grayMedium;
+		border: 0 none;
+	}
+	pre { // block of code using triple ``` backticks.
+		margin: 0.4rem 0;
+		padding: 0.4rem;
+		line-height: 1.5;
+		background-color: $grayMedium;
+		code { // code inside block of code (yes, Markdown renders it like that)
+			padding: 0;
+		}
+	}
+	hr {
+		border-color: $grayLight;
 	}
 }
 

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_popovers.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_popovers.scss
@@ -121,6 +121,9 @@ $popoverArrowOuterColor: $grayLight;
 	hr {
 		border-color: $grayLight;
 	}
+  img {
+    margin: auto auto 0.4rem auto;
+  }
 }
 
 // Arrows

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_variables.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_variables.scss
@@ -142,9 +142,9 @@ $dropdownLinkBackgroundHover:   $dropdownLinkBackgroundActive !default;
 // Used for a bird's eye view of components dependent on the z-axis
 // Try to avoid customizing these :)
 $zindexDropdown:          1000 !default;
-$zindexPopover:           1010 !default;
 $zindexTooltip:           1030 !default;
 $zindexFixedNavbar:       1030 !default;
+$zindexPopover:           10030 !default;
 $zindexModalBackdrop:     10040 !default;
 $zindexModal:             10050 !default;
 

--- a/TYPO3.Neos/Resources/Private/Styles/Inspector/_Inspector.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Inspector/_Inspector.scss
@@ -677,6 +677,20 @@
 		}
 	}
 
+	.neos-help-message-button {
+		// Popover positions itself automatically and it's relative to this element.
+		// We need to add some offset to make space for Popover arrow
+		// and then de-offset it so it's not too far away from the label text.
+		margin-left: -5px;
+		.neos-help-message-icon {
+			margin-left: 10px;
+		}
+	}
+
+	.neos-popover {
+		width: $popoverSizeForHelpMessages;
+	}
+
 	@import "Views/ColumnView";
 	@import "Views/TableView";
 	@import "Views/TimeSeriesView";

--- a/TYPO3.Neos/Resources/Private/Styles/Neos.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Neos.scss
@@ -89,6 +89,7 @@
 	@import "Notifications";
 	@import "Components/LoginDialog";
 	@import "Components/PositionSelector";
+	@import "Components/HelpMessage";
 	@import "Widget/pagination";
 	@import "ContextBar/AlohaLinkEditor";
 	@import "ContextBar/AlohaAddTable";

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -115,7 +115,7 @@ function(
 				this._setPagePosition();
 			}
 
-			this._initializeDropdowns();
+			this._initializeTwitterBootstrap();
 
 			if (window.T3.isContentModule) {
 				this._initializeHistoryManagement();
@@ -235,8 +235,13 @@ function(
 			CreateJS.initialize();
 		},
 
-		_initializeDropdowns: function() {
+		_initializeTwitterBootstrap: function() {
 			$('.dropdown-toggle', this.rootElement).dropdown();
+			$('html').click(function(e) {
+				if ($(e.target).parents('.neos-popover').length === 0) {
+					$('.neos-popover-toggle').popover('hide');
+				}
+			});
 		},
 
 		_initializeHistoryManagement: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
@@ -17,6 +17,9 @@
 							{{/if}}
 							{{unbound label}}
 						</button>
+						{{#if helpMessage}}
+							{{view view.HelpMessage titleBinding="label" contentBinding="helpMessage" popoverContainer=".neos-insert-node-panel"}}
+						{{/if}}
 					</li>
 				{{/each}}
 			</ul>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
@@ -1,15 +1,18 @@
 define([
 	'emberjs',
 	'Shared/AbstractModal',
+	'./HelpMessage',
 	'text!./AbstractInsertNodePanel.html'
 ], function(
 	Ember,
 	AbstractModal,
+	HelpMessage,
 	template
 ) {
 	return AbstractModal.extend({
 		template: Ember.Handlebars.compile(template),
 		nodeTypeGroups: Ember.required,
-		insertNode: Ember.required
+		insertNode: Ember.required,
+		HelpMessage: HelpMessage
 	});
 });

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/HelpMessage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/HelpMessage.js
@@ -1,0 +1,19 @@
+/**
+* Help message popover for providing contextual help
+*/
+define([
+		'emberjs',
+		'Library/jquery-with-dependencies',
+		'Shared/Popover'
+	], function(
+		Ember,
+		$,
+		Popover
+	) {
+		return Popover.extend({
+			tagName: 'a',
+			classNames: ['neos-help-message-button'],
+			anchorContent: '<i class="icon-question-sign neos-help-message-icon"></i>'
+		});
+	}
+);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/HelpMessage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/HelpMessage.js
@@ -13,7 +13,8 @@ define([
 		return Popover.extend({
 			tagName: 'a',
 			classNames: ['neos-help-message-button'],
-			anchorContent: '<i class="icon-question-sign neos-help-message-icon"></i>'
+			anchorContent: '<i class="icon-question-sign neos-help-message-icon"></i>',
+			placement: 'bottom'
 		});
 	}
 );

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorView.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorView.html
@@ -26,9 +26,17 @@
 							<label for="{{unbound elementId}}" class="neos-checkbox">
 								{{view view.parentView.parentView.PropertyEditor propertyDefinitionBinding="view.content" inspectorBinding="controller"}}
 								{{unbound ui.label}}
+								{{#if ui.help.message}}
+									{{view view.parentView.parentView.HelpMessage titleBinding="ui.label" contentBinding="ui.help.message" popoverContainer="#neos-inspector" placement="left"}}
+								{{/if}}
 							</label>
 						{{else}}
-							<label for="{{unbound elementId}}" title="{{unbound ui.label}}">{{unbound ui.label}}</label>
+							<label for="{{unbound elementId}}" title="{{unbound ui.label}}">
+								{{unbound ui.label}}
+								{{#if ui.help.message}}
+									{{view view.parentView.parentView.HelpMessage titleBinding="ui.label" contentBinding="ui.help.message" popoverContainer="#neos-inspector" placement="left"}}
+								{{/if}}
+							</label>
 							{{view view.parentView.parentView.PropertyEditor propertyDefinitionBinding="view.content" inspectorBinding="controller"}}
 						{{/if}}
 					{{/collection}}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Section.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Section.js
@@ -6,16 +6,19 @@ define(
 	'emberjs',
 	'./PropertyEditor',
 	'./ViewView',
+	'Content/Components/HelpMessage',
 	'Content/Model/NodeSelection'
 ], function(
 	Ember,
 	PropertyEditor,
 	ViewView,
+	HelpMessage,
 	NodeSelection
 ) {
 	return Ember.View.extend({
 		PropertyEditor: PropertyEditor,
 		ViewView: ViewView,
+		HelpMessage: HelpMessage,
 		_hasValidationErrors: false,
 		_collapsed: false,
 		_nodeType: '',

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
@@ -40,10 +40,11 @@ define(
 							'nodeTypes': []
 						};
 					}
+					var helpMessage;
 					if (nodeType.ui.help && nodeType.ui.help.message) {
-						var helpMessage = nodeType.ui.help.message;
+						helpMessage = nodeType.ui.help.message;
 					} else {
-						var helpMessage = '';
+						helpMessage = '';
 					}
 					groupedNodeTypes[groupName].nodeTypes.push({
 						'nodeType': nodeTypeName,

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
@@ -40,10 +40,15 @@ define(
 							'nodeTypes': []
 						};
 					}
-
+					if (nodeType.ui.help && nodeType.ui.help.message) {
+						var helpMessage = nodeType.ui.help.message;
+					} else {
+						var helpMessage = '';
+					}
 					groupedNodeTypes[groupName].nodeTypes.push({
 						'nodeType': nodeTypeName,
 						'label': I18n.translate(nodeType.ui.label),
+						'helpMessage': helpMessage,
 						'icon': 'icon' in nodeType.ui ? nodeType.ui.icon : 'icon-file',
 						'position': nodeType.ui.position
 					});

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -66,9 +66,15 @@ function(
 							nodeTypes: []
 						};
 					}
+					if (type.metadata.ui.help && type.metadata.ui.help.message) {
+						var helpMessage = type.metadata.ui.help.message;
+					} else {
+						var helpMessage = '';
+					}
 					groups[type.metadata.ui.group].nodeTypes.push({
 						'nodeType': nodeTypeName,
 						'label': I18n.translate(type.metadata.ui.label),
+						'helpMessage': helpMessage,
 						'icon': 'icon' in type.metadata.ui ? type.metadata.ui.icon : 'icon-file',
 						'position': type.metadata.ui.position
 					});

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -66,10 +66,11 @@ function(
 							nodeTypes: []
 						};
 					}
+					var helpMessage;
 					if (type.metadata.ui.help && type.metadata.ui.help.message) {
-						var helpMessage = type.metadata.ui.help.message;
+						helpMessage = type.metadata.ui.help.message;
 					} else {
-						var helpMessage = '';
+						helpMessage = '';
 					}
 					groups[type.metadata.ui.group].nodeTypes.push({
 						'nodeType': nodeTypeName,

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Popover.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Popover.js
@@ -29,7 +29,7 @@ define([
 					trigger: that.triggerMode,
 					html: true
 				}).click(function(e) {
-					// Prevent popover to be immediaely closed
+					// Prevent popover to be immediately closed
 					e.stopPropagation();
 					e.preventDefault();
 				});

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Popover.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Popover.js
@@ -1,0 +1,42 @@
+/**
+* A Bootstrap Popover widget
+*/
+define([
+		'emberjs',
+		'Library/jquery-with-dependencies'
+	], function(
+		Ember,
+		$
+	) {
+		return Ember.View.extend({
+			defaultTemplate: Ember.Handlebars.compile('{{{view.anchorContent}}}'),
+			classNames: ['neos-popover-toggle'],
+
+			anchorContent: Ember.required,
+			title: '',
+			content: '',
+			popoverContainer: false,
+			placement: 'top',
+			triggerMode: 'click',
+
+			didInsertElement: function () {
+				var that = this;
+				that.$().popover({
+					placement: that.placement,
+					title: that.title,
+					content: that.content,
+					container: that.popoverContainer,
+					trigger: that.triggerMode,
+					html: true
+				}).click(function(e) {
+					// Prevent popover to be immediaely closed
+					e.stopPropagation();
+					e.preventDefault();
+				});
+			},
+			willDestroyElement: function () {
+				this.$().popover('destroy');
+			}
+		});
+	}
+);

--- a/TYPO3.Neos/composer.json
+++ b/TYPO3.Neos/composer.json
@@ -10,7 +10,8 @@
         "typo3/setup": "*",
         "typo3/twitter-bootstrap": "*",
         "typo3/typo3cr": "*",
-        "typo3/typoscript": "*"
+        "typo3/typoscript": "*",
+        "league/commonmark": "*"
     },
     "suggest": {
         "typo3/neos-kickstarter": "Helps with creating new site packages for Neos."

--- a/TYPO3.Neos/composer.json
+++ b/TYPO3.Neos/composer.json
@@ -11,7 +11,7 @@
         "typo3/twitter-bootstrap": "*",
         "typo3/typo3cr": "*",
         "typo3/typoscript": "*",
-        "league/commonmark": "*"
+        "league/commonmark": "^0.12.0"
     },
     "suggest": {
         "typo3/neos-kickstarter": "Helps with creating new site packages for Neos."

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "typo3/party": "*",
         "typo3/setup": "*",
         "typo3/twitter-bootstrap": "*",
-        "league/commonmark": "*",
+        "league/commonmark": "^0.12.0",
         "typo3/eel": "*",
         "gedmo/doctrine-extensions": "2.3.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "typo3/party": "*",
         "typo3/setup": "*",
         "typo3/twitter-bootstrap": "*",
+        "league/commonmark": "*",
         "typo3/eel": "*",
         "gedmo/doctrine-extensions": "2.3.*"
     },


### PR DESCRIPTION
Allows to show contextual help messages in a popover element for node
types and node properties.
Supports markdown for styling message text.

Usage:
For node types:
```
'My.Package:SpecialHeadline':
  ui:
    help:
      message: 'Special headline displays text in **gold color**.'
```

For node properties:
```
'My.Package:SpecialHeadline':
  properties:
    title:
      ui:
        help:
          message: 'Lorem ipsum `dolor` sit amet'
```

Releases: master
Resolves: NEOS-1303