### PR TITLE
[!!!][TASK] Use identifier instead of node path for PluginView reference

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
@@ -1,0 +1,71 @@
+<?php
+namespace TYPO3\Neos\Controller;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A trait to add create a content context
+ */
+trait CreateContentContextTrait
+{
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Service\ContentContextFactory
+     */
+    protected $_contextFactory;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     */
+    protected $_domainRepository;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     */
+    protected $_siteRepository;
+
+    /**
+     * Create a ContentContext based on the given workspace name
+     *
+     * @param string $workspaceName Name of the workspace to set for the context
+     * @param array $dimensions Optional list of dimensions and their values which should be set
+     * @return \TYPO3\Neos\Domain\Service\ContentContext
+     */
+    protected function createContentContext($workspaceName, array $dimensions = array())
+    {
+        $contextProperties = array(
+            'workspaceName' => $workspaceName,
+            'invisibleContentShown' => true,
+            'inaccessibleContentShown' => true
+        );
+
+        if ($dimensions !== array()) {
+            $contextProperties['dimensions'] = $dimensions;
+            $contextProperties['targetDimensions'] = array_map(function ($dimensionValues) {
+                return array_shift($dimensionValues);
+            }, $dimensions);
+        }
+
+        $currentDomain = $this->_domainRepository->findOneByActiveRequest();
+        if ($currentDomain !== null) {
+            $contextProperties['currentSite'] = $currentDomain->getSite();
+            $contextProperties['currentDomain'] = $currentDomain;
+        } else {
+            $contextProperties['currentSite'] = $this->_siteRepository->findFirstOnline();
+        }
+
+        return $this->_contextFactory->create($contextProperties);
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
@@ -11,15 +11,12 @@ namespace TYPO3\Neos\Controller\Service;
  * source code.
  */
 
-use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
-use TYPO3\Neos\Domain\Repository\DomainRepository;
-use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Controller\CreateContentContextTrait;
 use TYPO3\Neos\Domain\Service\ContentContext;
-use TYPO3\Neos\Domain\Service\ContentContextFactory;
 use TYPO3\Neos\Domain\Service\NodeSearchServiceInterface;
 use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -35,24 +32,7 @@ use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 class NodesController extends ActionController
 {
     use BackendUserTranslationTrait;
-
-    /**
-     * @Flow\Inject
-     * @var DomainRepository
-     */
-    protected $domainRepository;
-
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
-
-    /**
-     * @Flow\Inject
-     * @var ContentContextFactory
-     */
-    protected $contextFactory;
+    use CreateContentContextTrait;
 
     /**
      * @Flow\Inject
@@ -194,39 +174,6 @@ class NodesController extends ActionController
         } else {
             $this->throwStatus(400, sprintf('The create mode "%s" is not supported.', $mode));
         }
-    }
-
-    /**
-     * Create a ContentContext based on the given workspace name
-     *
-     * @param string $workspaceName Name of the workspace to set for the context
-     * @param array $dimensions Optional list of dimensions and their values which should be set
-     * @return ContentContext
-     */
-    protected function createContentContext($workspaceName, array $dimensions = array())
-    {
-        $contextProperties = array(
-            'workspaceName' => $workspaceName,
-            'invisibleContentShown' => true,
-            'inaccessibleContentShown' => true
-        );
-
-        if ($dimensions !== array()) {
-            $contextProperties['dimensions'] = $dimensions;
-            $contextProperties['targetDimensions'] = array_map(function ($dimensionValues) {
-                return array_shift($dimensionValues);
-            }, $dimensions);
-        }
-
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
-
-        return $this->contextFactory->create($contextProperties);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/PluginService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/PluginService.php
@@ -214,7 +214,7 @@ class PluginService
             if ($pluginViewNode->isRemoved()) {
                 continue;
             }
-            if ($pluginViewNode->getProperty('plugin') === $node->getPath()
+            if ($pluginViewNode->getProperty('plugin') === $node->getIdentifier()
                 && $pluginViewNode->getProperty('view') === $viewName) {
                 return $pluginViewNode;
             }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TYPO3CR/Transformations/PluginViewTransformation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TYPO3CR/Transformations/PluginViewTransformation.php
@@ -1,0 +1,71 @@
+<?php
+namespace TYPO3\Neos\TYPO3CR\Transformations;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TYPO3CR\Domain\Model\NodeData;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+use TYPO3\TYPO3CR\Migration\Transformations\AbstractTransformation;
+
+/**
+ * Convert PluginViews references from node paths to identifiers
+ */
+class PluginViewTransformation extends AbstractTransformation
+{
+    /**
+     * @Flow\Inject
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @var boolean
+     */
+    public $reverse = false;
+
+    /**
+     * @param NodeData $node
+     * @return boolean
+     */
+    public function isTransformable(NodeData $node)
+    {
+        return true;
+    }
+
+    /**
+     * Change the property on the given node.
+     *
+     * @param NodeData $node
+     * @return NodeData
+     */
+    public function execute(NodeData $node)
+    {
+        $reference = (string)$node->getProperty('plugin');
+        $workspace = $node->getWorkspace();
+        do {
+            if ($this->reverse === false && preg_match(NodeInterface::MATCH_PATTERN_PATH, $reference)) {
+                $pluginNode = $this->nodeDataRepository->findOneByPath($reference, $node->getWorkspace());
+            } else {
+                $pluginNode = $this->nodeDataRepository->findOneByIdentifier($reference, $node->getWorkspace());
+            }
+            if (isset($pluginNode)) {
+                break;
+            }
+            $workspace = $workspace->getBaseWorkspace();
+        } while ($workspace && $workspace->getName() !== 'live');
+        if (isset($pluginNode)) {
+            $node->setProperty('plugin', $this->reverse === false ? $pluginNode->getIdentifier() : $pluginNode->getPath());
+        }
+        return $node;
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
@@ -25,16 +25,15 @@ use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 class PluginViewImplementation extends PluginImplementation
 {
     /**
-     * @var \TYPO3\Flow\Property\PropertyMapper
-     * @Flow\Inject
-     */
-    protected $propertyMapper;
-
-    /**
      * @var PluginService
      * @Flow\Inject
      */
     protected $pluginService;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $pluginViewNode;
 
     /**
      * Build the proper pluginRequest to render the PluginView
@@ -48,7 +47,7 @@ class PluginViewImplementation extends PluginImplementation
         $parentRequest = $this->tsRuntime->getControllerContext()->getRequest();
         $pluginRequest = new ActionRequest($parentRequest);
 
-        if (!$this->node instanceof NodeInterface) {
+        if (!$this->pluginViewNode instanceof NodeInterface) {
             $pluginRequest->setArgumentNamespace('--' . $this->getPluginNamespace());
             $this->passArgumentsToPluginRequest($pluginRequest);
             $pluginRequest->setControllerPackageKey($this->getPackage());
@@ -58,14 +57,17 @@ class PluginViewImplementation extends PluginImplementation
             return $pluginRequest;
         }
 
-        $pluginNodePath = $this->node->getProperty('plugin');
-        if (strlen($pluginNodePath) === 0) {
+        $pluginNodeIdentifier = $this->pluginViewNode->getProperty('plugin');
+        if (strlen($pluginNodeIdentifier) === 0) {
             return $pluginRequest;
         }
-        $pluginViewName = $this->node->getProperty('view');
 
-        // Set the node to render this to the masterPlugin node
-        $this->node = $this->propertyMapper->convert($pluginNodePath, 'TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+        // Set the node to render this to the master plugin node
+        $this->node = $this->pluginViewNode->getContext()->getNodeByIdentifier($pluginNodeIdentifier);
+        if ($this->node === null) {
+            return $pluginRequest;
+        }
+
         $pluginRequest->setArgument('__node', $this->node);
         $pluginRequest->setArgumentNamespace('--' . $this->getPluginNamespace());
         $this->passArgumentsToPluginRequest($pluginRequest);
@@ -75,8 +77,8 @@ class PluginViewImplementation extends PluginImplementation
         }
 
         $controllerObjectPairs = array();
+        $pluginViewName = $this->pluginViewNode->getProperty('view');
         foreach ($this->pluginService->getPluginViewDefinitionsByPluginNodeType($this->node->getNodeType()) as $pluginViewDefinition) {
-
             /** @var PluginViewDefinition $pluginViewDefinition */
             if ($pluginViewDefinition->getName() !== $pluginViewName) {
                 continue;
@@ -106,7 +108,7 @@ class PluginViewImplementation extends PluginImplementation
     public function evaluate()
     {
         $currentContext = $this->tsRuntime->getCurrentContext();
-        $this->node = $currentContext['node'];
+        $this->pluginViewNode = $currentContext['node'];
         /** @var $parentResponse Response */
         $parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
         $pluginResponse = new Response($parentResponse);
@@ -114,13 +116,13 @@ class PluginViewImplementation extends PluginImplementation
         $pluginRequest = $this->buildPluginRequest();
         if ($pluginRequest->getControllerObjectName() === '') {
             $message = 'Master View not selected';
-            if ($this->node->getProperty('plugin')) {
+            if ($this->pluginViewNode->getProperty('plugin')) {
                 $message = 'Plugin View not selected';
             }
-            if ($this->node->getProperty('view')) {
+            if ($this->pluginViewNode->getProperty('view')) {
                 $message ='Master View or Plugin View not found';
             }
-            return $this->node->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
+            return $this->pluginViewNode->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
         }
         $this->dispatcher->dispatch($pluginRequest, $pluginResponse);
         return $pluginResponse->getContent();

--- a/TYPO3.Neos/Migrations/TYPO3CR/Version20150907194505.yaml
+++ b/TYPO3.Neos/Migrations/TYPO3CR/Version20150907194505.yaml
@@ -1,0 +1,28 @@
+up:
+  comments: 'Migrate PluginViews references from node paths to identifiers.'
+  migration:
+    -
+      filters:
+        -
+          type: 'NodeType'
+          settings:
+            nodeType: 'TYPO3.Neos:PluginView'
+      transformations:
+        -
+          type: 'TYPO3\Neos\TYPO3CR\Transformations\PluginViewTransformation'
+          settings: []
+
+down:
+  comments: 'Migrate PluginViews references from identifiers to node paths.'
+  migration:
+    -
+      filters:
+        -
+          type: 'NodeType'
+          settings:
+            nodeType: 'TYPO3.Neos:PluginView'
+      transformations:
+        -
+          type: 'TYPO3\Neos\TYPO3CR\Transformations\PluginViewTransformation'
+          settings:
+            reverse: TRUE

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/MasterPluginEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/MasterPluginEditor.js
@@ -2,22 +2,36 @@ define(
 [
 	'Library/jquery-with-dependencies',
 	'Content/Inspector/Editors/SelectBoxEditor',
+	'Shared/HttpClient',
 	'Shared/I18n'
 ],
 function(
 	$,
 	SelectBoxEditor,
+	HttpClient,
 	I18n
 ) {
 	return SelectBoxEditor.extend({
+		allowEmpty: true,
+
 		init: function() {
-			var that = this,
-				url = $('link[rel="neos-masterplugins"]').attr('href');
+			this._super();
+			var that = this;
 
 			this.set('placeholder', I18n.translate('TYPO3.Neos:Main:loading', 'Loading') + ' ...');
-			this._loadValuesFromController(url, function(results) {
-				var values = {}, placeholder, i = 0;
-				values[''] = {};
+			HttpClient.getResource(
+				$('link[rel="neos-masterplugins"]').attr('href'),
+				{
+					data: {
+						workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
+						dimensions: $('#neos-document-metadata').data('neos-context-dimensions')
+					},
+					dataType: 'json'
+				}
+			).then(function(results) {
+				var values = {},
+					placeholder,
+					i = 0;
 
 				for (var key in results) {
 					if (results[key] === undefined) {
@@ -33,15 +47,14 @@ function(
 					placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.selectPlugin', 'Select a Plugin');
 				} else {
 					placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.noPluginConfigured', 'No plugin configured');
-					values = {};
+					values = [];
 				}
+
 				that.setProperties({
 					placeholder: placeholder,
 					values: values
 				});
 			});
-
-			this._super();
 		}
 	});
 });

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewEditor.js
@@ -4,6 +4,7 @@ define(
 	'Library/jquery-with-dependencies',
 	'Content/Inspector/Editors/SelectBoxEditor',
 	'Content/Inspector/InspectorController',
+	'Shared/HttpClient',
 	'Shared/I18n'
 ],
 function(
@@ -11,9 +12,12 @@ function(
 	$,
 	SelectBoxEditor,
 	InspectorController,
+	HttpClient,
 	I18n
 ) {
 	return SelectBoxEditor.extend({
+		allowEmpty: true,
+
 		init: function() {
 			this.set('placeholder', I18n.translate('TYPO3.Neos:Main:loading', 'Loading') + ' ...');
 			this._loadOptionsOnChange();
@@ -24,47 +28,45 @@ function(
 
 		_loadOptionsOnChange: function() {
 			var that = this,
-				nodePath = InspectorController.get('nodeProperties.plugin'),
-				workspaceName = $('#neos-document-metadata').data('neos-context-workspace-name'),
-				dimensions = $('#neos-document-metadata').data('neos-context-dimensions'),
-				dimensionValues = Object.keys(dimensions).reduce(function (previous, key) {
-					return previous + (previous ? '&' : '') + key + '=' + dimensions[key].join(',');
-				}, '');
+				nodeIdentifier = InspectorController.get('nodeProperties.plugin');
 
-			if (!Ember.empty(nodePath)) {
-				this._loadValuesFromController(
+			if (!Ember.empty(nodeIdentifier)) {
+				HttpClient.getResource(
 					$('link[rel="neos-pluginviews"]').attr('href'),
-					[{name: 'node', value: nodePath + '@' + workspaceName + (dimensionValues !== '' ? ';' + dimensionValues : '')}],
-					function(results) {
-						var values = {},
-							placeholder,
-							i = 0;
-
-						values[''] = {};
-
-						for (var key in results) {
-							if (results[key] === undefined || results[key].label === undefined) {
-								continue;
-							}
-							values[key] = {
-								value: key,
-								label: results[key].label,
-								disabled: results[key].pageNode !== undefined
-							};
-							i++;
-						}
-						if (i > 0) {
-							placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.selectPlugin', 'Select a Plugin');
-						} else {
-							placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.noPluginConfigured', 'No plugin configured');
-							values = {};
-						}
-						that.setProperties({
-							placeholder: placeholder,
-							values: values
-					   });
+					{
+						data: {
+							identifier: nodeIdentifier,
+							workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
+							dimensions: $('#neos-document-metadata').data('neos-context-dimensions')
+						},
+						dataType: 'json'
 					}
-				);
+				).then(function(results) {
+					var values = {},
+						placeholder,
+						i = 0;
+
+					for (var key in results) {
+						if (results[key] === undefined || results[key].label === undefined) {
+							continue;
+						}
+						values[key] = {
+							value: key,
+							label: results[key].label
+						};
+						i++;
+					}
+					if (i > 0) {
+						placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.selectPluginView', 'Select a plugin view');
+					} else {
+						placeholder = I18n.translate('TYPO3.Neos:Main:content.inspector.editors.masterPluginEditor.noPluginViewsConfigured', 'No plugin views configured');
+						values = [];
+					}
+					that.setProperties({
+						placeholder: placeholder,
+						values: values
+				   });
+				});
 			} else {
 				that.setProperties({
 					placeholder: 'No plugin selected',

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewsEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/PluginViewsEditor.js
@@ -19,13 +19,21 @@ function(
 		tagName: 'ul',
 		classNames: ['neos-inspector-list-stacked'],
 		content: null,
+
 		init: function() {
 			var that = this,
-				nodePath = InspectorController.nodeSelection.get('selectedNode.nodePath');
+				nodeIdentifier = InspectorController.get('nodeProperties._identifier');
 
 			HttpClient.getResource(
-				$('link[rel="neos-pluginviews"]').attr('href') + '?node=' + nodePath,
-				{dataType: 'json'}
+				$('link[rel="neos-pluginviews"]').attr('href'),
+				{
+					data: {
+						identifier: nodeIdentifier,
+						workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
+						dimensions: $('#neos-document-metadata').data('neos-context-dimensions')
+					},
+					dataType: 'json'
+				}
 			).then(
 				function(views) {
 					var viewsArray = [];


### PR DESCRIPTION
Replaces the usage of node path for referencing the master plugin in PluginView.
Instead the identifier is used, like with node linking/reference properties.
This is done to make it more bulletproof in case the master plugin is moved.

Run the following node migration to adjust existing PluginViews::

  ./flow node:migrate 20150907194505

Resolves: NEOS-1501