### PR TITLE
TASK: Small cleanup in reference(s) editor and publish menu

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/PublishMenu.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/PublishMenu.js
@@ -152,7 +152,6 @@ define(
         }.observes('autoPublish').on('init'),
 
         disabled: function () {
-          console.log(this.get('_targetWorkspaceReadOnly'));
           return this.get('_noChanges') || this.get('autoPublish') || this.get('_saveRunning') || this.get('_savePending') || this.get('_publishRunning') || this.get('_workspaceRebasePending') || this.get('_targetWorkspaceReadOnly');
         }.property('_noChanges', 'autoPublish', '_saveRunning', '_savePending', '_publishRunning', '_workspaceRebasePending', '_targetWorkspaceReadOnly'),
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferenceEditor.js
@@ -50,7 +50,7 @@ define(
 						$itemContent.attr('title', $itemContent.text().trim() + (info ? ' (' + info + ')' : ''));
 						$itemContent.append('<span class="neos-select2-result-path">' + info + '</span>');
 
-						var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon;
+						var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui ? NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon : null;
 						if (iconClass) {
 							$itemContent.prepend('<i class="' + iconClass + '"></i>');
 						}
@@ -64,7 +64,7 @@ define(
 							var info = item.data.path ? item.data.path : item.data.identifier;
 							$itemContent.attr('title', $itemContent.text().trim() + (info ? ' (' + info + ')' : ''));
 
-							var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon;
+							var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui ? NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon : null;
 							if (iconClass) {
 								$itemContent.prepend('<i class="' + iconClass + '"></i>');
 							}
@@ -77,12 +77,14 @@ define(
 							window.clearTimeout(currentQueryTimer);
 						}
 						currentQueryTimer = window.setTimeout(function() {
+							var parameters;
+							var $metadata = $('#neos-document-metadata');
 							currentQueryTimer = null;
 
-							var parameters = {
+							parameters = {
 								searchTerm: query.term,
-								workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
-								dimensions: $('#neos-document-metadata').data('neos-context-dimensions'),
+								workspaceName: $metadata.data('neos-context-workspace-name'),
+								dimensions: $metadata.data('neos-context-dimensions'),
 								contextNode: that.get('startingPoint'),
 								nodeTypes: that.get('nodeTypes')
 							};
@@ -128,6 +130,8 @@ define(
 			// actual value used and expected by the inspector, in case of this Editor a string (node identifier):
 			value: function(key, value) {
 				var that = this;
+				var parameters;
+				var $metadata = $('#neos-document-metadata');
 
 				if (value && value !== this.get('content.id')) {
 					var item = Ember.Object.extend({
@@ -138,9 +142,9 @@ define(
 					}).create();
 					that.set('content', item);
 
-					var parameters = {
-						workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
-						dimensions: $('#neos-document-metadata').data('neos-context-dimensions')
+					parameters = {
+						workspaceName: $metadata.data('neos-context-workspace-name'),
+						dimensions: $metadata.data('neos-context-dimensions')
 					};
 					HttpRestClient.getResource('neos-service-nodes', value, {data: parameters}).then(function(result) {
 						item.set('text', $('.node-label', result.resource).text().trim());

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ReferencesEditor.js
@@ -50,7 +50,7 @@ define(
 						$itemContent.attr('title', $itemContent.text().trim() + (info ? ' (' + info + ')' : ''));
 						$itemContent.append('<span class="neos-select2-result-path">' + info + '</span>');
 
-						var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon;
+						var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui ? NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon : null;
 						if (iconClass) {
 							$itemContent.prepend('<i class="' + iconClass + '"></i>');
 						}
@@ -64,7 +64,7 @@ define(
 							var info = item.data.path ? item.data.path : item.data.identifier;
 							$itemContent.attr('title', $itemContent.text().trim() + (info ? ' (' + info + ')' : ''));
 
-							var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon;
+							var iconClass = NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui ? NodeTypeService.getNodeTypeDefinition(item.data.nodeType).ui.icon : null;
 							if (iconClass) {
 								$itemContent.prepend('<i class="' + iconClass + '"></i>');
 							}
@@ -77,12 +77,14 @@ define(
 							window.clearTimeout(currentQueryTimer);
 						}
 						currentQueryTimer = window.setTimeout(function() {
+							var parameters;
+							var $metadata = $('#neos-document-metadata');
 							currentQueryTimer = null;
 
-							var parameters = {
+							parameters = {
 								searchTerm: query.term,
-								workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
-								dimensions: $('#neos-document-metadata').data('neos-context-dimensions'),
+								workspaceName: $metadata.data('neos-context-workspace-name'),
+								dimensions: $metadata.data('neos-context-dimensions'),
 								contextNode: that.get('startingPoint'),
 								nodeTypes: that.get('nodeTypes')
 							};
@@ -131,6 +133,8 @@ define(
 					that.set('content', []);
 					// load names of already selected nodes via the Node REST service:
 					$(JSON.parse(value)).each(function(index, nodeIdentifier) {
+						var parameters;
+						var $metadata = $('#neos-document-metadata');
 						var item = Ember.Object.extend({
 							id: nodeIdentifier,
 							text: function() {
@@ -140,9 +144,9 @@ define(
 
 						that.get('content').pushObject(item);
 
-						var parameters = {
-							workspaceName: $('#neos-document-metadata').data('neos-context-workspace-name'),
-							dimensions: $('#neos-document-metadata').data('neos-context-dimensions')
+						parameters = {
+							workspaceName: $metadata.data('neos-context-workspace-name'),
+							dimensions: $metadata.data('neos-context-dimensions')
 						};
 						HttpRestClient.getResource('neos-service-nodes', nodeIdentifier, {data: parameters}).then(function(result) {
 							item.set('text', $('.node-label', result.resource).text().trim());


### PR DESCRIPTION
This removes a console log call from PublishMenu.js and tweaks the
reference(s) editor to be a tiny bit nicer and allow to display node
suggestions even if the node in question does not have any ui
configuration in it's nodetype (can happen with startingPoint set for
the editor to select "nodes without a UI").