### PR TITLE
[TASK] Make NodeTypeManager easier to read

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeTypeManager.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeTypeManager.php
@@ -14,6 +14,8 @@ namespace TYPO3\TYPO3CR\Domain\Service;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TYPO3CR\Exception\NodeConfigurationException;
+use TYPO3\TYPO3CR\Exception\NodeTypeIsFinalException;
 use TYPO3\TYPO3CR\Exception\NodeTypeNotFoundException;
 
 /**
@@ -51,6 +53,11 @@ class NodeTypeManager
     protected $fallbackNodeTypeName;
 
     /**
+     * @var array
+     */
+    protected $completeNodeTypeConfiguration;
+
+    /**
      * Return all registered node types.
      *
      * @param boolean $includeAbstractNodeTypes Whether to include abstract node types, defaults to TRUE
@@ -64,15 +71,13 @@ class NodeTypeManager
         }
         if ($includeAbstractNodeTypes) {
             return $this->cachedNodeTypes;
-        } else {
-            $nonAbstractNodeTypes = array();
-            foreach ($this->cachedNodeTypes as $nodeTypeName => $nodeType) {
-                if (!$nodeType->isAbstract()) {
-                    $nonAbstractNodeTypes[$nodeTypeName] = $nodeType;
-                }
-            }
-            return $nonAbstractNodeTypes;
         }
+
+        $nonAbstractNodeTypes = array_filter($this->cachedNodeTypes, function ($nodeType) {
+            return !$nodeType->isAbstract();
+        });
+
+        return $nonAbstractNodeTypes;
     }
 
     /**
@@ -90,19 +95,21 @@ class NodeTypeManager
             $this->loadNodeTypes();
         }
 
-        if (!isset($this->cachedSubNodeTypes[$superTypeName])) {
-            $filteredNodeTypes = array();
-            /** @var NodeType $nodeType */
-            foreach ($this->cachedNodeTypes as $nodeTypeName => $nodeType) {
-                if ($includeAbstractNodeTypes === false && $nodeType->isAbstract()) {
-                    continue;
-                }
-                if ($nodeType->isOfType($superTypeName) && $nodeTypeName !== $superTypeName) {
-                    $filteredNodeTypes[$nodeTypeName] = $nodeType;
-                }
-            }
-            $this->cachedSubNodeTypes[$superTypeName] = $filteredNodeTypes;
+        if (isset($this->cachedSubNodeTypes[$superTypeName])) {
+            return $this->cachedSubNodeTypes[$superTypeName];
         }
+
+        $filteredNodeTypes = [];
+        /** @var NodeType $nodeType */
+        foreach ($this->cachedNodeTypes as $nodeTypeName => $nodeType) {
+            if ($includeAbstractNodeTypes === false && $nodeType->isAbstract()) {
+                continue;
+            }
+            if ($nodeType->isOfType($superTypeName) && $nodeTypeName !== $superTypeName) {
+                $filteredNodeTypes[$nodeTypeName] = $nodeType;
+            }
+        }
+        $this->cachedSubNodeTypes[$superTypeName] = $filteredNodeTypes;
 
         return $this->cachedSubNodeTypes[$superTypeName];
     }
@@ -164,13 +171,22 @@ class NodeTypeManager
     /**
      * Loads all node types into memory.
      *
+     * @return array $completeNodeTypeConfiguration
      * @return void
      */
-    protected function loadNodeTypes()
+    protected function loadNodeTypes(array $completeNodeTypeConfiguration = [])
     {
-        $completeNodeTypeConfiguration = $this->configurationManager->getConfiguration('NodeTypes');
+        if ($this->cachedNodeTypes !== []) {
+            return;
+        }
+
+        if ($completeNodeTypeConfiguration === []) {
+            $completeNodeTypeConfiguration = $this->configurationManager->getConfiguration('NodeTypes');
+        }
+        $this->completeNodeTypeConfiguration = $completeNodeTypeConfiguration;
+
         foreach (array_keys($completeNodeTypeConfiguration) as $nodeTypeName) {
-            $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration);
+            $this->loadNodeType($nodeTypeName);
         }
     }
 
@@ -187,74 +203,102 @@ class NodeTypeManager
     public function overrideNodeTypes(array $completeNodeTypeConfiguration)
     {
         $this->cachedNodeTypes = array();
-        foreach (array_keys($completeNodeTypeConfiguration) as $nodeTypeName) {
-            $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration);
-        }
+        $this->loadNodeTypes($completeNodeTypeConfiguration);
     }
 
     /**
      * Load one node type, if it is not loaded yet.
      *
      * @param string $nodeTypeName
-     * @param array $completeNodeTypeConfiguration the full node type configuration for all node types
      * @return NodeType
      * @throws \TYPO3\TYPO3CR\Exception
      */
