### PR TITLE
[TASK] Allow to override TYPO3.Form configuration from TS

### DIFF
--- a/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
@@ -2,7 +2,7 @@
 <div{attributes -> f:format.raw()}>
 	<f:if condition="{formIdentifier}">
 		<f:then>
-			<form:render persistenceIdentifier="{formIdentifier}" presetName="{presetName}" />
+			<form:render persistenceIdentifier="{formIdentifier}" presetName="{presetName}" overrideConfiguration="{overrideConfiguration}" />
 		</f:then>
 		<f:else>
 			<p>Please select a valid Form identifier in the inspector</p>


### PR DESCRIPTION

This change allow to override the Form configuration from TypoScript::

    prototype(TYPO3.Neos.NodeTypes:Form) {
        overrideConfiguration = TYPO3.TYPO3TypoScript:RawArray {
            finishers = TYPO3.TypoScript:RawArray {
                copy = TYPO3.TypoScript:RawArray {
                    options = TYPO3.TypoScript:RawArray {
                        recipientAddress = ${q(node).property('email')}
                    }
                }
            }
        }
    }

Change-Id: Ic82428c61992ae6c2729806360bbeccfda1fabd1
Releases: master
Depends: I51b4ad9f2c1e4abed271e7586f4c828137842c1f
