### PR TITLE
[BUGFIX] Avoid "Missing constructor argument" exception

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/AssetInterfaceConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/AssetInterfaceConverter.php
@@ -240,7 +240,11 @@ class AssetInterfaceConverter extends PersistentObjectConverter
     protected function buildObject(array &$possibleConstructorArgumentValues, $objectType)
     {
         $className = $this->objectManager->getClassNameByObjectName($objectType) ?: static::$defaultNewAssetType;
-        return parent::buildObject($possibleConstructorArgumentValues, $className);
+        if (count($possibleConstructorArgumentValues)) {
+            return parent::buildObject($possibleConstructorArgumentValues, $className);
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
The type converter would always call ``buildObject()`` on the parent,
even if the possible constructor arguments were empty. This lead to:

Missing constructor argument "resource" for object of type
``TYPO3\Media\Domain\Model\Asset``.

A check is added to avoid that.