### PR TITLE
[TASK] Use runtime cache in user service

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -163,6 +163,28 @@ class UserService
     }
 
     /**
+     * Returns the username of the given user
+     *
+     * Technically, this method will look for the user's backend account (or, if authenticationProviderName is specified,
+     * for the account matching the given authentication provider) and return the account's identifier.
+     *
+     * @param User $user
+     * @param string $authenticationProviderName
+     * @return string The username or null if the given user does not have a backend account
+     */
+    public function getUsername(User $user, $authenticationProviderName = null)
+    {
+        $authenticationProviderName = $authenticationProviderName ?: $this->defaultAuthenticationProviderName;
+        foreach ($user->getAccounts() as $account) {
+            /** @var Account $account */
+            if ($account->getAuthenticationProviderName() === $authenticationProviderName) {
+                return $account->getAccountIdentifier();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns the currently logged in user, if any
      *
      * @return User The currently logged in user, or NULL
@@ -170,10 +192,14 @@ class UserService
      */
     public function getCurrentUser()
     {
-        $account = $this->securityContext->getAccount();
-        if ($account !== null) {
-            return $this->getUser($account->getAccountIdentifier());
+        if ($this->securityContext->canBeInitialized() === true) {
+            $account = $this->securityContext->getAccount();
+            if ($account !== null) {
+                return $this->getUser($account->getAccountIdentifier());
+            }
         }
+
+        return null;
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
@@ -12,7 +12,6 @@ namespace TYPO3\Neos\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Security\Context;
 use TYPO3\Neos\Domain\Model\User;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
@@ -27,9 +26,9 @@ class UserService
 {
     /**
      * @Flow\Inject
-     * @var Context
+     * @var \TYPO3\Neos\Domain\Service\UserService
      */
-    protected $securityContext;
+    protected $userDomainService;
 
     /**
      * @Flow\Inject
@@ -48,10 +47,7 @@ class UserService
      */
     public function getBackendUser()
     {
-        if ($this->securityContext->canBeInitialized() === true) {
-            return $this->securityContext->getPartyByType('TYPO3\Neos\Domain\Model\User');
-        }
-        return null;
+        return $this->userDomainService->getCurrentUser();
     }
 
     /**
@@ -76,11 +72,14 @@ class UserService
      */
     public function getCurrentWorkspaceName()
     {
-        $account = $this->securityContext->getAccount();
-        if ($account === null) {
+        $currentUser = $this->userDomainService->getCurrentUser();
+
+        if (!$currentUser instanceof User) {
             return 'live';
         }
-        return 'user-' . preg_replace('/[^a-z0-9]/i', '', $account->getAccountIdentifier());
+
+        $username = $this->userDomainService->getUsername($currentUser);
+        return 'user-' . preg_replace('/[^a-z0-9]/i', '', $username);
     }
 
     /**


### PR DESCRIPTION
To prevent making a database lookup every time a user is requested
through the ``UserService`` a runtime cache is used. This prevents
lots of lookups since the user is requested many times in the backend,
e.g. once for every translate view helper.