### PR TITLE
[FEATURE] Nodetype option for collapsing inspector group by default

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -13,14 +13,15 @@
           position: 20
           icon: 'icon-cog'
       groups:
-        nodeInfo:
-          label: i18n
-          tab: 'meta'
-          position: 990
         type:
           label: i18n
           tab: 'meta'
+          position: 990
+        nodeInfo:
+          label: i18n
+          tab: 'meta'
           position: 1000
+          collapsed: true
       views:
         nodeInfo:
           label: i18n

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -123,6 +123,9 @@ The following options are allowed:
       ``tab``
         The tab the group belongs to. If left empty the group is added to the ``default`` tab.
 
+      ``collapsed``
+        If the group should be collapsed by default (true or false). If left empty, the group will be expanded.
+
 ``properties``
   A list of named properties for this node type. For each property the following settings are available.
 

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -156,6 +156,8 @@ additionalProperties:
 
                   'position': { type: integer, description: 'Position of the inspector group, small numbers are sorted on top' }
 
+                  'collapsed': { type: boolean, description: 'If TRUE, the group in the inspector panel is collapsed by default.' }
+
             'views':
               type: dictionary
               additionalProperties:

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorView.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorView.html
@@ -15,7 +15,7 @@
 	{{#each tab in groupedViews}}
 		<div {{bindAttr class="tab.isActive:is-visible :neos-inspector-tab-content"}}>
 			{{#each group in tab.groups}}
-				{{#view view.Section classNames="neos-inspector-section" groupBinding="group.group" propertiesBinding="group.properties" viewsBinding="group.views" inspectorBinding="controller"}}
+				{{#view view.Section classNames="neos-inspector-section" groupBinding="group" groupNameBinding="group.group" propertiesBinding="group.properties" viewsBinding="group.views" inspectorBinding="controller"}}
 					<div {{bindAttr class=":neos-inspector-headline view._hasValidationErrors:neos-validation-error"}}>
 						<span>{{unbound group.label}}</span>
 						{{#if view._hasValidationErrors}}<i class="icon-warning-sign"></i>{{/if}}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Section.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Section.js
@@ -1,5 +1,5 @@
 /**
- * Property Editor
+ * A section within a group within a tab in the inspector.
  */
 define(
 [
@@ -25,10 +25,13 @@ define(
 			var that = this,
 				selectedNode = NodeSelection.get('selectedNode'),
 				nodeType = (selectedNode.$element ? selectedNode.$element.attr('typeof').replace(/\./g,'_') : 'ALOHA'),
-				collapsed = this.get('inspector.configuration.' + nodeType + '.' + this.get('group')),
+				collapsed = this.get('inspector.configuration.' + nodeType + '.' + this.get('groupName')),
 				properties = this.get('properties') || [];
 
 			this.set('_nodeType', nodeType);
+			if (collapsed === undefined) {
+				collapsed = this.get('group.collapsed');
+			}
 			if (collapsed) {
 				this.$().find('.neos-inspector-field,.neos-inspector-view').hide();
 				this.set('_collapsed', true);
@@ -44,7 +47,7 @@ define(
 			if (!this.get('inspector.configuration.' + this.get('_nodeType'))) {
 				this.set('inspector.configuration.' + this.get('_nodeType'), {});
 			}
-			this.set('inspector.configuration.' + this.get('_nodeType') + '.' + this.get('group'), this.get('_collapsed'));
+			this.set('inspector.configuration.' + this.get('_nodeType') + '.' + this.get('groupName'), this.get('_collapsed'));
 			Ember.propertyDidChange(this.get('inspector'), 'configuration');
 		},
 


### PR DESCRIPTION
This change introduces a new option for the Nodetypes configuration
which defines if a specific inspector group should be collapsed by
default. If a user decides to expand a group in the inspector, this
state (which is stored in Local Storage) takes precedence.

Example:
```yaml
  groups:
    nodeInfo:
      label: i18n
      tab: 'meta'
      position: 1000
      collapsed: true
```
Related: NEOS-1045
Releases: master