### PR TITLE
Task skip command without nodetype support

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/AbstractThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/AbstractThumbnailGenerator.php
@@ -1,0 +1,108 @@
+<?php
+namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use Imagine\Image\ImagineInterface;
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Exception;
+
+/**
+ * Abstract Thumbnail Generator
+ */
+abstract class AbstractThumbnailGenerator implements ThumbnailGeneratorInterface
+{
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Utility\Environment
+     */
+    protected $environment;
+
+    /**
+     * @var ImagineInterface
+     * @Flow\Inject(lazy = false)
+     */
+    protected $imagineService;
+
+    /**
+     * @var ResourceManager
+     * @Flow\Inject
+     */
+    protected $resourceManager;
+
+    /**
+     * The priority for this thumbnail generator.
+     *
+     * @var integer
+     * @api
+     */
+    protected $priority;
+
+    /**
+     * @var array
+     */
+    protected $supportedExtensions = array();
+
+    /**
+     * @var string
+     */
+    protected $currentExtension;
+
+    /**
+     * @Flow\InjectConfiguration(path="image.defaultOptions")
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @return integer
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean TRUE if this ThumbnailGenerator can convert the given thumbnail, FALSE otherwise.
+     * @api
+     */
+    public function canRefresh(Thumbnail $thumbnail)
+    {
+        return true;
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean
+     */
+    protected function isExtensionSupported(Thumbnail $thumbnail)
+    {
+        $this->currentExtension = $thumbnail->getOriginalAsset()->getResource()->getFileExtension();
+        return in_array($this->currentExtension, $this->supportedExtensions);
+    }
+
+    /**
+     * @param array $files
+     */
+    protected function unlinkTemporaryFiles(array $files)
+    {
+        foreach ($files as $file) {
+            if (!is_file($file)) {
+                continue;
+            }
+            unlink($file);
+        }
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -1,0 +1,84 @@
+<?php
+namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Media\Domain\Model\Document;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Exception;
+
+/**
+ * A system-generated preview version of an Pdf
+ */
+class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
+{
+    /**
+     * @var array
+     */
+    protected $supportedExtensions = array('pdf', 'eps', 'ai');
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean
+     */
+    public function canRefresh(Thumbnail $thumbnail)
+    {
+        return (
+            $thumbnail->getOriginalAsset() instanceof Document &&
+            $this->isExtensionSupported($thumbnail) &&
+            $this->imagineService instanceof \Imagine\Imagick\Imagine
+        );
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return void
+     * @throws Exception\NoThumbnailAvailableException
+     */
+    public function refresh(Thumbnail $thumbnail)
+    {
+        $transformedImageTemporaryPathAndFilename = null;
+        try {
+            $filename = pathinfo($thumbnail->getOriginalAsset()->getResource()->getFilename(), PATHINFO_FILENAME);
+
+            $temporaryLocalCopyFilename = $thumbnail->getOriginalAsset()->getResource()->createTemporaryLocalCopy();
+            $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('ProcessedDocumentThumbnail-') . '.' . $filename . '.png';
+
+            if ($this->currentExtension === 'pdf') {
+                // Just to be sure we extract only the first page of the PDF
+                $imageFile = sprintf('%s[0]', $temporaryLocalCopyFilename);
+            } else {
+                $imageFile = sprintf('%s', $temporaryLocalCopyFilename);
+            }
+
+            $imagick = new \Imagick();
+            $imagick->setResolution($this->options['resolution'], $this->options['resolution']);
+            $imagick->readImage($imageFile);
+            $imagick->setImageFormat('png');
+            $imagick->setImageBackgroundColor(new \ImagickPixel('white'));
+            $imagick->setImageCompose(\Imagick::COMPOSITE_OVER);
+            $imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
+            $imagick->thumbnailImage($thumbnail->getConfigurationValue('maximumWidth') ?: 1000, $thumbnail->getConfigurationValue('maximumHeight') ?: 1000, true);
+            $imagick->flattenImages();
+            $imagick->writeImage($transformedImageTemporaryPathAndFilename);
+
+            $resource = $this->resourceManager->importResource($transformedImageTemporaryPathAndFilename);
+            $thumbnail->setResource($resource, $imagick->getImageWidth(), $imagick->getImageHeight());
+
+            $this->unlinkTemporaryFiles([$transformedImageTemporaryPathAndFilename]);
+        } catch (\Exception $exception) {
+            $this->unlinkTemporaryFiles([$transformedImageTemporaryPathAndFilename]);
+            throw new Exception\NoThumbnailAvailableException('Unable to generate thumbnail for the given document', 1433109652, $exception);
+        }
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/FontDocumentThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/FontDocumentThumbnailGenerator.php
@@ -1,0 +1,81 @@
+<?php
+namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use Imagine\Image\ImagineInterface;
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Media\Domain\Model\Document;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Exception;
+
+/**
+ * A system-generated preview version of a TTF font
+ */
+class FontDocumentThumbnailGenerator extends AbstractThumbnailGenerator
+{
+    /**
+     * @var array
+     */
+    protected $supportedExtensions = array('ttf');
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean
+     */
+    public function canRefresh(Thumbnail $thumbnail)
+    {
+        return (
+            $this->isExtensionSupported($thumbnail) &&
+            function_exists('imagecreatetruecolor')
+        );
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return void
+     * @throws Exception\NoThumbnailAvailableException
+     */
+    public function refresh(Thumbnail $thumbnail)
+    {
+        $transformedImageTemporaryPathAndFilename = null;
+        try {
+            $filename = pathinfo($thumbnail->getOriginalAsset()->getResource()->getFilename(), PATHINFO_FILENAME);
+
+            $temporaryLocalCopyFilename = $thumbnail->getOriginalAsset()->getResource()->createTemporaryLocalCopy();
+            $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('ProcessedFontThumbnail-') . '.' . $filename . '.jpg';
+
+            $im = imagecreatetruecolor(300, 205);
+            $red = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
+            $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
+
+            imagefilledrectangle($im, 0, 0, 299, 204, $red);
+            imagefttext($im, 18, 0, 40, 50, $black, $temporaryLocalCopyFilename, 'Neos Font Preview');
+            imagefttext($im, 13, 0, 40, 80, $black, $temporaryLocalCopyFilename, 'ABCDEFGHIJK');
+            imagefttext($im, 13, 0, 40, 105, $black, $temporaryLocalCopyFilename, 'abcdefghijk');
+            imagefttext($im, 13, 0, 40, 130, $black, $temporaryLocalCopyFilename, '1234567890');
+            imagefttext($im, 12, 0, 40, 155, $black, $temporaryLocalCopyFilename, 'If something can corrupt you,');
+            imagefttext($im, 12, 0, 40, 174, $black, $temporaryLocalCopyFilename, 'you\'re corrupted already.');
+
+            imagejpeg($im, $transformedImageTemporaryPathAndFilename);
+
+            $resource = $this->resourceManager->importResource($transformedImageTemporaryPathAndFilename);
+            $thumbnail->setResource($resource, 300, 205);
+
+            $this->unlinkTemporaryFiles([$transformedImageTemporaryPathAndFilename]);
+        } catch (\Exception $exception) {
+            $this->unlinkTemporaryFiles([$transformedImageTemporaryPathAndFilename]);
+            throw new Exception\NoThumbnailAvailableException('Unable to generate thumbnail for the given font', 1433109671, $exception);
+        }
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -1,0 +1,72 @@
+<?php
+namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
+use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Domain\Service\ImageService;
+use TYPO3\Media\Exception;
+
+/**
+ * A system-generated preview version of an Image
+ */
+class ImageThumbnailGenerator extends AbstractThumbnailGenerator
+{
+    /**
+     * @var ImageService
+     * @Flow\Inject
+     */
+    protected $imageService;
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean
+     */
+    public function canRefresh(Thumbnail $thumbnail)
+    {
+        return (
+            $thumbnail->getOriginalAsset() instanceof ImageInterface
+        );
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return void
+     * @throws Exception\NoThumbnailAvailableException
+     */
+    public function refresh(Thumbnail $thumbnail)
+    {
+        try {
+            $adjustments = array(
+                new ResizeImageAdjustment(
+                    array(
+                        'width' => $thumbnail->getConfigurationValue('width'),
+                        'maximumWidth' => $thumbnail->getConfigurationValue('maximumWidth'),
+                        'height' => $thumbnail->getConfigurationValue('height'),
+                        'maximumHeight' => $thumbnail->getConfigurationValue('maximumHeight'),
+                        'ratioMode' => $thumbnail->getConfigurationValue('ratioMode'),
+                        'allowUpScaling' => $thumbnail->getConfigurationValue('allowUpScaling'),
+                    )
+                )
+            );
+
+            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments);
+
+            $thumbnail->setResource($processedImageInfo['resource'], $processedImageInfo['width'], $processedImageInfo['height']);
+        } catch (\Exception $exception) {
+            throw new Exception\NoThumbnailAvailableException('Unable to generate thumbnail for the given image', 1433109566, $exception);
+        }
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ThumbnailGeneratorInterface.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ThumbnailGeneratorInterface.php
@@ -1,0 +1,45 @@
+<?php
+namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Exception;
+
+/**
+ * Thumbnail Generate Interface
+ */
+interface ThumbnailGeneratorInterface
+{
+    /**
+     * Return the priority of this ThumbnailGenerator. ThumbnailGenerator with a high priority are chosen before low priority.
+     *
+     * @return integer
+     * @api
+     */
+    public function getPriority();
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean TRUE if this ThumbnailGenerator can convert the given thumbnail, FALSE otherwise.
+     * @api
+     */
+    public function canRefresh(Thumbnail $thumbnail);
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return void
+     * @api
+     */
+    public function refresh(Thumbnail $thumbnail);
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -41,15 +41,15 @@ class AssetService
      */
     public function getThumbnailUriAndSizeForAsset(AssetInterface $asset, ThumbnailConfiguration $configuration)
     {
-        if ($asset instanceof ImageInterface) {
-            $thumbnailImage = $this->thumbnailService->getThumbnail($asset, $configuration);
+        $thumbnailImage = $this->thumbnailService->getThumbnail($asset, $configuration);
+        if ($thumbnailImage instanceof ImageInterface) {
             $thumbnailData = array(
                 'width' => $thumbnailImage->getWidth(),
                 'height' => $thumbnailImage->getHeight(),
                 'src' => $this->resourceManager->getPublicPersistentResourceUri($thumbnailImage->getResource())
             );
         } else {
-            $thumbnailData = $this->getAssetThumbnailImage($asset, $configuration->getWidth() ?: $configuration->getMaximumWidth(), $configuration->getHeight() ?: $configuration->getMaximumHeight());
+            $thumbnailData = $this->getAssetIcon($asset, $configuration->getWidth() ?: $configuration->getMaximumWidth(), $configuration->getHeight() ?: $configuration->getMaximumHeight());
         }
 
         return $thumbnailData;
@@ -61,7 +61,7 @@ class AssetService
      * @param integer $maximumHeight
      * @return array
      */
-    protected function getAssetThumbnailImage(AssetInterface $asset, $maximumWidth, $maximumHeight)
+    protected function getAssetIcon(AssetInterface $asset, $maximumWidth, $maximumHeight)
     {
         // TODO: Could be configurable at some point
         $iconPackage = 'TYPO3.Media';

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
@@ -1,0 +1,78 @@
+<?php
+namespace TYPO3\Media\Domain\Strategy;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Utility\PositionalArraySorter;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Domain\Model\ThumbnailGenerator\ThumbnailGeneratorInterface;
+
+/**
+ * A strategy to detect the correct thumbnail generator
+ *
+ * @Flow\Scope("singleton")
+ */
+class ThumbnailGeneratorStrategy
+{
+    /**
+     * @var ObjectManagerInterface
+     * @Flow\Inject
+     */
+    protected $objectManager;
+
+    /**
+     * Refresh the given thumbnail
+     *
+     * @param Thumbnail $thumbnail
+     * @return void
+     */
+    public function refresh(Thumbnail $thumbnail)
+    {
+        $generatorClassNames = static::getThumbnailGeneratorClassNames($this->objectManager);
+        foreach ($generatorClassNames as $generator) {
+            $generator = $this->objectManager->get($generator['className']);
+            if (!$generator->canRefresh($thumbnail)) {
+                continue;
+            }
+            $generator->refresh($thumbnail);
+            return;
+        }
+    }
+
+    /**
+     * Returns all class names implementing the ThumbnailGeneratorInterface.
+     *
+     * @param ObjectManagerInterface $objectManager
+     * @return ThumbnailGeneratorInterface[]
+     * @Flow\CompileStatic
+     */
+    protected static function getThumbnailGeneratorClassNames($objectManager)
+    {
+        /** @var ReflectionService $reflectionService */
+        $reflectionService = $objectManager->get('TYPO3\Flow\Reflection\ReflectionService');
+        $generatorClassNames = $reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Media\Domain\Model\ThumbnailGenerator\ThumbnailGeneratorInterface');
+        $generators = array();
+        foreach ($generatorClassNames as $generatorClassName) {
+            /** @var ThumbnailGeneratorInterface $generator */
+            $generator = $objectManager->get($generatorClassName);
+            $generators[] = array(
+                'priority' => (integer)$generator->getPriority(),
+                'className' => $generatorClassName
+            );
+        }
+
+        $sorter = new PositionalArraySorter($generators, 'priority');
+        return array_reverse($sorter->toArray());
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
@@ -1,0 +1,127 @@
+<?php
+namespace TYPO3\Media\ViewHelpers;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "TYPO3.Media".           *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3 of the   *
+ * License, or (at your option) any later version.                        *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
+
+/**
+ * Renders an <img> HTML tag from a given TYPO3.Media's asset instance
+ *
+ * = Examples =
+ *
+ * <code title="Rendering an image as-is">
+ * <typo3.media:image image="{imageObject}" alt="a sample image without scaling" />
+ * </code>
+ * <output>
+ * (depending on the image, no scaling applied)
+ * <img src="_Resources/Persistent/b29[...]95d.jpeg" width="120" height="180" alt="a sample image without scaling" />
+ * </output>
+ *
+ *
+ * <code title="Rendering an image with scaling at a given width only">
+ * <typo3.media:image image="{imageObject}" maximumWidth="80" alt="sample" />
+ * </code>
+ * <output>
+ * (depending on the image; scaled down to a maximum width of 80 pixels, keeping the aspect ratio)
+ * <img src="_Resources/Persistent/b29[...]95d.jpeg" width="80" height="120" alt="sample" />
+ * </output>
+ *
+ *
+ * <code title="Rendering an image with scaling at given width and height, keeping aspect ratio">
+ * <typo3.media:image image="{imageObject}" maximumWidth="80" maximumHeight="80" alt="sample" />
+ * </code>
+ * <output>
+ * (depending on the image; scaled down to a maximum width and height of 80 pixels, keeping the aspect ratio)
+ * <img src="_Resources/Persistent/b29[...]95d.jpeg" width="53" height="80" alt="sample" />
+ * </output>
+ *
+ *
+ * <code title="Rendering an image with crop-scaling at given width and height">
+ * <typo3.media:image image="{imageObject}" maximumWidth="80" maximumHeight="80" allowCropping="true" alt="sample" />
+ * </code>
+ * <output>
+ * (depending on the image; scaled down to a width and height of 80 pixels, possibly changing aspect ratio)
+ * <img src="_Resources/Persistent/b29[...]95d.jpeg" width="80" height="80" alt="sample" />
+ * </output>
+ *
+ * <code title="Rendering an image with allowed up-scaling at given width and height">
+ * <typo3.media:image image="{imageObject}" maximumWidth="5000" allowUpScaling="true" alt="sample" />
+ * </code>
+ * <output>
+ * (depending on the image; scaled up or down to a width 5000 pixels, keeping aspect ratio)
+ * <img src="_Resources/Persistent/b29[...]95d.jpeg" width="80" height="80" alt="sample" />
+ * </output>
+ *
+ */
+class ThumbnailViewHelper extends AbstractTagBasedViewHelper
+{
+    /**
+     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @Flow\Inject
+     */
+    protected $resourceManager;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Media\Domain\Service\ThumbnailService
+     */
+    protected $thumbnailService;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Media\Domain\Service\AssetService
+     */
+    protected $assetService;
+
+    /**
+     * name of the tag to be created by this view helper
+     *
+     * @var string
+     */
+    protected $tagName = 'img';
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerUniversalTagAttributes();
+        $this->registerTagAttribute('alt', 'string', 'Specifies an alternate text for an image', true);
+    }
+
+    /**
+     * Renders an HTML img tag with a thumbnail image, created from a given asset.
+     *
+     * @param AssetInterface $asset The asset to be rendered as an thumbnail
+     * @param integer $maximumWidth Desired maximum height of the image
+     * @param integer $maximumHeight Desired maximum width of the image
+     * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
+     * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
+     *
+     * @return string an <img...> html tag
+     */
+    public function render(AssetInterface $asset = null, $maximumWidth = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false)
+    {
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $maximumWidth, $maximumHeight, $allowCropping, $allowUpScaling);
+
+        $this->tag->addAttributes(array(
+            'width' => $thumbnailData['width'],
+            'height' => $thumbnailData['height'],
+            'src' => $thumbnailData['src']
+        ));
+
+        return $this->tag->render();
+    }
+}

--- a/TYPO3.Media/Configuration/Settings.yaml
+++ b/TYPO3.Media/Configuration/Settings.yaml
@@ -25,6 +25,8 @@ TYPO3:
       defaultOptions:
         # Image quality, from 0 to 100
         'quality': 90
+        # Resolution used for Document preview (like PDF)
+        'resolution': 200
     bodyClasses: 'media-browser'
     scripts:
       - resource://TYPO3.Twitter.Bootstrap/Public/Libraries/jQuery/jquery-1.10.1.min.js

--- a/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
@@ -2,7 +2,7 @@
 <div{attributes -> f:format.raw()}>
 	<f:if condition="{formIdentifier}">
 		<f:then>
-			<form:render persistenceIdentifier="{formIdentifier}" presetName="{presetName}" />
+			<form:render persistenceIdentifier="{formIdentifier}" presetName="{presetName}" overrideConfiguration="{overrideConfiguration}" />
 		</f:then>
 		<f:else>
 			<p>Please select a valid Form identifier in the inspector</p>

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -108,7 +108,11 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
         $this->output = $output;
         switch ($controllerCommandName) {
             case 'repair':
-                $this->generateUriPathSegments($workspaceName, $dryRun);
+                if ($nodeType !== null) {
+                    $this->output->outputLine('Skip <u>Generate missing URI path segments</u>, nodeType argument not supported');
+                } else {
+                    $this->generateUriPathSegments($workspaceName, $dryRun);
+                }
         }
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
@@ -95,13 +95,14 @@ class NodesController extends ActionController
      * Shows a list of nodes
      *
      * @param string $searchTerm An optional search term used for filtering the list of nodes
+     * @param array $nodeIdentifiers An optional list of node identifiers
      * @param string $workspaceName Name of the workspace to search in, "live" by default
      * @param array $dimensions Optional list of dimensions and their values which should be used for querying
      * @param array $nodeTypes A list of node types the list should be filtered by
      * @param NodeInterface $contextNode a node to use as context for the search
      * @return string
      */
-    public function indexAction($searchTerm = '', $workspaceName = 'live', array $dimensions = array(), array $nodeTypes = array('TYPO3.Neos:Document'), NodeInterface $contextNode = null)
+    public function indexAction($searchTerm = '', array $nodeIdentifiers = array(), $workspaceName = 'live', array $dimensions = array(), array $nodeTypes = array('TYPO3.Neos:Document'), NodeInterface $contextNode = null)
     {
         $searchableNodeTypeNames = array();
         foreach ($nodeTypes as $nodeTypeName) {
@@ -117,7 +118,11 @@ class NodesController extends ActionController
         }
 
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
-        $nodes = $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode);
+        if ($nodeIdentifiers === array()) {
+            $nodes = $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode);
+        } else {
+            $nodes = $this->nodeSearchService->findByIdentifiers($nodeIdentifiers, $contentContext, $contextNode);
+        }
 
         $this->view->assign('nodes', $nodes);
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeSearchService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeSearchService.php
@@ -71,4 +71,26 @@ class NodeSearchService implements NodeSearchServiceInterface
 
         return $searchResult;
     }
+
+    /**
+     * @param array $nodeIdentifiers
+     * @param Context $context
+     * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
+     */
+    public function findByIdentifiers(array $nodeIdentifiers, Context $context)
+    {
+        if ($nodeIdentifiers === array()) {
+            throw new \InvalidArgumentException('"nodeIdentifiers" cannot be empty: provide a list of node identifiers to search for.', 1421329285);
+        }
+        $searchResult = array();
+        foreach ($nodeIdentifiers as $identifier) {
+            $nodeData = $this->nodeDataRepository->findOneByIdentifier($identifier, $context->getWorkspace(), $context->getDimensions());
+            $node = $this->nodeFactory->createFromNodeData($nodeData, $context);
+            if ($node !== null) {
+                $searchResult[$node->getPath()] = $node;
+            }
+        }
+
+        return $searchResult;
+    }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeSearchServiceInterface.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeSearchServiceInterface.php
@@ -26,4 +26,11 @@ interface NodeSearchServiceInterface
      * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
      */
     public function findByProperties($term, array $searchNodeTypes, Context $context);
+
+    /**
+     * @param array $nodeIdentifiers
+     * @param Context $context
+     * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
+     */
+    public function findByIdentifiers(array $nodeIdentifiers, Context $context);
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -161,9 +161,21 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
         switch ($controllerCommandName) {
             case 'repair':
                 if ($cleanup === true) {
-                    $this->removeAbstractAndUndefinedNodes($workspaceName, $dryRun);
-                    $this->removeOrphanNodes($workspaceName, $dryRun);
-                    $this->removeDisallowedChildNodes($workspaceName, $dryRun);
+                    if ($nodeType !== null) {
+                        $this->output->outputLine('Skip <u>Remove abstract and undefined node types</u>, nodeType argument not supported');
+                    } else {
+                        $this->removeAbstractAndUndefinedNodes($workspaceName, $dryRun);
+                    }
+                    if ($nodeType !== null) {
+                        $this->output->outputLine('Skip <u>Remove orphan (parentless) nodes</u>, nodeType argument not supported');
+                    } else {
+                        $this->removeOrphanNodes($workspaceName, $dryRun);
+                    }
+                    if ($nodeType !== null) {
+                        $this->output->outputLine('Skip <u>Remove disallowed child nodes</u>, nodeType argument not supported');
+                    } else {
+                        $this->removeDisallowedChildNodes($workspaceName, $dryRun);
+                    }
                     $this->removeUndefinedProperties($nodeType, $workspaceName, $dryRun);
                 }
                 $this->createMissingChildNodes($nodeType, $workspaceName, $dryRun);


### PR DESCRIPTION
Current when running a command with $nodeType not null, the node:repair command run all command, even those without support for $nodeType argument. This change just skip command if they don't implement the $nodeType filter.