### PR TITLE
TASK: Allow Aloha preset settings to be used

### DIFF
--- a/TYPO3.Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
+++ b/TYPO3.Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
@@ -27,28 +27,7 @@
       ui:
         inlineEditable: TRUE
         aloha:
-          placeholder: i18n
-          autoparagraph: TRUE
-          'format':
-            'strong': TRUE
-            'em': TRUE
-            'u': FALSE
-            'sub': FALSE
-            'sup': FALSE
-            'del': FALSE
-            'p': TRUE
-            'h1': TRUE
-            'h2': TRUE
-            'h3': TRUE
-            'pre': TRUE
-            'removeFormat': TRUE
-          'table':
-            'table': TRUE
-          'list':
-            'ol': TRUE
-            'ul': TRUE
-          'link':
-            'a': TRUE
+          preset: 'Standard'
 
 # Image mixin
 'TYPO3.Neos.NodeTypes:ImageMixin':

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -161,6 +161,33 @@ TYPO3:
         'ru': 'Pусский – Russian'
 #        'sv': 'Svenska – Swedish'
 
+      # Aloha presets used in nodeType configuration
+      aloha:
+        presets:
+          'Standard':
+            placeholder: i18n
+            autoparagraph: TRUE
+            'format':
+              'strong': TRUE
+              'em': TRUE
+              'u': FALSE
+              'sub': FALSE
+              'sup': FALSE
+              'del': FALSE
+              'p': TRUE
+              'h1': TRUE
+              'h2': TRUE
+              'h3': TRUE
+              'pre': TRUE
+              'removeFormat': TRUE
+            'table':
+              'table': TRUE
+            'list':
+              'ol': TRUE
+              'ul': TRUE
+            'link':
+              'a': TRUE
+
       navigateComponent:
         nodeTree:
           # number of levels inside the node tree which shall be loaded eagerly, at start.


### PR DESCRIPTION
Allow to create Aloha config in `TYPO3.Neos.UserInterface.aloha` and set them as preset in your property configuration for Aloha edited properties.

Comes with the former configuration as a default preset.

NEOS-262 #close
