### PR TITLE
[TASK] Allow setting a new Node name in move operations

### DIFF
--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/NodesTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/NodesTest.php
@@ -793,6 +793,29 @@ class NodesTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function moveAndRenameAtTheSameTime()
+    {
+        $rootNode = $this->context->getRootNode();
+
+        $parentNode = $rootNode->createNode('parentNode');
+        $childNodeA = $parentNode->createNode('childNodeA');
+        $childNodeB = $parentNode->createNode('childNodeB');
+        $childNodeB1 = $childNodeB->createNode('childNodeB1');
+
+        $this->persistenceManager->persistAll();
+
+        $childNodeB->moveInto($childNodeA, 'renamedChildNodeB');
+
+        $this->persistenceManager->persistAll();
+
+        $this->assertNull($parentNode->getNode('childNodeB'));
+        $this->assertSame($childNodeB, $childNodeA->getNode('renamedChildNodeB'));
+        $this->assertSame($childNodeB1, $childNodeA->getNode('renamedChildNodeB')->getNode('childNodeB1'));
+    }
+
+    /**
      * Testcase for bug #34291 (TYPO3CR reordering does not take unpersisted
      * node order changes into account)
      *


### PR DESCRIPTION
It would be convenient to change the name of a node while moving
it to a new destination. To avoid exceptions due to existing nodes
you only need to find an available name at the target location then.

Additionally refactors duplicate logic code into separate methods.