### PR TITLE
[TASK] Adjust default label for Content nodetype

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -265,6 +265,7 @@
           editor: 'TYPO3.Neos/Inspector/Editors/PluginViewEditor'
 
 'TYPO3.Neos:Content':
+  label: "${String.cropAtWord(String.trim(String.stripTags(q(node).property('title') || q(node).property('text') || I18n.translate(node.nodeType.label))), 100, '...')}"
   superTypes:
     'TYPO3.Neos:Node': TRUE
     'TYPO3.Neos:Hidable': TRUE


### PR DESCRIPTION
The label inherited from the Node nodetype included the node name, which
for content nodes is not very helpful.

With this change, the label (displayed in the structure tree) for nodes
inheriting from TYPO3.Neos:Content no longer includes the node name.