### PR TITLE
BUGFIX: Re-add missing inspector tab label for 'metadata'

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -10,6 +10,7 @@
           position: 10
           icon: 'icon-pencil'
         meta:
+          label: i18n
           position: 20
           icon: 'icon-cog'
       groups:


### PR DESCRIPTION
During the change to add translation support to the inspector tabs/groups, this appears to have been missed.

See: https://github.com/neos/neos-development-collection/commit/421c8218f54627a175bba3af1f7aa08150b56ac4#diff-3b7b31a90bfc18f8fbbdec4e8f83424f