### PR TITLE
BUGFIX: Allow to delete a user from the CLI

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -791,7 +791,7 @@ class UserService
     {
         /** @var Workspace $workspace */
         foreach ($this->workspaceRepository->findByOwner($user) as $workspace) {
-            $workspace->setOwner();
+            $workspace->setOwner(null);
             $this->workspaceRepository->update($workspace);
         }
     }


### PR DESCRIPTION
Removing a Neos user with user:delete resulted in an error, because
setting the owner of a workspace requires an argument.

This fixes that by passing null.