### PR TITLE
BUGFIX: Correctly assign account to party in UserService

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -247,7 +247,7 @@ class UserService
         }
         $roleIdentifiers = $this->normalizeRoleIdentifiers($roleIdentifiers);
         $account = $this->accountFactory->createAccountWithPassword($username, $password, $roleIdentifiers, $authenticationProviderName ?: $this->defaultAuthenticationProviderName);
-        $user->addAccount($account);
+        $this->partyService->assignAccountToParty($account, $user);
 
         $this->partyRepository->add($user);
         $this->accountRepository->add($account);


### PR DESCRIPTION
When a user is created, the corresponding account was added directly.
This lead to the party not being found when asking the account for it,
unless changes were persisted in between.

This uses the PartyService method assignAccountToParty() now.