### PR TITLE
[TASK] Media browser performance improvements

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -183,9 +183,14 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
             $this->browserState->set('tagMode', self::TAG_ALL);
         }
 
+        $assetCollections = array();
+        foreach ($this->assetCollectionRepository->findAll() as $assetCollection) {
+            $assetCollections[] = array('object' => $assetCollection, 'count' => $this->assetRepository->countByAssetCollection($assetCollection));
+        }
+
         $tags = array();
         foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $tag) {
-            $tags[] = array('tag' => $tag, 'count' => $this->assetRepository->countByTag($tag, $activeAssetCollection));
+            $tags[] = array('object' => $tag, 'count' => $this->assetRepository->countByTag($tag, $activeAssetCollection));
         }
 
         if ($searchTerm !== null) {
@@ -208,7 +213,7 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
             'allCount' => $activeAssetCollection ? $this->assetRepository->countByAssetCollection($activeAssetCollection) : $allCollectionsCount,
             'untaggedCount' => $this->assetRepository->countUntagged($activeAssetCollection),
             'tagMode' => $this->browserState->get('tagMode'),
-            'assetCollections' => $this->assetCollectionRepository->findAll(),
+            'assetCollections' => $assetCollections,
             'argumentNamespace' => $this->request->getArgumentNamespace(),
             'maximumFileUploadSize' => $maximumFileUploadSize,
             'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($maximumFileUploadSize)

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -177,7 +177,7 @@ class AssetRepository extends Repository
      * @param AssetCollection $assetCollection
      * @return integer
      */
-    public function countByAssetCollection(AssetCollection $assetCollection = null)
+    public function countByAssetCollection(AssetCollection $assetCollection)
     {
         $query = $this->createQuery();
         $this->addImageVariantFilterClause($query);

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -95,9 +95,9 @@ class AssetRepository extends Repository
         $rsm->addScalarResult('c', 'c');
 
         if ($assetCollection === null) {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join mm ON a.persistence_object_identifier = mm.media_asset WHERE mm.media_tag = ?';
+            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset WHERE tagmm.media_tag = ? AND a.dtype != "typo3_media_imagevariant"';
         } else {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_tag = ? AND collectionmm.media_assetcollection = ?';
+            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_tag = ? AND collectionmm.media_assetcollection = ? AND a.dtype != "typo3_media_imagevariant"';
         }
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -95,9 +95,9 @@ class AssetRepository extends Repository
         $rsm->addScalarResult('c', 'c');
 
         if ($assetCollection === null) {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset WHERE tagmm.media_tag = ? AND a.dtype != "typo3_media_imagevariant"';
+            $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset WHERE tagmm.media_tag = ? AND a.dtype != 'typo3_media_imagevariant'";
         } else {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_tag = ? AND collectionmm.media_assetcollection = ? AND a.dtype != "typo3_media_imagevariant"';
+            $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_tag = ? AND collectionmm.media_assetcollection = ? AND a.dtype != 'typo3_media_imagevariant'";
         }
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);
@@ -127,7 +127,7 @@ class AssetRepository extends Repository
         $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
-        $queryString = 'SELECT count(persistence_object_identifier) c FROM typo3_media_domain_model_asset WHERE dtype != "typo3_media_imagevariant"';
+        $queryString = "SELECT count(persistence_object_identifier) c FROM typo3_media_domain_model_asset WHERE dtype != 'typo3_media_imagevariant'";
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);
         return $query->getSingleScalarResult();
@@ -160,9 +160,9 @@ class AssetRepository extends Repository
         $rsm->addScalarResult('c', 'c');
 
         if ($assetCollection === null) {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset WHERE tagmm.media_asset IS NULL AND a.dtype != "typo3_media_imagevariant"';
+            $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset WHERE tagmm.media_asset IS NULL AND a.dtype != 'typo3_media_imagevariant'";
         } else {
-            $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_asset IS NULL AND collectionmm.media_assetcollection = ? AND a.dtype != "typo3_media_imagevariant"';
+            $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_asset_tags_join tagmm ON a.persistence_object_identifier = tagmm.media_asset LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE tagmm.media_asset IS NULL AND collectionmm.media_assetcollection = ? AND a.dtype != 'typo3_media_imagevariant'";
         }
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);
@@ -195,7 +195,7 @@ class AssetRepository extends Repository
         $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
