### PR TITLE
TASK: Mark editable content on hover

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/_Content.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/_Content.scss
@@ -11,6 +11,14 @@
 		outline: 2px solid rgba(0, 0, 0, .2);
 		outline-offset: 6px;
 
+		// Mark content elements which are inline-editable
+		.neos-inline-editable:hover {
+			outline: 2px dashed rgba(0, 0, 0, .2) !important;
+		}
+		> .neos-inline-editable:hover {
+			outline: none !important;
+		}
+
 		// Content elements which "shine through" from other content dimensions should appear with orange outline
 		&.neos-contentelement-shine-through {
 			outline: 2px solid $orange;
@@ -20,6 +28,11 @@
 	&.neos-contentelement-active {
 		outline: 2px solid $blue !important;
 		outline-offset: 6px;
+
+		// Mark content elements which are inline-editable
+		.neos-inline-editable:hover {
+			outline: 2px dashed $blue !important;
+		}
 	}
 
 	&.neos-contentelement-hover > .neos-contentelement-overlay,


### PR DESCRIPTION
This change adds a dashed border around inline-editable elements when
hovering over them. This it becomes easier to see what exactly can be
edited in an element with multiple editable parts.