### PR TITLE
[TASK] Adjust default label for nodes

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -1,6 +1,6 @@
 # Base node, which just configures the "removed" property of the node.
 'TYPO3.Neos:Node':
-  label: "${String.cropAtWord(String.trim(String.stripTags(q(node).property('title') || q(node).property('text') || ((node.nodeType.label || node.nodeType.name) + ' (' + node.name + ')'))), 100, '...')}"
+  label: "${String.cropAtWord(String.trim(String.stripTags(q(node).property('title') || q(node).property('text') || ((node.nodeType.label || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')))), 100, '...')}"
   abstract: TRUE
   properties:
     _removed:


### PR DESCRIPTION
The label inherited from the Node nodetype included the node name, which
is not very helpful for content nodes and can be confusing.

With this change, the (default) label for nodes no longer includes the
node name unless the node has been auto-created. That means that for
ContentCollection nodes it will still be shown like before in most cases.