### PR TITLE
[FEATURE] Allow uriSegment to be empty for default presets

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -63,13 +63,19 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     protected $siteRepository;
 
     /**
+     * @Flow\InjectConfiguration("routing.supportEmptySegmentForDimensions")
+     * @var boolean
+     */
+    protected $supportEmptySegmentForDimensions;
+
+    /**
      * @Flow\Inject
      * @var ContentDimensionPresetSourceInterface
      */
     protected $contentDimensionPresetSource;
 
     const DIMENSION_REQUEST_PATH_MATCHER = '|^
-        (?<dimensionPresetUriSegments>[^/@]+)      # the first part of the URI, before the first slash is the encoded dimension preset
+        (?<firstUriPart>[^/@]+)                    # the first part of the URI, before the first slash, may contain the encoded dimension preset
         (?:                                        # start of non-capturing submatch for the remaining URL
             /?                                     # a "/"; optional. it must also match en@user-admin
             (?<remainingRequestPath>.*)            # the remaining request path
@@ -99,13 +105,13 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * Matches a frontend URI pointing to a node (for example a page).
      *
      * This function tries to find a matching node by the given request path. If one was found, its
-     * absolute context node path is set in $this->value and TRUE is returned.
+     * absolute context node path is set in $this->value and true is returned.
      *
      * Note that this matcher does not check if access to the resolved workspace or node is allowed because at the point
      * in time the route part handler is invoked, the security framework is not yet fully initialized.
      *
      * @param string $requestPath The request path (without leading "/", relative to the current Site Node)
-     * @return boolean TRUE if the $requestPath could be matched, otherwise FALSE
+     * @return boolean true if the $requestPath could be matched, otherwise false
      * @throws \Exception
      * @throws Exception\NoHomepageException if no node could be found on the homepage (empty $requestPath)
      */
@@ -199,7 +205,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * $this->value:       homepage/about@user-admin
      *
      * @param mixed $node Either a Node object or an absolute context node path
-     * @return boolean TRUE if value could be resolved successfully, otherwise FALSE.
+     * @return boolean true if value could be resolved successfully, otherwise false.
      */
     protected function resolveValue($node)
     {
@@ -386,7 +392,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      *
      * This method traverses the segments of the given request path and tries to find nodes on the current level which
      * have a matching "uriPathSegment" property. If no node could be found which would match the given request path,
-     * FALSE is returned.
+     * false is returned.
      *
      * @param NodeInterface $siteNode The site node, used as a starting point while traversing the tree
      * @param string $relativeRequestPath The request path, relative to the site's root path
@@ -445,8 +451,79 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     }
 
     /**
+    * Choose between default method for parsing dimensions or the one which allows uriSegment to be empty for default preset.
+    *
+    * @param string &$requestPath The request path currently being processed by this route part handler, e.g. "de_global/startseite/ueber-uns"
+    * @return array An array of dimension name => dimension values (array of string)
+    */
+    protected function parseDimensionsAndNodePathFromRequestPath(&$requestPath)
+    {
+        if ($this->supportEmptySegmentForDimensions) {
+            $dimensionsAndDimensionValues = $this->parseDimensionsAndNodePathFromRequestPathAllowingEmptySegment($requestPath);
+        } else {
+            $dimensionsAndDimensionValues = $this->parseDimensionsAndNodePathFromRequestPathAllowingNonUniqueSegment($requestPath);
+        }
+        return $dimensionsAndDimensionValues;
+    }
+
+    /**
      * Parses the given request path and checks if the first path segment is one or a set of content dimension preset
      * identifiers. If that is the case, the return value is an array of dimension names and their preset URI segments.
+     * Allows uriSegment to be empty for default dimension preset.
+     *
+     * If the first path segment contained content dimension information, it is removed from &$requestPath.
+     *
+     * @param string &$requestPath The request path currently being processed by this route part handler, e.g. "de_global/startseite/ueber-uns"
+     * @return array An array of dimension name => dimension values (array of string)
+     * @throws InvalidDimensionPresetCombinationException
+     */
+    protected function parseDimensionsAndNodePathFromRequestPathAllowingEmptySegment(&$requestPath)
+    {
+        $dimensionPresets = $this->contentDimensionPresetSource->getAllPresets();
+        if (count($dimensionPresets) === 0) {
+            return [];
+        }
+        $dimensionsAndDimensionValues = [];
+        $chosenDimensionPresets = [];
+        $matches = [];
+        preg_match(self::DIMENSION_REQUEST_PATH_MATCHER, $requestPath, $matches);
+        $firstUriPartIsValidDimension = true;
+        foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
+            $dimensionsAndDimensionValues[$dimensionName] = $dimensionPreset['presets'][$dimensionPreset['defaultPreset']]['values'];
+            $chosenDimensionPresets[$dimensionName] = $dimensionPreset['defaultPreset'];
+        }
+        if (isset($matches['firstUriPart'])) {
+            $firstUriPartExploded = explode('_', $matches['firstUriPart']);
+            foreach ($firstUriPartExploded as $uriSegment) {
+                $uriSegmentIsValid = false;
+                foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
+                    $preset = $this->contentDimensionPresetSource->findPresetByUriSegment($dimensionName, $uriSegment);
+                    if ($preset !== null) {
+                        $uriSegmentIsValid = true;
+                        $dimensionsAndDimensionValues[$dimensionName] = $preset['values'];
+                        $chosenDimensionPresets[$dimensionName] = $preset['identifier'];
+                        break;
+                    }
+                }
+                if (!$uriSegmentIsValid) {
+                    $firstUriPartIsValidDimension = false;
+                    break;
+                }
+            }
+            if ($firstUriPartIsValidDimension) {
+                $requestPath = (isset($matches['remainingRequestPath']) ? $matches['remainingRequestPath'] : '');
+            }
+        }
+        if (!$this->contentDimensionPresetSource->isPresetCombinationAllowedByConstraints($chosenDimensionPresets)) {
+            throw new InvalidDimensionPresetCombinationException(sprintf('The resolved content dimension preset combination (%s) is invalid or restricted by content dimension constraints. Check your content dimension settings if you think that this is an error.', 'x'), 1428657721);
+        }
+        return $dimensionsAndDimensionValues;
+    }
+
+    /**
+     * Parses the given request path and checks if the first path segment is one or a set of content dimension preset
+     * identifiers. If that is the case, the return value is an array of dimension names and their preset URI segments.
+     * Doesn't allow empty uriSegment, but allows uriSegment to be not unique across presets.
      *
      * If the first path segment contained content dimension information, it is removed from &$requestPath.
      *
@@ -456,7 +533,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * @throws InvalidRequestPathException
      * @throws NoSuchDimensionValueException
      */
