### PR TITLE
[BUGFIX] Improve Node context path match pattern

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeInterface.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeInterface.php
@@ -28,32 +28,30 @@ interface NodeInterface
      * workspace name. This pattern is used at least in the route part handler.
      */
     const MATCH_PATTERN_CONTEXTPATH = '/^   # A Context Path consists of...
-		(?P<NodePath>                       # 1) a NODE PATH
+		(?>(?P<NodePath>                       # 1) a NODE PATH
 			\/?                             #    A node Path starts with optional slash
 			[a-z0-9\-]+                     #    followed by a path part
 			(?:                             #    and (optionally) more path-parts)
 				\/
 				[a-z0-9\-]+
 			)*
-		)?
+		))
 		(?:                                 # 2) a CONTEXT
 			@                               #    which is delimited from the node path by the "@" sign
-			(?P<WorkspaceName>              #    followed by the workspace name (NON-EMPTY)
+			(?>(?P<WorkspaceName>              #    followed by the workspace name (NON-EMPTY)
 				[a-z0-9\-]+
-			)
+			))
 			(?:                             #    OPTIONALLY followed by dimension values
 				;                           #    ... which always start with ";"
 				(?P<Dimensions>
-					(?:                     #        A Dimension Value is a key=value structure, delimited by &
-						(?:
-							[a-zA-Z_]+
-							=
-							[^=&]+
-						)
-						&?
-					)+
-				))?
-		)?$/ix';
+					(?>                     #        A Dimension Value is a key=value structure
+						[a-zA-Z_]+
+						=
+						[^=&]+
+					)
+					(?>&(?-1))?             #        ... delimited by &
+				)){0,1}
+		){0,1}$/ix';
 
     /**
      * Regex pattern which matches a Node Name (ie. segment of a node path)

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeTest.php
@@ -81,7 +81,6 @@ class NodeTest extends \TYPO3\Flow\Tests\UnitTestCase
             'empty node path' => array(
                 'path' => '',
                 'expected' => array(
-                    0 => ''
                 )
             ),
             'node path starting with /' => array(
@@ -147,6 +146,31 @@ class NodeTest extends \TYPO3\Flow\Tests\UnitTestCase
         preg_match(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::MATCH_PATTERN_CONTEXTPATH, $path, $matches);
 
         $this->assertSame($expected, $matches);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataSourceForInvalidContextPaths()
+    {
+        return [
+            'invalid dimension values' => [
+                'path' => 'features@user-admin;language=de_DE,mul_ZZ=something'
+            ],
+            'superfluous separator with more data' => [
+                'path' => 'features@user-admin;language=de_DE;mul_ZZ=multilanguage'
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSourceForInvalidContextPaths
+     */
+    public function contextPathPatternShouldNotMatchOnInvalidPaths($path)
+    {
+        $result = preg_match(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::MATCH_PATTERN_CONTEXTPATH, $path, $matches);
+        $this->assertEquals(0, $result, 'The invalid context path yielded matches: ' . print_r($matches, true));
     }
 
     /**


### PR DESCRIPTION
The original match pattern for context paths would match dimensions
like ``@user;language=de,en=bar`` just fine even though in fact it
is not a valid context path.
The adapted pattern uses recursion to exactly match parts of the
dimensions string. Additionally it introduces atomic groups around
parts of the path to reduce backtracking amount in case of a non
matching path.

This increases matching speed while reducing possible sources of error
by disallowing more invalid cases.