### PR TITLE
[BUGFIX] Prevent fetching unmanaged entity in ``WorkspacesTest``

### DIFF
--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/WorkspacesTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/WorkspacesTest.php
@@ -279,7 +279,6 @@ class WorkspacesTest extends FunctionalTestCase
         $this->saveNodesAndTearDownRootNodeAndRepository();
         $this->setUpRootNodeAndRepository();
 
-        $teaserNode = $this->rootNode->getNode('/homepage/teaser/node52697bdfee199');
         $this->rootNode->getWorkspace()->publishNode($teaserNode, $this->liveWorkspace);
 
         $this->saveNodesAndTearDownRootNodeAndRepository();


### PR DESCRIPTION
Needed for ``doctrine/orm`` 2.4 compatibility (already done in 2.0)