### PR TITLE
[TASK] Remove superfluous quotes from PluginView label

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -228,7 +228,7 @@ class ContentController extends \TYPO3\Flow\Mvc\Controller\ActionController
                     ->uriFor('show', array('node' => $page), 'Frontend\Node', 'TYPO3.Neos');
                 $pageTitle = $page->getProperty('title');
                 $views[$pluginViewDefinition->getName()] = array(
-                    'label' => sprintf('"%s"', $label, $pageTitle),
+                    'label' => $label,
                     'pageNode' => array(
                         'title' => $pageTitle,
                         'path' => $page->getPath(),


### PR DESCRIPTION
Removes superfluous quotes around PluginView label seen in the plugin view editor for plugin views.