### PR TITLE
[TASK] Adjust Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - git clone https://github.com/neos/neos-development-distribution.git -b 2.0
   - cd neos-development-distribution
 install:
-  - composer install --no-progress --no-interaction
+  - composer update --no-progress --no-interaction
   - rm -rf Packages/Neos
   - mv ../neos-development-collection Packages/Neos
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
   - git clone https://github.com/neos/neos-development-distribution.git -b 2.0
   - cd neos-development-distribution
 install:
+  - composer self-update -q
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - composer install --no-progress --no-interaction
   - composer update --no-progress --no-interaction
   - rm -rf Packages/Neos

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - git clone https://github.com/neos/neos-development-distribution.git -b 2.0
   - cd neos-development-distribution
 install:
+  - composer install --no-progress --no-interaction
   - composer update --no-progress --no-interaction
   - rm -rf Packages/Neos
   - mv ../neos-development-collection Packages/Neos


### PR DESCRIPTION
This makes sure the travis tests run as planned by using a github
API token to circumvent the bandwith limit and additionally run
composer update after composer install to make sure the latest
package versions get installed for testing.