### PR TITLE
[BUGFIX] Fix a PostgreSQL down migration

### DIFF
--- a/TYPO3.Media/Migrations/Postgresql/Version20150701113247.php
+++ b/TYPO3.Media/Migrations/Postgresql/Version20150701113247.php
@@ -31,7 +31,6 @@ class Version20150701113247 extends AbstractMigration {
 	public function down(Schema $schema) {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
-		$this->addSql("CREATE SCHEMA public");
 		$this->addSql("ALTER TABLE typo3_media_domain_model_image ALTER width SET NOT NULL");
 		$this->addSql("ALTER TABLE typo3_media_domain_model_image ALTER height SET NOT NULL");
 		$this->addSql("ALTER TABLE typo3_media_domain_model_imagevariant ALTER width SET NOT NULL");


### PR DESCRIPTION
In cb89c7a053b00a0dd3b2b538fdb5c41c668ef226 a missing migration was
added. That migration works fine when migrating up, but in the down
migration one line too much causes it to break.