### PR TITLE
[BUGFIX] Allow publishing of nodes with modified schema

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -14,6 +14,7 @@ namespace TYPO3\TYPO3CR\Domain\Model;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\TYPO3CR\Domain\Service\NodeService;
 use TYPO3\TYPO3CR\Exception\WorkspaceException;
 
 /**
@@ -70,6 +71,12 @@ class Workspace
      * @var \TYPO3\TYPO3CR\Service\PublishingServiceInterface
      */
     protected $publishingService;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\TYPO3CR\Domain\Service\NodeService
+     */
+    protected $nodeService;
 
     /**
      * Constructs a new workspace
@@ -232,6 +239,7 @@ class Workspace
                 $targetNodeData->setPath($node->getPath(), false);
             }
             $node->setNodeData($targetNodeData);
+            $this->nodeService->cleanUpProperties($node);
         }
         $this->nodeDataRepository->remove($sourceNodeData);
     }
@@ -259,6 +267,7 @@ class Workspace
             $this->nodeDataRepository->remove($nodeData);
         } else {
             $nodeData->setWorkspace($targetWorkspace);
+            $this->nodeService->cleanUpProperties($node);
         }
         $node->setNodeDataIsMatchingContext(null);
     }
@@ -342,4 +351,5 @@ class Workspace
     protected function emitAfterNodePublishing(NodeInterface $node, Workspace $targetWorkspace)
     {
     }
+
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
@@ -81,20 +81,21 @@ class NodeService
     }
 
     /**
-     * Remove all property not configured in the current Node Type
+     * Remove all properties not configured in the current Node Type.
+     * This will not do anything on Nodes marked as removed as those could be queued up for deletion
+     * which contradicts updates (that would be necessary to remove the properties).
      *
      * @param NodeInterface $node
      * @return void
      */
     public function cleanUpProperties(NodeInterface $node)
     {
-        $nodeTypeProperties = $node->getNodeType()->getProperties();
-        foreach ($node->getProperties() as $name => $value) {
-            if (!isset($nodeTypeProperties[$name])) {
-                try {
-                    $this->systemLogger->log(sprintf('Remove property "%s" from: %s', $name, (string)$node), LOG_DEBUG, null, 'TYPO3CR');
-                    $node->removeProperty($name);
-                } catch (NodeException $exception) {
+        if ($node->isRemoved() === FALSE) {
+            $nodeData = $node->getNodeData();
+            $nodeTypeProperties = $node->getNodeType()->getProperties();
+            foreach ($node->getProperties() as $name => $value) {
+                if (!isset($nodeTypeProperties[$name])) {
+                    $nodeData->removeProperty($name);
                 }
             }
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Package.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Package.php
@@ -31,7 +31,6 @@ class Package extends BasePackage
         $dispatcher->connect('TYPO3\Flow\Persistence\Doctrine\PersistenceManager', 'allObjectsPersisted', 'TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'flushNodeRegistry');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'repositoryObjectsPersisted', 'TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'flushNodeRegistry');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\NodeData', 'nodePathChanged', 'TYPO3\TYPO3CR\Domain\Service\ContextFactory', 'flushFirstLevelNodeCaches');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Workspace', 'beforeNodePublishing', 'TYPO3\TYPO3CR\Domain\Service\NodeService', 'cleanUpProperties');
 
         $dispatcher->connect('TYPO3\Flow\Configuration\ConfigurationManager', 'configurationManagerReady', function (ConfigurationManager $configurationManager) {
             $configurationManager->registerConfigurationType('NodeTypes', ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_DEFAULT, true);

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/PublishUserWorkspace.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/PublishUserWorkspace.feature
@@ -48,3 +48,48 @@ Feature: Publish user workspace
     Then I expect to have 0 unpublished nodes for the following context:
       | Workspace |
       | live      |
+
+  @fixtures
+  Scenario: When changing the node type of a node in my workspace to one that has fewer properties it is possible to publish it
+    And I have the following NodeTypes configuration:
+    """
+    'unstructured':
+      constraints:
+        nodeTypes:
+          '*': TRUE
+
+    'TYPO3.TYPO3CR.Testing:Page':
+      properties:
+        pageTitle:
+          type: 'string'
+        additionalTitle:
+          type: 'string'
+    """
+    And I create the following nodes:
+      | Path        | Node Type                  | Properties                                                   | Workspace |
+      | /sites/home | TYPO3.TYPO3CR.Testing:Page | {"pageTitle": "neos", "additionalTitle": "The neos project"} | live      |
+    When I get a node by path "/sites/home" with the following context:
+      | Workspace |
+      | user-demo |
+    And I set the node property "pageTitle" to "Homepage"
+    When I have the following NodeTypes configuration:
+    """
+    'unstructured':
+      constraints:
+        nodeTypes:
+          '*': TRUE
+
+    'TYPO3.TYPO3CR.Testing:Page':
+      properties:
+        pageTitle:
+          type: 'string'
+    """
+    And I publish the workspace "user-demo"
+    Then I expect to have 0 unpublished nodes for the following context:
+      | Workspace |
+      | user-demo |
+    And I get a node by path "/sites/home" with the following context:
+      | Workspace |
+      | live      |
+    Then the node should not have a property "additionalTitle"
+    Then the node property "pageTitle" should be "Homepage"

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -442,6 +442,19 @@ class FeatureContext extends Behat\Behat\Context\BehatContext
     }
 
     /**
+     * @Then /^the node should (not |)have a property "([^"]*)"$/
+     */
+    public function theNodeShouldHaveAProperty($not, $propertyName)
+    {
+        $currentNode = $this->iShouldHaveOneNode();
+        $expected = false;
+        if (empty($not)) {
+            $expected = true;
+        }
+        Assert::assertEquals($expected, $currentNode->hasProperty($propertyName));
+    }
+
+    /**
      * @Then /^the node should be hidden in index$/
      */
     public function theNodeShouldBeHiddenInIndex()

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -13,6 +13,7 @@ namespace TYPO3\TYPO3CR\Tests\Unit\Domain\Model;
 
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Service\NodeService;
 
 /**
  * Testcase for the "Workspace" domain model
@@ -62,6 +63,9 @@ class WorkspaceTest extends UnitTestCase
 
         $mockPublishingService = $this->getMockBuilder('TYPO3\Neos\Service\PublishingService')->disableOriginalConstructor()->getMock();
         $this->inject($currentWorkspace, 'publishingService', $mockPublishingService);
+
+        $mockNodeService = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\NodeService')->disableOriginalConstructor()->getMock();
+        $this->inject($currentWorkspace, 'nodeService', $mockNodeService);
 
         $existingNodeData = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
 

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -227,8 +227,13 @@ class NodeServiceTest extends \TYPO3\Flow\Tests\UnitTestCase
         $nodeService = $this->createNodeService();
 
         $mockNode = $this->getMock('\TYPO3\TYPO3CR\Domain\Model\Node', array(), array(), '', false);
-
+        $mockNodeData = $this->getMock('\TYPO3\TYPO3CR\Domain\Model\NodeData', array(), array(), '', false);
         $mockNodeType = $this->mockNodeType('TYPO3.TYPO3CR.Testing:Content');
+
+        $mockNodeData->expects($this->once())
+            ->method('removeProperty')
+            ->with('invalidProperty');
+
         $mockNodeType->expects($this->once())
             ->method('getProperties')
             ->will($this->returnValue(array(
@@ -237,12 +242,16 @@ class NodeServiceTest extends \TYPO3\Flow\Tests\UnitTestCase
             )));
 
         $mockNode->expects($this->once())
-            ->method('getNodeType')
-            ->will($this->returnValue($mockNodeType));
+            ->method('isRemoved')
+            ->will($this->returnValue(false));
 
         $mockNode->expects($this->once())
-            ->method('removeProperty')
-            ->with('invalidProperty');
+            ->method('getNodeData')
+            ->will($this->returnValue($mockNodeData));
+
+        $mockNode->expects($this->once())
+            ->method('getNodeType')
+            ->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->once())
             ->method('getProperties')


### PR DESCRIPTION
When changing node types on existing nodes, the following publication would
fail under certain circumstances (see issue NEOS-1172 for details). This
change fixes those problems.

Adds a behat test as well: "When changing the node type of a node in my
workspace to one that has fewer properties it is still possible to publish it"

Resolves: NEOS-1172