### PR TITLE
TASK: Cleanup of internal VIE usage in JS backend

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -134,6 +134,15 @@ define([
 		},
 
 		/**
+		 * @param {string} key
+		 * @return {object}
+		 */
+		getPreviousAttribute: function(key) {
+			var vieEntity = this.get('_vieEntity');
+			return Entity.extractAttributesFromVieEntity(vieEntity, vieEntity.previousAttributes())[key];
+		},
+
+		/**
 		 * @return {string}
 		 */
 		nodePath: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -186,7 +186,6 @@ define([
 		}.property()
 	});
 
-	var namespace = Configuration.get('TYPO3_NAMESPACE');
 	Entity.reopenClass({
 		/**
 		 * @param {object} vieEntity
@@ -195,7 +194,8 @@ define([
 		 * @return {object}
 		 */
 		extractAttributesFromVieEntity: function(vieEntity, attributes, filterFn) {
-			var cleanAttributes = {};
+			var cleanAttributes = {},
+				namespace = vieEntity.vie.namespaces.get('typo3');
 			attributes = _.isEmpty(attributes) ? vieEntity.attributes : attributes;
 			_.each(attributes, function(value, subject) {
 				var property = vieEntity.fromReference(subject);
@@ -215,7 +215,8 @@ define([
 		 */
 		extractNodeTypeFromVieEntity: function(vieEntity) {
 			var types = vieEntity.get('@type'),
-				type;
+				type,
+				namespace = vieEntity.vie.namespaces.get('typo3');
 			if (!_.isArray(types)) {
 				types = [types];
 			}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -165,25 +165,21 @@ define([
 		 * @return {boolean}
 		 */
 		isHideable: function() {
-			return this.get('_vieEntity').has('typo3:_hidden');
+			return this.hasAttribute('_hidden');
 		},
 
 		/**
 		 * @return {boolean}
 		 */
 		isHidden: function() {
-			return this.get('_vieEntity').get('typo3:_hidden');
+			return this.getAttribute('_hidden');
 		},
 
 		/**
 		 * @return {string}
 		 */
 		nodeLabel: function() {
-			if (this.get('_vieEntity').get('typo3:title') !== undefined) {
-				return this.get('_vieEntity').get('typo3:title');
-			}
-
-			return '';
+			return this.getAttribute('title') || '';
 		}.property('_vieEntity'),
 
 		/**

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -76,21 +76,22 @@ define([
 		 */
 		init: function() {
 			var that = this,
-				vieEntity = this.get('_vieEntity'),
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+				vieEntity = this.get('_vieEntity');
 
 			this.set('modified', !$.isEmptyObject(vieEntity.changed));
-			this.set('publishable', vieEntity.get(namespace + '__workspaceName') !== 'live');
+			this.set('publishable', this.getAttribute('__workspaceName') !== 'live');
 
 			var $entityElement = vieInstance.service('rdfa').getElementBySubject(vieEntity.getSubject(), $(document));
-				// this event fires if inline content changes
+
+			// this event fires if inline content changes
 			$entityElement.bind('midgardeditablechanged', function(event, data) {
 				that.set('modified', !$.isEmptyObject(vieEntity.changed));
 			});
-				// this event fires if content changes through the property inspector
+
+			// this event fires if content changes through the property inspector
 			vieEntity.on('change', function() {
 				that.set('modified', !$.isEmptyObject(vieEntity.changed));
-				that.set('publishable', vieEntity.get(namespace + '__workspacename') !== 'live');
+				that.set('publishable', that.getAttribute('__workspacename') !== 'live');
 			});
 
 			this.set('$element', $entityElement);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -177,6 +177,7 @@ define([
 		}.property()
 	});
 
+	var namespace = Configuration.get('TYPO3_NAMESPACE');
 	Entity.reopenClass({
 		/**
 		 * @param {object} vieEntity
@@ -185,8 +186,7 @@ define([
 		 * @return {object}
 		 */
 		extractAttributesFromVieEntity: function(vieEntity, attributes, filterFn) {
-			var cleanAttributes = {},
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+			var cleanAttributes = {};
 			attributes = _.isEmpty(attributes) ? vieEntity.attributes : attributes;
 			_.each(attributes, function(value, subject) {
 				var property = vieEntity.fromReference(subject);
@@ -206,8 +206,7 @@ define([
 		 */
 		extractNodeTypeFromVieEntity: function(vieEntity) {
 			var types = vieEntity.get('@type'),
-				type,
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+				type;
 			if (!_.isArray(types)) {
 				types = [types];
 			}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -108,6 +108,17 @@ define([
 		}.property('_vieEntity').volatile(),
 
 		/**
+		 * Check if an attribute exists on the underlying VIE entity
+		 *
+		 * @param {string} key
+		 * @return {void}
+		 */
+		hasAttribute: function(key) {
+			var attributeName = 'typo3:' + key;
+			this.get('_vieEntity').has(attributeName);
+		},
+
+		/**
 		 * Set an attribute on the underlying VIE entity
 		 *
 		 * @param {string} key

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
@@ -324,7 +324,17 @@ define(
 		},
 
 		getNode: function(contextPath) {
-			return this._entitiesBySubject['<' + contextPath + '>'];
+			var node = this._entitiesBySubject['<' + contextPath + '>'];
+			if (node) {
+				return node;
+			}
+
+			var element = $('[about="' + contextPath + '"]');
+			if (element) {
+				return this._createEntityWrapper(element);
+			}
+
+			return null;
 		},
 
 		selectedNode: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
@@ -131,11 +131,10 @@ define(
               if (autoPublish !== true) {
                 var documentMetadata = $('#neos-document-metadata'),
                   nodeType = documentMetadata.data('node-_node-type'),
-                  page = vie.entities.get(vie.service('rdfa').getElementSubject(documentMetadata)),
-                  namespace = Configuration.get('TYPO3_NAMESPACE'),
-                  title = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : '',
-                  nodeTypeDefinition = NodeTypeService.getNodeTypeDefinition(nodeType);
-                Notification.ok('Published changes for ' + I18n.translate(nodeTypeDefinition.ui.label) + ' "' + $('<a />').html(title).text() + '"');
+                  page = NodeSelection.getNode(documentMetadata.attr('about')),
+                  pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || '',
+                  nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
+                Notification.ok('Published changes for ' + I18n.translate(nodeTypeConfiguration.ui.label) + ' "' + $('<a />').html(pageTitle).text() + '"');
               }
               that.set('publishRunning', false);
             },
@@ -205,11 +204,10 @@ define(
               );
               var documentMetadata = $('#neos-document-metadata'),
                 nodeType = documentMetadata.data('node-_node-type'),
-                page = vie.entities.get(vie.service('rdfa').getElementSubject(documentMetadata)),
-                namespace = Configuration.get('TYPO3_NAMESPACE'),
-                title = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : '',
-                nodeTypeDefinition = NodeTypeService.getNodeTypeDefinition(nodeType);
-              Notification.ok('Discarded changes for ' + nodeTypeDefinition.ui.label + ' "' + title + '"');
+                page = NodeSelection.getNode(documentMetadata.attr('about')),
+                pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || '',
+                nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
+              Notification.ok('Discarded changes for ' + I18n.translate(nodeTypeConfiguration.ui.label) + ' "' + $('<a />').html(pageTitle).text() + '"');
               that.set('discardRunning', false);
             },
             function (error) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -78,9 +78,10 @@ define(
 		},
 
 		_onPageNodePathChanged: function() {
-			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
+			var documentMetadata = $('#neos-document-metadata'),
+				page = NodeSelection.getNode(documentMetadata.attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
-				documentNodeType = page.get('typo3:_nodeType'),
+				documentNodeType = documentMetadata.data('node-_node-type'),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(documentNodeType),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
@@ -131,7 +132,7 @@ define(
 
 			var page = NodeSelection.getNode(documentMetadata.attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
-				nodeType = documentMetadata.attr('typeof').substr(6),
+				nodeType = documentMetadata.data('node-_node-type'),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
 
 			this.set('treeConfiguration', $.extend(true, this.get('treeConfiguration'), {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -81,11 +81,13 @@ define(
 			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
 				documentNodeType = page.get('typo3:_nodeType'),
+				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(documentNodeType),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
 				key: this.get('pageNodePath'),
 				title: pageTitle,
-				nodeType: documentNodeType
+				nodeType: documentNodeType,
+				nodeTypeLabel: nodeTypeConfiguration ? nodeTypeConfiguration.label : ''
 			});
 			this.refresh();
 		}.observes('pageNodePath'),

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -7,8 +7,6 @@ define(
 	'Library/jquery-with-dependencies',
 	'./AbstractNodeTree',
 	'Content/Application',
-	'Content/Model/Node',
-	'vie',
 	'Shared/Configuration',
 	'Shared/Notification',
 	'Shared/EventDispatcher',
@@ -23,8 +21,6 @@ define(
 	$,
 	AbstractNodeTree,
 	ContentModule,
-	EntityWrapper,
-	InstanceWrapper,
 	Configuration,
 	Notification,
 	EventDispatcher,
@@ -82,10 +78,9 @@ define(
 		},
 
 		_onPageNodePathChanged: function() {
-			var page = InstanceWrapper.entities.get(InstanceWrapper.service('rdfa').getElementSubject($('#neos-document-metadata'))),
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
-				pageTitle = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : this.get('pageNodePath'),
-				documentNodeType = page.get('typo3:_nodeType');
+			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
+				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
+				documentNodeType = page.get('typo3:_nodeType'),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
 				key: this.get('pageNodePath'),
@@ -132,9 +127,8 @@ define(
 				return;
 			}
 
-			var page = InstanceWrapper.entities.get(InstanceWrapper.service('rdfa').getElementSubject(documentMetadata)),
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
-				pageTitle = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : this.pageNodePath,
+			var page = NodeSelection.getNode(documentMetadata.attr('about')),
+				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
 				nodeType = documentMetadata.attr('typeof').substr(6),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -190,10 +190,10 @@ function (
 		}.property('nodeActions.clipboard', '_node'),
 
 		toggleHidden: function() {
-			var entity = this.get('_node._vieEntity'),
-				value = !entity.get('typo3:_hidden');
+			var node = this.get('_node'),
+				value = !node.getAttribute('_hidden');
 			this.set('_hidden', value);
-			entity.set('typo3:_hidden', value);
+			node.setAttribute('_hidden', value);
 			InspectorController.set('nodeProperties._hidden', value);
 			InspectorController.apply();
 		},

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -159,7 +159,7 @@ function (
 		}.property('nodeSelection.selectedNode', 'nodeActions.clipboard'),
 
 		_entityChanged: function() {
-			this.set('_hidden', this.get('_node._vieEntity').get('typo3:_hidden'));
+			this.set('_hidden', this.get('_node').getAttribute('_hidden'));
 		},
 
 		/** Content element actions **/

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -85,23 +85,25 @@ function (
 
 		_onNodeSelectionChange: function() {
 			this.$().find('.action-new').trigger('hidePopover');
-			var selectedNode = this.get('nodeSelection.selectedNode'),
-				entity = selectedNode.get('_vieEntity');
-
-			if (selectedNode && entity) {
-				this.set('_node', selectedNode);
-
-				entity.on('change', this._entityChanged, this);
-				this._entityChanged();
-
-				if (selectedNode.isHideable()) {
-					this.set('_showHide', true);
-					this.set('_hidden', selectedNode.isHidden());
-				} else {
-					this.set('_showHide', false);
-					this.set('_hidden', false);
-				}
+			var selectedNode = NodeSelection.get('selectedNode');
+			if (!selectedNode) {
+				return;
 			}
+
+			this.set('_node', selectedNode);
+
+			if (selectedNode.isHideable()) {
+				this.set('_showHide', true);
+				this.set('_hidden', selectedNode.isHidden());
+			} else {
+				this.set('_showHide', false);
+				this.set('_hidden', false);
+			}
+
+			var that = this;
+			selectedNode.addObserver('typo3:_hidden', function() {
+				that.set('_hidden', selectedNode.isHidden());
+			});
 		}.observes('nodeSelection.selectedNode'),
 
 		currentFocusedNodeCanBeModified: function() {
@@ -157,10 +159,6 @@ function (
 			}
 			return positions;
 		}.property('nodeSelection.selectedNode', 'nodeActions.clipboard'),
-
-		_entityChanged: function() {
-			this.set('_hidden', this.get('_node').getAttribute('_hidden'));
-		},
 
 		/** Content element actions **/
 		remove: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -30,7 +30,6 @@ function(
 
 		nodeTypeGroups: function() {
 			var groups = {},
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
 				node = this.get('_node'),
 				position = this.get('_position'),
 				types;
@@ -53,7 +52,7 @@ function(
 					return;
 				}
 
-				var nodeTypeName = type.id.substring(1, type.id.length - 1).replace(namespace, '');
+				var nodeTypeName = type.id.substring(1, type.id.length - 1).replace(type.metadata.url, '');
 				if (!contentTypes.hasOwnProperty(nodeTypeName)) {
 					return;
 				}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
@@ -12,8 +12,6 @@ function(Ember, $) {
 	 * @singleton
 	 */
 	return Ember.Object.extend({
-		TYPO3_NAMESPACE: 'http://www.typo3.org/ns/2012/Flow/Packages/Neos/Content/',
-
 		_data: {},
 
 		init: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/storage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/storage.js
@@ -3,7 +3,6 @@ define(
 	'Library/jquery-with-dependencies',
 	'Content/Model/Node',
 	'Library/backbone',
-	'Content/Model/PublishableNodes',
 	'Shared/Endpoint/NodeEndpoint',
 	'Shared/EventDispatcher',
 	'Shared/Notification'
@@ -11,7 +10,6 @@ define(
 	$,
 	Entity,
 	Backbone,
-	PublishableNodes,
 	NodeEndpoint,
 	EventDispatcher,
 	Notification
@@ -43,16 +41,15 @@ define(
 						//
 						// Furthermore, we do not want event listeners to be fired, as otherwise the content element
 						// would be redrawn leading to a loss of the current editing cursor position.
-						//
-						// The PublishableNodes are explicitly updated, as changes from the backbone models
-						// workspace name attribute are suppressed and our entity wrapper would not notice.
 						NodeEndpoint.set('_saveRunning', false);
 						EventDispatcher.trigger('contentSaved');
 
 						if (result !== undefined && (result.success === true || options.render)) {
 							if (!options.render) {
 								model.set('typo3:__workspaceName', result.data.workspaceNameOfNode, {silent: true});
-								PublishableNodes._updatePublishableEntities();
+								// The PublishableNodes are explicitly updated through the ``nodesUpdated`` event, as changes from
+								// the backbone models workspace name attribute are suppressed and our entity wrapper would not notice.
+								EventDispatcher.trigger('nodeUpdated');
 							}
 
 							NodeEndpoint.set('_lastSuccessfulTransfer', new Date());


### PR DESCRIPTION
This change removes a lot of the direct interaction with VIE and replaces it with the node model.
Additionally the VIE namespace is no longer used outside VIE so the configuration is removed.