-        $queryString = 'SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE collectionmm.media_assetcollection = ? AND a.dtype != "typo3_media_imagevariant"';
+        $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE collectionmm.media_assetcollection = ? AND a.dtype != 'typo3_media_imagevariant'";
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);
         $query->setParameter(1, $assetCollection);

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -61,6 +61,7 @@ class AssetRepository extends Repository
             $constraints[] = $query->contains('tags', $tag);
         }
         $query->matching($query->logicalOr($constraints));
+        $this->addImageVariantFilterClause($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }

--- a/TYPO3.Media/Resources/Public/Scripts/collections-and-tagging.js
+++ b/TYPO3.Media/Resources/Public/Scripts/collections-and-tagging.js
@@ -125,4 +125,25 @@
 			$('button[type="submit"]', this).addClass('neos-disabled').html(label + '<span class="neos-ellipsis" />');
 		}
 	});
+
+	$('[data-modal]').click(function(e) {
+		e.preventDefault();
+		var $this = $(this),
+			$modal = $('#' + $this.data('modal')),
+			$header = $('.neos-header', $modal),
+			headerText = $header.text();
+		$header.text(headerText.replace('{0}', $this.data('label')));
+		$('#modal-form-object', $modal).val($this.data('object-identifier'));
+		$(document).on('keyup.modal', function(e) {
+			if (e.keyCode == 27) {
+				$modal.modal('hide');
+			}
+		});
+		$modal.modal().one('hide', function() {
+			$this.focus();
+			$header.text(headerText);
+			$(document).off('keyup.modal');
+		});
+		$('[type="submit"]', $modal).focus();
+	});
 })(jQuery);

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
@@ -32,63 +32,40 @@
 			</tr>
 		</thead>
 		<tbody>
