### PR TITLE
[TASK] Ignore built JavaScript/CSS files during merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+TYPO3.Neos/Resources/Public/JavaScript/ContentModule-built.js merge=ours
+TYPO3.Neos/Resources/Public/Styles/Error.css merge=ours
+TYPO3.Neos/Resources/Public/Styles/Includes-built.css merge=ours
+TYPO3.Neos/Resources/Public/Styles/Login.css merge=ours
+TYPO3.Neos/Resources/Public/Styles/Neos.css merge=ours
+TYPO3.Neos/Resources/Public/Styles/RawContentMode.css merge=ours
+


### PR DESCRIPTION
When merging a lower branch to an upper one the built files often conflict.
To avoid that the file in the current branch is used when solving conflicts.
This is done using ``.gitattributes`` stored in the root of the repository.

Enable this with::

  git config merge.ours.driver true