-    protected function parseDimensionsAndNodePathFromRequestPath(&$requestPath)
+    protected function parseDimensionsAndNodePathFromRequestPathAllowingNonUniqueSegment(&$requestPath)
     {
         $dimensionPresets = $this->contentDimensionPresetSource->getAllPresets();
         if (count($dimensionPresets) === 0) {
@@ -469,20 +546,20 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
 
         preg_match(self::DIMENSION_REQUEST_PATH_MATCHER, $requestPath, $matches);
 
-        if (!isset($matches['dimensionPresetUriSegments'])) {
+        if (!isset($matches['firstUriPart'])) {
             foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
                 $dimensionsAndDimensionValues[$dimensionName] = $dimensionPreset['presets'][$dimensionPreset['defaultPreset']]['values'];
                 $chosenDimensionPresets[$dimensionName] = $dimensionPreset['defaultPreset'];
             }
         } else {
-            $dimensionPresetUriSegments = explode('_', $matches['dimensionPresetUriSegments']);
+            $firstUriPart = explode('_', $matches['firstUriPart']);
 
-            if (count($dimensionPresetUriSegments) !== count($dimensionPresets)) {
+            if (count($firstUriPart) !== count($dimensionPresets)) {
                 throw new InvalidRequestPathException(sprintf('The first path segment of the request URI (%s) does not contain the necessary content dimension preset identifiers for all configured dimensions. This might be an old URI which doesn\'t match the current dimension configuration anymore.', $requestPath), 1413389121);
             }
 
             foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
-                $uriSegment = array_shift($dimensionPresetUriSegments);
+                $uriSegment = array_shift($firstUriPart);
                 $preset = $this->contentDimensionPresetSource->findPresetByUriSegment($dimensionName, $uriSegment);
                 if ($preset === null) {
                     throw new NoSuchDimensionValueException(sprintf('Could not find a preset for content dimension "%s" through the given URI segment "%s".', $dimensionName, $uriSegment), 1413389321);

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -109,9 +109,10 @@ TYPO3:
         'TYPO3.Neos': TRUE
 
     routing:
-      # Setting this to TRUE would allow to set empty uriPreset for default dimensions.
+      # Setting this to TRUE allows to use an empty uriSegment for default dimensions.
       # The only limitation is that all segments must be unique across all dimenions.
       supportEmptySegmentForDimensions: TRUE
+
     nodeTypes:
       groups:
         general:

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -108,6 +108,10 @@ TYPO3:
         'TYPO3.TypoScript': TRUE
         'TYPO3.Neos': TRUE
 
+    routing:
+      # Setting this to TRUE would allow to set empty uriPreset for default dimensions.
+      # The only limitation is that all segments must be unique across all dimenions.
+      supportEmptySegmentForDimensions: TRUE
     nodeTypes:
       groups:
         general:
@@ -631,4 +635,3 @@ TYPO3:
           classNamePattern: '/^.*Helper$/i'
         parser:
           implementationClassName: 'TYPO3\DocTools\Domain\Service\EelHelperClassParser'
-

--- a/TYPO3.Neos/Documentation/CreatingASite/ContentDimensions.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/ContentDimensions.rst
@@ -192,6 +192,36 @@ dimension preset for all configured dimensions. This means URIs will not contain
 no content dimension is configured. Multiple dimensions are joined with a ``_`` character, so the ``uriSegment`` value
 must not include an underscore.
 
+The default preset can have an empty `uriSegment` value. The following example will lead to URLs that do not contain
+`en` if the `en_US` preset is active, but will show the `uriSegment` for other languages that are defined as well:
+
+.. code-block:: yaml
+
+  TYPO3:
+    TYPO3CR:
+      contentDimensions:
+
+        'language':
+          default: 'en'
+          defaultPreset: 'en_US'
+          label: 'Language'
+          icon: 'icon-language'
+          presets:
+            'en':
+              label: 'English (US)'
+              values: ['en_US']
+              uriSegment: ''
+
+The only limitation is that all segments must be unique across all dimensions. If you need non-unique segments, you can
+switch support for non-empty dimensions off:
+
+.. code-block:: yaml
+
+  TYPO3:
+    Neos:
+      routing:
+        supportEmptySegmentForDimensions: FALSE
+
 Limitations
 ===========
 

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -722,7 +722,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 'doesMatch' => true,
                 'expected' => array(
                     0 => 'de_global',
-                    'dimensionPresetUriSegments' => 'de_global',
+                    'firstUriPart' => 'de_global',
                     1 => 'de_global',
                     'remainingRequestPath' => '',
                     2 => ''
@@ -733,7 +733,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 'doesMatch' => true,
                 'expected' => array(
                     0 => 'de_global@user-admin',
-                    'dimensionPresetUriSegments' => 'de_global',
+                    'firstUriPart' => 'de_global',
                     1 => 'de_global',
                     'remainingRequestPath' => '@user-admin',
                     2 => '@user-admin'
@@ -744,7 +744,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 'doesMatch' => true,
                 'expected' => array(
                     0 => 'de_global/foo/bar?baz=foo[]',
-                    'dimensionPresetUriSegments' => 'de_global',
+                    'firstUriPart' => 'de_global',
                     1 => 'de_global',
                     'remainingRequestPath' => 'foo/bar?baz=foo[]',
                     2 => 'foo/bar?baz=foo[]'
@@ -755,7 +755,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 'doesMatch' => true,
                 'expected' => array(
                     0 => 'de_global/foo/bar@user-admin',
-                    'dimensionPresetUriSegments' => 'de_global',
+                    'firstUriPart' => 'de_global',
                     1 => 'de_global',
                     'remainingRequestPath' => 'foo/bar@user-admin',
                     2 => 'foo/bar@user-admin'


### PR DESCRIPTION
Introduce ``supportEmptySegmentForDimensions`` settings switch that would
allow uriSegment to be empty for default preset. If the option is on,
there are two restrictions:

* uriSegment must be unique across all dimensions
* empty uriSegment may only be set for default preset

Without this setting old behavior is used: uriSegment doesn't
have to be unique, but can't be empty.

Resolves: NEOS-295