### PR TITLE
[BUGFIX] Fix parentsUntil operation

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -70,7 +70,7 @@ class ParentsUntilOperation extends AbstractOperation
                 $until = $untilQuery->get();
             }
 
-            if (isset($until[0]) && !empty($until)) {
+            if ((is_array($until) && !empty($until)) && isset($until[0])) {
                 $parentNodes = $this->getNodesUntil($parentNodes, $until[0]);
             }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -65,15 +65,13 @@ class ParentsUntilOperation extends AbstractOperation
             $parentNodes = $this->getParents($contextNode, $siteNode);
 
             if (isset($arguments[0]) && !empty($arguments[0])) {
-                $untilQuery = new FlowQuery($parentNodes);
-                $untilQuery->pushOperation('filter', array($arguments[0]));
-
+                $untilQuery = new FlowQuery(array($contextNode));
+                $untilQuery->pushOperation('closest', array($arguments[0]));
                 $until = $untilQuery->get();
             }
 
-            if (isset($until) && !empty($until)) {
-                $until = end($until);
-                $parentNodes = $this->getNodesUntil($parentNodes, $until);
+            if (isset($until[0]) && !empty($until)) {
+                $parentNodes = $this->getNodesUntil($parentNodes, $until[0]);
             }
 
             if (is_array($parentNodes)) {

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -64,7 +64,7 @@ class ParentsUntilOperation extends AbstractOperation
             $siteNode = $contextNode->getContext()->getCurrentSiteNode();
             $parentNodes = $this->getParents($contextNode, $siteNode);
 
-            if (isset($arguments[0]) && !empty($arguments[0] && isset($parentNodes[0])) {
+            if (isset($arguments[0]) && !empty($arguments[0] && isset($parentNodes[0]))) {
                 $untilQuery = new FlowQuery(array($parentNodes[0]));
                 $untilQuery->pushOperation('closest', array($arguments[0]));
                 $until = $untilQuery->get();

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -70,7 +70,7 @@ class ParentsUntilOperation extends AbstractOperation
                 $until = $untilQuery->get();
             }
 
-            if ((is_array($until) && !empty($until)) && isset($until[0])) {
+            if ($until !== null && is_array($until) && !empty($until) && isset($until[0])) {
                 $parentNodes = $this->getNodesUntil($parentNodes, $until[0]);
             }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -70,7 +70,7 @@ class ParentsUntilOperation extends AbstractOperation
                 $until = $untilQuery->get();
             }
 
-            if ($until !== null && is_array($until) && !empty($until) && isset($until[0])) {
+            if (isset($until) && is_array($until) && !empty($until) && isset($until[0])) {
                 $parentNodes = $this->getNodesUntil($parentNodes, $until[0]);
             }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -64,8 +64,8 @@ class ParentsUntilOperation extends AbstractOperation
             $siteNode = $contextNode->getContext()->getCurrentSiteNode();
             $parentNodes = $this->getParents($contextNode, $siteNode);
 
-            if (isset($arguments[0]) && !empty($arguments[0])) {
-                $untilQuery = new FlowQuery(array($contextNode));
+            if (isset($arguments[0]) && !empty($arguments[0] && isset($parentNodes[0])) {
+                $untilQuery = new FlowQuery(array($parentNodes[0]));
                 $untilQuery->pushOperation('closest', array($arguments[0]));
                 $until = $untilQuery->get();
             }

--- a/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
@@ -55,27 +55,36 @@ class ParentsUntilOperationTest extends AbstractNodeTest
                 'expectedNodePaths' => array('/a'),
                 'unexpectedNodePaths' => array('/a/a5','/a/a3','/a/a2,')
             ),
+            array(
+                'currentNodePaths' => array('/b/b4/b4b/b4bb/b4bba'),
+                'subject' => '[instanceof TYPO3.TYPO3CR.Testing:NodeType]',
+                'expectedNodePaths' => array('/b/b4/b4b/b4bb'),
+                'unexpectedNodePaths' => array('b/b4','b/b4/b4b','/b/b3','/b')
+            ),
         );
     }
 
     /**
      * Tests on a tree:
      *
-     * a (testNodeType)
-     *   a1 (testNodeType)
+     * a (Testing:NodeType)
+     *   a1 (Testing:NodeType)
      *   a2
-     *   a3 (testNodeType)
+     *   a3 (Testing:NodeType)
      *   a4
      *   a5
-     * b (testNodeType3)
+     * b (Testing:NodeType)
      *   b1
-     *   b2 (testNodeType3)
+     *   b2 (Testing:NodeType)
      *   b3
-     *      b3a
-     *      b3b
-     *   b4
-     *
-     *
+     *     b3a
+     *     b3b
+     *   b4 (Testing:NodeType)
+     *     b4a
+     *     b4b (Testing:NodeType)
+     *       b4ba (Testing:NodeType)
+     *       b4bb
+     *         b4bba
      *
      * @test
      * @dataProvider parentsUntilOperationDataProvider()
@@ -99,7 +108,12 @@ class ParentsUntilOperationTest extends AbstractNodeTest
         $nodeB3 = $nodeB->createNode('b3');
         $nodeB3->createNode('b3a');
         $nodeB3->createNode('b3b');
-        $nodeB->createNode('b4');
+        $nodeB4 = $nodeB->createNode('b4', $testNodeType);
+        $nodeB4->createNode('b4a');
+        $nodeB4B = $nodeB4->createNode('b4b', $testNodeType);
+        $nodeB4B->createNode('b4ba', $testNodeType);
+        $nodeB4BB = $nodeB4B->createNode('b4bb');
+        $nodeB4BB->createNode('b4bba');
 
 
         $currentNodes = array();


### PR DESCRIPTION
Since the current parentsUntil operation does not return the correct parent nodes, this will fix the behaviour. `$until` did not return the first matched parent node.