### PR TITLE
[BUGFIX] ContextPath match pattern should match only slash

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeInterface.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeInterface.php
@@ -29,8 +29,11 @@ interface NodeInterface
      */
     const MATCH_PATTERN_CONTEXTPATH = '/^   # A Context Path consists of...
 		(?>(?P<NodePath>                       # 1) a NODE PATH
-			\/?                             #    A node Path starts with optional slash
-			[a-z0-9\-]+                     #    followed by a path part
+			(?>
+			\/ [a-z0-9\-]+ |                # Which either starts with a slash followed by a node name
+			\/ |                            # OR just a slash (the root node)
+			[a-z0-9\-]+                     # OR only a node name (if it is a relative path)
+			)
 			(?:                             #    and (optionally) more path-parts)
 				\/
 				[a-z0-9\-]+


### PR DESCRIPTION
The ContextPath match pattern would either match an absolute path
containing at least one segment or a relative path but not the root
node path ``/``. This change fixes that so that now all valid node
path variants are supported.