### PR TITLE
[TASK] Remove "Releases" badge

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -6,8 +6,6 @@
    :target: https://codeclimate.com/github/neos/neos-development-collection
 .. |StyleCI| image:: https://styleci.io/repos/40964014/shield?style=flat
    :target: https://styleci.io/repos/40964014
-.. |Latest Stable Version| image:: https://poser.pugx.org/neos/neos-development-collection/v/stable
-   :target: https://packagist.org/packages/neos/neos-development-collection
 .. |License| image:: https://poser.pugx.org/neos/neos-development-collection/license
    :target: https://packagist.org/packages/neos/neos-development-collection
 


### PR DESCRIPTION
As the development collections are new since the github move any released 
versions don't have a composer.json file in the root and are therefore not
picked up by packagist. This is confusing and therefore the badge is removed.
It can be reintroduced once we have had a couple of releases on github.