### PR TITLE
[BUGFIX] Reset date picker to current date instead of null

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/DateTimeEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/DateTimeEditor.js
@@ -198,7 +198,8 @@ function (Ember, $, template) {
 		reset: function() {
 			this.close();
 			this.set('hrValue', '');
-			this.$('.neos-editor-datetimepicker').datetimepicker('update', null);
+			this.$('.neos-editor-datetimepicker').datetimepicker('update', new Date());
+			this.$('.neos-editor-datetimepicker').datetimepicker('showMode', 2);
 			this.set('value', '');
 		},
 


### PR DESCRIPTION
If reset to null, the date picker would default to 1899 instead of the
current date when being opened again.

Fixes: NEOS-1351