### PR TITLE
FEATURE: New FlowQuery filter operation ``!instanceof``

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
@@ -135,7 +135,7 @@ class FilterOperation extends \TYPO3\Eel\FlowQuery\Operations\Object\FilterOpera
                 $isOfType = $value->getNodeType()->isOfType($operand[0] === '!' ? substr($operand, 1) : $operand);
                 return $operand[0] === '!' ? $isOfType === false : $isOfType;
             }
-        } else if ($operator === '!instanceof' && $value instanceof \TYPO3\TYPO3CR\Domain\Model\NodeInterface) {
+        } elseif ($operator === '!instanceof' && $value instanceof \TYPO3\TYPO3CR\Domain\Model\NodeInterface) {
             return !$this->evaluateOperator($value, 'instanceof', $operand);
         }
         return parent::evaluateOperator($value, $operator, $operand);

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Eel/FlowQueryOperations/FilterOperation.php
@@ -135,6 +135,8 @@ class FilterOperation extends \TYPO3\Eel\FlowQuery\Operations\Object\FilterOpera
                 $isOfType = $value->getNodeType()->isOfType($operand[0] === '!' ? substr($operand, 1) : $operand);
                 return $operand[0] === '!' ? $isOfType === false : $isOfType;
             }
+        } else if ($operator === '!instanceof' && $value instanceof \TYPO3\TYPO3CR\Domain\Model\NodeInterface) {
+            return !$this->evaluateOperator($value, 'instanceof', $operand);
         }
         return parent::evaluateOperator($value, $operator, $operand);
     }

--- a/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
@@ -161,7 +161,8 @@ class FilterOperationTest extends AbstractNodeTest
     /**
      * @test
      */
-    public function notInstanceofFilterUsingNodeTypeIsSupported() {
+    public function notInstanceofFilterUsingNodeTypeIsSupported()
+    {
         $productsNode = $this->node->getNode('products');
         $teaserNode = $this->node->getNode('teaser');
         $sidebarNode = $this->node->getNode('sidebar');
@@ -240,7 +241,8 @@ class FilterOperationTest extends AbstractNodeTest
     /**
      * @test
      */
-    public function doubleNegatedInstanceofFilterUsingNodeTypeIsSupported() {
+    public function doubleNegatedInstanceofFilterUsingNodeTypeIsSupported()
+    {
         $productsNode = $this->node->getNode('products');
         $teaserNode = $this->node->getNode('teaser');
         $sidebarNode = $this->node->getNode('sidebar');

--- a/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
@@ -161,6 +161,30 @@ class FilterOperationTest extends AbstractNodeTest
     /**
      * @test
      */
+    public function notInstanceofFilterUsingNodeTypeIsSupported() {
+        $productsNode = $this->node->getNode('products');
+        $teaserNode = $this->node->getNode('teaser');
+        $sidebarNode = $this->node->getNode('sidebar');
+        $dummy = $sidebarNode->getNode('dummy43');
+        $q = new FlowQuery(array($this->node, $dummy, $productsNode, $teaserNode, $sidebarNode));
+        $foundNodes = $q->filter('[!instanceof TYPO3.TYPO3CR.Testing:Html]')->get();
+        $this->assertSame($this->node, $foundNodes[0]);
+        $this->assertSame($productsNode, $foundNodes[1]);
+        $this->assertSame($teaserNode, $foundNodes[2]);
+        $this->assertSame($sidebarNode, $foundNodes[3]);
+        $this->assertEquals(4, count($foundNodes));
+        $foundNodes = $q->filter('[!instanceof TYPO3.TYPO3CR.Testing:ContentCollection]')->get();
+        $this->assertSame($this->node, $foundNodes[0]);
+        $this->assertSame($dummy, $foundNodes[1]);
+        $this->assertSame($productsNode, $foundNodes[2]);
+        $this->assertEquals(3, count($foundNodes));
+        $foundNodes = $q->filter('[!instanceof X]')->get();
+        $this->assertEquals(5, count($foundNodes));
+    }
+
+    /**
+     * @test
+     */
     public function twoInstanceofFiltersUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -211,5 +235,25 @@ class FilterOperationTest extends AbstractNodeTest
         $this->assertEquals(2, count($foundNodes));
         $foundNodes = $q->filter('[instanceof !X]')->get();
         $this->assertEquals(4, count($foundNodes));
+    }
+
+    /**
+     * @test
+     */
+    public function doubleNegatedInstanceofFilterUsingNodeTypeIsSupported() {
+        $productsNode = $this->node->getNode('products');
+        $teaserNode = $this->node->getNode('teaser');
+        $sidebarNode = $this->node->getNode('sidebar');
+        $q = new FlowQuery(array($this->node, $productsNode, $teaserNode, $sidebarNode));
+        $foundNodes = $q->filter('[!instanceof !TYPO3.TYPO3CR.Testing:Page]')->get();
+        $this->assertSame($this->node, $foundNodes[0]);
+        $this->assertSame($productsNode, $foundNodes[1]);
+        $this->assertEquals(2, count($foundNodes));
+        $foundNodes = $q->filter('[!instanceof !TYPO3.TYPO3CR.Testing:ContentCollection]')->get();
+        $this->assertSame($teaserNode, $foundNodes[0]);
+        $this->assertSame($sidebarNode, $foundNodes[1]);
+        $this->assertEquals(2, count($foundNodes));
+        $foundNodes = $q->filter('[!instanceof !X]')->get();
+        $this->assertEquals(0, count($foundNodes));
     }
 }


### PR DESCRIPTION
This is the rebased version of this PR:
https://github.com/neos/neos-development-collection/pull/23

The essentials for flow have already been merged into master a while ago:
https://github.com/neos/flow-development-collection/commit/6cabed2e2f7ca2d72cd0f89f391fc21288596f87
But they have to be in the current flow release aswell. I guess this is also the reason why most of the tests fail.

NEOS-1321 #close