### PR TITLE
[BUGFIX] Compare base workspaces by name instead of identity

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -396,8 +396,8 @@ class Workspace
      */
     protected function verifyPublishingTargetWorkspace(Workspace $targetWorkspace)
     {
-        $baseWorkspace = $this->baseWorkspace;
-        while ($targetWorkspace !== $baseWorkspace) {
+        $baseWorkspace = $this;
+        while ($baseWorkspace === null || $targetWorkspace->getName() !== $baseWorkspace->getName()) {
             if ($baseWorkspace === null) {
                 throw new WorkspaceException(sprintf('The specified workspace "%s" is not a base workspace of "%s".', $targetWorkspace->getName(), $this->getName()), 1289499117);
             }


### PR DESCRIPTION
This change is needed when using configurable review workflows.

Without this change, the user gets very often an exception when publishing
his content changes to review: "The specified workspace "foo" is not a base
workspace of "foo"."; and once this exception appears, there is no way
to get rid of this exception except removing all content changes and starting
all over again, and then hope for the best.

The error often occured not with simple content changes (a single content
element), but moreover if you tried to edit a few content elements, create
new content, or delete content and then tried to publish a bunch of these
changes.

After some investigation, it showed up that the $targetWorkspace was a
doctrine proxy, while the $baseWorkspace was not (or the other way around)
in the cases where the error occured -- thus the object identity comparison
did not work.

Comparing the workspace name fixes the issue and is a lot more reliable,
I think. As the workspace name is the identity of the Workspace object,
it should be safe to do this.

Related: NEOS-930