### PR TITLE
Fixed typo in package management template

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Packages/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Packages/Index.html
@@ -88,14 +88,14 @@
 													</button>
 												</f:then>
 												<f:else>
-													<f:link.action action="deactivate" class="neos-button neos-button-warning" arguments="{packageKey: packageKey}" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'click to Deacktivate')}">
+													<f:link.action action="deactivate" class="neos-button neos-button-warning" arguments="{packageKey: packageKey}" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}">
 														<i class="icon-pause icon-white"></i>
 													</f:link.action>
 												</f:else>
 											</f:if>
 										</f:then>
 										<f:else>
-											<f:link.action action="activate" class="neos-button neos-button-success" arguments="{packageKey: packageKey}" title="{neos:backend.translate(id: 'clickToActivate', value: 'click to Activate')}">
+											<f:link.action action="activate" class="neos-button neos-button-success" arguments="{packageKey: packageKey}" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}">
 												<i class="icon-play icon-white"></i>
 											</f:link.action>
 										</f:else>


### PR DESCRIPTION
Fixed a typo in the tooltips for the package activation/deactivation links