### PR TITLE
[FEATURE] Allow property editors to listen to changes

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/DependingProperties.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/DependingProperties.rst
@@ -4,72 +4,78 @@ Depending Properties
 ====================
 
 .. note:: This API is still experimental, we might change details about the handler
-   signature and implementation to reduce the amount of exposed internal code, also
-   the UI code is undergoing major changes right now which also might make
-   adjustments necessary.
+   signature and implementation to reduce the amount of exposed internal code. The
+   UI code is undergoing major changes right now which also might make adjustments
+   necessary.
 
 Sometimes it might be necessary to depend one property editor on another,
 such as two select boxes where one selection is not meaningful without the other.
 For that you can setup listeners that get triggered each time a property changes.
 
-The general configuration would look like this::
+Here is an example of the configuration:
 
-	'Some.Package:NodeType':
-	  properties:
-	    border-width:
-	      type: integer
-	    border-color:
-	      type: string
-	      ui:
-	        label: i18n
-	        inspector:
-	          editorListeners:
-	            activeWithNonEmptyValue:
-	              property: 'border-width'
-	              handler: 'Some.Package/Handlers/BorderHandler'
-	              handlerOptions:
-	                something: true
+.. code-block:: yaml
 
-Now this would setup a listener named ``activeWithNonEmptyValue``, a name which
-you can decide on. This allows you to override specific listeners in other packages by
-refering to that name.
+  'Some.Package:NodeType':
+    properties:
+      border-width:
+        type: integer
+      border-color:
+        type: string
+        ui:
+          label: i18n
+          inspector:
+            editorListeners:
+              activeWithNonEmptyValue:
+                property: 'border-width'
+                handler: 'Some.Package/Handlers/BorderHandler'
+                handlerOptions:
+                  something: true
+
+This sets up a listener named ``activeWithNonEmptyValue``. The name can be freely chosen.
+This allows to override specific listeners in other packages by refering to that name.
 The ``property`` setting defines the name of the property on the same Node that will be
 observed. That means any change to this property will trigger the configured ``handler``.
+
 Configuring the ``handler`` means defining a require path to the handler object just like
-with custom property editors :ref:`custom-editors`.
+with :ref:`custom-editors` for properties. Namespaces can be registered like this:
 
-Namespaces can be registered like this, as with validators::
+.. code-block:: yaml
 
-	TYPO3:
-	  Neos:
-	    userInterface:
-	      requireJsPathMapping:
-	        'Some.Package/Handlers': 'resource://Some.Package/Public/Scripts/Inspector/Handlers'
+  TYPO3:
+    Neos:
+      userInterface:
+        requireJsPathMapping:
+          'Some.Package/Handlers': 'resource://Some.Package/Public/Scripts/Inspector/Handlers'
 
-The handler should be compatible to RequireJS and be an Ember.Object that has a ``handle`` function.
-The ``handlerOptions`` configured for the listener in the NdoeType configuration will be given to the
-handler and available in the handle method.
+The handler should be compatible to RequireJS and be an ``Ember.Object`` that has a ``handle`` function.
+The ``handlerOptions`` configured for the listener in the NodeType configuration will be given to the
+handler upon creation and are available in the ``handle`` method.
 
-A code example for a handler::
+A code example for a handler:
 
-	define(
-	[
-	    'emberjs',
-	],
-	function (Ember) {
-	    return Ember.Object.extend({
-	        handle: function(listeningEditor, newValue, property, listenerName) {
-	            listeningEditor.set('disabled', (newValue === null || newValue === ''));
-	        }
-	    });
-	});
+.. code-block:: js
+
+  define(
+  [
+      'emberjs'
+  ],
+  function (Ember) {
+      return Ember.Object.extend({
+          handle: function(listeningEditor, newValue, property, listenerName) {
+              if (this.get('something') === true) {
+                  listeningEditor.set('disabled', (newValue === null || newValue === ''));
+              }
+          }
+      });
+  });
 
 The handle function receives the following arguments:
 
