### PR TITLE
[BUGFIX] No longer use invalid data in functional test

### DIFF
--- a/TYPO3.TYPO3CR/Tests/Functional/Migration/Domain/Repository/MigrationStatusRepositoryTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Migration/Domain/Repository/MigrationStatusRepositoryTest.php
@@ -43,9 +43,9 @@ class MigrationStatusRepositoryTest extends FunctionalTestCase
      */
     public function findAllReturnsResultsInAscendingVersionOrder()
     {
-        $this->repository->add(new MigrationStatus('zyx', 'direction', new \DateTime()));
-        $this->repository->add(new MigrationStatus('abc', 'direction', new \DateTime()));
-        $this->repository->add(new MigrationStatus('mnk', 'direction', new \DateTime()));
+        $this->repository->add(new MigrationStatus('zyx', MigrationStatus::DIRECTION_DOWN, new \DateTime()));
+        $this->repository->add(new MigrationStatus('abc', MigrationStatus::DIRECTION_UP, new \DateTime()));
+        $this->repository->add(new MigrationStatus('mnk', MigrationStatus::DIRECTION_DOWN, new \DateTime()));
 
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();


### PR DESCRIPTION
The MigrationStatusRepositoryTest used invalid fixture data, the
direction was filled with strings that were too long for the related
DB column. On MySQL this is silently truncated, but on PostgreSQL it
leads to an error.

Now the expected class constants are used in the test.