### PR TITLE
[TASK] Cache backend interface labels client side

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/BackendController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/BackendController.php
@@ -15,7 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\Locale;
 
 /**
- * The TYPO3 Backend controller
+ * The Neos Backend controller
  *
  * @Flow\Scope("singleton")
  */
@@ -34,12 +34,6 @@ class BackendController extends \TYPO3\Flow\Mvc\Controller\ActionController
     protected $xliffService;
 
     /**
-     * @Flow\Inject
-     * @var \TYPO3\Neos\Service\UserService
-     */
-    protected $userService;
-
-    /**
      * Default action of the backend controller.
      *
      * @return void
@@ -56,13 +50,12 @@ class BackendController extends \TYPO3\Flow\Mvc\Controller\ActionController
     /**
      * Returns the cached json array with the xliff labels
      *
+     * @param string $locale
      * @return string
      */
-    public function getXliffAsJsonAction()
+    public function xliffAsJsonAction($locale)
     {
         $this->response->setHeader('Content-Type', 'application/json');
-        $locale = new Locale($this->userService->getInterfaceLanguage());
-
-        return $this->xliffService->getCachedJson($locale);
+        return $this->xliffService->getCachedJson(new Locale($locale));
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/XliffService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/XliffService.php
@@ -76,8 +76,8 @@ class XliffService
      * The json will be cached.
      *
      * @param Locale $locale The locale
-     * @throws \TYPO3\Flow\I18n\Exception
      * @return \TYPO3\Flow\Error\Result
+     * @throws \TYPO3\Flow\I18n\Exception
      */
     public function getCachedJson(Locale $locale)
     {
@@ -125,8 +125,9 @@ class XliffService
      * @param string $xliffPathAndFilename The file to read
      * @param string $packageKey
      * @param string $sourceName
-     * @todo remove the override handling once Flow takes care of that, see FLOW-61
      * @return array
+     *
+     * @todo remove the override handling once Flow takes care of that, see FLOW-61
      */
     public function parseXliffToArray($xliffPathAndFilename, $packageKey, $sourceName)
     {
@@ -144,6 +145,19 @@ class XliffService
         }
 
         return $arrayData;
+    }
+
+    /**
+     * @return integer The current cache version identifier
+     */
+    public function getCacheVersion()
+    {
+        $version = $this->xliffToJsonTranslationsCache->get('ConfigurationVersion');
+        if ($version === false) {
+            $version = time();
+            $this->xliffToJsonTranslationsCache->set('ConfigurationVersion', (string)$version);
+        }
+        return $version;
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/InterfaceLanguageViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/InterfaceLanguageViewHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace TYPO3\Neos\ViewHelpers\Backend;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\Neos\Service\UserService;
+
+/**
+ * ViewHelper for rendering the current backend users interface language.
+ */
+class InterfaceLanguageViewHelper extends AbstractViewHelper
+{
+
+    /**
+     * @Flow\Inject
+     * @var UserService
+     */
+    protected $userService;
+
+    /**
+     * @return string The current backend users interface language
+     */
+    public function render()
+    {
+        return $this->userService->getInterfaceLanguage();
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -75,12 +75,6 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
     protected $backendAssetsUtility;
 
     /**
-     * @Flow\InjectConfiguration("userInterface.defaultLocale")
-     * @var string
-     */
-    protected $defaultLocale;
-
-    /**
      * @param array $settings
      * @return void
      */
@@ -96,8 +90,6 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
     {
         $configuration = array(
             'window.T3Configuration = {};',
-            'window.T3Configuration.locale = "' . $this->defaultLocale . '";',
-            'window.T3Configuration.localeInclude = ' . json_encode($this->getXliffAsJsonUri()) . ';',
             'window.T3Configuration.UserInterface = ' . json_encode($this->settings['userInterface']) . ';',
             'window.T3Configuration.nodeTypes = {};',
             'window.T3Configuration.nodeTypes.groups = ' . json_encode($this->getNodeTypeGroupsSettings()) . ';',
@@ -119,19 +111,6 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
         }
 
         return implode("\n", $configuration);
-    }
-
-    /**
-     * Returns the I18n json uri
-     *
-     * @return array
-     */
-    protected function getXliffAsJsonUri()
-    {
-        $uriBuilder = $this->controllerContext->getUriBuilder();
-        $uriBuilder->setCreateAbsoluteUri(true);
-
-        return $uriBuilder->uriFor('getXliffAsJson', array(), 'Backend\\Backend', 'TYPO3.Neos');
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/XliffCacheVersionViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/XliffCacheVersionViewHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace TYPO3\Neos\ViewHelpers\Backend;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * ViewHelper for rendering the current version identifier for the
+ * xliff cache.
+ */
+class XliffCacheVersionViewHelper extends AbstractViewHelper
+{
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Service\XliffService
+     */
+    protected $xliffService;
+
+    /**
+     * @return string The current cache version identifier
+     */
+    public function render()
+    {
+        return $this->xliffService->getCacheVersion();
+    }
+}

--- a/TYPO3.Neos/Configuration/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Policy.yaml
@@ -19,7 +19,7 @@ privilegeTargets:
       matcher: 'method(TYPO3\Neos\Controller\LoginController->(index|authenticate)Action()) || method(TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController->authenticateAction())'
 
     'TYPO3.Neos:Backend.GeneralAccess':
-      matcher: 'method(TYPO3\Neos\Controller\Backend\BackendController->(index|getXliffAsJson)Action()) || method(TYPO3\Neos\Controller\Backend\ModuleController->indexAction()) || method(TYPO3\Neos\Controller\LoginController->logoutAction()) || method(TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController->logoutAction()) || method(TYPO3\Neos\Controller\Module\AbstractModuleController->indexAction())'
+      matcher: 'method(TYPO3\Neos\Controller\Backend\BackendController->(index|xliffAsJson)Action()) || method(TYPO3\Neos\Controller\Backend\ModuleController->indexAction()) || method(TYPO3\Neos\Controller\LoginController->logoutAction()) || method(TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController->logoutAction()) || method(TYPO3\Neos\Controller\Module\AbstractModuleController->indexAction())'
 
     'TYPO3.Neos:Backend.Module.Content':
       matcher: 'method(TYPO3\Neos\Controller\Backend\SchemaController->(nodeTypeSchema|vieSchema)Action()) || method(TYPO3\Neos\Controller\Backend\MenuController->indexAction()) || method(TYPO3\Neos\Controller\Backend\SettingsController->editPreviewAction())'

--- a/TYPO3.Neos/Configuration/Routes.Backend.yaml
+++ b/TYPO3.Neos/Configuration/Routes.Backend.yaml
@@ -126,10 +126,10 @@
   appendExceedingArguments: TRUE
 
 -
-  name: 'Backend UI XLIFF configuration'
+  name: 'Backend UI XLIFF labels'
   uriPattern: 'xliff.json'
   defaults:
     '@package': 'TYPO3.Neos'
     '@controller': 'Backend\Backend'
-    '@action': 'getXliffAsJson'
+    '@action': 'xliffAsJson'
   appendExceedingArguments: TRUE

--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendEndpoints.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendEndpoints.html
@@ -13,8 +13,9 @@
 	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
 	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
 	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
-	<link rel="neos-service-contentdimensions-index" type="application/vnd.typo3.neos.contentdimensions" href="{f:uri.action(action: 'index', controller: 'Service\ContentDimensions', package: 'TYPO3.Neos', absolute: true)}" />
 </f:alias>
+<link rel="neos-service-contentdimensions-index" type="application/vnd.typo3.neos.contentdimensions" href="{f:uri.action(action: 'index', controller: 'Service\ContentDimensions', package: 'TYPO3.Neos', absolute: true)}" />
+<link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'TYPO3.Neos', absolute: true) -> f:format.raw()}" />
 
 <!-- Temporary URL endpoints, will be removed / grouped when a REST interface is fully implemented -->
 <link rel="neos-service-workspace-publishNode" href="{f:uri.action(action: 'publishNode', controller: 'Workspace', package: 'TYPO3.Neos', subpackage: 'Service', absolute: true)}" />

--- a/TYPO3.Neos/Resources/Public/JavaScript/ContentModuleBootstrap.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/ContentModuleBootstrap.js
@@ -28,7 +28,6 @@ require(
 		'Shared/Configuration',
 		'ExternalApi',
 		'Library/underscore',
-		'Shared/HttpClient',
 		'Shared/I18n',
 		'Shared/NodeTypeService',
 		'InlineEditing/PositioningHelper',
@@ -44,10 +43,8 @@ require(
 		Notification,
 		Configuration,
 		ExternalApi,
-		_,
-		HttpClient
-		) {
-
+		_
+	) {
 		ResourceCache.fetch(Configuration.get('VieSchemaUri'));
 
 		/**
@@ -55,7 +52,7 @@ require(
 		 */
 		Ember.RSVP.Promise(function (resolve, reject) {
 			// Get all translations and merge them
-			HttpClient.getResource(Configuration.get('localeInclude')).then(function(labels) {
+			ResourceCache.getItem(Configuration.get('XliffUri')).then(function(labels) {
 				try {
 					$.extend(Ember.I18n.translations, labels);
 				} catch (exception) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
@@ -44,6 +44,10 @@ function(Ember, $) {
 						this._data[key] = $('link[rel="neos-menudata"]').attr('href');
 						return this._data[key];
 
+					case 'XliffUri':
+						this._data[key] = $('link[rel="neos-xliff"]').attr('href');
+						return this._data[key];
+
 					case 'EditPreviewDataUri':
 						this._data[key] = $('link[rel="neos-editpreviewdata"]').attr('href');
 						return this._data[key];


### PR DESCRIPTION
Makes the backend interface labels cacheable by storing the version
XLIFF cache and generating a URI using that version. When a label is
changed or the selected language is changed, the URI is automatically
updated.