### PR TITLE
FEATURE: Allow relation between arbitrary entities and nodes

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Controller\Backend;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\EelHelper\TranslationHelper;
 use TYPO3\Flow\Property\PropertyMappingConfiguration;
+use TYPO3\Flow\Property\TypeConverter\ObjectConverter;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Flow\Mvc\Controller\ActionController;
@@ -272,12 +273,14 @@ class ContentController extends ActionController
     {
         $propertyMappingConfiguration = $this->arguments->getArgument('assets')->getPropertyMappingConfiguration();
         $propertyMappingConfiguration->allowAllProperties();
+        $propertyMappingConfiguration->setTypeConverterOption(AssetInterfaceConverter::class, AssetInterfaceConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
+        $propertyMappingConfiguration->forProperty('*')->setTypeConverterOption(AssetInterfaceConverter::class, AssetInterfaceConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
     }
 
     /**
      * Fetch the metadata for multiple assets
      *
-     * @param array<TYPO3\Media\Domain\Model\Asset> $assets
+     * @param array<TYPO3\Media\Domain\Model\AssetInterface> $assets
      * @return string JSON encoded response
      */
     public function assetsWithMetadataAction(array $assets)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
@@ -19,6 +19,7 @@ use TYPO3\Neos\Controller\CreateContentContextTrait;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\Domain\Service\NodeSearchServiceInterface;
 use TYPO3\Neos\Domain\Service\SiteService;
+use TYPO3\Neos\Service\Mapping\NodePropertyConverterService;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
@@ -51,6 +52,12 @@ class NodesController extends ActionController
      * @var PropertyMapper
      */
     protected $propertyMapper;
+
+    /**
+     * @Flow\Inject
+     * @var NodePropertyConverterService
+     */
+    protected $nodePropertyConverterService;
 
     /**
      * @var array
@@ -128,18 +135,9 @@ class NodesController extends ActionController
             $this->throwStatus(404);
         }
 
-        $convertedProperties = array();
-        foreach ($node->getProperties() as $propertyName => $propertyValue) {
-            try {
-                $convertedProperties[$propertyName] = $this->propertyMapper->convert($propertyValue, 'string');
-            } catch (\TYPO3\Flow\Property\Exception $exception) {
-                $convertedProperties[$propertyName] = '';
-            }
-        }
-
         $this->view->assignMultiple(array(
             'node' => $node,
-            'convertedNodeProperties' => $convertedProperties
+            'convertedNodeProperties' => $this->nodePropertyConverterService->getPropertiesArray($node)
         ));
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/DateStringConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/DateStringConverter.php
@@ -1,0 +1,66 @@
+<?php
+namespace TYPO3\Neos\Service\Mapping;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+
+/**
+ * Converts a Date to a JavaScript compatible representation, meaning also to convert it to UTC timezone.
+ *
+ * @Flow\Scope("singleton")
+ */
+class DateStringConverter extends AbstractTypeConverter
+{
+    /**
+     * The source types this converter can convert.
+     *
+     * @var array<string>
+     * @api
+     */
+    protected $sourceTypes = array(\DateTime::class);
+
+    /**
+     * The target type this converter can convert to.
+     *
+     * @var string
+     * @api
+     */
+    protected $targetType = 'string';
+
+    /**
+     * The priority for this converter.
+     *
+     * @var integer
+     * @api
+     */
+    protected $priority = 0;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param \DateTime $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string the target type
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
+    {
+        if (!$source instanceof \DateTime) {
+            return null;
+        }
+        $value = clone $source;
+        return $value->setTimezone(new \DateTimeZone('UTC'))->format(\DateTime::W3C);
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodePropertyConverterService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodePropertyConverterService.php
@@ -1,0 +1,247 @@
+<?php
+namespace TYPO3\Neos\Service\Mapping;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Log\SystemLoggerInterface;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Property\PropertyMapper;
+use TYPO3\Flow\Property\PropertyMappingConfiguration;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Flow\Utility\TypeHandling;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\Flow\Property\Exception as PropertyException;
+
+/**
+ * Creates PropertyMappingConfigurations to map NodeType properties for the Neos interface.
+ *
+ * @Flow\Scope("singleton")
+ */
+class NodePropertyConverterService
+{
+    /**
+     * @Flow\InjectConfiguration(package="TYPO3.Neos", path="userInterface.inspector.dataTypes")
+     * @var array
+     */
+    protected $typesConfiguration;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
+     * @Flow\Transient
+     * @var array
+     */
+    protected $generatedPropertyMappingConfigurations = [];
+
+    /**
+     * @Flow\Inject
+     * @var SystemLoggerInterface
+     */
+    protected $systemLogger;
+
+    /**
+     * Get a single property reduced to a simple type representation
+     *
+     * @param NodeInterface $node
+     * @param string $propertyName
+     * @return string
+     */
+    public function getProperty(NodeInterface $node, $propertyName)
+    {
+        if ($propertyName[0] === '_') {
+            $propertyValue = ObjectAccess::getProperty($node, ltrim($propertyName, '_'));
+        } else {
+            $propertyValue = $node->getProperty($propertyName);
+        }
+
+        $dataType = $node->getNodeType()->getPropertyType($propertyName);
+        try {
+            $convertedValue = $this->convertValue($propertyValue, $dataType);
+        } catch (PropertyException $exception) {
+            $this->systemLogger->logException($exception);
+            $convertedValue = null;
+        }
+
+        if ($convertedValue === null) {
+            $convertedValue = $this->getDefaultValueForProperty($node->getNodeType(), $propertyName);
+        }
+
+        return $convertedValue;
+    }
+
+    /**
+     * Get all properties as JSON encoded string representation
+     *
+     * @param NodeInterface $node
+     * @return string
+     */
+    public function getPropertiesJson(NodeInterface $node)
+    {
+        $properties = $this->getPropertiesArray($node);
+        return json_encode($properties);
+    }
+
+    /**
+     * Get all properties reduced to simple type representations in an array
+     *
+     * @param NodeInterface $node
+     * @return array
+     */
+    public function getPropertiesArray(NodeInterface $node)
+    {
+        $properties = [];
+        foreach ($node->getNodeType()->getProperties() as $propertyName => $propertyConfiguration) {
+            if ($propertyName[0] === '_' && $propertyName[1] === '_') {
+                // skip fully-private properties
+                continue;
+            }
+
+            $properties[$propertyName] = $this->getProperty($node, $propertyName);
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param mixed $propertyValue
+     * @param string $dataType
+     * @return mixed
+     * @throws PropertyException
+     */
+    protected function convertValue($propertyValue, $dataType)
+    {
+        $rawType = TypeHandling::truncateElementType($dataType);
+
+        // This hardcoded handling is to circumvent rewriting PropertyMappers that convert objects. Usually they expect the source to be an object already and break if not.
+        if (!TypeHandling::isSimpleType($rawType) && !is_object($propertyValue)) {
+            return null;
+        }
+
+        if ($rawType === 'array') {
+            $conversionTargetType = 'array<string>';
+        } elseif (TypeHandling::isSimpleType($rawType)) {
+            $conversionTargetType = TypeHandling::normalizeType($rawType);
+        } else {
+            $conversionTargetType = 'array';
+        }
+
+        $propertyMappingConfiguration = $this->createConfiguration($dataType);
+        $convertedValue = $this->propertyMapper->convert($propertyValue, $conversionTargetType, $propertyMappingConfiguration);
+
+        if ($convertedValue instanceof \TYPO3\Flow\Error\Error) {
+            throw new PropertyException($convertedValue->getMessage(), $convertedValue->getCode());
+        }
+
+        return $convertedValue;
+    }
+
+    /**
+     * Tries to find a default value for the given property trying:
+     * 1) The specific property configuration for the given NodeType
+     * 2) The generic configuration for the property type in setings.
+     *
+     * @param NodeType $nodeType
+     * @param string $propertyName
+     * @return mixed
+     */
+    protected function getDefaultValueForProperty(NodeType $nodeType, $propertyName)
+    {
+        $defaultValues = $nodeType->getDefaultValuesForProperties();
+        if (!isset($defaultValues[$propertyName])) {
+            return null;
+        }
+
+        return $defaultValues[$propertyName];
+    }
+
+    /**
+     * Create a property mapping configuration for the given dataType to convert a Node property value from the given dataType to a simple type.
+     *
+     * @param string $dataType
+     * @return PropertyMappingConfigurationInterface
+     */
+    protected function createConfiguration($dataType)
+    {
+        if (!isset($this->generatedPropertyMappingConfigurations[$dataType])) {
+            $propertyMappingConfiguration = new PropertyMappingConfiguration();
+            $propertyMappingConfiguration->allowAllProperties();
+
+            $parsedType = [
+                'elementType' => null,
+                'type' => $dataType
+            ];
+            // Special handling for "reference(s)", should be deprecated and normlized to array<NodeInterface>
+            if ($dataType !== 'references' && $dataType !== 'reference') {
+                $parsedType = TypeHandling::parseType($dataType);
+            }
+
+            if ($this->setTypeConverterForType($propertyMappingConfiguration, $dataType) === false) {
+                $this->setTypeConverterForType($propertyMappingConfiguration, $parsedType['type']);
+            }
+
+            $elementConfiguration = $propertyMappingConfiguration->forProperty('*');
+            $this->setTypeConverterForType($elementConfiguration, $parsedType['elementType']);
+
+            $this->generatedPropertyMappingConfigurations[$dataType] = $propertyMappingConfiguration;
+        }
+
+        return $this->generatedPropertyMappingConfigurations[$dataType];
+    }
+
+    /**
+     * @param PropertyMappingConfiguration $propertyMappingConfiguration
+     * @param string $dataType
+     * @return boolean
+     */
+    protected function setTypeConverterForType(PropertyMappingConfiguration $propertyMappingConfiguration, $dataType)
+    {
+        if (!isset($this->typesConfiguration[$dataType]) || !isset($this->typesConfiguration[$dataType]['typeConverter'])) {
+            return false;
+        }
+
+        $typeConverter = $this->objectManager->get($this->typesConfiguration[$dataType]['typeConverter']);
+        $propertyMappingConfiguration->setTypeConverter($typeConverter);
+        $this->setTypeConverterOptionsForType($propertyMappingConfiguration, $this->typesConfiguration[$dataType]['typeConverter'], $dataType);
+
+        return true;
+    }
+
+    /**
+     * @param PropertyMappingConfiguration $propertyMappingConfiguration
+     * @param string $typeConverterClass
+     * @param string $dataType
+     * @return void
+     */
+    protected function setTypeConverterOptionsForType(PropertyMappingConfiguration $propertyMappingConfiguration, $typeConverterClass, $dataType)
+    {
+        if (!isset($this->typesConfiguration[$dataType]['typeConverterOptions']) || !is_array($this->typesConfiguration[$dataType]['typeConverterOptions'])) {
+            return;
+        }
+
+        foreach ($this->typesConfiguration[$dataType]['typeConverterOptions'] as $option => $value) {
+            $propertyMappingConfiguration->setTypeConverterOption($typeConverterClass, $option, $value);
+        }
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodeReferenceConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodeReferenceConverter.php
@@ -1,0 +1,77 @@
+<?php
+namespace TYPO3\Neos\Service\Mapping;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+
+/**
+ * Converter to convert node references to their identifiers
+ *
+ * @Flow\Scope("singleton")
+ */
+class NodeReferenceConverter extends AbstractTypeConverter
+{
+    /**
+     * The source types this converter can convert.
+     *
+     * @var array<string>
+     * @api
+     */
+    protected $sourceTypes = array(NodeInterface::class, 'array');
+
+    /**
+     * The target type this converter can convert to.
+     *
+     * @var string
+     * @api
+     */
+    protected $targetType = 'string';
+
+    /**
+     * The priority for this converter.
+     *
+     * @var integer
+     * @api
+     */
+    protected $priority = 0;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param NodeInterface|array<NodeInterface> $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string the target type
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
+    {
+        if (is_array($source)) {
+            $result = [];
+            /** @var NodeInterface $node */
+            foreach ($source as $node) {
+                $result[] = $node->getIdentifier();
+            }
+        } else {
+            if ($source instanceof NodeInterface) {
+                $result = $source->getIdentifier();
+            } else {
+                $result = '';
+            }
+        }
+
+        return $result;
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodeTypeStringConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodeTypeStringConverter.php
@@ -1,0 +1,60 @@
+<?php
+namespace TYPO3\Neos\Service\Mapping;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+
+/**
+ * Convert a boolean to a JavaScript compatible string representation.
+ *
+ * @Flow\Scope("singleton")
+ */
+class NodeTypeStringConverter extends AbstractTypeConverter
+{
+    /**
+     * The source types this converter can convert.
+     *
+     * @var array<string>
+     * @api
+     */
+    protected $sourceTypes = array(NodeType::class);
+
+    /**
+     * The target type this converter can convert to.
+     *
+     * @var string
+     * @api
+     */
+    protected $targetType = 'string';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string
+     * @api
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
+    {
+        if ($source instanceof NodeType) {
+            return $source->getName();
+        }
+
+        return '';
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
@@ -73,7 +73,12 @@ class ContentElementWrappingImplementation extends AbstractTypoScriptObject
         if ($node->isRemoved()) {
             $content = '';
         }
-        return $this->contentElementWrappingService->wrapContentObject($node, $this->getContentElementTypoScriptPath(), $content, $this->tsValue('renderCurrentDocumentMetadata'));
+
+        if ($this->tsValue('renderCurrentDocumentMetadata')) {
+            return $this->contentElementWrappingService->wrapCurrentDocumentMetadata($node, $content, $this->getContentElementTypoScriptPath());
+        }
+
+        return $this->contentElementWrappingService->wrapContentObject($node, $content, $this->getContentElementTypoScriptPath());
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/NodeWrappingHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/NodeWrappingHandler.php
@@ -74,7 +74,7 @@ class NodeWrappingHandler extends AbstractRenderingExceptionHandler
                 $output = '<div class="neos-rendering-exception"><div class="neos-rendering-exception-title">Failed to render element' . $output . '</div></div>';
             }
 
-            return $this->contentElementWrappingService->wrapContentObject($node, $typoScriptPath, $output);
+            return $this->contentElementWrappingService->wrapContentObject($node, $output, $typoScriptPath);
         }
 
         return $output;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/PageHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/PageHandler.php
@@ -69,7 +69,7 @@ class PageHandler extends AbstractRenderingExceptionHandler
 
         if ($documentNode !== null && $documentNode->getContext()->getWorkspace()->getName() !== 'live' && $this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess')) {
             $isBackend = true;
-            $fluidView->assign('metaData', $this->contentElementWrappingService->wrapContentObject($documentNode, $typoScriptPath, '<div id="neos-document-metadata"></div>', true));
+            $fluidView->assign('metaData', $this->contentElementWrappingService->wrapCurrentDocumentMetadata($documentNode, '<div id="neos-document-metadata"></div>', $typoScriptPath));
         }
 
         $fluidView->assignMultiple(array(

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -69,6 +69,6 @@ class WrapViewHelper extends AbstractViewHelper
         if ($node === null) {
             $node = $currentContext['node'];
         }
-        return $this->contentElementWrappingService->wrapContentObject($node, $typoScriptObject->getPath(), $this->renderChildren());
+        return $this->contentElementWrappingService->wrapContentObject($node, $this->renderChildren(), $typoScriptObject->getPath());
     }
 }

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -206,16 +206,22 @@ TYPO3:
         dataTypes:
           'string':
             editor: 'TYPO3.Neos/Inspector/Editors/TextFieldEditor'
+            defaultValue: ''
           'integer':
             editor: 'TYPO3.Neos/Inspector/Editors/TextFieldEditor'
+            defaultValue: 0
           'boolean':
             editor: 'TYPO3.Neos/Inspector/Editors/BooleanEditor'
+            defaultValue: FALSE
           'array':
+            typeConverter: 'TYPO3\Flow\Property\TypeConverter\TypedArrayConverter'
             editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
             editorOptions:
               multiple: TRUE
               placeholder: 'Choose'
+            defaultValue: []
           'TYPO3\Media\Domain\Model\ImageInterface':
+            typeConverter: 'TYPO3\Media\TypeConverter\ImageInterfaceJsonSerializer'
             editor: 'TYPO3.Neos/Inspector/Editors/ImageEditor'
             editorOptions:
               # With this option you can limit the maximum file size to the specified number of bytes.
@@ -253,18 +259,22 @@ TYPO3:
                     width: 0
                     height: 0
           'TYPO3\Media\Domain\Model\Asset':
+            typeConverter: 'TYPO3\Neos\TypeConverter\EntityToIdentityConverter'
             editor: 'TYPO3.Neos/Inspector/Editors/AssetEditor'
           'array<TYPO3\Media\Domain\Model\Asset>':
             editor: 'TYPO3.Neos/Inspector/Editors/AssetEditor'
             editorOptions:
               multiple: TRUE
           'DateTime':
+            typeConverter: 'TYPO3\Neos\Service\Mapping\DateStringConverter'
             editor: 'TYPO3.Neos/Inspector/Editors/DateTimeEditor'
             editorOptions:
               format: 'd-m-Y'
           'reference':
+            typeConverter: 'TYPO3\Neos\Service\Mapping\NodeReferenceConverter'
             editor: 'TYPO3.Neos/Inspector/Editors/ReferenceEditor'
           'references':
+            typeConverter: 'TYPO3\Neos\Service\Mapping\NodeReferenceConverter'
             editor: 'TYPO3.Neos/Inspector/Editors/ReferencesEditor'
         editors:
           'TYPO3.Neos/Inspector/Editors/CodeEditor':


### PR DESCRIPTION
  This removes all special type handling to format node properties for
  the Neos user interface and replaces it with using ``PropertyMapper``.
  The introduced ``NodePropertyConverterService`` is fully responsible to
  provide a portable representation of the Node properties.

  Node property types can be configured to use specific ``TypeConverter``
  implementations to give all necessary information to the inspector
  editor. Additionally a fallback ``defaultValue`` for property types
  can be added in Settings.

  Please note that we introduce some default values in case you didn't set
  a default value in your ``NodeTypes.yaml``. All of those are common sense
  but you might want to check if they work for you in all cases.

  This allows to map arbitrary objects to node properties and interact with
  them in the Neos user interface.

  NEOS-381 #close