### PR TITLE
[TASK] Remove custom exception handling in ``PluginImplementation``

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/PluginImplementation.php
@@ -147,20 +147,15 @@ class PluginImplementation extends AbstractArrayTypoScriptObject
      */
     public function evaluate()
     {
-        try {
-            $currentContext = $this->tsRuntime->getCurrentContext();
-            $this->node = $currentContext['node'];
-            $this->documentNode = $currentContext['documentNode'];
-            /** @var $parentResponse Response */
-            $parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
-            $pluginResponse = new Response($parentResponse);
+        $currentContext = $this->tsRuntime->getCurrentContext();
+        $this->node = $currentContext['node'];
+        $this->documentNode = $currentContext['documentNode'];
+        /** @var $parentResponse Response */
+        $parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
+        $pluginResponse = new Response($parentResponse);
 
-            $this->dispatcher->dispatch($this->buildPluginRequest(), $pluginResponse);
-            $content = $pluginResponse->getContent();
-        } catch (\Exception $exception) {
-            $content = $this->tsRuntime->handleRenderingException($this->path, $exception);
-        }
-        return $content;
+        $this->dispatcher->dispatch($this->buildPluginRequest(), $pluginResponse);
+        $content = $pluginResponse->getContent();
     }
 
     /**

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/PluginView.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/PluginView.ts2
@@ -11,5 +11,4 @@ prototype(TYPO3.Neos:PluginView) < prototype(TYPO3.Neos:Content) {
 			1 = 'node'
 		}
 	}
-	@exceptionHandler = 'TYPO3\\Neos\\TypoScript\\ExceptionHandlers\\NodeWrappingHandler'
 }


### PR DESCRIPTION
Removes the custom handling of exceptions for PluginViews, which is unnecessary.
Instead the general ``NodeWrapping`` exception handler is used.

Additionally removes redundant ``@exceptionHandler`` from plugin view,
since it's inherited from the content prototype.