### PR TITLE
[BUGFIX] Workspace identifier suffixes are not random (enough)

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -186,9 +186,9 @@ class WorkspacesController extends AbstractModuleController
             $this->redirect('new');
         }
 
-        $workspaceName = Utility::renderValidNodeName($title) . '-' . substr(uniqid(), 0, 4);
+        $workspaceName = Utility::renderValidNodeName($title) . '-' . substr(base_convert(microtime(false), 10, 36), -5, 5);
         while ($this->workspaceRepository->findOneByName($workspaceName) instanceof Workspace) {
-            $workspaceName = Utility::renderValidNodeName($title) . '-' . substr(uniqid(), 0, 4);
+            $workspaceName = Utility::renderValidNodeName($title) . '-' . substr(base_convert(microtime(false), 10, 36), -5, 5);
         }
 
         if ($visibility === 'private') {


### PR DESCRIPTION
This solves an issue with the automatically generated suffix for
names of workpsaces created through the Workspace Management module.

Previously, workspace suffixes (like "-7603") were identical or very
close to previously generated names, because they were derived from
the first four characters of the output of uniqid(), which is based
on microtime.

The new solution converts the current microtime into an alpha-numeric
string and takes the last 5 characters, which change very often.

Resolves: NEOS-1683