### PR TITLE
[BUGFIX] Broken workspace managment backend module

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -224,12 +224,16 @@ class WorkspacesController extends AbstractModuleController
      * Update a workspace
      *
      * @param Workspace $workspace A workspace to update
+     * @param User $newOwner New owner for the workspace, if any
      * @return void
      */
-    public function updateAction(Workspace $workspace)
+    public function updateAction(Workspace $workspace, $newOwner = null)
     {
         if ($workspace->getTitle() === '') {
             $workspace->setTitle($workspace->getName());
+        }
+        if ($newOwner !== null) {
+            $workspace->setOwner($newOwner);
         }
 
         $this->workspaceRepository->update($workspace);
@@ -292,7 +296,7 @@ class WorkspacesController extends AbstractModuleController
     public function rebaseAndRedirectAction(NodeInterface $targetNode, Workspace $targetWorkspace)
     {
         $currentAccount = $this->securityContext->getAccount();
-        $personalWorkspace = $this->workspaceRepository->$this->findOneByName('user-' . $currentAccount->getAccountIdentifier());
+        $personalWorkspace = $this->workspaceRepository->findOneByName('user-' . $currentAccount->getAccountIdentifier());
         /** @var Workspace $personalWorkspace */
 
         if ($this->publishingService->getUnpublishedNodesCount($personalWorkspace) > 0) {
@@ -500,7 +504,7 @@ class WorkspacesController extends AbstractModuleController
         $baseWorkspaceOptions = [];
         foreach ($this->workspaceRepository->findAll() as $workspace) {
             /** @var Workspace $workspace */
-            if (!$workspace->isPersonalWorkspace() && $workspace !== $excludedWorkspace) {
+            if (!$workspace->isPersonalWorkspace() && $workspace !== $excludedWorkspace && ($workspace->isPublicWorkspace() || $workspace->isInternalWorkspace() || $this->userService->currentUserCanManageWorkspace($workspace))) {
                 $baseWorkspaceOptions[$workspace->getName()] = $workspace->getTitle();
             }
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -224,16 +224,12 @@ class WorkspacesController extends AbstractModuleController
      * Update a workspace
      *
      * @param Workspace $workspace A workspace to update
-     * @param User $newOwner New owner for the workspace, if any
      * @return void
      */
-    public function updateAction(Workspace $workspace, $newOwner = null)
+    public function updateAction(Workspace $workspace)
     {
         if ($workspace->getTitle() === '') {
             $workspace->setTitle($workspace->getName());
-        }
-        if ($newOwner !== null) {
-            $workspace->setOwner($newOwner);
         }
 
         $this->workspaceRepository->update($workspace);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -605,6 +605,10 @@ class UserService
             return $this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.Module.Management.Workspaces.ManageOwnWorkspaces');
         }
 
+        if ($workspace->isPrivateWorkspace() && $workspace->getOwner() != $this->getCurrentUser()) {
+            return $this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.Module.Management.Workspaces.ManageAllPrivateWorkspaces');
+        }
+
         return false;
     }
 

--- a/TYPO3.Neos/Configuration/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Policy.yaml
@@ -66,7 +66,7 @@ privilegeTargets:
       matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(index|show|publishNode|discardNode|publishOrDiscardNodes|publishWorkspace|discardWorkspace|rebaseAndRedirect)Action()) || method(TYPO3\Neos\Service\Controller\AbstractServiceController->(error)Action())'
 
     'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageOwnWorkspaces':
-      matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action())'
+      matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action(workspace.owner == current.userInformation.backendUser))'
 
     'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageInternalWorkspaces':
       matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action(workspace.owner == null))'

--- a/TYPO3.Neos/Configuration/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Policy.yaml
@@ -36,6 +36,7 @@ privilegeTargets:
     'TYPO3.Neos:Backend.PersonalWorkspaceReadAccess.NodeConverter':
       matcher: 'method(TYPO3\Neos\TypeConverter\NodeConverter->prepareContextProperties(workspaceName == current.userInformation.userWorkspaceName))'
 
+    # No role should have this privilege assigned:
     'TYPO3.Neos:Backend.OtherUsersPersonalWorkspaceAccess':
       matcher: 'method(TYPO3\TYPO3CR\Domain\Service\Context->validateWorkspace()) && evaluate(this.workspace.owner != current.userInformation.backendUser, this.workspace.personalWorkspace == true)'
 
@@ -65,15 +66,18 @@ privilegeTargets:
       matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(index|show|publishNode|discardNode|publishOrDiscardNodes|publishWorkspace|discardWorkspace|rebaseAndRedirect)Action()) || method(TYPO3\Neos\Service\Controller\AbstractServiceController->(error)Action())'
 
     'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageOwnWorkspaces':
-      matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action(workspace.owner == current.userInformation.backendUser))'
+      matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action())'
 
     'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageInternalWorkspaces':
       matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action(workspace.owner == null))'
 
+    'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageAllPrivateWorkspaces':
+      matcher: 'method(TYPO3\Neos\Controller\Module\Management\WorkspacesController->(publishWorkspace|discardWorkspace|edit|update|delete)Action()) && evaluate(this.workspace.owner != current.userInformation.backendUser, this.workspace.personalWorkspace == false)'
+
     'TYPO3.Neos:Backend.Service.Workspaces.Index':
       matcher: 'method(TYPO3\Neos\Controller\Service\WorkspacesController->(index|error|show)Action())'
 
-    'TYPO3.Neos:Backend.Service.Workspacs.ManageOwnWorkspaces':
+    'TYPO3.Neos:Backend.Service.Workspaces.ManageOwnWorkspaces':
       matcher: 'method(TYPO3\Neos\Controller\Service\WorkspacesController->(update|delete)Action(workspace.owner == current.userInformation.backendUser))'
 
     #
