### PR TITLE
[TASK] Remove custom exception handling in PluginViewImplementation

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
@@ -14,7 +14,6 @@ namespace TYPO3\Neos\TypoScript;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Http\Response;
-use TYPO3\Flow\Mvc\Exception\RequiredArgumentMissingException;
 use TYPO3\Flow\Mvc\Exception\StopActionException;
 use TYPO3\Neos\Domain\Model\PluginViewDefinition;
 use TYPO3\Neos\Service\PluginService;
@@ -110,21 +109,18 @@ class PluginViewImplementation extends PluginImplementation {
 		$parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
 		$pluginResponse = new Response($parentResponse);
 
-		try {
-			$pluginRequest = $this->buildPluginRequest();
-			if ($pluginRequest->getControllerObjectName() === '') {
-				return '<p>No PluginView Configured</p>';
+		$pluginRequest = $this->buildPluginRequest();
+		if ($pluginRequest->getControllerObjectName() === '') {
+			$message = 'Master View not selected';
+			if ($this->node->getProperty('plugin')) {
+				$message = 'Plugin View not selected';
 			}
-			$this->dispatcher->dispatch($pluginRequest, $pluginResponse);
-			return $pluginResponse->getContent();
-		} catch (StopActionException $stopActionException) {
-			throw $stopActionException;
-		} catch (RequiredArgumentMissingException $exception) {
-			return '<p>' . $exception->getMessage() . '</p>';
-		} catch (\Exception $exception) {
-			$this->systemLogger->logException($exception);
-			$message = 'Exception #' . $exception->getCode() . ' thrown while rendering ' . get_class($this) . '. See log for more details.';
-			return ($this->objectManager->getContext()->isDevelopment()) ? ('<p><strong>' . $message . '</strong></p>') : ('<!--' . $message . '-->');
+			if ($this->node->getProperty('view')) {
+				$message ='Master View or Plugin View not found';
+			}
+			return $this->pluginViewNode->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
 		}
+		$this->dispatcher->dispatch($pluginRequest, $pluginResponse);
+		return $pluginResponse->getContent();
 	}
 }

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/PluginView.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/PluginView.ts2
@@ -11,4 +11,5 @@ prototype(TYPO3.Neos:PluginView) < prototype(TYPO3.Neos:Content) {
 			1 = 'node'
 		}
 	}
+	@exceptionHandler = 'TYPO3\\Neos\\TypoScript\\ExceptionHandlers\\NodeWrappingHandler'
 }


### PR DESCRIPTION
Removes the custom handling of exceptions for PluginViews, which is limited
and unnecessary. Instead the general NodeWrapping exception handler is used.

Resolves: NEOS-1537