### PR TITLE
[BUGFIX] Prevent fatal error for missing master plugin in PluginViews

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
@@ -66,6 +66,10 @@ class PluginViewImplementation extends PluginImplementation {
 
 		// Set the node to render this to the masterPlugin node
 		$this->node = $this->propertyMapper->convert($pluginNodePath, 'TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+		if ($this->node === NULL) {
+			return $pluginRequest;
+		}
+
 		$pluginRequest->setArgument('__node', $this->node);
 		$pluginRequest->setArgumentNamespace('--' . $this->getPluginNamespace());
 		$this->passArgumentsToPluginRequest($pluginRequest);


### PR DESCRIPTION
Prevents PluginViews with a master plugin selected that cannot be found
from throwing a fatal error. This can happen when the master plugin is
removed/moved or is not available in the context.

Fixes: NEOS-1530