### PR TITLE
[BUGFIX] Flush on change of descendants of referenced node

### DIFF
--- a/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
@@ -117,6 +117,7 @@ prototype(TYPO3.Neos.NodeTypes:ContentReferences) {
 		entryTags {
 			1 = ${'Node_' + node.identifier}
 			2 = ${Neos.Caching.nodeTag(referenceNodesArray)}
+			3 = ${Neos.Caching.descendantOfTag(referenceNodesArray)}
 		}
 	}
 }


### PR DESCRIPTION
Add descendants of referenced nodes to cache tags of the "Content References"
node type. This ensures that nested nodes inside a node inserted as a reference
will be updated when those nodes are flushed.