### PR TITLE
[BUGFIX] Use correct object property in PluginViewImplementation

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginViewImplementation.php
@@ -120,7 +120,7 @@ class PluginViewImplementation extends PluginImplementation
             if ($this->node->getProperty('view')) {
                 $message ='Master View or Plugin View not found';
             }
-            return $this->pluginViewNode->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
+            return $this->node->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
         }
         $this->dispatcher->dispatch($pluginRequest, $pluginResponse);
         return $pluginResponse->getContent();


### PR DESCRIPTION
Regression introduced in 13517506b9ae5ac0050b5336266677b2ee4e3963
by using wrong variable name for the current node in the ``PluginViewImplementation``.