### PR TITLE
[FEATURE] Auto-update shortcut properties when editing

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -205,6 +205,10 @@
                 label: i18n
               selectedTarget:
                 label: i18n
+          editorListeners:
+            removeTargetIfNotUsed:
+              property: 'target'
+              handler: 'TYPO3.Neos/Inspector/Handlers/ShortcutHandler'
     target:
       type: string
       ui:
@@ -213,6 +217,10 @@
         inspector:
           group: 'document'
           editor: 'TYPO3.Neos/Inspector/Editors/LinkEditor'
+          editorListeners:
+            setTargetModeIfNotEmpty:
+              property: 'targetMode'
+              handler: 'TYPO3.Neos/Inspector/Handlers/ShortcutHandler'
 
 # Base class for all "Plugins"; that are PHP controllers being called during the rendering.
 'TYPO3.Neos:Plugin':

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -142,6 +142,7 @@ TYPO3:
       requireJsPathMapping:
         'TYPO3.Neos/Validation': 'resource://TYPO3.Neos/Public/JavaScript/Shared/Validation/'
         'TYPO3.Neos/Inspector/Editors': 'resource://TYPO3.Neos/Public/JavaScript/Content/Inspector/Editors/'
+        'TYPO3.Neos/Inspector/Handlers': 'resource://TYPO3.Neos/Public/JavaScript/Content/Inspector/Handlers/'
 
       # the default language for the backend interface (can be overridden by user preference through availableLanguages)
       defaultLanguage: 'en'

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Handlers/ShortcutHandler.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Handlers/ShortcutHandler.js
@@ -1,0 +1,22 @@
+define(
+  [
+    'emberjs'
+  ],
+  function (Ember) {
+    return Ember.Object.extend({
+      handle: function (listeningEditor, newValue, propertyName, listenerName) {
+        switch (propertyName) {
+          case 'target':
+            if (newValue !== null && newValue !== '') {
+              listeningEditor.set('value', 'selectedTarget');
+            }
+            break;
+          case 'targetMode':
+            if (newValue !== 'selectedTarget') {
+              listeningEditor.set('value', '');
+            }
+            break;
+        }
+      }
+    });
+  });


### PR DESCRIPTION
This changes automates the following when editing a Shortcut:

1. If the target is set to a non-empty value, the target mode is set
   to "Selected Target"
2. If the target mode is set to not use the selected target, the target
   is removed.