### PR TITLE
[BUGFIX] Add missing properties to import service

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -512,6 +512,8 @@ class NodeImportService {
 	 */
 	protected function parseEndElement(\XMLReader $reader) {
 		switch ($reader->name) {
+			case 'hiddenBeforeDateTime':
+			case 'hiddenAfterDateTime':
 			case 'creationDateTime':
 			case 'lastModificationDateTime':
 			case 'lastPublicationDateTime':


### PR DESCRIPTION
The node import service was missing node properties 'hiddenBeforeDateTime' and 'hiddenAfterDateTime' and therefor crashed when eported nodes contained those properties.

Fixes: NEOS-1554