### PR TITLE
[BUGFIX] Behat tests

### DIFF
--- a/TYPO3.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
+++ b/TYPO3.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
@@ -44,6 +44,7 @@ trait HistoryDefinitionsTrait
      */
     public function iShouldHaveTheFollowingHistoryEntries($ignoringOrder, TableNode $table)
     {
+        $this->getSubcontext('flow')->persistAll();
         $allEvents = $this->getEventRepository()->findAll()->toArray();
         $eventsByInternalId = array();
         $unmatchedParentEvents = array();

--- a/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
@@ -9,16 +9,16 @@ Feature: Publish user workspace
     Given I have the following nodes:
       | Identifier                           | Path                 | Node Type                 | Properties        | Workspace |
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites               | unstructured              |                   | live      |
-      | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/neosdemotypo3 | TYPO3.Neos.NodeTypes:Page | {"title": "Home"} | live      |
+      | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/example       | TYPO3.Neos.NodeTypes:Page | {"title": "Home"} | live      |
 
   @fixtures
   Scenario: Publish a new ContentCollection with Content
     When I create the following nodes:
       | Path                                     | Node Type                      | Properties              | Workspace |
-      | /sites/neosdemotypo3/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
-      | /sites/neosdemotypo3/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+      | /sites/example/main/twocol               | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text  | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     And I publish the workspace "user-demo"
-    And I get a node by path "/sites/neosdemotypo3/twocol/column0/text" with the following context:
+    And I get a node by path "/sites/example/main/twocol/column0/text" with the following context:
       | Workspace |
       | live      |
     Then I should have one node
@@ -27,8 +27,8 @@ Feature: Publish user workspace
   Scenario: Unpublished nodes returns the correct count before publish
     And I create the following nodes:
       | Path                                     | Node Type                      | Properties              | Workspace |
-      | /sites/neosdemotypo3/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
-      | /sites/neosdemotypo3/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+      | /sites/example/main/twocol               | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text  | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     # We expect 4, the 2 column element with 2 columns (3) and the text element (1)
     Then I expect to have 4 unpublished nodes for the following context:
       | Workspace |
@@ -38,8 +38,8 @@ Feature: Publish user workspace
   Scenario: Unpublished nodes returns the correct count after publish
     And I create the following nodes:
       | Path                                     | Node Type                      | Properties              | Workspace |
-      | /sites/neosdemotypo3/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
-      | /sites/neosdemotypo3/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+      | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     And I publish the workspace "user-demo"
     Then I expect to have 0 unpublished nodes for the following context:
       | Workspace |

--- a/TYPO3.Neos/Tests/Behavior/Features/EventLog/Entities/AccountsUsers.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/EventLog/Entities/AccountsUsers.feature
@@ -13,7 +13,6 @@ Feature: Accounts / User Entity Monitoring
         accountIdentifier: '${entity.accountIdentifier}'
         authenticationProviderName: '${entity.authenticationProviderName}'
         expirationDate: '${entity.expirationDate}'
-        roles: '${entity.roles}'
         party: '${entity.party.name.fullName}'
     'TYPO3\Neos\Domain\Model\User':
       events:

--- a/TYPO3.Neos/Tests/Functional/Command/BehatTestHelper.php
+++ b/TYPO3.Neos/Tests/Functional/Command/BehatTestHelper.php
@@ -13,8 +13,13 @@ namespace TYPO3\Neos\Tests\Functional\Command;
 
 require_once(FLOW_PATH_PACKAGES . '/Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/IsolatedBehatStepsTrait.php');
 require_once(FLOW_PATH_PACKAGES . '/Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php');
-require_once(__DIR__ . '/../../../../TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
-require_once(__DIR__ . '/../../../../TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+if (file_exists(FLOW_PATH_PACKAGES . '/Neos')) {
+    require_once(FLOW_PATH_PACKAGES . '/Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+    require_once(FLOW_PATH_PACKAGES . '/Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+} else {
+    require_once(FLOW_PATH_PACKAGES . '/Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+    require_once(FLOW_PATH_PACKAGES . '/Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+}
 
 use TYPO3\Flow\Tests\Behavior\Features\Bootstrap\SecurityOperationsTrait;
 use TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeAuthorizationTrait;

--- a/TYPO3.TYPO3CR/Tests/Functional/Command/BehatTestHelper.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Command/BehatTestHelper.php
@@ -13,8 +13,13 @@ namespace TYPO3\TYPO3CR\Tests\Functional\Command;
 
 require_once(FLOW_PATH_PACKAGES . '/Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/IsolatedBehatStepsTrait.php');
 require_once(FLOW_PATH_PACKAGES . '/Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php');
-require_once(__DIR__ . '/../../Behavior/Features/Bootstrap/NodeOperationsTrait.php');
-require_once(__DIR__ . '/../../Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+if (file_exists(FLOW_PATH_PACKAGES . '/Neos')) {
+    require_once(FLOW_PATH_PACKAGES . '/Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+    require_once(FLOW_PATH_PACKAGES . '/Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+} else {
+    require_once(FLOW_PATH_PACKAGES . '/Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+    require_once(FLOW_PATH_PACKAGES . '/Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
+}
 
 use TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeAuthorizationTrait;
 use TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeOperationsTrait;


### PR DESCRIPTION
Using relative paths fails when using isolated tests that are run
in a subprocess. To support the development collection and
read-only repositories full paths are used by checking which
structure is present.

Related: cdbffb7f5ab28d630601c733e97568c27a8b0cbf