### PR TITLE
[BUGFIX] Fix license header text

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosLicenseHeader.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosLicenseHeader.html
@@ -1,5 +1,5 @@
 <!--
-	This website is powered by the Neos, the Open Source Content Application Platform licensed under the GNU/GPL.
+	This website is powered by Neos, the Open Source Content Application Platform licensed under the GNU/GPL.
 	Neos is based on Flow, a powerful PHP application framework licensed under the MIT license.
 
 	More information and contribution opportunities at https://www.neos.io

--- a/TYPO3.Neos/Tests/Functional/TypoScript/RenderingTest.php
+++ b/TYPO3.Neos/Tests/Functional/TypoScript/RenderingTest.php
@@ -188,7 +188,7 @@ class RenderingTest extends AbstractNodeTest
      */
     protected function assertTeaserConformsToBasicRendering($output)
     {
-        $this->assertContains('This website is powered by the Neos, the Open Source Content Application Platform licensed under the GNU/GPL.', $output);
+        $this->assertContains('This website is powered by Neos, the Open Source Content Application Platform licensed under the GNU/GPL.', $output);
         $this->assertSelectEquals('h1', 'Home', true, $output);
 
         $this->assertSelectEquals('.teaser > .neos-contentcollection > .typo3-neos-nodetypes-headline > div > h1', 'Welcome to this example', true, $output);


### PR DESCRIPTION
Removes a superfluous "the" in the license header, it's
not "THE Neos".