### PR TITLE
[TASK] Fix support for thumbnail with fixed width and height

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
@@ -309,7 +309,8 @@ class Asset implements AssetInterface
      */
     public function getThumbnail($maximumWidth = null, $maximumHeight = null, $ratioMode = ImageInterface::RATIOMODE_INSET, $allowUpScaling = null)
     {
-        return $this->thumbnailService->getThumbnail($this, $maximumWidth, $maximumHeight, $ratioMode, $allowUpScaling);
+        $thumbnailConfiguration = new ThumbnailConfiguration(null, $maximumWidth, null, $maximumHeight, $ratioMode === ImageInterface::RATIOMODE_OUTBOUND, $allowUpScaling);
+        return $this->thumbnailService->getThumbnail($this, $thumbnailConfiguration);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailConfiguration.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailConfiguration.php
@@ -1,0 +1,183 @@
+<?php
+namespace TYPO3\Media\Domain\Model;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        */
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Log\SystemLoggerInterface;
+
+/**
+ * An Thumbnail Configuration
+ */
+class ThumbnailConfiguration
+{
+    /**
+     * @var integer
+     */
+    protected $width;
+
+    /**
+     * @var integer
+     */
+    protected $maximumWidth;
+
+    /**
+     * @var integer
+     */
+    protected $height;
+
+    /**
+     * @var integer
+     */
+    protected $maximumHeight;
+
+    /**
+     * @var boolean
+     */
+    protected $allowCropping;
+
+    /**
+     * @var boolean
+     */
+    protected $allowUpScaling;
+
+    /**
+     * @Flow\InjectConfiguration("behaviourFlag")
+     * @var string
+     */
+    protected $behaviourFlag;
+
+    /**
+     * @Flow\Inject
+     * @var SystemLoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * ImageConfiguration constructor.
+     * @param integer $width
+     * @param integer $maximumWidth
+     * @param integer $height
+     * @param integer $maximumHeight
+     * @param boolean $allowCropping
+     * @param boolean $allowUpScaling
+     */
+    public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
+    {
+        $this->width = $width ? (integer)$width : null;
+        $this->maximumWidth = $maximumWidth ? (integer)$maximumWidth : null;
+        $this->height = $height ? (integer)$height : null;
+        $this->maximumHeight = $maximumHeight ? (integer)$maximumHeight : null;
+        $this->allowCropping = $allowCropping ? (boolean)$allowCropping : false;
+        $this->allowUpScaling = $allowUpScaling ? (boolean)$allowUpScaling : false;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getWidth()
+    {
+        if ($this->width !== null) {
+            return $this->width;
+        }
+        if ($this->behaviourFlag === '1.2') {
+            // @deprecated since 2.0, simulate the behaviour of 1.2
+            if ($this->height === null && $this->isCroppingAllowed() && $this->getMaximumWidth() !== null && $this->getMaximumHeight() !== null) {
+                return $this->getMaximumWidth();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getMaximumWidth()
+    {
+        return $this->maximumWidth;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getHeight()
+    {
+        if ($this->height !== null) {
+            return $this->height;
+        }
+        if ($this->behaviourFlag === '1.2') {
+            // @deprecated since 2.0, simulate the behaviour of 1.2
+            if ($this->width === null && $this->isCroppingAllowed() && $this->getMaximumWidth() !== null && $this->getMaximumHeight() !== null) {
+                $this->logger->log('TYPO3.Media is configured to simulate the deprecated Neos 1.2 behaviour check the setting "TYPO3.Media.behaviourFlag"', LOG_DEBUG);
+                return $this->getMaximumHeight();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getMaximumHeight()
+    {
+        return $this->maximumHeight;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getRatioMode()
+    {
+        return ($this->isCroppingAllowed() ? ImageInterface::RATIOMODE_OUTBOUND : ImageInterface::RATIOMODE_INSET);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isCroppingAllowed()
+    {
+        return $this->allowCropping;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isUpScalingAllowed()
+    {
+        return $this->allowUpScaling;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHash()
+    {
+        return md5(json_encode($this->toArray()));
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $data = array_filter([
+            'width' => $this->getWidth(),
+            'maximumWidth' => $this->getMaximumWidth(),
+            'height' => $this->getHeight(),
+            'maximumHeight' => $this->getMaximumHeight(),
+            'ratioMode' => $this->getRatioMode(),
+            'allowUpScaling' => $this->isUpScalingAllowed()
+        ], function ($value) {
+            return $value !== null;
+        });
+        ksort($data);
+        return $data;
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/ThumbnailRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/ThumbnailRepository.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\QueryBuilder;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\Repository;
 use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
 /**
  * A repository for Thumbnails
@@ -74,42 +75,17 @@ class ThumbnailRepository extends Repository
      * Returns a thumbnail of the given asset with the specified dimensions.
      *
      * @param AssetInterface $asset The asset to render a thumbnail for
-     * @param string $ratioMode The thumbnail's ratio mode, see ImageInterface::RATIOMODE_* constants
-     * @param integer $maximumWidth The thumbnail's maximum width in pixels
-     * @param integer $maximumHeight The thumbnail's maximum height in pixels
-     * @param boolean $allowUpScaling Whether the resulting image should be upscaled
+     * @param ThumbnailConfiguration $configuration
      * @return \TYPO3\Media\Domain\Model\Thumbnail The thumbnail or NULL
      */
-    public function findOneByAssetAndDimensions(AssetInterface $asset, $ratioMode, $maximumWidth = null, $maximumHeight = null, $allowUpScaling = null)
+    public function findOneByAssetAndThumbnailConfiguration(AssetInterface $asset, ThumbnailConfiguration $configuration)
     {
-
         /**
          * @var $query \Doctrine\ORM\Query
          */
-        $query = $this->entityManager->createQuery('SELECT t FROM TYPO3\Media\Domain\Model\Thumbnail t WHERE t.originalAsset = :originalAsset AND t.ratioMode = :ratioMode');
+        $query = $this->entityManager->createQuery('SELECT t FROM TYPO3\Media\Domain\Model\Thumbnail t WHERE t.originalAsset = :originalAsset AND t.configurationHash = :configurationHash');
         $query->setParameter('originalAsset', $this->persistenceManager->getIdentifierByObject($asset));
-        $query->setParameter('ratioMode', $ratioMode);
-
-        if ($maximumWidth !== null) {
-            $query->setDQL($query->getDQL() . ' AND t.maximumWidth = :maximumWidth');
-            $query->setParameter('maximumWidth', $maximumWidth);
-        } else {
-            $query->setDQL($query->getDQL() . ' AND t.maximumWidth IS NULL');
-        }
-
-        if ($maximumHeight !== null) {
-            $query->setDQL($query->getDQL() . ' AND t.maximumHeight = :maximumHeight');
-            $query->setParameter('maximumHeight', $maximumHeight);
-        } else {
-            $query->setDQL($query->getDQL() . ' AND t.maximumHeight IS NULL');
-        }
-
-        if ($allowUpScaling !== null) {
-            $query->setDQL($query->getDQL() . ' AND t.allowUpScaling = :allowUpScaling');
-            $query->setParameter('allowUpScaling', $allowUpScaling);
-        } else {
-            $query->setDQL($query->getDQL() . ' AND t.allowUpScaling IS NULL');
-        }
+        $query->setParameter('configurationHash', $configuration->getHash());
 
         $query->setMaxResults(1);
         $result = $query->getOneOrNullResult();

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use \TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
 class AssetService
 {
@@ -35,44 +36,23 @@ class AssetService
      * In case of Images this is a thumbnail of the image, in case of other assets an icon representation.
      *
      * @param AssetInterface $asset
-     * @param integer $maximumWidth
-     * @param integer $maximumHeight
-     * @param boolean $allowCropping
-     * @param boolean $allowUpScaling
+     * @param ThumbnailConfiguration $configuration
      * @return array with keys "width", "height" and "src"
      */
-    public function getThumbnailUriAndSizeForAsset(AssetInterface $asset, $maximumWidth, $maximumHeight, $allowCropping = false, $allowUpScaling = null)
+    public function getThumbnailUriAndSizeForAsset(AssetInterface $asset, ThumbnailConfiguration $configuration)
     {
         if ($asset instanceof ImageInterface) {
-            $thumbnailImage = $this->getImageThumbnailImage($asset, $maximumWidth, $maximumHeight, $allowCropping, $allowUpScaling);
+            $thumbnailImage = $this->thumbnailService->getThumbnail($asset, $configuration);
             $thumbnailData = array(
                 'width' => $thumbnailImage->getWidth(),
                 'height' => $thumbnailImage->getHeight(),
                 'src' => $this->resourceManager->getPublicPersistentResourceUri($thumbnailImage->getResource())
             );
         } else {
-            $thumbnailData = $this->getAssetThumbnailImage($asset, $maximumWidth, $maximumHeight);
+            $thumbnailData = $this->getAssetThumbnailImage($asset, $configuration->getWidth() ?: $configuration->getMaximumWidth(), $configuration->getHeight() ?: $configuration->getMaximumHeight());
         }
 
         return $thumbnailData;
-    }
-
-    /**
-     * Calculates the dimensions of the thumbnail to be generated and returns the thumbnail image if the new dimensions
-     * differ from the specified image dimensions, otherwise the original image is returned.
-     *
-     * @param ImageInterface $image
-     * @param integer $maximumWidth
-     * @param integer $maximumHeight
-     * @param boolean $allowCropping
-     * @param boolean $allowUpScaling
-     * @return ImageInterface
-     */
-    protected function getImageThumbnailImage(ImageInterface $image, $maximumWidth = null, $maximumHeight = null, $allowCropping = null, $allowUpScaling = null)
-    {
-        $ratioMode = ($allowCropping ? ImageInterface::RATIOMODE_OUTBOUND : ImageInterface::RATIOMODE_INSET);
-
-        return $this->thumbnailService->getThumbnail($image, $maximumWidth, $maximumHeight, $ratioMode, $allowUpScaling);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -17,6 +17,7 @@ use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\SignalSlot\Dispatcher;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 use TYPO3\Media\Domain\Model\Thumbnail;
 use TYPO3\Media\Domain\Repository\ThumbnailRepository;
 use TYPO3\Media\Exception\NoThumbnailAvailableException;
@@ -73,21 +74,18 @@ class ThumbnailService
      * the original asset is used.
      *
      * @param AssetInterface $asset The asset to render a thumbnail for
-     * @param integer $maximumWidth The thumbnail's maximum width in pixels
-     * @param integer $maximumHeight The thumbnail's maximum height in pixels
-     * @param string $ratioMode Whether the resulting image should be cropped if both edge's sizes are supplied that would hurt the aspect ratio
-     * @param boolean $allowUpScaling Whether the resulting image should be upscaled
+     * @param ThumbnailConfiguration $configuration
      * @return Thumbnail
      * @throws \Exception
      */
-    public function getThumbnail(AssetInterface $asset, $maximumWidth = null, $maximumHeight = null, $ratioMode = ImageInterface::RATIOMODE_INSET, $allowUpScaling = null)
+    public function getThumbnail(AssetInterface $asset, ThumbnailConfiguration $configuration)
     {
-        $thumbnail = $this->thumbnailRepository->findOneByAssetAndDimensions($asset, $ratioMode, $maximumWidth, $maximumHeight, $allowUpScaling);
+        $thumbnail = $this->thumbnailRepository->findOneByAssetAndThumbnailConfiguration($asset, $configuration);
         if ($thumbnail === null) {
             if (!$asset instanceof ImageInterface) {
                 throw new NoThumbnailAvailableException(sprintf('ThumbnailService could not generate a thumbnail for asset of type "%s" because currently only Image assets are supported.', get_class($asset)), 1381493670);
             }
-            $thumbnail = new Thumbnail($asset, $maximumWidth, $maximumHeight, $ratioMode, $allowUpScaling);
+            $thumbnail = new Thumbnail($asset, $configuration);
 
             // Allow thumbnails to be persisted even if this is a "safe" HTTP request:
             $this->thumbnailRepository->add($thumbnail);

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -13,7 +13,9 @@ namespace TYPO3\Media\ViewHelpers;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 use TYPO3\Media\Domain\Model\ThumbnailSupportInterface;
 
 /**
@@ -110,19 +112,21 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      * Renders an HTML img tag with a thumbnail image, created from a given asset.
      *
      * @param ImageInterface $image The image to be rendered as an image
-     * @param integer $maximumWidth Desired maximum height of the image
-     * @param integer $maximumHeight Desired maximum width of the image
+     * @param integer $width Desired width of the image
+     * @param integer $maximumWidth Desired maximum width of the image
+     * @param integer $height Desired height of the image
+     * @param integer $maximumHeight Desired maximum height of the image
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
-     *
      * @return string an <img...> html tag
      */
-    public function render(ImageInterface $image = null, $maximumWidth = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
     {
         if ($image === null && $this->hasArgument('asset')) {
             $image = $this->arguments['asset'];
         }
-        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $maximumWidth, $maximumHeight, $allowCropping, $allowUpScaling);
+        $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling);
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration);
 
         $this->tag->addAttributes(array(
             'width' => $thumbnailData['width'],

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Media\ViewHelpers\Uri;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
 /**
  * Renders the src path of a thumbnail image of a given TYPO3.Media asset instance
@@ -72,17 +73,20 @@ class ImageViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
      * Renders the path to a thumbnail image, created from a given asset.
      *
      * @param ImageInterface $image
-     * @param integer $maximumWidth Desired maximum height of the image
-     * @param integer $maximumHeight Desired maximum width of the image
+     * @param integer $width Desired width of the image
+     * @param integer $maximumWidth Desired maximum width of the image
+     * @param integer $height Desired height of the image
+     * @param integer $maximumHeight Desired maximum height of the image
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
      * @return string the relative image path, to be used as src attribute for <img /> tags
      */
-    public function render(ImageInterface $image = null, $maximumWidth = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
     {
         if ($image === null && $this->hasArgument('asset')) {
             $image = $this->arguments['asset'];
         }
-        return $this->assetService->getThumbnailUriAndSizeForAsset($image, $maximumWidth, $maximumHeight, $allowCropping, $allowUpScaling)['src'];
+        $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling);
+        return $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration)['src'];
     }
 }

--- a/TYPO3.Media/Configuration/Settings.yaml
+++ b/TYPO3.Media/Configuration/Settings.yaml
@@ -7,6 +7,10 @@ TYPO3:
             events: ['postRemove']
             listener: 'TYPO3\Media\Domain\EventListener\ImageEventListener'
   Media:
+    # The setting simulate how Neos 1.2 handle image cropping with maximumWidth and maximumHeight
+    # this behaviour is deprecated and will be remove in Neos 3.0, maximumWidth and maximumHeight
+    # need to be replace by width and height if you need fixed dimensions.
+    behaviourFlag: '1.2'
     asset:
       modelMappingStrategy:
         default: TYPO3\Media\Domain\Model\Document

--- a/TYPO3.Media/Migrations/Mysql/Version20150913173832.php
+++ b/TYPO3.Media/Migrations/Mysql/Version20150913173832.php
@@ -1,0 +1,69 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * A properties configuration and configurationHash for Thumbnails
+ */
+class Version20150913173832 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail ADD configuration LONGTEXT NOT NULL COMMENT '(DC2Type:json_array)', ADD configurationhash VARCHAR(32) NOT NULL");
+
+        $thumbnailResult = $this->connection->executeQuery('SELECT * FROM typo3_media_domain_model_thumbnail');
+        while ($thumbnailInfo = $thumbnailResult->fetch(\PDO::FETCH_ASSOC)) {
+            $configurationArray = array_filter([
+                'maximumWidth' => $thumbnailInfo['maximumwidth'],
+                'maximumHeight' => $thumbnailInfo['maximumheight'],
+                'ratioMode' => $thumbnailInfo['ratiomode'],
+                'allowUpScaling' => $thumbnailInfo['allowupscaling'] === 1 ? true : false
+            ], function ($value) {
+                return $value !== null;
+            });
+            ksort($configurationArray);
+            $configuration = json_encode($configurationArray, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
+            $configurationHash = md5(json_encode($configurationArray));
+            $this->addSql(sprintf("UPDATE typo3_media_domain_model_thumbnail SET configuration = '%s', configurationhash = '%s' WHERE persistence_object_identifier = '%s'", $configuration, $configurationHash, $thumbnailInfo['persistence_object_identifier']));
+        }
+
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail DROP maximumwidth, DROP maximumheight, DROP ratiomode, DROP allowupscaling");
+        $this->addSql("CREATE INDEX originalasset_configurationhash ON typo3_media_domain_model_thumbnail (originalasset, configurationhash)");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail ADD maximumwidth INT DEFAULT NULL, ADD maximumheight INT DEFAULT NULL, ADD ratiomode VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, ADD allowupscaling TINYINT(1) DEFAULT NULL");
+
+        $thumbnailResult = $this->connection->executeQuery('SELECT * FROM typo3_media_domain_model_thumbnail');
+        while ($thumbnailInfo = $thumbnailResult->fetch(\PDO::FETCH_ASSOC)) {
+            $configuration = json_decode($thumbnailInfo['configuration'], true);
+            $maximumWidth = isset($configuration['maximumWidth']) ? (integer)$configuration['maximumWidth'] : null;
+            $maximumWidth = $maximumWidth === 0 ? null : $maximumWidth;
+            $maximumHeight = isset($configuration['maximumHeight']) ? (integer)$configuration['maximumHeight'] : null;
+            $maximumHeight = $maximumHeight === 0 ? null : $maximumHeight;
+            $ratioMode = isset($configuration['ratioMode']) ? $configuration['ratioMode'] : null;
+            $allowUpScaling = isset($configuration['allowUpScaling']) ? $configuration['allowUpScaling'] : null;
+            $allowUpScaling = $allowUpScaling ? 1 : 0;
+            $types = [\PDO::PARAM_NULL];
+            $this->addSql("UPDATE typo3_media_domain_model_thumbnail SET maximumwidth = ?, maximumheight = ?, ratiomode = ?, allowupscaling = ?  WHERE persistence_object_identifier = ?", [$maximumWidth, $maximumHeight, $ratioMode, $allowUpScaling, $thumbnailInfo['persistence_object_identifier']], $types);
+        }
+
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail DROP INDEX originalasset_configurationhash");
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail DROP configuration, DROP configurationhash");
+    }
+}

--- a/TYPO3.Media/Migrations/Postgresql/Version20150913173935.php
+++ b/TYPO3.Media/Migrations/Postgresql/Version20150913173935.php
@@ -1,0 +1,74 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * A properties configuration and configurationHash for Thumbnails
+ */
+class Version20150913173935 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail ADD configuration JSON, ADD configurationhash VARCHAR(32)");
+        $this->addSql("COMMENT ON COLUMN typo3_media_domain_model_thumbnail.configuration IS '(DC2Type:flow_json_array)'");
+
+        $thumbnailResult = $this->connection->executeQuery('SELECT * FROM typo3_media_domain_model_thumbnail');
+        while ($thumbnailInfo = $thumbnailResult->fetch(\PDO::FETCH_ASSOC)) {
+            $configurationArray = array_filter([
+                'maximumWidth' => $thumbnailInfo['maximumwidth'],
+                'maximumHeight' => $thumbnailInfo['maximumheight'],
+                'ratioMode' => $thumbnailInfo['ratiomode'],
+                'allowUpScaling' => $thumbnailInfo['allowupscaling'] === 1 ? true : false
+            ], function ($value) {
+                return $value !== null;
+            });
+            ksort($configurationArray);
+            $configuration = json_encode($configurationArray, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
+            $configurationHash = md5(json_encode($configurationArray));
+            $this->addSql(sprintf("UPDATE typo3_media_domain_model_thumbnail SET configuration = '%s', configurationhash = '%s' WHERE persistence_object_identifier = '%s'", $configuration, $configurationHash, $thumbnailInfo['persistence_object_identifier']));
+        }
+
+        $this->addSql('ALTER TABLE typo3_media_domain_model_thumbnail ALTER configuration SET NOT NULL,  ALTER configurationhash SET NOT NULL');
+
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail DROP maximumwidth, DROP maximumheight, DROP ratiomode, DROP allowupscaling");
+        $this->addSql("CREATE INDEX originalasset_configurationhash ON typo3_media_domain_model_thumbnail (originalasset, configurationhash)");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail ADD maximumwidth INT DEFAULT NULL, ADD maximumheight INT DEFAULT NULL, ADD ratiomode VARCHAR(255), ADD allowupscaling BOOLEAN");
+
+        $thumbnailResult = $this->connection->executeQuery('SELECT * FROM typo3_media_domain_model_thumbnail');
+        while ($thumbnailInfo = $thumbnailResult->fetch(\PDO::FETCH_ASSOC)) {
+            $configuration = json_decode($thumbnailInfo['configuration'], true);
+            $maximumWidth = isset($configuration['maximumWidth']) ? (integer)$configuration['maximumWidth'] : null;
+            $maximumWidth = $maximumWidth === 0 ? null : $maximumWidth;
+            $maximumHeight = isset($configuration['maximumHeight']) ? (integer)$configuration['maximumHeight'] : null;
+            $maximumHeight = $maximumHeight === 0 ? null : $maximumHeight;
+            $ratioMode = isset($configuration['ratioMode']) ? $configuration['ratioMode'] : null;
+            $allowUpScaling = isset($configuration['allowUpScaling']) ? $configuration['allowUpScaling'] : null;
+            $allowUpScaling = $allowUpScaling ? 1 : 0;
+            $types = [\PDO::PARAM_NULL];
+            $this->addSql("UPDATE typo3_media_domain_model_thumbnail SET maximumwidth = ?, maximumheight = ?, ratiomode = ?, allowupscaling = ?  WHERE persistence_object_identifier = ?", [$maximumWidth, $maximumHeight, $ratioMode, $allowUpScaling, $thumbnailInfo['persistence_object_identifier']], $types);
+        }
+
+        $this->addSql('ALTER TABLE typo3_media_domain_model_thumbnail ALTER ratiomode SET NOT NULL');
+
+        $this->addSql("DROP INDEX originalasset_configurationhash");
+        $this->addSql("ALTER TABLE typo3_media_domain_model_thumbnail DROP configuration, DROP configurationhash");
+    }
+}

--- a/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Partials/Image.html
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Partials/Image.html
@@ -5,12 +5,10 @@
 		<f:then>
 			<f:if condition="{link}">
 				<f:then>
-					<a href="{link}"><media:image asset="{image}" alt="{alternativeText}" title="{title}" maximumWidth="{maximumWidth}" maximumHeight="{maximumHeight}" allowCropping="{allowCropping
-}" allowUpScaling="{allowUpScaling}" /></a>
+					<a href="{link}"><media:image asset="{image}" alt="{alternativeText}" title="{title}" width="{width}" maximumWidth="{maximumWidth}" height="{height}" maximumHeight="{maximumHeight}" allowUpScaling="{allowUpScaling}" /></a>
 				</f:then>
 				<f:else>
-					<media:image asset="{image}" alt="{alternativeText}" title="{title}" maximumWidth="{maximumWidth}" maximumHeight="{maximumHeight}" allowCropping="{allowCropping
-}" allowUpScaling="{allowUpScaling}" />
+					<media:image asset="{image}" alt="{alternativeText}" title="{title}" width="{width}" maximumWidth="{maximumWidth}" height="{height}" maximumHeight="{maximumHeight}" allowUpScaling="{allowUpScaling}" />
 				</f:else>
 			</f:if>
 		</f:then>

--- a/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
@@ -41,7 +41,9 @@ prototype(TYPO3.Neos.NodeTypes:Menu) {
 # Image TS Object
 prototype(TYPO3.Neos.NodeTypes:Image) {
 	maximumWidth = 2560
+	width = NULL
 	maximumHeight = 2560
+	height = NULL
 	imageClassName = ${q(node).property('alignment') ? ('typo3-neos-alignment-' + q(node).property('alignment')) : ''}
 	allowCropping = FALSE
 	allowUpScaling = FALSE

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ImageUriImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ImageUriImplementation.php
@@ -13,12 +13,13 @@ namespace TYPO3\Neos\TypoScript;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 use TYPO3\Media\Domain\Service\AssetService;
 use TYPO3\TypoScript\TypoScriptObjects\AbstractTypoScriptObject;
 
 /**
  * Render an AssetInterface: object. Accepts the same parameters as the uri.image ViewHelper of the TYPO3.Media package:
- * asset, maximumWidth, maximumHeight, allowCropping, allowUpScaling.
+ * asset, width, maximumWidth, height, maximumHeight, allowCropping, allowUpScaling.
  *
  */
 class ImageUriImplementation extends AbstractTypoScriptObject
@@ -42,6 +43,16 @@ class ImageUriImplementation extends AbstractTypoScriptObject
     }
 
     /**
+     * Width
+     *
+     * @return integer
+     */
+    public function getWidth()
+    {
+        return $this->tsValue('width');
+    }
+
+    /**
      * MaximumWidth
      *
      * @return integer
@@ -49,6 +60,16 @@ class ImageUriImplementation extends AbstractTypoScriptObject
     public function getMaximumWidth()
     {
         return $this->tsValue('maximumWidth');
+    }
+
+    /**
+     * Height
+     *
+     * @return integer
+     */
+    public function getHeight()
+    {
+        return $this->tsValue('height');
     }
 
     /**
@@ -85,18 +106,15 @@ class ImageUriImplementation extends AbstractTypoScriptObject
      * Returns a processed image path
      *
      * @return string
+     * @throws \Exception
      */
     public function evaluate()
     {
         $asset = $this->getAsset();
-        $maximumWidth = $this->getMaximumWidth();
-        $maximumHeight = $this->getMaximumHeight();
-        $allowCropping = $this->getAllowCropping();
-        $allowUpScaling = $this->getAllowUpScaling();
-
         if (!$asset instanceof AssetInterface) {
             throw new \Exception('No asset given for rendering.', 1415184217);
         }
-        return $this->assetService->getThumbnailUriAndSizeForAsset($asset, $maximumWidth, $maximumHeight, $allowCropping, $allowUpScaling)['src'];
+        $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling());
+        return $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration)['src'];
     }
 }

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ImageUri.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ImageUri.ts2
@@ -2,7 +2,9 @@
 prototype(TYPO3.Neos:ImageUri) {
 	@class = 'TYPO3\\Neos\\TypoScript\\ImageUriImplementation'
 	maximumWidth = 2560
+	width = NULL
 	maximumHeight = 2560
+	height = NULL
 	allowCropping = FALSE
 	allowUpScaling = FALSE
 	@exceptionHandler = 'TYPO3\\TypoScript\\Core\\ExceptionHandlers\\AbsorbingHandler'
@@ -12,11 +14,15 @@ prototype(TYPO3.Neos:ImageUri) {
 prototype(TYPO3.Neos:ImageTag) < prototype(TYPO3.TypoScript:Tag) {
 	asset = 'pass-the-media-asset'
 	maximumWidth = 2560
+	width = NULL
 	maximumHeight = 2560
+	height = NULL
 	allowCropping = FALSE
 	allowUpScaling = FALSE
 	@context.asset = ${this.asset}
+	@context.width = ${this.width}
 	@context.maximumWidth = ${this.maximumWidth}
+	@context.height = ${this.height}
 	@context.maximumHeight = ${this.maximumHeight}
 	@context.allowCropping = ${this.allowCropping}
 	@context.allowUpScaling = ${this.allowUpScaling}
@@ -25,7 +31,9 @@ prototype(TYPO3.Neos:ImageTag) < prototype(TYPO3.TypoScript:Tag) {
 	attributes {
 		src = TYPO3.Neos:ImageUri {
 			asset = ${asset}
+			width = ${width}
 			maximumWidth = ${maximumWidth}
+			height = ${height}
 			maximumHeight = ${maximumHeight}
 			allowCropping = ${allowCropping}
 			allowUpScaling = ${allowUpScaling}


### PR DESCRIPTION
Neos 2.0 introduce a regression that break thumbnails with fixed height
and width (if the ratio of the original image is different than the
ratio of the Thumbnail).

This change allow to set fixed width and height in Image ViewHelpers, TS
Objects and change the internal API. This change is currently breaking
(internal API only) but BC if you use only the ViewHelpers or the TS objects.

This change introduce ```ThumbnailConfiguration``` value object to make
the method signature more readable and make the breaking change more visible.

This change change the database structure for thumbnail entity to store
a JSON representation of the configuration and a hash of this configuration.
The hash is used to check if a thumbnail exist with the same configuration.
By default NULL value are not stored in the database to allow change in the
ThumbnailConfiguration without invalidating all the generated thumbnails.

This change require a database migration:

```
flow doctrine:migrationexecute --version 20150913173832 --direction up
```

This change also simulate to behaviour of Neos 1.2 for BC, where
this snippet will generate a square image of 200x200:

```
<typo3.media:image image="{image}" maximumWidth="200"
maximumHeight="200" allowCropping="true" alt="{title}" />
```

In Neos 2.0, this snipped should be adjusted to:

```
<typo3.media:image image="{image}" width="200" height="200" allowCropping="true"
alt="{title}" />
```

You can unset the settings ```TYPO3.Media.behaviourFlag``` to disable the
Neos 1.2 behaviour compatibility. Previously Neos can generate fixed
dimensions by setting maximumWidth and maximumHeight. The new behaviour
introduced by Neos 2.0 is to use width and height.

Resolves: NEOS-1511