### PR TITLE
[TASK] Cache content dimensions backend request client side

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
@@ -71,7 +71,7 @@ function(
 		 */
 		_loadConfiguration: function() {
 			var that = this;
-			HttpRestClient.getResource('neos-service-contentdimensions').then(function(result) {
+			ResourceCache.getItem('neos-service-contentdimensions').then(function(result) {
 				var configuration = {};
 
 				$.each($('.contentdimensions', result.resource).children('li'), function(key, contentDimensionSnippet) {


### PR DESCRIPTION
Instead of fetching the content dimensions every time the backend is loaded,
the request is cached using the ``ResourceCache``. This eliminates a request
for something that rarely changes and is automatically updated when the
configuration changes.