### PR TITLE
[BUGFIX] Position master plugin selection above plugin view selection

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -223,7 +223,7 @@
         reloadIfChanged: TRUE
         inspector:
           group: 'pluginViews'
-          position: 20
+          position: 10
           editor: 'TYPO3.Neos/Inspector/Editors/MasterPluginEditor'
     view:
       type: string


### PR DESCRIPTION
Positions the master plugin selection in the inspector for a PluginView above
instead of undernearth the plugin view selection, to avoid confusion since
the plugin view selection depends on the master plugin selection.

Fixes: NEOS-1544