### PR TITLE
[BUGFIX] Use current node as document node if no document node is found

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
@@ -87,7 +87,7 @@ class TypoScriptView extends AbstractView
 
         $typoScriptRuntime->pushContextArray(array(
             'node' => $currentNode,
-            'documentNode' => $this->getClosestDocumentNode($currentNode),
+            'documentNode' => $this->getClosestDocumentNode($currentNode) ?: $currentNode,
             'site' => $currentSiteNode,
             'account' => $this->securityContext->canBeInitialized() ? $this->securityContext->getAccount() : null,
             'editPreviewMode' => isset($this->variables['editPreviewMode']) ? $this->variables['editPreviewMode'] : null


### PR DESCRIPTION
When the fallback node mode is triggered, the ``documentNode`` TypoScript
variable is empty leading to various issues. This solves that by using the
current node as the document node in that case.

Fixes: NEOS-1624