### PR TITLE
[!!!][TASK] Set useful defaults for Menu

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
@@ -5,6 +5,10 @@ prototype(TYPO3.Neos:Menu) < prototype(TYPO3.TypoScript:Template) {
 	templatePath = 'resource://TYPO3.Neos/Private/Templates/TypoScriptObjects/Menu.html'
 	node = ${node}
 	items = ${this.items}
+
+	entryLevel = 1
+	maximumLevels = 2
+
 	filter = 'TYPO3.Neos:Document'
 	attributes = TYPO3.TypoScript:Attributes
 

--- a/TYPO3.Neos/Tests/Functional/TypoScript/Fixtures/BaseTypoScript.ts2
+++ b/TYPO3.Neos/Tests/Functional/TypoScript/Fixtures/BaseTypoScript.ts2
@@ -36,6 +36,7 @@ page1.body {
 
 	parts.productCategoryMenu = TYPO3.Neos:Menu {
 		startingPoint = ${q(node).find('products').get(0)}
+		entryLevel = 0
 	}
 
 	content {


### PR DESCRIPTION
Menu should have useful defaults for ``entryLevel`` and ``maximumLevels``
to make it usable in it's default state without changing too much.
The ``entryLevel`` is therefore set to 1 and maximumLevels to 2.
Maximum shouldn't be too high to avoid loading a lot of nodes unnecessarily.

This is breaking if you rely on the previous behavior with no defaults
set for the two values.