### PR TITLE
BUGFIX: ``NodeView::collectTreeNodeData`` breaks in some conditions

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
@@ -237,7 +237,9 @@ class NodeView extends \TYPO3\Flow\Mvc\View\JsonView
                     $collectTreeNodeData($children, $childNode);
                 }
             }
-            $treeNodes[] = $self->collectTreeNodeData($node['node'], true, $children, $children !== array(), isset($node['matched']));
+            if (isset($node['node']) && $node['node'] instanceof NodeInterface) {
+                $treeNodes[] = $self->collectTreeNodeData($node['node'], true, $children, $children !== array(), isset($node['matched']));
+            }
         };
 
         foreach ($nodeCollection as $firstLevelNode) {


### PR DESCRIPTION
It can happen that the key `node` is not a NodeInterface, this check make this method more solid.
