### PR TITLE
[BUGFIX] site:prune also removes all personal workspaces

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
@@ -80,21 +80,14 @@ class SiteService
     }
 
     /**
-     * Remove all nodes, workspaces, domains and sites.
+     * Remove all sites and their respective nodes and domains
      *
      * @return void
      */
     public function pruneAll()
     {
-        $sites = $this->siteRepository->findAll();
-
-        $this->nodeDataRepository->removeAll();
-        $this->workspaceRepository->removeAll();
-        $this->domainRepository->removeAll();
-        $this->siteRepository->removeAll();
-
-        foreach ($sites as $site) {
-            $this->emitSitePruned($site);
+        foreach ($this->siteRepository->findAll() as $site) {
+            $this->pruneSite($site);
         }
     }
 


### PR DESCRIPTION
This change fixes an issue with the "site:prune" command related to
workspaces which could result in an inaccessible Neos backend for all
existing users, even after a new site had been imported.

In addition to the actual nodes and domains, the site:prune command also
removed all existing workspaces. Since personal workspaces are not
re-generated automatically (anymore), existing users wouldn't be able
to login even if a new site had been imported because they were lacking
a personal workspace.

Instead of simply removing all data from the domain repositories, the
site:prune command now iterates over all existing sites and calls the
pruneSite() method, which leaves workspaces intact.