### PR TITLE
[BUGFIX] Unset selected plugin view when changing master view

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewEditor.js
@@ -64,7 +64,11 @@ function(
 					}
 				);
 			} else {
-				this.set('placeholder', 'No Plugin selected');
+				that.setProperties({
+					placeholder: 'No plugin selected',
+					values: {},
+					value: ''
+				});
 			}
 		}
 	});


### PR DESCRIPTION
When changing the master view selection for a PluginView,
the selected plugin view is not unset causing confusion.

Fixes: NEOS-1541