### PR TITLE
Fix documentation typo: Image{Variant => Interface}

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -261,7 +261,7 @@ Here is one of the standard Neos node types (slightly shortened)::
 	          position: 5
 	  properties:
 	    image:
-	      type: TYPO3\Media\Domain\Model\ImageVariant
+	      type: TYPO3\Media\Domain\Model\ImageInterface
 	      ui:
 	        label: 'Image'
 	        reloadIfChanged: TRUE


### PR DESCRIPTION
Using `ImageVariant` as node property type as suggested in this section of the documentation results in errors in the Neos backend:

> Couldn't create editor for property "image" (no editor configured). Please check your NodeTypes.yaml configuration.