### PR TITLE
[FEATURE] Support creating absolute node uris

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
@@ -138,16 +138,17 @@ class LinkingService
      * @param string|Uri $uri
      * @param NodeInterface $contextNode
      * @param ControllerContext $controllerContext
+     * @param bool $absolute
      * @return string
      */
-    public function resolveNodeUri($uri, NodeInterface $contextNode, ControllerContext $controllerContext)
+    public function resolveNodeUri($uri, NodeInterface $contextNode, ControllerContext $controllerContext, $absolute = false)
     {
         $targetObject = $this->convertUriToObject($uri, $contextNode);
         if ($targetObject === null) {
             $this->systemLogger->log(sprintf('Could not resolve "%s" to an existing node; The node was probably deleted.', $uri));
             return null;
         }
-        return $this->createNodeUri($controllerContext, $targetObject);
+        return $this->createNodeUri($controllerContext, $targetObject, null, null, $absolute);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ConvertUrisImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ConvertUrisImplementation.php
@@ -41,6 +41,12 @@ use TYPO3\TypoScript\TypoScriptObjects\AbstractTypoScriptObject;
  *     externalLinkTarget = '_blank'
  *     resourceLinkTarget = '_blank'
  *   }
+ *
+ * The optional property ``absolute`` can be used to convert node uris to absolute links::
+ *
+ *   someTextProperty.@process.1 = TYPO3.Neos:ConvertUris {
+ *     absolute = true
+ *   }
  */
 class ConvertUrisImplementation extends AbstractTypoScriptObject
 {
@@ -85,10 +91,12 @@ class ConvertUrisImplementation extends AbstractTypoScriptObject
         $linkingService = $this->linkingService;
         $controllerContext = $this->tsRuntime->getControllerContext();
 
-        $processedContent = preg_replace_callback(LinkingService::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $linkingService, $controllerContext, &$unresolvedUris) {
+        $absolute = $this->tsValue('absolute');
+
+        $processedContent = preg_replace_callback(LinkingService::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $linkingService, $controllerContext, &$unresolvedUris, $absolute) {
             switch ($matches[1]) {
                 case 'node':
-                    $resolvedUri = $linkingService->resolveNodeUri($matches[0], $node, $controllerContext);
+                    $resolvedUri = $linkingService->resolveNodeUri($matches[0], $node, $controllerContext, $absolute);
                     break;
                 case 'asset':
                     $resolvedUri = $linkingService->resolveAssetUri($matches[0]);

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ConvertUris.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ConvertUris.ts2
@@ -8,4 +8,5 @@ prototype(TYPO3.Neos:ConvertUris) {
 	node = ${node}
 	externalLinkTarget = '_blank'
 	resourceLinkTarget = '_blank'
+	absolute = false
 }

--- a/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
+++ b/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
@@ -104,7 +104,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->convertUrisImplementation->_set('tsRuntime', $this->mockTsRuntime);
     }
 
-    protected function addValueExpectation($value, $node = null, $forceConversion = false, $externalLinkTarget = null, $resourceLinkTarget = null)
+    protected function addValueExpectation($value, $node = null, $forceConversion = false, $externalLinkTarget = null, $resourceLinkTarget = null, $absolute = false)
     {
         $this->convertUrisImplementation
             ->expects($this->atLeastOnce())
@@ -114,7 +114,8 @@ class ConvertUrisImplementationTest extends UnitTestCase
                 array('node', $node ?: $this->mockNode),
                 array('forceConversion', $forceConversion),
                 array('externalLinkTarget', $externalLinkTarget),
-                array('resourceLinkTarget', $resourceLinkTarget)
+                array('resourceLinkTarget', $resourceLinkTarget),
+                array('absolute', $absolute)
             )));
     }
 


### PR DESCRIPTION
Previously the ConvertUris helper just created relative links.
This change introduces a new setting `createAbsoluteUris`:

    someTextProperty.@process.1 = TYPO3.Neos:ConvertUris {
        absolute = true
    }

Resolves: NEOS-1534