### PR TITLE
[FEATURE] Make reference starting point configurable

### DIFF
--- a/TYPO3.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/TYPO3.Neos/Documentation/References/PropertyEditorReference.rst
@@ -347,6 +347,12 @@ Options Reference:
 ``placeholder`` (string)
 	Placeholder text to be shown if nothing is selected
 
+``startingPoint`` (string)
+	The starting point (node path) for finding possible nodes to create a reference.
+	This allows to search for nodes outside the current site. If not given, nodes
+	will be searched for in the current site. For all nodes outside the current site
+	the node path is shown instead of the url path.
+
 ``threshold`` (number)
 	Minimum amount of characters which trigger a search
 

--- a/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -10,9 +10,11 @@
 				<li class="node">
 					<span class="node-path">{node.path}</span>
 					<f:alias map="{documentNode: '{neos:node.closestDocument(node: node)}'}">
-					<neos:link.node node="{documentNode}" absolute="true" resolveShortcuts="false" class="node-frontend-uri">
-						<neos:uri.node node="{documentNode}" absolute="false" resolveShortcuts="false" />
-					</neos:link.node>
+						<f:alias map="{relativeUrl: '{neos:uri.node(node: documentNode, absolute: false, resolveShortcuts: false)}'}">
+							<a href="{neos:uri.node(node: documentNode, absolute: true, resolveShortcuts:false)}" class="node-frontend-uri">
+								{f:if(condition: relativeUrl, then: relativeUrl, else: node.path)}
+							</a>
+						</f:alias>
 					</f:alias>
 					<label class="node-label">{node.label}</label>
 					(<span class="node-identifier">{node.identifier}</span>)

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
@@ -25,9 +25,16 @@ define(
 			// Minimum amount of characters to trigger search
 			threshold: 2,
 
+			// The path to a node that defines the starting point for the reference search
+			startingPoint: null,
+
 			didInsertElement: function() {
 				var that = this,
 					currentQueryTimer = null;
+
+				if (this.get('startingPoint') === null) {
+					this.set('startingPoint', $('#neos-document-metadata').data('neos-site-node-context-path'));
+				}
 
 				this.$().select2({
 					multiple: true,
@@ -76,7 +83,7 @@ define(
 								searchTerm: query.term,
 								workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
 								dimensions: $('#neos-document-metadata').data('neos-context-dimensions'),
-								contextNode: $('#neos-document-metadata').data('neos-site-node-context-path'),
+								contextNode: that.get('startingPoint'),
 								nodeTypes: that.get('nodeTypes')
 							};
 
@@ -84,6 +91,7 @@ define(
 								var data = {results: []};
 								$(result.resource).find('li').each(function(index, value) {
 									var identifier = $('.node-identifier', value).text();
+
 									data.results.push({
 										id: identifier,
 										text: $('.node-label', value).text().trim(),

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
@@ -32,7 +32,7 @@ define(
 				var that = this,
 					currentQueryTimer = null;
 
-				if (this.get('startingPoint') === null) {
+				if (this.get('startingPoint') === null || this.get('startingPoint') === '') {
 					this.set('startingPoint', $('#neos-document-metadata').data('neos-site-node-context-path'));
 				}
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
@@ -33,7 +33,7 @@ define(
 				var that = this,
 					currentQueryTimer = null;
 
-				if (this.get('startingPoint') === null) {
+				if (this.get('startingPoint') === null || this.get('startingPoint') === '') {
 					this.set('startingPoint', $('#neos-document-metadata').data('neos-site-node-context-path'));
 				}
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
@@ -26,10 +26,17 @@ define(
 			// Minimum amount of characters to trigger search
 			threshold: 2,
 
-			didInsertElement: function() {
-				var that = this;
+			// The path to a node that defines the starting point for the reference search
+			startingPoint: null,
 
-				var currentQueryTimer = null;
+			didInsertElement: function() {
+				var that = this,
+					currentQueryTimer = null;
+
+				if (this.get('startingPoint') === null) {
+					this.set('startingPoint', $('#neos-document-metadata').data('neos-site-node-context-path'));
+				}
+
 				this.$().select2({
 					multiple: true,
 					minimumInputLength: that.get('threshold'),
@@ -76,7 +83,7 @@ define(
 								searchTerm: query.term,
 								workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
 								dimensions: $('#neos-document-metadata').data('neos-context-dimensions'),
-								contextNode: $('#neos-document-metadata').data('neos-site-node-context-path'),
+								contextNode: that.get('startingPoint'),
 								nodeTypes: that.get('nodeTypes')
 							};
 
@@ -84,6 +91,7 @@ define(
 								var data = {results: []};
 								$(result.resource).find('li').each(function(index, value) {
 									var identifier = $('.node-identifier', value).text();
+
 									data.results.push({
 										id: identifier,
 										text: $('.node-label', value).text().trim(),


### PR DESCRIPTION
With this feature the starting point for finding possible nodes
to create a reference becomes configurable via ``NodeTypes``
configuration. This allows to search for nodes outside the
current site.

For all nodes outside the current site the node path is shown instead
of the url path.