### PR TITLE
[BUGFIX] NodeContextPath should contain a node path

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -258,9 +258,17 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         $workspaceName = 'live';
         $dimensionsAndDimensionValues = $this->parseDimensionsAndNodePathFromRequestPath($requestPath);
 
-        if ($requestPath !== '' && NodePaths::isContextPath($requestPath)) {
+        // This is a workaround as NodePaths::explodeContextPath() (correctly)
+        // expects a context path to have something before the '@', but the requestPath
+        // could potentially contain only the context information.
+        $contextPath = $requestPath;
+        if (strpos($contextPath, '@') === 0) {
+            $contextPath = '/' . $contextPath;
+        }
+
+        if ($contextPath !== '' && NodePaths::isContextPath($contextPath)) {
             try {
-                $nodePathAndContext = NodePaths::explodeContextPath($requestPath);
+                $nodePathAndContext = NodePaths::explodeContextPath($contextPath);
                 $workspaceName = $nodePathAndContext['workspaceName'];
             } catch (\InvalidArgumentException $exception) {
             }


### PR DESCRIPTION
The change ccb1c0e contained a regression because the adapted
pattern for NodeContextPath now only matches if there is actually
a path and not only a context (which is correct in regards to the
naming), but the FrontendNodeRoutePartHandler used it with request
paths that might start only with the context information. These would
no longer match and therefore the request path is prepended with a
`/` before filtering out the context information.