### PR TITLE
 [TASK] Enable PostgreSQL for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: php
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql
 matrix:
   fast_finish: true
   include:
     - php: 7.0
       env: DB=mysql
     - php: 7.0
+      env: DB=pgsql
+    - php: 7.0
       env: DB=mysql BEHAT=true
+    - php: 7.0
+      env: DB=pgsql BEHAT=true
     - php: 5.6
       env: DB=sqlite
     - php: 5.5


### PR DESCRIPTION
This adds two more setups to the test matrix: PostgreSQL 9.4 on PHP 7.0.