### PR TITLE
[TASK] Remove unnecessary method from RoutePartHandler

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -209,7 +209,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
 
         if (is_string($node)) {
             $nodeContextPath = $node;
-            $contentContext = $this->buildContextFromContextPath($nodeContextPath);
+            $contentContext = $this->buildContextFromPath($nodeContextPath, true);
             if ($contentContext->getWorkspace() === null) {
                 return false;
             }
@@ -236,15 +236,6 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         $this->value = $routePath;
 
         return true;
-    }
-
-    /**
-     * @param string $contextPath
-     * @return ContentContext
-     */
-    protected function buildContextFromContextPath($contextPath)
-    {
-        return $this->buildContextFromPath($contextPath, true);
     }
 
     /**


### PR DESCRIPTION
The method didn't have any obvious benefit and was only used in a
single place, removing it and directly calling the method that was
called inside removes a bit of clutter.