### PR TITLE
[BUGFIX] Keep status code from module response on redirect

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
@@ -77,7 +77,7 @@ class ModuleController extends \TYPO3\Flow\Mvc\Controller\ActionController
         $this->dispatcher->dispatch($moduleRequest, $moduleResponse);
 
         if ($moduleResponse->hasHeader('Location')) {
-            $this->redirectToUri($moduleResponse->getHeader('Location'));
+            $this->redirectToUri($moduleResponse->getHeader('Location'), 0, $moduleResponse->getStatusCode());
         } else {
             $user = $this->securityContext->getPartyByType('TYPO3\Neos\Domain\Model\User');
 


### PR DESCRIPTION
The response of a module loses the status code if it contains a Location
header. This is caused by the ModuleController redirecting to the found
location but ignoring any status code that may have been set. This means
that a module will only create 303 redirects.

This change takes the status code of a module response and applies it to
the generated redirect, fixing this behavior.