- - listeningEditor - The property editor this listener is configured for, in the above example it will
-   be the ``border-color`` editor.
- - newValue will be the value of the observed property, which is the ``border-width`` probpery in the
-   above example.
- - property is the name of the observed property, literally ``border-width`` in the above example.
- - listenerName is the configured name of the listener in question, literally ``activeWithNonEmptyValue``
-   in the example above.
+- ``listeningEditor`` - The property editor this listener is configured for, in the above example it will
+  be the ``border-color`` editor.
+- ``newValue`` will be the value of the observed property, which is the ``border-width`` probpery in the
+  above example.
+- ``property`` is the name of the observed property, literally ``border-width`` in the above example.
+- ``listenerName`` is the configured name of the listener in question, literally ``activeWithNonEmptyValue``
+  in the example above.

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/DependingProperties.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/DependingProperties.rst
@@ -1,0 +1,75 @@
+.. _depending-properties:
+
+Depending Properties
+====================
+
+.. note:: This API is still experimental, we might change details about the handler
+   signature and implementation to reduce the amount of exposed internal code, also
+   the UI code is undergoing major changes right now which also might make
+   adjustments necessary.
+
+Sometimes it might be necessary to depend one property editor on another,
+such as two select boxes where one selection is not meaningful without the other.
+For that you can setup listeners that get triggered each time a property changes.
+
+The general configuration would look like this::
+
+	'Some.Package:NodeType':
+	  properties:
+	    border-width:
+	      type: integer
+	    border-color:
+	      type: string
+	      ui:
+	        label: i18n
+	        inspector:
+	          editorListeners:
+	            activeWithNonEmptyValue:
+	              property: 'border-width'
+	              handler: 'Some.Package/Handlers/BorderHandler'
+	              handlerOptions:
+	                something: true
+
+Now this would setup a listener named ``activeWithNonEmptyValue``, a name which
+you can decide on. This allows you to override specific listeners in other packages by
+refering to that name.
+The ``property`` setting defines the name of the property on the same Node that will be
+observed. That means any change to this property will trigger the configured ``handler``.
+Configuring the ``handler`` means defining a require path to the handler object just like
+with custom property editors :ref:`custom-editors`.
+
+Namespaces can be registered like this, as with validators::
+
+	TYPO3:
+	  Neos:
+	    userInterface:
+	      requireJsPathMapping:
+	        'Some.Package/Handlers': 'resource://Some.Package/Public/Scripts/Inspector/Handlers'
+
+The handler should be compatible to RequireJS and be an Ember.Object that has a ``handle`` function.
+The ``handlerOptions`` configured for the listener in the NdoeType configuration will be given to the
+handler and available in the handle method.
+
+A code example for a handler::
+
+	define(
+	[
+	    'emberjs',
+	],
+	function (Ember) {
+	    return Ember.Object.extend({
+	        handle: function(listeningEditor, newValue, property, listenerName) {
+	            listeningEditor.set('disabled', (newValue === null || newValue === ''));
+	        }
+	    });
+	});
+
+The handle function receives the following arguments:
+
+ - listeningEditor - The property editor this listener is configured for, in the above example it will
+   be the ``border-color`` editor.
+ - newValue will be the value of the observed property, which is the ``border-width`` probpery in the
+   above example.
+ - property is the name of the observed property, literally ``border-width`` in the above example.
+ - listenerName is the configured name of the listener in question, literally ``activeWithNonEmptyValue``
+   in the example above.

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -243,6 +243,9 @@ The following options are allowed:
       ``editorOptions``
         A set of options for the given editor, see the :ref:`property-editor-reference`.
 
+      ``editorListeners``
+        Allows to observe changes of other properties in order to react to them. For details see :ref:`depending-properties`
+
   ``validation``
     A list of validators to use on the property. Below each validator type any options for the validator
     can be given. See below for more information.

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/index.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/index.rst
@@ -10,3 +10,4 @@ These are the development guidelines of Neos.
 	NodeTypeDefinition
 	NodeConstraints
 	TranslateNodeTypes
+	DependingProperties

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -104,6 +104,18 @@ additionalProperties:
 
                   'editorOptions': { type: dictionary, description: 'options for the given editor' }
 
+                  'editorListeners':
+                    type: dictionary
+                    additionalProperties:
+                      type: dictionary
+                      properties:
+                        'property': { type: ['string'], description: 'The name of an observed property in the same NodeType.' }
+                        'handler': { type: ['string'], description: 'The path to a handler JavaScript object, similar to custom editors and validators.' }
+                        'handlerOptions':
+                          type: dictionary
+                          additionalProperties:
+                            type: ['string', 'null', 'dictionary', 'boolean', 'array']
+
     'ui':
       # here, we specify ONLY the "ui" part of the schema, as the remaining parts
       # are already specified in the NodeTypes schema of the TYPO3CR package

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -108,13 +108,11 @@ additionalProperties:
                     type: dictionary
                     additionalProperties:
                       type: dictionary
+                      additionalProperties: FALSE
                       properties:
                         'property': { type: ['string'], description: 'The name of an observed property in the same NodeType.' }
                         'handler': { type: ['string'], description: 'The path to a handler JavaScript object, similar to custom editors and validators.' }
