### PR TITLE
[FEATURE] Make SelectBoxEditor search configurable

### DIFF
--- a/TYPO3.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/TYPO3.Neos/Documentation/References/PropertyEditorReference.rst
@@ -261,6 +261,10 @@ Options Reference:
 ``multiple`` (boolean)
 	If ``TRUE``, multi-selection is allowed. Default ``FALSE``.
 
+``minimumResultsForSearch`` (integer)
+	The minimum amount of items in the select before showing a search box,
+	if set to ``-1`` the search box will never be shown.
+
 ``dataSourceUri`` (string)
 	If set, this URI will be called for loading the options of the select field.
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/SelectBoxEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/SelectBoxEditor.js
@@ -88,6 +88,7 @@ define([
 		attributeBindings: ['size', 'disabled', 'multiple'],
 		optionLabelPath: 'content.label',
 		optionValuePath: 'content.value',
+		minimumResultsForSearch: 5,
 
 		init: function() {
 			this._super();
@@ -187,7 +188,7 @@ define([
 		_initializeSelect2: function() {
 			this.$().select2('destroy').select2({
 				maximumSelectionSize: this.get('multiple') ? 0 : 1,
-				minimumResultsForSearch: 5,
+				minimumResultsForSearch: this.get('minimumResultsForSearch'),
 				allowClear: this.get('allowEmpty') || this.get('content.0.value') === '',
 				placeholder: this.get('_placeholder'),
 				relative: true,


### PR DESCRIPTION
The JavaScript widget we use for select boxes supports a search
feature to quickly find an entry. The threshold for showing the
search box was hardcoded with a value of 5 entries, but different
values can make sense depending on the project. Therefore this
value now becomes configurable with the default still being ``5``.

```
  editorOptions:
    minimumResultsForSearch: -1
```
This example configuration would set the minimum to -1 effectively
deactivating the search box. Any value greater or equal ``0`` will
show the search box when the entries in the select are more than
the configured value.