### PR TITLE
[TASK] Improve logging for "no homepage found" situations

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -104,12 +104,10 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         try {
             $node = $this->convertRequestPathToNode($requestPath);
         } catch (Exception $exception) {
+            $this->systemLogger->log('FrontendNodeRoutePartHandler matchValue(): ' . $exception->getMessage(), LOG_DEBUG);
             if ($requestPath === '') {
                 throw new Exception\NoHomepageException('Homepage could not be loaded. Probably you haven\'t imported a site yet', 1346950755, $exception);
             }
-
-            $this->systemLogger->log('FrontendNodeRoutePartHandler matchValue(): ' . $exception->getMessage(), LOG_DEBUG);
-
             return false;
         }
         if ($this->onlyMatchSiteNodes() && $node !== $node->getContext()->getCurrentSiteNode()) {
@@ -152,7 +150,8 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
 
         $siteNode = $contentContext->getCurrentSiteNode();
         if ($siteNode === null) {
-            throw new Exception\NoSiteNodeException(sprintf('No site node found for request path "%s"', $requestPath), 1346949728);
+            $currentDomain = $contentContext->getCurrentDomain() ? 'Domain with host pattern "' . $contentContext->getCurrentDomain()->getHostPattern() . '" matched.' : 'No specific domain matched.';
+            throw new Exception\NoSiteNodeException(sprintf('No site node found for request path "%s". %s', $requestPath, $currentDomain), 1346949728);
         }
 
         if ($requestPathWithoutContext === '') {


### PR DESCRIPTION
When the Node Route Part Handler wasn't able to find a site node,
the exception now contains information about if at least a domain
could be detected and if so, which one matched.

Additionally, `matchValue()` will now also log an exception if the
request path was empty (that is, the user requested the homepage) and
not only for sub pages.