### PR TITLE
BUGFIX: Event logging fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: php
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql
 matrix:
   fast_finish: true
   include:
@@ -6,10 +10,14 @@ matrix:
       env: DB=mysql
     - php: 7.0
       env: DB=mysql BEHAT=true
+    - php: 7.0
+      env: DB=pgsql BEHAT=true
     - php: 5.6
       env: DB=sqlite
     - php: 5.6
       env: DB=mysql BEHAT=true
+    - php: 5.6
+      env: DB=pgsql BEHAT=true
     - php: 5.5
       env: DB=sqlite
 cache:

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/Event.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/Event.php
@@ -22,7 +22,7 @@ use TYPO3\Flow\Annotations as Flow;
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\Table(
  *    indexes={
- * 		@ORM\Index(name="eventtype",columns={"eventtype"})
+ *        @ORM\Index(name="eventtype",columns={"eventtype"})
  *    }
  * )
  */
@@ -63,6 +63,7 @@ class Event
     /**
      * Payload of the event.
      *
+     * @ORM\Column(type="flow_json_array")
      * @var array
      */
     protected $data = array();

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/NodeEvent.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/NodeEvent.php
@@ -30,7 +30,7 @@ use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
  * The following annotation is not correctly picked up so doctrine migrations would never create this index. It is still contained in the migration.
  * @ORM\Table(
  *    indexes={
- *		@ORM\Index(name="documentnodeidentifier", columns={"documentnodeidentifier"})
+ *      @ORM\Index(name="documentnodeidentifier", columns={"documentnodeidentifier"})
  *    }
  * )
  */

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
@@ -59,9 +59,7 @@ class EventRepository extends Repository
         $classMetaData = $this->entityManager->getClassMetadata($this->getEntityClassName());
         $connection = $this->entityManager->getConnection();
         $databasePlatform = $connection->getDatabasePlatform();
-        $connection->query('SET FOREIGN_KEY_CHECKS=0');
         $truncateTableQuery = $databasePlatform->getTruncateTableSql($classMetaData->getTableName());
         $connection->executeUpdate($truncateTableQuery);
-        $connection->query('SET FOREIGN_KEY_CHECKS=1');
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
@@ -469,7 +469,8 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
 
             $qb = $entityManager->createQueryBuilder();
             $qb->update('TYPO3\Neos\EventLog\Domain\Model\NodeEvent', 'e')
-                ->set('e.parentEvent', $qb->expr()->literal($parentEventIdentifier))
+                ->set('e.parentEvent', ':parentEventIdentifier')
+                ->setParameter('parentEventIdentifier', $parentEventIdentifier)
                 ->where('e.parentEvent IS NULL')
                 ->andWhere('e.workspaceName = :workspaceName')
                 ->setParameter('workspaceName', $documentPublish['workspaceName'])

--- a/TYPO3.Neos/Migrations/Postgresql/Version20151126122252.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20151126122252.php
@@ -1,0 +1,42 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust column type and index names on Event schema to match code
+ *
+ * Note: the indexes are manually maintained, since the annotation adding them is not picked
+ * up, seemingly because of the single table inheritance (Event > NodeEvent).
+ */
+class Version20151126122252 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+		$this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data TYPE jsonb USING data::jsonb");
+		$this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data DROP DEFAULT");
+
+		$this->addSql("ALTER INDEX neos_eventlog_eventtype RENAME TO eventtype");
+		$this->addSql("ALTER INDEX neos_eventlog_documentnodeidentifier RENAME TO documentnodeidentifier");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+		$this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data TYPE TEXT");
+		$this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data DROP DEFAULT");
+
+		$this->addSql("ALTER INDEX eventtype RENAME TO neos_eventlog_eventtype");
+		$this->addSql("ALTER INDEX documentnodeidentifier RENAME TO neos_eventlog_documentnodeidentifier");
+	}
+}

--- a/TYPO3.Neos/Tests/Behavior/Features/EventLog/Entities/AccountsUsers.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/EventLog/Entities/AccountsUsers.feature
@@ -19,7 +19,7 @@ Feature: Accounts / User Entity Monitoring
         created: PERSON_CREATED
       data:
         name: '${entity.name.fullName}'
-        electronicAddresses: '${entity.electronicAddresses}'
+        primaryElectronicAddress: '${entity.primaryElectronicAddress}'
     """
 
     # TODO: subclasses in monitorEntities


### PR DESCRIPTION
This fixes a few issues with event logging:

- removes MySQL-specific SQL from the EventRepository
- fixes an invalid type error when setting the parentevent to null
- adjusts the data column to use the flow_json_array type to allow
  storing objects correctly.
- adjusts the event logging configuration (only used in Behat tests)
  to not extract the collection of electronic addresses associated with a
  Neos user, but only the primary electronic address.

NEOS-1726 #comment Removes MySQL-specific code and adjusts schema to be PostgreSQL compatible