### PR TITLE
[FEATURE] node:repair sub command for removing broken entity references

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -70,7 +70,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 	static public function getSubCommandShortDescription($controllerCommandName) {
 		switch ($controllerCommandName) {
 			case 'repair':
-				return 'Generate missing URI path segments';
+				return 'Run integrity checks related to Neos features';
 		}
 	}
 
@@ -131,7 +131,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 			$flowQuery = new FlowQuery($baseContextSiteNodes);
 			$siteNodes = $flowQuery->context(['dimensions' => $dimensionCombination, 'targetDimensions' => []])->get();
 			if (count($siteNodes) > 0) {
-				$this->output->outputLine('Searching for nodes with missing URI path segment in dimension "%s"', array(trim(NodePaths::generateContextPath('', '', $dimensionCombination), '@;')));
+				$this->output->outputLine('Checking for nodes with missing URI path segment in dimension "%s"', array(trim(NodePaths::generateContextPath('', '', $dimensionCombination), '@;')));
 				foreach ($siteNodes as $siteNode) {
 					$this->generateUriPathSegmentsForNode($siteNode, $dryRun);
 				}

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -97,7 +97,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 	static public function getSubCommandShortDescription($controllerCommandName) {
 		switch ($controllerCommandName) {
 			case 'repair':
-				return 'Run several operations to ensure the node integrity';
+				return 'Run checks for basic node integrity in the content repository';
 		}
 	}
 
@@ -367,7 +367,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 	 * @return void
 	 */
 	protected function removeAbstractAndUndefinedNodes($workspaceName, $dryRun) {
-		$this->output->outputLine('<b>Checking for nodes with abstract or undefined node types ...</b>');
+		$this->output->outputLine('Checking for nodes with abstract or undefined node types ...');
 
 		$abstractNodeTypes = array();
 		$nonAbstractNodeTypes = array();
@@ -493,7 +493,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 	 * @return void
 	 */
 	protected function removeOrphanNodes($workspaceName, $dryRun) {
-		$this->output->outputLine('<b>Checking for orphan nodes ...</b>');
+		$this->output->outputLine('Checking for orphan nodes ...');
 
 		/** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
 		$queryBuilder = $this->entityManager->createQueryBuilder();

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -14,6 +14,7 @@ namespace TYPO3\TYPO3CR\Command;
 use Doctrine\ORM\QueryBuilder;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\ConsoleOutput;
+use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -21,7 +22,6 @@ use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContentDimensionCombinator;
-use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Exception\NodeTypeNotFoundException;
@@ -76,6 +76,12 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 	 * @var \Doctrine\Common\Persistence\ObjectManager
 	 */
 	protected $entityManager;
+
+	/**
+	 * @Flow\Inject
+	 * @var PropertyMapper
+	 */
+	protected $propertyMapper;
 
 	/**
 	 * @var array
@@ -138,7 +144,12 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 					PHP_EOL .
 					'For all nodes (or only those which match the --node-type filter specified with this' . PHP_EOL .
 					'command) which currently don\'t have a property that have a default value configuration' . PHP_EOL .
-					'the default value for that property will be set.' . PHP_EOL;
+					'the default value for that property will be set.' . PHP_EOL .
+					PHP_EOL .
+					'<u>Remove broken object references</u>' . PHP_EOL .
+					PHP_EOL .
+					'Detects and removes references from nodes to entities which don\'t exist anymore (for' . PHP_EOL .
+					'example Image nodes referencing ImageVariant objects which are gone for some reason).' . PHP_EOL;
 		}
 	}
 
@@ -162,6 +173,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 					$this->removeOrphanNodes($workspaceName, $dryRun);
 					$this->removeDisallowedChildNodes($workspaceName, $dryRun);
 					$this->removeUndefinedProperties($nodeType, $workspaceName, $dryRun);
+					$this->removeBrokenEntityReferences($workspaceName, $dryRun);
 				}
 				$this->createMissingChildNodes($nodeType, $workspaceName, $dryRun);
 				$this->reorderChildNodes($nodeType, $workspaceName, $dryRun);
@@ -609,6 +621,76 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 			}
 			$this->output->outputLine();
 		}
+	}
+
+	/**
+	 * Remove broken entity references
+	 *
+	 * This removes references from nodes to entities which don't exist anymore.
+	 *
+	 * @param string $workspaceName
+	 * @param boolean $dryRun
+	 * @return void
+	 */
+	public function removeBrokenEntityReferences($workspaceName, $dryRun) {
+		$this->output->outputLine('Checking for broken entity references ...');
+
+		/** @var \TYPO3\TYPO3CR\Domain\Model\Workspace $workspace */
+		$workspace = $this->workspaceRepository->findByIdentifier($workspaceName);
+
+		$nodeTypesWithEntityReferences = array();
+		foreach ($this->nodeTypeManager->getNodeTypes() as $nodeType) {
+			/** @var NodeType $nodeType */
+			foreach (array_keys($nodeType->getProperties()) as $propertyName) {
+				$propertyType = $nodeType->getPropertyType($propertyName);
+				if (strpos($propertyType, '\\') !== FALSE) {
+					if (!isset($nodeTypesWithEntityReferences[$nodeType->getName()])) {
+						$nodeTypesWithEntityReferences[$nodeType->getName()] = array();
+					}
+					$nodeTypesWithEntityReferences[$nodeType->getName()][$propertyName] = $propertyType;
+				}
+			}
+		}
+
+		$nodesWithBrokenEntityReferences = array();
+		$brokenReferencesCount = 0;
+		foreach ($nodeTypesWithEntityReferences as $nodeTypeName => $properties) {
+			$nodeDatas = $this->nodeDataRepository->findByParentAndNodeTypeRecursively('/', $nodeTypeName, $workspace);
+			foreach ($nodeDatas as $nodeData) {
+				/** @var NodeData $nodeData */
+				foreach ($properties as $propertyName => $propertyType) {
+					$propertyValue = $nodeData->getProperty($propertyName);
+					if (is_string($propertyValue) && strlen($propertyValue) === 36) {
+						$convertedProperty = $this->propertyMapper->convert($propertyValue, $propertyType);
+						if ($convertedProperty === NULL) {
+							$nodesWithBrokenEntityReferences[$nodeData->getIdentifier()][$propertyName] = $nodeData;
+							$this->output->outputLine('Broken reference in "%s", property "%s" (%s) referring to %s.', array($nodeData->getPath(), $nodeData->getIdentifier(), $propertyName, $propertyType, $propertyValue));
+							$brokenReferencesCount ++;
+						}
+					}
+				}
+			}
+		}
+
+		if ($brokenReferencesCount > 0) {
+			$this->output->outputLine();
+			if (!$dryRun) {
+				$self = $this;
+				$this->askBeforeExecutingTask('Do you want to remove the broken entity references?', function() use ($self, $nodesWithBrokenEntityReferences, $brokenReferencesCount, $workspaceName, $dryRun) {
+					foreach ($nodesWithBrokenEntityReferences as $nodeIdentifier => $properties) {
+						foreach ($properties as $propertyName => $nodeData) {
+							/** @var NodeData $nodeData */
+							$nodeData->setProperty($propertyName, NULL);
+						}
+					}
+					$self->output->outputLine('Removed %s broken entity reference%s.', array($brokenReferencesCount, $brokenReferencesCount > 1 ? 's' : ''));
+				});
+			} else {
+				$this->output->outputLine('Found %s broken entity reference%s to be removed.', array($brokenReferencesCount, $brokenReferencesCount > 1 ? 's' : ''));
+			}
+			$this->output->outputLine();
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
This change introduces a new sub command for node:repair which detects
and removes node property references to entities which don't exist.

One practical example are Image nodes whose "image" property points to
ImageVariant objects which, for whatever reason, have been removed
in the meantime. For these nodes, node:repair will now set the "image"
property to NULL.

Releases: master