### PR TITLE
BUGFIX: Improve slow aloha settings selector 

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -87,6 +87,7 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
         }
 
         $this->tag->addAttribute('property', 'typo3:' . $property);
+        $this->tag->addAttribute('data-neos-node-type', $node->getNodeType()->getName());
         $this->tag->addAttribute('class', $this->tag->hasAttribute('class') ? 'neos-inline-editable ' . $this->tag->getAttribute('class') : 'neos-inline-editable');
         return $this->tag->render();
     }

--- a/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
@@ -29,7 +29,7 @@ function(
 		$.each(nodeTypes, function (nodeTypeName, nodeType) {
 			if (nodeType.properties && typeof nodeType.properties === 'object') {
 				$.each(nodeType.properties, function (propertyName, propertyConfiguration) {
-					var selector = '[typeof="typo3:' + nodeTypeName + '"] [property="typo3:' + propertyName + '"]:not([typeof="typo3:' + nodeTypeName + '"] [typeof] [property="typo3:' + propertyName + '"])';
+					var selector = '[data-neos-node-type="' + nodeTypeName + '"][property="typo3:' + propertyName + '"]';
 					$.each(['table', 'link', 'list', 'format', 'formatlesspaste'], function (i, mode) {
 						if (propertyConfiguration.ui && propertyConfiguration.ui.aloha && propertyConfiguration.ui.aloha[mode]) {
 							nodeSettings[mode] = nodeSettings[mode] || {};

--- a/TYPO3.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -19,6 +19,7 @@ use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\ViewHelpers\ContentElement\EditableViewHelper;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TypoScript\Core\Runtime;
 use TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView;
 use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
@@ -89,6 +90,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
 
         $this->mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
         $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContentContext));
+        $this->mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue(new NodeType('Acme.Test:Headline', [], [])));
 
         $this->mockTsContext = array('node' => $this->mockNode);
         $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));


### PR DESCRIPTION
Current selector to match property editor of given node type is
extremely slow, because it has to use very inefficient selector.

Add additional `data-neos-node-type` attribute to editable property wrap
to simplify the selector.

This brings a huge performance improvement on pages with a lot of
editable properties.