### PR TITLE
[BUGFIX] Allow to search for nodes without a Document parent

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -1,11 +1,11 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}<html>
 	<head>
-		<title>{neos:backend.translate(id: 'nodes', value: 'Nodes')}</title>
+		<title>{neos:backend.translate(id: 'service.nodes.title', value: 'Nodes')}</title>
 		<meta charset="UTF-8" />
 	</head>
 	<body>
 		<div>
-			<h1>{neos:backend.translate(id: 'nodes', value: 'Nodes')}</h1>
+			<h1>{neos:backend.translate(id: 'service.nodes.title', value: 'Nodes')}</h1>
 			<ul class="nodes"><f:for each="{nodes}" as="node">
 				<li class="node">
 					<span class="node-path">{node.path}</span>
@@ -20,7 +20,7 @@
 							</f:then>
 							<f:else>
 								<a class="node-frontend-uri">
-									This node can't be accessed through a public URL
+									{neos:backend.translate(id: 'service.nodes.noPublicUrl', value: 'This node cannot be accessed through a public URL')}
 								</a>
 						</f:else>
 						</f:if>
@@ -28,7 +28,7 @@
 					<label class="node-label">{node.label}</label>
 					(<span class="node-identifier">{node.identifier}</span>)
 					[<span class="node-type">{node.nodeType.name}</span>]
-					<f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'show', value: 'Show')}</f:link.action>
+					<f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
 				</li></f:for>
 			</ul>
 		</div>

--- a/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -10,11 +10,20 @@
 				<li class="node">
 					<span class="node-path">{node.path}</span>
 					<f:alias map="{documentNode: '{neos:node.closestDocument(node: node)}'}">
-						<f:alias map="{relativeUrl: '{neos:uri.node(node: documentNode, absolute: false, resolveShortcuts: false)}'}">
-							<a href="{neos:uri.node(node: documentNode, absolute: true, resolveShortcuts:false)}" class="node-frontend-uri">
-								{f:if(condition: relativeUrl, then: '{relativeUrl}', else: '{node.path}')}
-							</a>
-						</f:alias>
+						<f:if condition="{documentNode}">
+							<f:then>
+								<f:alias map="{relativeUrl: '{neos:uri.node(node: documentNode, absolute: false, resolveShortcuts: false)}'}">
+									<a href="{neos:uri.node(node: documentNode, absolute: true, resolveShortcuts:false)}" class="node-frontend-uri">
+										{f:if(condition: relativeUrl, then: '{relativeUrl}', else: '{node.path}')}
+									</a>
+								</f:alias>
+							</f:then>
+							<f:else>
+								<a class="node-frontend-uri">
+									This node can't be accessed through a public URL
+								</a>
+						</f:else>
+						</f:if>
 					</f:alias>
 					<label class="node-label">{node.label}</label>
 					(<span class="node-identifier">{node.identifier}</span>)

--- a/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Show.html
@@ -18,9 +18,18 @@
 					</f:for>
 				</table>
 				<f:alias map="{documentNode: '{neos:node.closestDocument(node: node)}'}">
-					<neos:link.node node="{documentNode}" absolute="true" resolveShortcuts="false" class="node-frontend-uri">
-						<neos:uri.node node="{documentNode}" absolute="false" resolveShortcuts="false" />
-					</neos:link.node>
+					<f:if condition="{documentNode}">
+						<f:then>
+							<neos:link.node node="{documentNode}" absolute="true" resolveShortcuts="false" class="node-frontend-uri">
+								<neos:uri.node node="{documentNode}" absolute="false" resolveShortcuts="false" />
+							</neos:link.node>
+						</f:then>
+						<f:else>
+							<a class="node-frontend-uri">
+								This node can't be accessed through a public URL
+							</a>
+						</f:else>
+					</f:if>
 				</f:alias>
 				<f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'show', value: 'Show')}</f:link.action>
 			</div>

--- a/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Service/Nodes/Show.html
@@ -9,7 +9,7 @@
 			<div class="node">
 				<label class="node-label">{node.label}</label>
 				<table class="node-properties">
-					<caption>{neos:backend.translate(id: 'nodes.properties', value: 'Node Properties')}</caption>
+					<caption>{neos:backend.translate(id: 'service.nodes.nodeProperties', value: 'Node Properties')}</caption>
 					<tr><th>_identifier</th><td class="node-identifier">{node.identifier}</td></tr>
 					<tr><th>_path</th><td class="node-path">{node.path}</td></tr>
 					<tr><th>_type</th><td class="node-type">{node.nodeType.name}</td></tr>
@@ -26,12 +26,12 @@
 						</f:then>
 						<f:else>
 							<a class="node-frontend-uri">
-								This node can't be accessed through a public URL
+								{neos:backend.translate(id: 'service.nodes.noPublicUrl', value: 'This node cannot be accessed through a public URL')}
 							</a>
 						</f:else>
 					</f:if>
 				</f:alias>
-				<f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'show', value: 'Show')}</f:link.action>
+				<f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
 			</div>
 		</div>
 	</body>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
@@ -30,6 +30,9 @@
 			<trans-unit id="content" xml:space="preserve">
 				<source>Content</source>
 			</trans-unit>
+			<trans-unit id="node" xml:space="preserve">
+				<source>Node</source>
+			</trans-unit>
 			<trans-unit id="contentView" xml:space="preserve">
 				<source>Content View</source>
 			</trans-unit>
@@ -494,6 +497,20 @@
 			<!-- Miscellaneous -->
 			<trans-unit id="masterPlugins.nodeTypeOnPageLabel" xml:space="preserve">
 				<source>"{nodeTypeName}" on page "{pageLabel}"</source>
+			</trans-unit>
+
+			<!-- Service output -->
+			<trans-unit id="service.nodes.title" xml:space="preserve">
+				<source>Nodes</source>
+			</trans-unit>
+			<trans-unit id="service.nodes.show" xml:space="preserve">
+				<source>Show</source>
+			</trans-unit>
+			<trans-unit id="service.nodes.noPublicUrl" xml:space="preserve">
+				<source>This node cannot be accessed through a public URL</source>
+			</trans-unit>
+			<trans-unit id="service.nodes.nodeProperties" xml:space="preserve">
+				<source>Node Properties</source>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION
This checks whether a documentNode has been found before rendering a
link to the frontend for nodes that have been found by the nodes
service controller.

Fixes NEOS-1695