### PR TITLE
[BUGFIX] Graceful handling of node linking exceptions

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\ViewHelpers\Link;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Exception\NoMatchingRouteException;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\Neos\Service\LinkingService;
@@ -169,6 +170,8 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             );
             $this->tag->addAttribute('href', $uri);
         } catch (NeosException $exception) {
+            $this->systemLogger->logException($exception);
+        } catch (NoMatchingRouteException $exception) {
             $this->systemLogger->logException($exception);
         }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Exception\NoMatchingRouteException;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Neos\Service\LinkingService;
@@ -133,7 +134,9 @@ class NodeViewHelper extends AbstractViewHelper
             );
         } catch (NeosException $exception) {
             $this->systemLogger->logException($exception);
-            return '';
+        } catch (NoMatchingRouteException $exception) {
+            $this->systemLogger->logException($exception);
         }
+        return '';
     }
 }

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Breadcrumb.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Breadcrumb.ts2
@@ -9,7 +9,7 @@ prototype(TYPO3.Neos:Breadcrumb) < prototype(TYPO3.TypoScript:Template) {
 	node = ${node}
 	items = ${q(node).add(q(node).parents('[instanceof TYPO3.Neos:Document]')).get()}
 
-	@exceptionHandler = 'TYPO3\\Neos\\TypoScript\\ExceptionHandlers\\NodeWrappingHandler'
+	@exceptionHandler = 'TYPO3\\TypoScript\\Core\\ExceptionHandlers\\ContextDependentHandler'
 
 	@cache {
 		mode = 'cached'

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
@@ -18,7 +18,7 @@ prototype(TYPO3.Neos:Menu) < prototype(TYPO3.TypoScript:Template) {
 		class = 'normal'
 	}
 
-	@exceptionHandler = 'TYPO3\\Neos\\TypoScript\\ExceptionHandlers\\NodeWrappingHandler'
+	@exceptionHandler = 'TYPO3\\TypoScript\\Core\\ExceptionHandlers\\ContextDependentHandler'
 
 	@cache {
 		mode = 'cached'

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/NodeUri.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/NodeUri.ts2
@@ -6,4 +6,5 @@ prototype(TYPO3.Neos:NodeUri) {
 	arguments = TYPO3.TypoScript:RawArray
 	additionalParams = TYPO3.TypoScript:RawArray
 	argumentsToBeExcludedFromQueryString = TYPO3.TypoScript:RawArray
+	@exceptionHandler = 'TYPO3\\TypoScript\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }


### PR DESCRIPTION
- Gracefully handle exceptions in the NodeUri TS object
- Gracefully handle exceptions in node linking view helpers

Resolves: NEOS-1625