### PR TITLE
TASK: Create ContentContext with site matching given node

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -12,6 +12,8 @@ namespace TYPO3\Neos\Domain\Repository;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\TYPO3CR\Domain\Utility\NodePaths;
 
 /**
  * The Site Repository
@@ -50,5 +52,26 @@ class SiteRepository extends \TYPO3\Flow\Persistence\Repository
     public function findFirstOnline()
     {
         return $this->findOnline()->getFirst();
+    }
+
+    /**
+     * Find the matching site for a given Node
+     *
+     * @param string $nodePath
+     * @return Site
+     */
+    public function findOneByNodePath($nodePath)
+    {
+        if (!NodePaths::isSubPathOf('/sites', $nodePath)) {
+            return null;
+        }
+
+        $nodePathParts =explode('/', $nodePath);
+        if (!isset($nodePathParts[2])) {
+            return null;
+        }
+
+        $siteNodeName = $nodePathParts[2];
+        return $this->findOneByNodeName($siteNodeName);
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
 
 /**
  * An Object Converter for nodes which can be used for routing (but also for other
@@ -43,17 +44,12 @@ class NodeConverter extends \TYPO3\TYPO3CR\TypeConverter\NodeConverter
      *
      * {@inheritdoc}
      */
-    protected function prepareContextProperties($workspaceName, \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
+    protected function prepareContextProperties($nodePath, $workspaceName, PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
     {
-        $contextProperties = parent::prepareContextProperties($workspaceName, $configuration, $dimensions);
-
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
+        $contextProperties = parent::prepareContextProperties($nodePath, $workspaceName, $configuration, $dimensions);
+        $site = $this->siteRepository->findOneByNodePath($nodePath);
+        $contextProperties['currentSite'] = $site;
+        $contextProperties['currentDomain'] = $site->getFirstActiveDomain();
 
         return $contextProperties;
     }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
@@ -151,7 +151,7 @@ class NodeConverter extends AbstractTypeConverter
             return new Error('Could not convert array to Node object because the node path was invalid.', 1285162903);
         }
 
-        $context = $this->contextFactory->create($this->prepareContextProperties($workspaceName, $configuration, $dimensions));
+        $context = $this->contextFactory->create($this->prepareContextProperties($nodePath, $workspaceName, $configuration, $dimensions));
         $workspace = $context->getWorkspace(false);
         if (!$workspace) {
             return new Error(sprintf('Could not convert the given source to Node object because the workspace "%s" as specified in the context node path does not exist.', $workspaceName), 1383577859);
@@ -270,12 +270,13 @@ class NodeConverter extends AbstractTypeConverter
     /**
      * Prepares the context properties for the nodes based on the given workspace and dimensions
      *
+     * @param string $nodePath
      * @param string $workspaceName
      * @param PropertyMappingConfigurationInterface $configuration
      * @param array $dimensions
      * @return array
      */
-    protected function prepareContextProperties($workspaceName, PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
+    protected function prepareContextProperties($nodePath, $workspaceName, PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
     {
         $contextProperties = array(
             'workspaceName' => $workspaceName,

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeTemplateConverter.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeTemplateConverter.php
@@ -81,7 +81,7 @@ class NodeTemplateConverter extends NodeConverter
 
         // we don't need a context or workspace for creating NodeTemplate objects, but in order to satisfy the method
         // signature of setNodeProperties(), we do need one:
-        $context = $this->contextFactory->create($this->prepareContextProperties('live'));
+        $context = $this->contextFactory->create($this->prepareContextProperties('', 'live'));
 
         $this->setNodeProperties($nodeTemplate, $nodeTemplate->getNodeType(), $source, $context);
         return $nodeTemplate;


### PR DESCRIPTION
The `ContentContext` should not be created from the current request
in the `NodeConverter` or `NodeSearchService` but rather be defined
by the node in question.
