### PR TITLE
[TASK] Change the testing timezone to Antartica/Troll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - rm -rf Packages/Neos
   - mv ../neos-development-collection Packages/Neos
 before_script:
-  - echo 'date.timezone = "Europe/Berlin"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'date.timezone = "Antarctica/Troll"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp Configuration/Settings.yaml.example Configuration/Settings.yaml
   - Build/BuildEssentials/TravisCi/SetupDatabase.sh
   - cp Configuration/Settings.yaml Configuration/Testing/


### PR DESCRIPTION
This change sets the timezone in which the tests are ran
to a timezone less contributors work in to prevent false
test results if hardcoded timezones are used by accident.