### PR TITLE
[BUGFIX] Editing title in node tree marks it as unpublished

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
@@ -58,6 +58,7 @@ define(
 			EventDispatcher
 				.on('nodeCreated', this, 'getWorkspaceWideUnpublishedNodes')
 				.on('nodeDeleted', this, 'getWorkspaceWideUnpublishedNodes')
+				.on('nodeUpdated', this, 'getWorkspaceWideUnpublishedNodes')
 				.on('nodeMoved', this, 'getWorkspaceWideUnpublishedNodes')
 				.on('nodesUpdated', this, '_updatePublishableEntities');
 		},

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
@@ -358,6 +358,7 @@ define(
 									if (isCurrentNode) {
 										ContentModule.loadPage(node.data.href);
 									}
+									EventDispatcher.trigger('nodeUpdated');
 								} else {
 									Notification.error('Unexpected error while updating node: ' + JSON.stringify(result));
 									node.setLazyNodeStatus(that.statusCodes.error);


### PR DESCRIPTION
If you change a nodes title in the node tree that node is not marked as unpublished. This change introduces a new internal event ``nodeEdited`` which is triggered after a node is edited in the node tree. The event will then automatically trigger an update of ``workspaceWideUnpublishedNodes``, which will mark the node as unpublished in the node tree.

Resolves: NEOS-1129