### PR TITLE
[BUGFIX] Route cache flush shouldn't load all documents

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -76,7 +76,7 @@ class Package extends BasePackage {
 		$dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 		$dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodeDiscarded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
-		$dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodePathChange');
+		$dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
 		$dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
 		$dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
 		$dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', function($node, $targetWorkspace) use ($bootstrap) {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Aspects/RouteCacheAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Aspects/RouteCacheAspect.php
@@ -30,7 +30,7 @@ class RouteCacheAspect {
 	protected $contextFactory;
 
 	/**
-	 * Add the current node identifier to be used for cache entry tagging
+	 * Add the current node and all parent identifiers to be used for cache entry tagging
 	 *
 	 * @Flow\Before("method(TYPO3\Flow\Mvc\Routing\RouterCachingService->extractUuids())")
 	 * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
@@ -44,10 +44,21 @@ class RouteCacheAspect {
 		list($nodePath, $contextArguments) = explode('@', $values['node']);
 		$context = $this->getContext($contextArguments);
 		$node = $context->getNode($nodePath);
-		if ($node instanceof NodeInterface) {
-			$values['node-identifier'] = $node->getIdentifier();
-			$joinPoint->setMethodArgument('values', $values);
+
+		if (!$node instanceof NodeInterface) {
+			return;
 		}
+
+		$values['node-identifier'] = $node->getIdentifier();
+		$node = $node->getParent();
+
+		$values['node-parent-identifier'] = array();
+		while ($node !== NULL) {
+			$values['node-parent-identifier'][] = $node->getIdentifier();
+			$node = $node->getParent();
+		}
+
+		$joinPoint->setMethodArgument('values', $values);
 	}
 
 	/**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
@@ -35,13 +35,13 @@ class RouteCacheFlusher {
 	protected $tagsToFlush = array();
 
 	/**
-	 * Schedules flushing of the routing cache entry for the given $nodeData
-	 * Note: This is not done recursively because the nodePathChanged signal is triggered for any affected node data instance
+	 * Schedules flushing of the routing cache entries for the given $node
+	 * Note that child nodes are flushed automatically because they are tagged with all parents.
 	 *
-	 * @param NodeInterface $node The affected node data instance
+	 * @param NodeInterface $node The node which has changed in some way
 	 * @return void
 	 */
-	public function registerNodePathChange(NodeInterface $node) {
+	public function registerNodeChange(NodeInterface $node) {
 		if (in_array($node->getIdentifier(), $this->tagsToFlush)) {
 			return;
 		}
@@ -49,20 +49,6 @@ class RouteCacheFlusher {
 			return;
 		}
 		$this->tagsToFlush[] = $node->getIdentifier();
-	}
-
-	/**
-	 * Schedules recursive flushing of the routing cache entries for the given $node
-	 *
-	 * @param NodeInterface $node The node which has changed in some way
-	 * @return void
-	 */
-	public function registerNodeChange(NodeInterface $node) {
-		$this->registerNodePathChange($node);
-		/** @var NodeInterface $childNode */
-		foreach ($node->getChildNodes('TYPO3.Neos:Document') as $childNode) {
-			$this->registerNodeChange($childNode);
-		}
 	}
 
 	/**


### PR DESCRIPTION
To avoid loading all documents in a Neos instance the route cache
for a node will be tagged will all parent node identifiers so that
flushing the cache for a particular node identifier will automatically
flush all child node entries as well.

Releases: master, 2.0, 1.2