### PR TITLE
[BUGFIX] Prevent fatal error in ``node:repair`` with broken node structure

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -123,8 +123,14 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
     public function generateUriPathSegments($workspaceName, $dryRun)
     {
         $baseContext = $this->createContext($workspaceName, []);
-        $baseContextSiteNodes = $baseContext->getNode('/sites')->getChildNodes();
+        $baseContextSitesNode = $baseContext->getNode('/sites');
+        if (!$baseContextSitesNode) {
+            $this->output->outputLine('<error>Could not find "/sites" root node</error>');
+            return;
+        }
+        $baseContextSiteNodes = $baseContextSitesNode->getChildNodes();
         if ($baseContextSiteNodes === []) {
+            $this->output->outputLine('<error>Could not find any site nodes in "/sites" root node</error>');
             return;
         }
 


### PR DESCRIPTION
When the "/sites" root node or it's children cannot be found a fatal error
is thrown or it's silently ignored. Instead output an error message that the
nodes could not be found.