### PR TITLE
[BUGFIX] Remove autofocus from search field on condensed media library layout

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
@@ -66,7 +66,7 @@
 	<form action="{f:uri.action(action: 'index')}" method="get" class="neos-search">
 		<button type="submit" title="{neos:backend.translate(id: 'media.search.title', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip"><i class="icon-search"></i></button>
 		<div>
-			<input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'media.search.placeholder', source: 'Modules', package: 'TYPO3.Neos')}" value="{searchTerm}" autofocus="autofocus" />
+			<input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'media.search.placeholder', source: 'Modules', package: 'TYPO3.Neos')}" value="{searchTerm}"{f:if(condition: '{tags -> f:count()} =< 25', then: ' autofocus="autofocus"')} />
 		</div>
 	</form>
 	<div class="neos-media-aside-group">


### PR DESCRIPTION
When the condensed aside media library layout is shown (more than 25 tags),
the search field is automatically focussed causing the view to jump down to
the search field. This is annoying and unexpected and thus disabled for that view.