### PR TITLE
[BUGFIX] Set dimension to array() instead of null

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Utility/NodePaths.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Utility/NodePaths.php
@@ -76,7 +76,7 @@ abstract class NodePaths
 
         $nodePath = $matches['NodePath'];
         $workspaceName = (isset($matches['WorkspaceName']) && $matches['WorkspaceName'] !== '' ? $matches['WorkspaceName'] : 'live');
-        $dimensions = isset($matches['Dimensions']) ? static::parseDimensionValueStringToArray($matches['Dimensions']) : null;
+        $dimensions = isset($matches['Dimensions']) ? static::parseDimensionValueStringToArray($matches['Dimensions']) : array();
 
         return array(
             'nodePath' => $nodePath,


### PR DESCRIPTION
The dimensions have to be an Array instead of null.

Fixes: NEOS-1697