-		<f:for each="{paginatedAssets}" as="asset" iteration="iterator">
-			<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
-				<td>
-					<f:if condition="{asset.width}">
-						<f:then>
-							<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{asset.width} x {asset.height}" data-html="true" data-content="{m:image(asset: asset, maximumWidth: 250, maximumHeight: 250, alt: asset.label) -> f:format.htmlentities()}">
-								<m:image asset="{asset}" allowCropping="false" maximumWidth="40" maximumHeight="40" alt="{asset.label}"/>
-							</div>
-						</f:then>
-						<f:else>
-							<div class="neos-list-thumbnail">
-								<m:image asset="{asset}" allowCropping="false" maximumWidth="40" maximumHeight="40" alt="{asset.label}"/>
-							</div>
-						</f:else>
-					</f:if>
-					<i class="icon-move" title="{neos:backend.translate(id: 'media.tooltip.dragAndDropOnTagOrCollection', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip"></i>
-				</td>
-				<td><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
-				<td><span title="{asset.lastModified -> f:format.date(format: 'd-m-Y H:i')}" data-neos-toggle="tooltip">{asset.lastModified -> m:format.relativeDate()}</span></td>
-				<td>{asset.resource.fileSize -> f:format.bytes()}</td>
-				<td>{asset.resource.mediatype}</td>
-				<td class="tags">
-					<f:for each="{asset.tags}" as="tag">
-						<span class="neos-label">{tag.label}</span>
-					</f:for>
-				</td>
-				<td class="neos-action">
-					<f:link.action action="edit" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}" class="neos-button neos-button-mini" arguments="{asset: asset}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-					<button class="neos-button neos-button-mini neos-button-danger" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#asset-{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
-					<div class="neos-hide" id="asset-{asset -> f:format.identifier()}">
-						<div class="neos-modal">
-							<div class="neos-modal-header">
-								<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-								<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteAsset', arguments: {0:asset.label}, source: 'Modules', package: 'TYPO3.Neos')}</div>
-								<div>
-									<div class="neos-subheader">
-										<p>
-											{neos:backend.translate(id: 'media.message.willBeDeleted', source: 'Modules', package: 'TYPO3.Neos')}<br />
-											{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
-										</p>
-									</div>
+		<f:alias map="{'dragAndDropOnTagOrCollectionLabel': '{neos:backend.translate(id: \'media.tooltip.dragAndDropOnTagOrCollection\', source: \'Modules\', package: \'TYPO3.Neos\')}', 'editAsset': '{neos:backend.translate(id: \'media.tooltip.editAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
+			<f:for each="{paginatedAssets}" as="asset" iteration="iterator">
+				<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
+					<td>
+						<f:if condition="{asset.width}">
+							<f:then>
+								<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{asset.width} x {asset.height}" data-html="true" data-content="{m:image(asset: asset, maximumWidth: 250, maximumHeight: 250, alt: asset.label) -> f:format.htmlentities()}">
+									<m:image asset="{asset}" allowCropping="false" maximumWidth="40" maximumHeight="40" alt="{asset.label}"/>
 								</div>
-							</div>
-							<div class="neos-modal-footer">
-								<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
-								<f:form action="delete" method="post" object="{asset}" objectName="asset" class="neos-inline">
-									<button type="submit" title="Delete asset" class="neos-button neos-button-mini neos-button-danger">
-										{neos:backend.translate(id: 'media.message.confirmDelete', source: 'Modules', package: 'TYPO3.Neos')}
-									</button>
-								</f:form>
-							</div>
-						</div>
-						<div class="neos-modal-backdrop neos-in"></div>
-					</div>
-				</td>
-			</tr>
-		</f:for>
+							</f:then>
+							<f:else>
+								<div class="neos-list-thumbnail">
+									<m:image asset="{asset}" allowCropping="false" maximumWidth="40" maximumHeight="40" alt="{asset.label}"/>
+								</div>
+							</f:else>
+						</f:if>
+						<i class="icon-move" title="{dragAndDropOnTagOrCollectionLabel}" data-neos-toggle="tooltip"></i>
+					</td>
+					<td class="asset-label"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
+					<td><span title="{asset.lastModified -> f:format.date(format: 'd-m-Y H:i')}" data-neos-toggle="tooltip">{asset.lastModified -> m:format.relativeDate()}</span></td>
+					<td>{asset.resource.fileSize -> f:format.bytes()}</td>
+					<td>{asset.resource.mediatype}</td>
+					<td class="tags">
+						<f:for each="{asset.tags}" as="tag">
+							<span class="neos-label">{tag.label}</span>
+						</f:for>
+					</td>
+					<td class="neos-action">
+						<f:link.action action="edit" title="{editAsset}" class="neos-button neos-button-mini" arguments="{asset: asset}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
+						<button class="neos-button neos-button-mini neos-button-danger" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
+					</td>
+				</tr>
+			</f:for>
+		</f:alias>
 		</tbody>
 	</table>
 </f:widget.paginate>

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
@@ -2,41 +2,18 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
 <f:widget.paginate objects="{assets}" as="paginatedAssets" configuration="{itemsPerPage: 30, maximumNumberOfLinks: 5}">
 	<ul class="neos-thumbnails asset-list">
-		<f:for each="{paginatedAssets}" as="asset">
-			<li class="asset">
-				<f:link.action action="edit" title="{neos:backend.translate(id: 'media.thumbnail.editTitle', arguments:{0:asset.label}, source: 'Modules', package: 'TYPO3.Neos')}" class="neos-thumbnail" arguments="{asset: asset}">
-					<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
-						<m:image asset="{asset}" maximumWidth="250" maximumHeight="250" alt="{asset.label}" />
-						<button class="neos-button neos-media-delete" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#asset-{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
-					</div>
-					<span class="neos-caption"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
-				</f:link.action>
-				<div class="neos-hide" id="asset-{asset -> f:format.identifier()}">
-					<div class="neos-modal">
-						<div class="neos-modal-header">
-							<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-							<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteAsset', arguments: {0:asset.label}, source: 'Modules', package: 'TYPO3.Neos')}</div>
-							<div>
-								<div class="neos-subheader">
-									<p>
-										{neos:backend.translate(id: 'media.message.willBeDeleted', source: 'Modules', package: 'TYPO3.Neos')}<br />
-										{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
-									</p>
-								</div>
-							</div>
+		<f:alias map="{'deleteAssetLabel': '{neos:backend.translate(id: \'media.tooltip.deleteAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
+			<f:for each="{paginatedAssets}" as="asset">
+				<li class="asset">
+					<f:link.action action="edit" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}" class="neos-thumbnail" arguments="{asset: asset}">
+						<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
+							<m:image asset="{asset}" maximumWidth="250" maximumHeight="250" alt="{asset.label}" />
+							<button class="neos-button neos-media-delete" title="{deleteAssetLabel}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
 						</div>
-						<div class="neos-modal-footer">
-							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
-							<f:form action="delete" method="post" object="{asset}" objectName="asset" class="neos-inline">
-								<button type="submit" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" class="neos-button neos-button-mini neos-button-danger">
-									{neos:backend.translate(id: 'media.message.confirmDelete', source: 'Modules', package: 'TYPO3.Neos')}
-								</button>
-							</f:form>
-						</div>
-					</div>
-					<div class="neos-modal-backdrop neos-in"></div>
-				</div>
-			</li>
-		</f:for>
+						<span class="neos-caption asset-label"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
+					</f:link.action>
+				</li>
+			</f:for>
+		</f:alias>
 	</ul>
 </f:widget.paginate>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
@@ -99,36 +99,37 @@
 						</f:link.action>
 						<div class="neos-sidelist-edit-actions">
 							<f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'media.editCollection', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-							<button type="submit" class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#collection-{assetCollection.object -> f:format.identifier()}"><i class="icon-trash"></i></button>
-						</div>
-						<div class="neos-hide" id="collection-{assetCollection.object -> f:format.identifier()}">
-							<div class="neos-modal">
-								<div class="neos-modal-header">
-									<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-									<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteCollection', arguments: {0: '{assetCollection.object.title}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
-									<div>
-										<div class="neos-subheader">
-											<p>
-												{neos:backend.translate(id: 'media.message.willDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}<br />
-												{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
-											</p>
-										</div>
-									</div>
-								</div>
-								<div class="neos-modal-footer">
-									<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
-									<f:form action="deleteAssetCollection" arguments="{assetCollection: assetCollection.object}" class="neos-inline">
-										<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}">
-											{neos:backend.translate(id: 'media.message.confirmDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}
-										</button>
-									</f:form>
-								</div>
-							</div>
-							<div class="neos-modal-backdrop neos-in"></div>
+							<button type="submit" class="neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip"><i class="icon-trash"></i></button>
 						</div>
 					</li>
 				</f:for>
 			</ul>
+			<div class="neos-hide" id="delete-assetcollection-modal">
+				<div class="neos-modal">
+					<div class="neos-modal-header">
+						<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+						<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}</div>
+						<div>
+							<div class="neos-subheader">
+								<p>
+									{neos:backend.translate(id: 'media.message.willDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}<br />
+									{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
+								</p>
+							</div>
+						</div>
+					</div>
+					<div class="neos-modal-footer">
+						<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
+						<f:form action="deleteAssetCollection" class="neos-inline">
+							<f:form.hidden name="assetCollection" id="modal-form-object" />
+							<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}">
+								{neos:backend.translate(id: 'media.message.confirmDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}
+							</button>
+						</f:form>
+					</div>
+				</div>
+				<div class="neos-modal-backdrop neos-in"></div>
+			</div>
 		</f:if>
 		<f:security.ifAccess privilegeTarget="TYPO3.Media:ManageAssetCollections">
 			<f:form action="createAssetCollection" id="neos-assetcollections-create-form">
@@ -164,35 +165,36 @@
 					</f:link.action>
 					<div class="neos-sidelist-edit-actions">
 						<f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'media.editTag', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-						<button class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#tag-{tag.object -> f:format.identifier()}"><i class="icon-trash"></i></button>
-					</div>
-					<div class="neos-hide" id="tag-{tag.object -> f:format.identifier()}">
-						<div class="neos-modal">
-							<div class="neos-modal-header">
-								<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-								<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteTag', arguments: {0: '{tag.object.label}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
-								<div>
-									<div class="neos-subheader">
-										<p>
-											{neos:backend.translate(id: 'media.message.willDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}<br />
-											{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
-										</p>
-									</div>
-								</div>
-							</div>
-							<div class="neos-modal-footer">
-								<a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
-								<f:form action="deleteTag" arguments="{tag: tag.object}" class="neos-inline">
-									<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}">
-										{neos:backend.translate(id: 'media.message.confirmDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}
-									</button>
-								</f:form>
-							</div>
-						</div>
-						<div class="neos-modal-backdrop neos-in"></div>
+						<button class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="icon-trash"></i></button>
 					</div>
 				</li>
 			</f:for>
+			<div class="neos-hide" id="delete-tag-modal">
+				<div class="neos-modal">
+					<div class="neos-modal-header">
+						<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+						<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}</div>
+						<div>
+							<div class="neos-subheader">
+								<p>
+									{neos:backend.translate(id: 'media.message.willDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}<br />
+									{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
+								</p>
+							</div>
+						</div>
+					</div>
+					<div class="neos-modal-footer">
+						<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
+						<f:form action="deleteTag" class="neos-inline">
+							<f:form.hidden name="tag" id="modal-form-object" />
+							<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}">
+								{neos:backend.translate(id: 'media.message.confirmDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}
+							</button>
+						</f:form>
+					</div>
+				</div>
+				<div class="neos-modal-backdrop neos-in"></div>
+			</div>
 		</ul>
 		<f:form action="createTag" id="neos-tags-create-form">
 			<f:form.textfield name="label" placeholder="Enter tag label" /><br /><br />
@@ -214,6 +216,32 @@
 	<f:if condition="{assets}">
 		<f:then>
 			<f:render partial="{view}View" arguments="{assets: assets, sort: sort}" />
+			<div class="neos-hide" id="delete-asset-modal">
+				<div class="neos-modal">
+					<div class="neos-modal-header">
+						<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+						<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteAsset', source: 'Modules', package: 'TYPO3.Neos')}</div>
+						<div>
+							<div class="neos-subheader">
+								<p>
+									{neos:backend.translate(id: 'media.message.willBeDeleted', source: 'Modules', package: 'TYPO3.Neos')}<br />
+									{neos:backend.translate(id: 'media.message.operationCannotBeUndone', source: 'Modules', package: 'TYPO3.Neos')}
+								</p>
+							</div>
+						</div>
+					</div>
+					<div class="neos-modal-footer">
+						<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
+						<f:form action="delete" method="post" class="neos-inline">
+							<f:form.hidden name="asset" id="modal-form-object" />
+							<button type="submit" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" class="neos-button neos-button-mini neos-button-danger">
+								{neos:backend.translate(id: 'media.message.confirmDelete', source: 'Modules', package: 'TYPO3.Neos')}
+							</button>
+						</f:form>
+					</div>
+				</div>
+				<div class="neos-modal-backdrop neos-in"></div>
+			</div>
 		</f:then>
 		<f:else>
 			<p>{neos:backend.translate(id: 'media.noAssetsFound', source: 'Modules', package: 'TYPO3.Neos')}</p>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
@@ -93,19 +93,19 @@
 				</li>
 				<f:for each="{assetCollections}" as="assetCollection">
 					<li>
-						<f:link.action action="index" title="{assetCollection.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection} == {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection}" data="{assetcollection-identifier: '{assetCollection -> f:format.identifier()}'}">
-							{assetCollection.title}
-							<span class="count">{assetCollection.assets -> f:count()}</span>
+						<f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} == {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+							{assetCollection.object.title}
+							<span class="count">{assetCollection.count}</span>
 						</f:link.action>
 						<div class="neos-sidelist-edit-actions">
-							<f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection}" title="{neos:backend.translate(id: 'media.editCollection', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-							<button type="submit" class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#collection-{assetCollection -> f:format.identifier()}"><i class="icon-trash"></i></button>
+							<f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'media.editCollection', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
+							<button type="submit" class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#collection-{assetCollection.object -> f:format.identifier()}"><i class="icon-trash"></i></button>
 						</div>
-						<div class="neos-hide" id="collection-{assetCollection -> f:format.identifier()}">
+						<div class="neos-hide" id="collection-{assetCollection.object -> f:format.identifier()}">
 							<div class="neos-modal">
 								<div class="neos-modal-header">
 									<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-									<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteCollection', arguments: {0: '{assetCollection.title}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
+									<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteCollection', arguments: {0: '{assetCollection.object.title}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
 									<div>
 										<div class="neos-subheader">
 											<p>
@@ -117,7 +117,7 @@
 								</div>
 								<div class="neos-modal-footer">
 									<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</a>
-									<f:form action="deleteAssetCollection" arguments="{assetCollection: assetCollection}" class="neos-inline">
+									<f:form action="deleteAssetCollection" arguments="{assetCollection: assetCollection.object}" class="neos-inline">
 										<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteCollection', source: 'Modules', package: 'TYPO3.Neos')}">
 											{neos:backend.translate(id: 'media.message.confirmDeleteCollection', source: 'Modules', package: 'TYPO3.Neos')}
 										</button>
@@ -158,19 +158,19 @@
 			</li>
 			<f:for each="{tags}" as="tag">
 				<li>
-					<f:link.action action="index" title="{tag.tag.label}" class="droppable-tag{f:if(condition: '{tag.tag} == {activeTag}', then: ' neos-active')}" arguments="{tag: tag.tag}" data="{tag-identifier: '{tag.tag -> f:format.identifier()}'}">
-						{tag.tag.label}
+					<f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} == {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+						{tag.object.label}
 						<span class="count">{tag.count}</span>
 					</f:link.action>
 					<div class="neos-sidelist-edit-actions">
-						<f:link.action class="neos-button" action="editTag" arguments="{tag: tag.tag}" title="{neos:backend.translate(id: 'media.editTag', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-						<button class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#tag-{tag.tag -> f:format.identifier()}"><i class="icon-trash"></i></button>
+						<f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'media.editTag', source: 'Modules', package: 'TYPO3.Neos')}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
+						<button class="neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-toggle="modal" data-target="#tag-{tag.object -> f:format.identifier()}"><i class="icon-trash"></i></button>
 					</div>
-					<div class="neos-hide" id="tag-{tag.tag -> f:format.identifier()}">
+					<div class="neos-hide" id="tag-{tag.object -> f:format.identifier()}">
 						<div class="neos-modal">
 							<div class="neos-modal-header">
 								<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-								<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteTag', arguments: {0: '{tag.tag.label}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
+								<div class="neos-header">{neos:backend.translate(id: 'media.message.reallyDeleteTag', arguments: {0: '{tag.object.label}'}, source: 'Modules', package: 'TYPO3.Neos')}</div>
 								<div>
 									<div class="neos-subheader">
 										<p>
@@ -182,7 +182,7 @@
 							</div>
 							<div class="neos-modal-footer">
 								<a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
-								<f:form action="deleteTag" arguments="{tag: tag.tag}" class="neos-inline">
+								<f:form action="deleteTag" arguments="{tag: tag.object}" class="neos-inline">
 									<button type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'media.deleteTag', source: 'Modules', package: 'TYPO3.Neos')}">
 										{neos:backend.translate(id: 'media.message.confirmDeleteTag', source: 'Modules', package: 'TYPO3.Neos')}
 									</button>


### PR DESCRIPTION
Optimizes rendering performance of the media browser/module by
re-using modals, optimizing and using count queries.

Brings 0,5x-3x+ speed improvement depending on the selected view
and amount of assets and tags/asset collections visible.

No functional difference.

Additionally fixes a couple of bugs in the asset repository.

Resolves: NEOS-1698