### PR TITLE
BUGFIX: Change column type to flow_json_array on NodeData

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: php
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql
 matrix:
   fast_finish: true
   include:
     - php: 7.0
       env: DB=mysql
+    - php: 7.0
+      env: DB=pgsql
     - php: 7.0
       env: DB=mysql BEHAT=true
     - php: 5.6

--- a/TYPO3.Neos/Migrations/Postgresql/Version20151120170812.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20151120170812.php
@@ -1,0 +1,37 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Change column type from json to jsonb on dimensionvalues and accessroles
+ */
+class Version20151120170812 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues TYPE jsonb");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues DROP DEFAULT");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles TYPE jsonb");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles DROP DEFAULT");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues TYPE JSON USING dimensionvalues::json");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues DROP DEFAULT");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles TYPE JSON USING accessroles::json");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles DROP DEFAULT");
+	}
+}

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
@@ -97,7 +97,7 @@ abstract class AbstractNodeData
     /**
      * List of role names which are required to access this node at all
      *
-     * @ORM\Column(type="json_array")
+     * @ORM\Column(type="flow_json_array")
      * @var array<string>
      */
     protected $accessRoles = array();

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -187,7 +187,7 @@ class NodeData extends AbstractNodeData
     protected $hiddenAfterDateTime;
 
     /**
-     * @ORM\Column(type="json_array")
+     * @ORM\Column(type="flow_json_array")
      * @var array
      */
     protected $dimensionValues;


### PR DESCRIPTION
This changes the type of the properties `AbstractNodeData.accessRoles`
and the `NodeData.dimensionValues` from `json_array` to the Flow type
`flow_json_array`.

While those properties only hold plain arrays and can be stored just fine
with the Doctrine `json_array` type, Neos uses distinct in a query on
the NodeData table which leads to errors due to the `json` type in
PostgreSQL not being comparable. The Flow type uses `jsonb` instead,
which can be compared and makes the query work as expected.

NEOS-1726 #comment Fixes exporting on PostgreSQL
