### PR TITLE
[FEATURE] External event for node selection

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
@@ -40,6 +40,7 @@ events occur:
 * **Neos.ContentModuleLoaded** When the content module is loaded (i.e. when a user is logged in).
 * **Neos.NodeCreated** When a new node was added to the document. The event has a reference to the DOM element in ``event.detail.element``. Additional information can be fetched through the element's attributes.
 * **Neos.NodeRemoved** When a new node was removed from the document. The event has a reference to the DOM element in ``event.detail.element``. Additional information can be fetched through the element's attributes.
+* **Neos.NodeSelected** When a new node was added to the document. The event has a reference to the DOM element in ``event.detail.element`` and the node model object in ``event.detail.node``. Additional information can be fetched through the node model.
 * **Neos.LayoutChanged** When the content window layout changes (when panels that alter the body margin are opened/closed).
 * **Neos.NavigatePanelOpened** When the navigate panel is opened.
 * **Neos.NavigatePanelClosed** When the inspector panel is closed.
@@ -51,6 +52,17 @@ events occur:
 * **Neos.MenuPanelClosed** When the menu panel is closed.
 * **Neos.FullScreenModeActivated** When the backend switches to fullscreen mode.
 * **Neos.FullScreenModeDeactivated** When the backend leaves the fullscreen mode.
+
+Example of interacting with the selected node element using the ``NodeSelected`` event.
+
+.. code-block:: javascript
+
+  document.addEventListener('Neos.NodeSelected', function(event) {
+  	var node = event.detail.node;
+  	if (event.detail.node.get('nodeType') === 'Acme:Demo') {
+  		console.log(node.getAttribute('title'), node.get('attributes.title'), node.$element);
+  	}
+  }, false);
 
 Example of listening for the ``LayoutChanged`` event.
 

--- a/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/InteractionWithTheNeosBackend.rst
@@ -40,7 +40,7 @@ events occur:
 * **Neos.ContentModuleLoaded** When the content module is loaded (i.e. when a user is logged in).
 * **Neos.NodeCreated** When a new node was added to the document. The event has a reference to the DOM element in ``event.detail.element``. Additional information can be fetched through the element's attributes.
 * **Neos.NodeRemoved** When a new node was removed from the document. The event has a reference to the DOM element in ``event.detail.element``. Additional information can be fetched through the element's attributes.
-* **Neos.NodeSelected** When a new node was added to the document. The event has a reference to the DOM element in ``event.detail.element`` and the node model object in ``event.detail.node``. Additional information can be fetched through the node model.
+* **Neos.NodeSelected** When a node existing on the page is selected. The event has a reference to the DOM element in ``event.detail.element`` and the node model object in ``event.detail.node``. Additional information can be fetched through the node model.
 * **Neos.LayoutChanged** When the content window layout changes (when panels that alter the body margin are opened/closed).
 * **Neos.NavigatePanelOpened** When the navigate panel is opened.
 * **Neos.NavigatePanelClosed** When the inspector panel is closed.

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
@@ -324,8 +324,12 @@ define(
 		},
 
 		selectedNode: function() {
-			var nodes = this.get('nodes');
-			return nodes.length > 0 ? _.last(nodes) : null;
+			var nodes = this.get('nodes'),
+				selectedNode = nodes.length > 0 ? _.last(nodes) : null;
+			if (selectedNode) {
+				EventDispatcher.triggerExternalEvent('Neos.NodeSelected', 'Node was selected.', {element: selectedNode.$element.get(0), node: selectedNode});
+			}
+			return selectedNode;
 		}.property('nodes'),
 
 		selectedNodeSchema: function() {


### PR DESCRIPTION
This change adds a new event ``Neos.NodeSelected`` that will
be triggered when a node was selected on the page.

Resolves: NEOS-407