### PR TITLE
[TASK] Introduce new JavaScript events for fullscreen mode

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
@@ -49,6 +49,8 @@ events occur:
 * **Neos.EditPreviewPanelClosed** When the edit/preview panel is closed.
 * **Neos.MenuPanelOpened** When the menu panel is opened.
 * **Neos.MenuPanelClosed** When the menu panel is closed.
+* **Neos.FullScreenModeActivated** When the backend switches to fullscreen mode.
+* **Neos.FullScreenModeDeactivated** When the backend leaves the fullscreen mode.
 
 Example of listening for the ``LayoutChanged`` event.
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/FullScreenController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/FullScreenController.js
@@ -8,11 +8,13 @@ define(
 	'Library/jquery-with-dependencies',
 	'emberjs',
 	'Shared/LocalStorage',
+	'Shared/EventDispatcher',
 	'LibraryExtensions/Mousetrap'
 ], function(
 	$,
 	Ember,
 	LocalStorage,
+	EventDispatcher,
 	Mousetrap
 ) {
 	return Ember.Controller.extend({
@@ -38,10 +40,13 @@ define(
 				Mousetrap.bind('esc', function() {
 					that.toggleFullScreen();
 				});
+				EventDispatcher.triggerExternalEvent('Neos.FullScreenModeActivated', 'Neos fullscreen mode was activated.');
 			} else {
 				$('body > .' + fullScreenCloseClass).remove();
 				Mousetrap.unbind('esc');
+				EventDispatcher.triggerExternalEvent('Neos.FullScreenModeDeactivated', 'Neos fullscreen mode was deactivated.');
 			}
+			EventDispatcher.triggerExternalEvent('Neos.LayoutChanged');
 		},
 
 		onFullScreenModeChanged: function() {


### PR DESCRIPTION
This change introduces two new JavaScript events triggered when toggling fullscreen mode.
``Neos.FullscreenModeActivated`` will be dispatched when the backend switches to fullscreen mode.
``Neos.FullscreenModeDeactivated`` will dispatch if the backend leaves the fullscreen mode.

Fixes: NEOS-1546