@@ -197,7 +201,7 @@ roles:
         permission: GRANT
 
       -
-        privilegeTarget: 'TYPO3.Neos:Backend.Service.Workspacs.ManageOwnWorkspaces'
+        privilegeTarget: 'TYPO3.Neos:Backend.Service.Workspaces.ManageOwnWorkspaces'
         permission: GRANT
 
       -
@@ -275,6 +279,10 @@ roles:
 
       -
         privilegeTarget: 'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageInternalWorkspaces'
+        permission: GRANT
+
+      -
+        privilegeTarget: 'TYPO3.Neos:Backend.Module.Management.Workspaces.ManageAllPrivateWorkspaces'
         permission: GRANT
 
       -

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Edit.html
@@ -40,7 +40,7 @@
 			<div class="neos-control-group">
 				<label class="neos-control-label" for="owner">{neos:backend.translate(id: 'workspaces.workspace.owner', source: 'Modules', package: 'TYPO3.Neos')}</label>
 				<div class="neos-controls">
-					<f:form.select property="owner" name="newOwner" id="owner" options="{ownerOptions}" />
+					<f:form.select property="owner" name="owner" id="owner" options="{ownerOptions}" />
 				</div>
 			</div>
 		</f:if>

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -193,7 +193,7 @@
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'TYPO3.Neos')}</button>
 					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'TYPO3.Neos')}</button>
 					<button class="neos-button neos-button-danger" data-toggle="modal" href="#discard">{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'TYPO3.Neos')}</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChanges', source: 'Modules', package: 'TYPO3.Neos')}</button>
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'TYPO3.Neos', arguments: {0: baseWorkspaceLabel})}</button>
 				</f:then>
 				<f:else>
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'TYPO3.Neos')}</button>
@@ -202,13 +202,5 @@
 				</f:else>
 			</f:if>
 		</div>
-		<f:if condition="{canPublishToBaseWorkspace}">
-			<f:then>
-				<p class="neos-clear pull-right">{neos:backend.translate(id: 'workspaces.willPublishTo', source: 'Modules', package: 'TYPO3.Neos', arguments: {0: baseWorkspaceLabel})}</p>
-			</f:then>
-			<f:else>
-				<p class="neos-clear pull-right">{neos:backend.translate(id: 'workspaces.noLivePublishPermission', source: 'Modules', package: 'TYPO3.Neos')}</p>
-			</f:else>
-		</f:if>
 	</div>
 </f:section>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -134,6 +134,9 @@
 			<trans-unit id="workspaces.publishAllChanges" xml:space="preserve">
 				<source>Publish all changes</source>
 			</trans-unit>
+			<trans-unit id="workspaces.publishAllChangesTo" xml:space="preserve">
+				<source>Publish all changes to {0}</source>
+			</trans-unit>
 			<trans-unit id="workspaces.legendCaption" xml:space="preserve">
 				<source>Legend</source>
 			</trans-unit>
@@ -151,12 +154,6 @@
 			</trans-unit>
 			<trans-unit id="workspaces.legend.edited" xml:space="preserve">
 				<source>edited</source>
-			</trans-unit>
-			<trans-unit id="workspaces.willPublishTo" xml:space="preserve">
-				<source>Changes will be published to the "{0}" workspace.</source>
-			</trans-unit>
-			<trans-unit id="workspaces.noLivePublishPermission" xml:space="preserve">
-				<source>You have no permission to publish to the "live" workspace.</source>
 			</trans-unit>
 			<trans-unit id="workspaces.thereAreNoUnpublishedChanges" xml:space="preserve">
 				<source>There are no unpublished changes in this workspace.</source>

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -236,12 +236,20 @@ class Workspace
     /**
      * Returns the workspace owner.
      *
-     * @param UserInterface|string $user The new user
+     * @param UserInterface|string $user The new user, or user's UUID
      * @api
      */
     public function setOwner($user)
     {
-        if (is_string($user) && ($user === '' || preg_match('/^([a-f0-9]){8}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){12}$/', $user))) {
+        // Note: We need to do a bit of uuid juggling here, because we can't bind the workspaces Owner to a specific
+        // implementation, and creating entity relations via interfaces is not supported by Flow. Since the property
+        // mapper will call setOwner() with a string parameter (because the property $owner is string), but developers
+        // will want to use objects, we need to support both.
+        if ($user === null || $user === '') {
+            $this->owner = '';
+            return;
+        }
+        if (is_string($user) && preg_match('/^([a-f0-9]){8}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){12}$/', $user)) {
             $this->owner = $user;
             return;
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -241,7 +241,7 @@ class Workspace
      */
     public function setOwner($user)
     {
-        if (is_string($user) && preg_match('/^([a-f0-9]){8}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){12}$/', $user)) {
+        if (is_string($user) && ($user === '' || preg_match('/^([a-f0-9]){8}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){4}-([a-f0-9]){12}$/', $user))) {
             $this->owner = $user;
             return;
         }


### PR DESCRIPTION
This fixes a couple of issues with the new workspace management features
and improves the user interface in the workspace review screen.

Editing the owner of a workspace resulted in a fatal error due to
a wrong method signature. Ownership can now be transferred as intended.

The rebase and redirect action (which can conveniently be triggered
through an edit button in the review screen) complained about a wrong
"$this" in a fatal error. Removed $this and now that works.

At the bottom of the review workspace changes screen a small help
message explained what would happen when a user presses one of the
buttons. Removed that fine print and now let the buttons speak for
themselves.