### PR TITLE
[TASK] Keep track of link during TS rendering

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ConvertUrisImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ConvertUrisImplementation.php
@@ -97,9 +97,11 @@ class ConvertUrisImplementation extends AbstractTypoScriptObject
             switch ($matches[1]) {
                 case 'node':
                     $resolvedUri = $linkingService->resolveNodeUri($matches[0], $node, $controllerContext, $absolute);
+                    $this->tsRuntime->addCacheTag('node', $matches[2]);
                     break;
                 case 'asset':
                     $resolvedUri = $linkingService->resolveAssetUri($matches[0]);
+                    $this->tsRuntime->addCacheTag('asset', $matches[2]);
                     break;
                 default:
                     $resolvedUri = null;

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Runtime.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Runtime.php
@@ -144,6 +144,24 @@ class Runtime
     }
 
     /**
+     * Add a tag to the current cache segment
+     *
+     * During TS rendering the method can be used to add tag dynamicaly for the current cache segment.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     * @api
+     */
+    public function addCacheTag($key, $value)
+    {
+        if ($this->runtimeContentCache->getEnableContentCache() === false) {
+            return;
+        }
+        $this->runtimeContentCache->addTag($key, $value);
+    }
+
+    /**
      * Completely replace the context array with the new $contextArray.
      *
      * Purely internal method, should not be called outside of TYPO3.TypoScript.


### PR DESCRIPTION
This change add a new service in the TypoScript package to add dynamic tag
to the current TS rendering path.

This new service is used in the Neos ConvertUrisImplementation to keep
track of link to node and asset and tag the current patch correctly.

Resolves: NEOS-1640