-                        'handlerOptions':
-                          type: dictionary
-                          additionalProperties:
-                            type: ['string', 'null', 'dictionary', 'boolean', 'array']
+                        'handlerOptions':  { type: dictionary, description: 'options for the given handler' }
 
     'ui':
       # here, we specify ONLY the "ui" part of the schema, as the remaining parts

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -146,7 +146,7 @@ define(
 					}, selectedNodeSchema.properties[property]));
 
 					// we need to register any configured listeners for other properties.
-					if (selectedNodeSchema.properties[property].ui && selectedNodeSchema.properties[property].ui.inspector.editorListeners) {
+					if (selectedNodeSchema.properties[property].ui && selectedNodeSchema.properties[property].ui.inspector && selectedNodeSchema.properties[property].ui.inspector.editorListeners) {
 						for (var listenerName in selectedNodeSchema.properties[property].ui.inspector.editorListeners) {
 							var observedProperty = selectedNodeSchema.properties[property].ui.inspector.editorListeners[listenerName].property;
 							var handler = selectedNodeSchema.properties[property].ui.inspector.editorListeners[listenerName].handler;

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -15,7 +15,8 @@ define(
 	'Shared/I18n',
 	'create',
 	'vie',
-	'Shared/EventDispatcher'
+	'Shared/EventDispatcher',
+	'Shared/Notification'
 ], function(
 	Ember,
 	$,
@@ -29,7 +30,8 @@ define(
 	I18n,
 	CreateJS,
 	vie,
-	EventDispatcher
+	EventDispatcher,
+	Notification
 ) {
 
 	/**
@@ -394,7 +396,7 @@ define(
 				});
 			}, function () {
 				if (window.console && window.console.error) {
-					window.console.error('Couldn\'t create handler "' + handler + '" assigned to "' + listenerName + '"! Please check your configuration.');
+					window.console.error('Couldn\'t create handler "' + handlerConfiguration.handler + '" assigned to "' + listenerName + '"! Please check your configuration.');
 				}
 				Notification.error('Error in inspector', 'Inspector change handler could not be loaded. See console for further details.');
 			});

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -334,7 +334,6 @@ define(
 				enableTransactionalInspector = true;
 
 			this.set('registeredEditors', Ember.Object.create());
-			this.set('listeners', Ember.Object.create());
 
 			SecondaryInspectorController.hide();
 			this.set('selectedNode', selectedNode);
@@ -367,7 +366,7 @@ define(
 		 * This is triggered when one of the editors was changed even before the change was applied.
 		 */
 		registerPendingChange: function(propertyName, value) {
-			var registeredListeners, evaluator;
+			var registeredListeners;
 
 			registeredListeners = this.get('listeners.' + propertyName);
 			if (!registeredListeners) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/PropertyEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/PropertyEditor.js
@@ -22,6 +22,7 @@ define(
 		editorClassName: '',
 
 		_valueDidChange: function() {
+			this.get('inspector').registerPendingChange(this.get('propertyDefinition').key, this.get('value'));
 			if (this.get('inspector').isPropertyModified(this.get('propertyDefinition.key')) === true) {
 				this.set('isModified', true);
 			} else {
@@ -54,6 +55,7 @@ define(
 		init: function() {
 			this._super();
 			this._loadView();
+			this.get('inspector').registerPropertyEditor(this.get('propertyDefinition.key'), this);
 		},
 
 		_loadView: function() {


### PR DESCRIPTION
This feature allows configuring listeners to other properties
for editors. The listener will be triggered on any change of the
observed property even without applying the change. To keep the
usage flexible you can define a handler that will be triggered
on change.

Example configuration:

    subpageLayout:
      type: string
      ui:
        inspector:
          editorListeners:
            activeWithNonEmptyValue:
              property: 'layout'
              handler: 'TYPO3.NeosDemoTypo3Org/Handlers/LayoutHandler'

The handler would be an Ember.Object or more specifically the handler
should be loadable via require and return an object with a create()
method that in turn returns an object with a handle method with the
following signature:

    handle: function(listeningEditor, newValue, property, listenerName)

The ``listeningEditor`` is the Ember editor object for which the
listener is defined, ``newValue`` is the new value of the property which
was listened to, ``property`` is the name of this observed property and
finally ``listenerName`` is the (user defined) name of the listener from
the configuration.

This configuration makes not too much sense but you can easily see the
flexibility and possible usages of this.
Changes to editors to integrate nicely with this feature will
come in additional PRs.