### PR TITLE
[BUGFIX] CachingHelper generation of entry tags for descendants of a node

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Helper/CachingHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Helper/CachingHelper.php
@@ -92,7 +92,7 @@ class CachingHelper implements ProtectedContextAwareInterface
      */
     public function descendantOfTag($nodes)
     {
-        return $this->convertArrayOfNodesToArrayOfNodeIdentifiersWithPrefix($nodes, 'descendantOf');
+        return $this->convertArrayOfNodesToArrayOfNodeIdentifiersWithPrefix($nodes, 'DescendantOf');
     }
 
     /**


### PR DESCRIPTION
Cache entry tags are case sensitive.