### PR TITLE
[BUGFIX] Allow to edit in own workspace from Workspaces module

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -295,14 +295,16 @@ class WorkspacesController extends AbstractModuleController
         $personalWorkspace = $this->workspaceRepository->findOneByName('user-' . $currentAccount->getAccountIdentifier());
         /** @var Workspace $personalWorkspace */
 
-        if ($this->publishingService->getUnpublishedNodesCount($personalWorkspace) > 0) {
-            $message = $this->translator->translateById('workspaces.cantEditBecauseWorkspaceContainsChanges', [], null, null, 'Modules', 'TYPO3.Neos');
-            $this->addFlashMessage($message, '', Message::SEVERITY_WARNING, [], 1437833387);
-            $this->redirect('show', null, null, ['workspace' => $targetWorkspace]);
-        }
+        if ($personalWorkspace !== $targetWorkspace) {
+            if ($this->publishingService->getUnpublishedNodesCount($personalWorkspace) > 0) {
+                $message = $this->translator->translateById('workspaces.cantEditBecauseWorkspaceContainsChanges', [], null, null, 'Modules', 'TYPO3.Neos');
+                $this->addFlashMessage($message, '', Message::SEVERITY_WARNING, [], 1437833387);
+                $this->redirect('show', null, null, ['workspace' => $targetWorkspace]);
+            }
 
-        $personalWorkspace->setBaseWorkspace($targetWorkspace);
-        $this->workspaceRepository->update($personalWorkspace);
+            $personalWorkspace->setBaseWorkspace($targetWorkspace);
+            $this->workspaceRepository->update($personalWorkspace);
+        }
 
         $contextProperties = $targetNode->getContext()->getProperties();
         $contextProperties['workspaceName'] = $personalWorkspace->getName();


### PR DESCRIPTION
When reviewing changes in one's own workspace, the "Edit" button would
always show an error about the personal workspace not being clean.
Because in this case a rebase of the workspace is not needed (and would
not be possible), that check and the rebase can be skipped if the
target workspace is the personal workspace.