### PR TITLE
[BUGIFX] Editing a document title in the node tree marks it as changed

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
@@ -361,6 +361,7 @@ define(
 									node.data.fullTitle = title;
 									node.setLazyNodeStatus(that.statusCodes.ok);
 									node.render();
+									$(node.span).addClass('neos-dynatree-dirty');
 									if (isCurrentNode) {
 										ContentModule.loadPage(node.data.href);
 									}


### PR DESCRIPTION
When editing a node title in the node tree the node will now be marked as unpublished (orange border)

Fixes: NEOS-1129