### PR TITLE
[BUGFIX] Hidden before/after properties breaks site import

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -522,6 +522,8 @@ class NodeImportService
     protected function parseEndElement(\XMLReader $reader)
     {
         switch ($reader->name) {
+            case 'hiddenBeforeDateTime':
+            case 'hiddenAfterDateTime':
             case 'creationDateTime':
             case 'lastModificationDateTime':
             case 'lastPublicationDateTime':

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNode.xml
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNode.xml
@@ -7,6 +7,8 @@
 				<language>en_UK</language>
 			</dimensions>
 			<accessRoles __type="array" />
+			<hiddenBeforeDateTime __type="object" __classname="DateTime">2015-10-01T03:45:04+02:00</hiddenBeforeDateTime>
+			<hiddenAfterDateTime __type="object" __classname="DateTime">2015-10-22T07:50:04+02:00</hiddenAfterDateTime>
 			<properties>
 				<title __type="string">Home</title>
 				<layout __type="string">landingPage</layout>

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -73,6 +73,8 @@ class NodeImportServiceTest extends UnitTestCase
                 'imageTitleText' => 'Photo by www.daniel-bischoff.photo',
             ),
             'accessRoles' => array(),
+            'hiddenBeforeDateTime' => new \DateTime('2015-10-01T03:45:04+02:00'),
+            'hiddenAfterDateTime' => new \DateTime('2015-10-22T07:50:04+02:00'),
             'dimensionValues' => array(
                 'language' => array(
                     'en_US',
@@ -84,6 +86,12 @@ class NodeImportServiceTest extends UnitTestCase
             unset($nodeData['Persistence_Object_Identifier']);
             $actualNodeData = $nodeData;
             return true;
+        }));
+        $this->mockPropertyMapper->expects($this->any())->method('convert')->will($this->returnCallback(function ($source, $targetType) {
+            if ($targetType === 'DateTime') {
+                return new \DateTime($source);
+            }
+            throw new \Exception('Target type ' . $targetType . ' not supported in property mapper mock');
         }));
 
         $nodeImportService->import($xmlReader, '/');


### PR DESCRIPTION
The closing tags for the ``hiddenBeforeDateTime`` and ``hiddenAfterDateTime``
properties were not handled in the node import service.

Resolves: NEOS-1554