### PR TITLE
[TASK] Fixed documentation for creating a plugin

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -199,7 +199,7 @@ In the controller of your plugin you can access the value from TypoScript like t
 Linking to a Plugin
 ===================
 
-Inside of your Plugin you can use the usual f:link and f:uri ViewHelpers from fluid to link to other ControllerActions::
+Inside of your Plugin you can use the usual f:link.action and f:uri.action ViewHelpers from fluid to link to other ControllerActions::
 
   <f:link.action package="sarkosh.cdcollection" controller="standard" action="show" arguments="{collection: collection}" />
 

--- a/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -201,7 +201,7 @@ Linking to a Plugin
 
 Inside of your Plugin you can use the usual f:link and f:uri ViewHelpers from fluid to link to other ControllerActions::
 
-  <f:link.uri package="sarkosh.cdcollection" controller="standard" action="show" arguments="{collection: collection}" />
+  <f:link.action package="sarkosh.cdcollection" controller="standard" action="show" arguments="{collection: collection}" />
 
 
 If you want to create links to your plugin from outside the plugin context you have to use one of the following methods.

--- a/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -199,7 +199,7 @@ In the controller of your plugin you can access the value from TypoScript like t
 Linking to a Plugin
 ===================
 
-Inside of your Plugin you can use the usual f:link.action and f:uri.action ViewHelpers from fluid to link to other ControllerActions::
+Inside of your Plugin you can use the usual ``f:link.action`` and ``f:uri.action`` ViewHelpers from fluid to link to other ControllerActions::
 
   <f:link.action package="sarkosh.cdcollection" controller="standard" action="show" arguments="{collection: collection}" />
 


### PR DESCRIPTION
Wrong ViewHelper was used in an example.