### PR TITLE
BUGFIX: ``Node->getChildNodes`` bypasses node type filter for newly added nodes

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -441,9 +441,24 @@ class NodeDataRepository extends Repository
         } else {
             $childNodeDepth = substr_count($parentPath, '/') + 1;
             /** @var $addedNode NodeData */
+            $constraints = $nodeTypeFilter !== '' ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : array();
             foreach ($this->addedNodes as $addedNode) {
                 if ($addedNode->getDepth() === $childNodeDepth && substr($addedNode->getPath(), 0, strlen($parentPath) + 1) === ($parentPath . '/') && $addedNode->matchesWorkspaceAndDimensions($workspace, $dimensions)) {
-                    $foundNodes[$addedNode->getIdentifier()] = $addedNode;
+                    $nodeType = $addedNode->getNodeType();
+                    $disallowed = false;
+                    foreach ($constraints['includeNodeTypes'] as $includeNodeType) {
+                        if (!$nodeType->isOfType($includeNodeType)) {
+                            $disallowed = true;
+                        }
+                    }
+                    foreach ($constraints['excludeNodeTypes'] as $excludeNodeTypes) {
+                        if ($nodeType->isOfType($excludeNodeTypes)) {
+                            $disallowed = true;
+                        }
+                    }
+                    if ($disallowed === false) {
+                        $foundNodes[$addedNode->getIdentifier()] = $addedNode;
+                    }
                 }
             }
             /** @var $removedNode NodeData */

--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/NodesTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/NodesTest.php
@@ -1385,4 +1385,20 @@ class NodesTest extends \TYPO3\Flow\Tests\FunctionalTestCase
 
         $this->assertEquals('bar claps hands!', $happyNode->clapsHands());
     }
+
+
+    /**
+     * @test
+     */
+    public function getChildNodesWithNodeTypeFilterWorks()
+    {
+        $documentNodeType = $this->nodeTypeManager->getNodeType('TYPO3.TYPO3CR.Testing:Document');
+        $headlineNodeType = $this->nodeTypeManager->getNodeType('TYPO3.TYPO3CR.Testing:Headline');
+        $imageNodeType = $this->nodeTypeManager->getNodeType('TYPO3.TYPO3CR.Testing:Image');
+
+        $node = $this->context->getRootNode()->createNode('node-with-child-node', $documentNodeType);
+        $node->createNode('headline', $headlineNodeType);
+        $node->createNode('text', $imageNodeType);
+        $this->assertCount(1, $node->getChildNodes('TYPO3.TYPO3CR.Testing:Headline'));
+    }
 }

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
@@ -25,7 +25,7 @@ class NodeDataRepositoryTest extends UnitTestCase
     {
         $mockPersistenceManager = $this->getMock('TYPO3\Flow\Persistence\PersistenceManagerInterface');
 
-        $this->nodeDataRepository = $this->getMock('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', array('getNodeDataForParentAndNodeType', 'filterNodesOverlaidInBaseWorkspace'));
+        $this->nodeDataRepository = $this->getMock('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', array('getNodeDataForParentAndNodeType', 'filterNodesOverlaidInBaseWorkspace', 'getNodeTypeFilterConstraintsForDql'));
         $this->nodeDataRepository->expects($this->any())->method('filterNodesOverlaidInBaseWorkspace')->will($this->returnCallback(function (array $foundNodes, Workspace $baseWorkspace, $dimensions) {
             return $foundNodes;
         }));
@@ -132,6 +132,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         $recursiveFlag = true;
 
         $this->nodeDataRepository->expects($this->once())->method('getNodeDataForParentAndNodeType')->with($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, $removedNodesFlag, $recursiveFlag)->will($this->returnValue(array()));
+        $this->nodeDataRepository->expects($this->once())->method('getNodeTypeFilterConstraintsForDql')->with($nodeTypeFilter)->will($this->returnValue(array('excludeNodeTypes' => array(), 'includeNodeTypes' => array($nodeTypeFilter))));
 
         $this->nodeDataRepository->findByParentAndNodeTypeRecursively($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, true);
     }
@@ -155,6 +156,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         $nodeData->expects($this->atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will($this->returnValue(true));
 
         $this->nodeDataRepository->expects($this->any())->method('getNodeDataForParentAndNodeType')->will($this->returnValue(array()));
+        $this->nodeDataRepository->expects($this->once())->method('getNodeTypeFilterConstraintsForDql')->will($this->returnValue(array('excludeNodeTypes' => array(), 'includeNodeTypes' => array())));
 
         $result = $this->nodeDataRepository->findByParentAndNodeType('/foo', null, $liveWorkspace, $dimensions);
 


### PR DESCRIPTION
When inserting a node inside another node in the document node tree, non-document nodes were displayed as children incorrectly.