### PR TITLE
[BUGFIX] Render exception in HTML even if an other format is given

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/PageHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ExceptionHandlers/PageHandler.php
@@ -91,8 +91,8 @@ class PageHandler extends AbstractRenderingExceptionHandler
         $fluidView->setTemplatePathAndFilename('resource://TYPO3.Neos/Private/Templates/Error/NeosBackendMessage.html');
         $fluidView->setLayoutRootPath('resource://TYPO3.Neos/Private/Layouts');
         // FIXME find a better way than using templates as partials
-        $fluidView->setPartialRootPath('resource://TYPO3.Neos/Private/Templates/TypoScriptObjects');
         $fluidView->setFormat('html');
+        $fluidView->setPartialRootPath('resource://TYPO3.Neos/Private/Templates/TypoScriptObjects');
         return $fluidView;
     }
 }


### PR DESCRIPTION
If an exception is thrown while rendering a page with an alternative format
like .json, the ExceptionHandlers\PageHandler tries to fetch a layout for this alternative
format which raises another exception: `#1288092555: Could not load layout file`

Switching the setters of the RequestHandler and the format always renders the
exception as HTML.