### PR TITLE
[BUGFIX] Fix transient error when moving of nodes in Node Tree

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -177,7 +177,23 @@ class Node implements NodeInterface, CacheAwareInterface
 
             /** @var NodeData $nodeData */
             foreach ($nodeDataVariants as $nodeData) {
-                $nodeVariant = $this->createNodeForVariant($nodeData);
+                // $nodeDataVariants at this point also contains *our own NodeData reference* ($this->nodeData), as we find all NodeData objects
+                // (across all dimensions) with the same path.
+                //
+                // We need to ensure that our own Node object's nodeData reference ($this->nodeData) is also updated correctly if a new NodeData object
+                // is returned; as we rely on the fact that $this->getPath() will return the new node path in all circumstances.
+                //
+                // However, $this->createNodeForVariant() only returns $this if the Context object is the same as $this->context; which is not
+                // the case if $this->context contains dimension fallbacks such as "Language: EN, DE".
+                //
+                // The "if" statement below is actually a workaround to ensure that if the NodeData object is our own one, we update *ourselves* correctly,
+                // and thus return the correct (new) Node Path when calling $this->getPath() afterwards.
+                if ($this->nodeData === $nodeData) {
+                    $nodeVariant = $this;
+                } else {
+                    $nodeVariant = $this->createNodeForVariant($nodeData);
+                }
+
                 if ($nodeVariant !== null) {
                     $pathSuffix = substr($nodeVariant->getPath(), strlen($originalPath));
                     $possibleShadowedNodeData = $nodeData->move($path . $pathSuffix, $this->context->getWorkspace());

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
@@ -170,3 +170,29 @@ Feature: Move node with dimension support
       | Path                              |
       | /sites/typo3cr/company/main/text0 |
       | /sites/typo3cr/company/main/text1 |
+
+  @fixtures
+  Scenario: When a node is moved, this node's node path should change
+    This is needed inside Neos, when moving nodes inside the Node Tree, the system has to return
+    the updated Node Path to the User Interface. Thus, this test effectively checks whether
+    NodeInterface->getPath() can be used to retrieve the updated path after node moving.
+
+    When I get a node by path "/sites/typo3cr/service" with the following context:
+      | Workspace  | Language |
+      | user-admin | en       |
+    And I move the node into the node with path "/sites/typo3cr/company"
+    Then I should have the following nodes:
+      | Path                           |
+      | /sites/typo3cr/company/service |
+
+  @fixtures
+  Scenario: When a node is moved, this node's node path should change, even with fallback dimensions configured
+    See the description of the scenario above why this feature is important for Neos. This reproduces bug NEOS-1652.
+
+    When I get a node by path "/sites/typo3cr/service" with the following context:
+      | Workspace  | Language |
+      | user-admin | en, de   |
+    And I move the node into the node with path "/sites/typo3cr/company"
+    Then I should have the following nodes:
+      | Path                           |
+      | /sites/typo3cr/company/service |


### PR DESCRIPTION
How to Reproduce:

- have a website with dimension fallbacks configured; e.g. Language "de"
  which falls back to "en".
- Your content should be in German (no content in English actually needed)
- Try to move nodes across the tree with changing the Node's Parent Node
- watch the exception "Could not convert array to Node object because
  [the-old-node-path] does not exist" in the get-child-nodes-for-tree
  endpoint.

This error happens because the "move" operation, which is supposed to return
the *new* node path of the moved node, still returns the old path.

And this error, in turn, is triggered by some bug inside Node->setPath
(see inline comments for a full description).

Resolves: NEOS-1652