### PR TITLE
[BUGFIX] if in backend, do not intercept links to static resources

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -388,6 +388,12 @@ function(
 				if (href.indexOf('#') !== -1 && href.replace(protocolAndHost, '').split('#')[0] === location.pathname + location.search) {
 					return;
 				}
+
+				// Check if the link is link to a static resource
+				if (href.match(/_Resources\/Persistent/)) {
+					return;
+				}
+
 				// Check if the parent content element is selected if so don't trigger the link
 				if ($this.parents('.neos-contentelement-active').length !== 0) {
 					e.preventDefault();


### PR DESCRIPTION
Prevents loading links to static resources using AJAX in the backend interface,
which fail when loaded.