### PR TITLE
[BUGFIX] Route cache flush shouldn't load all documents

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -76,7 +76,7 @@ class Package extends BasePackage
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodeDiscarded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\NodeData', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodePathChange');
+        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\NodeData', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeDataChange');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodeDiscarded', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
@@ -35,13 +35,25 @@ class RouteCacheFlusher
     protected $tagsToFlush = array();
 
     /**
-     * Schedules flushing of the routing cache entry for the given $nodeData
-     * Note: This is not done recursively because the nodePathChanged signal is triggered for any affected node data instance
+     * Schedules flushing of the routing cache entries for the given $node
+     * Note that child nodes are flushed automatically because they are tagged with all parents.
      *
-     * @param NodeData $nodeData The affected node data instance
+     * @param NodeInterface $node
      * @return void
      */
-    public function registerNodePathChange(NodeData $nodeData)
+    public function registerNodeChange(NodeInterface $node)
+    {
+        $this->registerNodeDataChange($node->getNodeData());
+    }
+
+    /**
+     * Schedules flushing of the routing cache entries for the given $nodeData
+     * Note that child nodes are flushed automatically because they are tagged with all parents.
+     *
+     * @param NodeData $nodeData The node which has changed in some way
+     * @return void
+     */
+    public function registerNodeDataChange(NodeData $nodeData)
     {
         if (in_array($nodeData->getIdentifier(), $this->tagsToFlush)) {
             return;
@@ -50,21 +62,6 @@ class RouteCacheFlusher
             return;
         }
         $this->tagsToFlush[] = $nodeData->getIdentifier();
-    }
-
-    /**
-     * Schedules recursive flushing of the routing cache entries for the given $node
-     *
-     * @param NodeInterface $node The node which has changed in some way
-     * @return void
-     */
-    public function registerNodeChange(NodeInterface $node)
-    {
-        $this->registerNodePathChange($node->getNodeData());
-        /** @var NodeInterface $childNode */
-        foreach ($node->getChildNodes('TYPO3.Neos:Document') as $childNode) {
-            $this->registerNodeChange($childNode);
-        }
     }
 
     /**


### PR DESCRIPTION
To avoid loading all documents in a Neos instance the route cache
for a node will be tagged will all parent node identifiers so that
flushing the cache for a particular node identifier will automatically
flush all child node entries as well.