### PR TITLE
BUGFIX: Allow to have no space between value and opening confinement

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
@@ -149,7 +149,7 @@ class Parser implements ParserInterface
 		)
 		\s*
 		(?P<OpeningConfinement>
-			[^\${]\{              # optionally followed by an opening confinement
+			(?<![${])\{           # optionally followed by an opening confinement
 		)?
 		\s*$
 	/x';

--- a/TYPO3.TypoScript/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture05.ts2
+++ b/TYPO3.TypoScript/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture05.ts2
@@ -17,6 +17,9 @@ firstObject2 = Text {
 firstObject3 < firstObject2 {
 	value = "Overridden value"
 }
+firstObject4 = Text{
+	value = "Ugly syntax with no space works!"
+}
 
 secondObject {
 	subObject = Text

--- a/TYPO3.TypoScript/Tests/Unit/Core/ParserTest.php
+++ b/TYPO3.TypoScript/Tests/Unit/Core/ParserTest.php
@@ -308,6 +308,12 @@ class ParserTest extends \TYPO3\Flow\Tests\UnitTestCase
                 '__eelExpression' => null,
                 'value' => 'Overridden value'
             ),
+            'firstObject4' => array(
+                '__objectType' => 'TYPO3.TypoScript:Text',
+                '__value' => null,
+                '__eelExpression' => null,
+                'value' => 'Ugly syntax with no space works!'
+            ),
             'secondObject' => array(
                 'subObject' => array(
                     '__objectType' => 'TYPO3.TypoScript:Text',


### PR DESCRIPTION
Fix regression caused by multi-line EEL support.

NEOS-60 #comment fixes a regression introduced by this