### PR TITLE
[BUGFIX] masterPlugin-hashmap uses contextPath instead of identifier

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -400,7 +400,7 @@ class ContentController extends ActionController
                     continue;
                 }
                 $translationHelper = new TranslationHelper();
-                $masterPlugins[$pluginNode->getIdentifier()] = $translationHelper->translate(
+                $masterPlugins[$pluginNode->getContextPath()] = $translationHelper->translate(
                     'masterPlugins.nodeTypeOnPageLabel',
                     null,
                     ['nodeTypeName' => $translationHelper->translate($pluginNode->getNodeType()->getLabel()), 'pageLabel' => $page->getLabel()],


### PR DESCRIPTION
The master plugin hashmap was recently altered to use the node-identifier instead of the path. This breaks the implementation of the Plugin view component. This change uses the contextPath as identifier which also takes the translations into account.