### PR TITLE
[TASK] Change documentation for data sources

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/CustomizingInspector.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CustomizingInspector.rst
@@ -147,7 +147,7 @@ Yaml (Sites/Vendor.Site/Configuration/NodeTypes.yaml) ::
 Use custom DataSources for a selectbox element
 ==============================================
 
-To add custom selectbox-options Neos uses :ref:`data-sources` for the inspector that can be implemented via php.
+To add custom selectbox-options, Neos uses `data-sources` for the inspector that can be implemented via php. These custom data-sources needs to return a serializable data structure in a format like described in :ref:`property-editor-reference`.
 
 Yaml (Sites/Vendor.Site/Configuration/NodeTypes.yaml) ::
 
@@ -158,7 +158,7 @@ Yaml (Sites/Vendor.Site/Configuration/NodeTypes.yaml) ::
           inspector:
             editor: Content/Inspector/Editors/SelectBoxEditor
             editorOptions:
-              dataSourceIdentifier: 'acme-yourpackage-test''
+              dataSourceIdentifier: 'acme-yourpackage-test'
 
 
 Remove fields from an existing Node Type

--- a/TYPO3.Neos/Documentation/ExtendingNeos/DataSources.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/DataSources.rst
@@ -51,28 +51,28 @@ Example ``TestDataSource.php``:
 
 .. code-block:: php
 
-	<?php
-	namespace Acme\YourPackage\DataSource;
+    <?php
+    namespace Acme\YourPackage\DataSource;
 
-	use TYPO3\Neos\Service\DataSource\AbstractDataSource;
-	use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+    use TYPO3\Neos\Service\DataSource\AbstractDataSource;
+    use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
-	class TestDataSource extends AbstractDataSource {
+    class TestDataSource extends AbstractDataSource {
 
-		/**
-		 * @var string
-		 */
-		static protected $identifier = 'acme-yourpackage-test';
+        /**
+         * @var string
+         */
+        static protected $identifier = 'acme-yourpackage-test';
 
-		/**
-		 * Get data
-		 *
-		 * @param NodeInterface $node The node that is currently edited (optional)
-		 * @param array $arguments Additional arguments (key / value)
-		 * @return array JSON serializable data
-		 */
-		public function getData(NodeInterface $node = NULL, array $arguments) {
-			return isset($arguments['integers']) ? array(1, 2, 3) : array('a', 'b', 'c');
-		}
-
-	}
+        /**
+         * Get data
+         *
+         * @param NodeInterface $node The node that is currently edited (optional)
+         * @param array $arguments Additional arguments (key / value)
+         * @return array JSON serializable data
+         */
+        public function getData(NodeInterface $node = NULL, array $arguments)
+        {
+            return isset($arguments['integers']) ? array(1, 2, 3) : array('a', 'b', 'c');
+        }
+    }


### PR DESCRIPTION
Fix doubled quotes in CustomizingInspector.rst
Change the example in DataSources.rst - the example now makes sens for the use
in an inspector select box. Also adjust the code style.