-    protected function loadNodeType($nodeTypeName, array $completeNodeTypeConfiguration)
+    protected function loadNodeType($nodeTypeName)
     {
         if (isset($this->cachedNodeTypes[$nodeTypeName])) {
             return $this->cachedNodeTypes[$nodeTypeName];
         }
 
-        if (!isset($completeNodeTypeConfiguration[$nodeTypeName])) {
+        if (!isset($this->completeNodeTypeConfiguration[$nodeTypeName])) {
             throw new \TYPO3\TYPO3CR\Exception('Node type "' . $nodeTypeName . '" does not exist', 1316451800);
         }
 
-        $nodeTypeConfiguration = $completeNodeTypeConfiguration[$nodeTypeName];
-
-        $superTypes = array();
-        if (isset($nodeTypeConfiguration['superTypes'])) {
-            foreach ($nodeTypeConfiguration['superTypes'] as $superTypeName => $enabled) {
-                // Skip unset node types
-                if ($enabled === false || $enabled === null) {
-                    $superTypes[$superTypeName] = null;
-                    continue;
-                }
-
-                // Make this setting backwards compatible with old array schema (deprecated since 2.0)
-                if (!is_bool($enabled)) {
-                    $superTypeName = $enabled;
-                }
-
-                // when removing super types by setting them to null, only string keys can be overridden
-                if ($superTypeName === null) {
-                    throw new \TYPO3\TYPO3CR\Exception\NodeConfigurationException('Node type "' . $nodeTypeName . '" sets super type with a non-string key to NULL.', 1416578395);
-                }
-
-                $superType = $this->loadNodeType($superTypeName, $completeNodeTypeConfiguration);
-                if ($superType->isFinal() === true) {
-                    throw new \TYPO3\TYPO3CR\Exception\NodeTypeIsFinalException('Node type "' . $nodeTypeName . '" has a super type "' . $superType->getName() . '" which is final.', 1316452423);
-                }
-
-                $superTypes[$superTypeName] = $superType;
-            }
+        $nodeTypeConfiguration = $this->completeNodeTypeConfiguration[$nodeTypeName];
+        try {
+            $superTypes = isset($nodeTypeConfiguration['superTypes']) ? $this->evaluateSuperTypesConfiguration($nodeTypeConfiguration['superTypes']) : [];
+        } catch (NodeConfigurationException $exception) {
+            throw new NodeConfigurationException('Node type "' . $nodeTypeName . '" sets super type with a non-string key to NULL.', 1416578395);
+        } catch (NodeTypeIsFinalException $exception) {
+            throw new NodeTypeIsFinalException('Node type "' . $nodeTypeName . '" has a super type "' . $exception->getMessage() . '" which is final.', 1316452423);
         }
 
         // Remove unset properties
-        if (isset($nodeTypeConfiguration['properties'])) {
-            foreach ($nodeTypeConfiguration['properties'] as $propertyName => $propertyConfiguration) {
-                if ($propertyConfiguration === null) {
-                    unset($nodeTypeConfiguration['properties'][$propertyName]);
-                }
-            }
-            if ($nodeTypeConfiguration['properties'] === array()) {
-                unset($nodeTypeConfiguration['properties']);
-            }
+        $properties = [];
+        if (isset($nodeTypeConfiguration['properties']) && is_array($nodeTypeConfiguration['properties'])) {
+            $properties = $nodeTypeConfiguration['properties'];
+        }
+
+        $nodeTypeConfiguration['properties'] = array_filter($properties, function ($propertyConfiguration) {
+            return $propertyConfiguration !== null;
+        });
+
+        if ($nodeTypeConfiguration['properties'] === []) {
+            unset($nodeTypeConfiguration['properties']);
         }
 
         $nodeType = new NodeType($nodeTypeName, $superTypes, $nodeTypeConfiguration);
 
         $this->cachedNodeTypes[$nodeTypeName] = $nodeType;
         return $nodeType;
+    }
+
+    /**
+     * Evaluates the given superTypes configuation and returns the array of effective superTypes.
+     *
+     * @param array $superTypesConfiguration
+     * @return array
+     */
+    protected function evaluateSuperTypesConfiguration(array $superTypesConfiguration)
+    {
+        $superTypes = [];
+        foreach ($superTypesConfiguration as $superTypeName => $enabled) {
+            $superTypes[$superTypeName] = $this->evaluateSuperTypeConfiguration($superTypeName, $enabled);
+        }
+
+        return $superTypes;
+    }
+
+    /**
+     * Evaluates a single superType configuration and returns the NodeType if enabled.
+     *
+     * @param string $superTypeName
+     * @param boolean $enabled
+     * @return NodeType
+     * @throws NodeConfigurationException
+     * @throws NodeTypeIsFinalException
+     */
+    protected function evaluateSuperTypeConfiguration($superTypeName, $enabled)
+    {
+        // Skip unset node types
+        if ($enabled === false || $enabled === null) {
+            return null;
+        }
+
+        // Make this setting backwards compatible with old array schema (deprecated since 2.0)
+        if (!is_bool($enabled)) {
+            $superTypeName = $enabled;
+        }
+
+        // when removing super types by setting them to null, only string keys can be overridden
+        if ($superTypeName === null) {
+            throw new NodeConfigurationException('Node type sets super type with a non-string key to NULL.', 1444944152);
+        }
+
+        $superType = $this->loadNodeType($superTypeName);
+        if ($superType->isFinal() === true) {
+            throw new NodeTypeIsFinalException($superType->getName(), 1444944148);
+        }
+
+        return $superType;
     }
 }


### PR DESCRIPTION
Splits the NodeTypeManager into smaller methods and reduces
overall complexity.