### PR TITLE
BUGFIX: Fix some issues with the history module

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/NodeEvent.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Model/NodeEvent.php
@@ -200,7 +200,7 @@ class NodeEvent extends Event
             $context = $this->contextFactory->create(array(
                 'workspaceName' => $this->userService->getUserWorkspace()->getName(),
                 'dimensions' => $this->dimension,
-                'currentSite' => $this->siteRepository->findByIdentifier($this->data['site']),
+                'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true
             ));
             return $context->getNodeByIdentifier($this->documentNodeIdentifier);
@@ -224,13 +224,27 @@ class NodeEvent extends Event
             $context = $this->contextFactory->create(array(
                 'workspaceName' => $this->userService->getUserWorkspace()->getName(),
                 'dimensions' => $this->dimension,
-                'currentSite' => $this->siteRepository->findByIdentifier($this->data['site']),
+                'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true
             ));
             return $context->getNodeByIdentifier($this->nodeIdentifier);
         } catch (EntityNotFoundException $e) {
             return null;
         }
+    }
+
+    /**
+     * Prevents invalid calls to the site respository in case the site data property is not available.
+     *
+     * @return null|object
+     */
+    protected function getCurrentSite()
+    {
+        if (!isset($this->data['site']) || $this->data['site'] === null) {
+            return null;
+        }
+
+        return $this->siteRepository->findByIdentifier($this->data['site']);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\EventLog\Domain\Repository;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\Doctrine\Repository;
 use TYPO3\Flow\Persistence\QueryInterface;
+use TYPO3\Neos\EventLog\Domain\Model\NodeEvent;
 
 /**
  * The repository for events
@@ -30,13 +31,49 @@ class EventRepository extends Repository
     );
 
     /**
+     * Find all events which are "top-level" and in a given workspace (or are not NodeEvents)
+     *
+     * @param integer $offset
+     * @param integer $limit
+     * @param string $workspaceName
+     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     * @throws \TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException
+     */
+    public function findRelevantEventsByWorkspace($offset, $limit, $workspaceName)
+    {
+        $query = $this->prepareRelevantEventsQuery();
+        $query->getQueryBuilder()->select('DISTINCT e');
+        $query->getQueryBuilder()
+            ->andWhere('e NOT INSTANCE OF ' . NodeEvent::class . ' OR e IN (SELECT nodeevent.uid FROM ' . NodeEvent::class . ' nodeevent WHERE nodeevent.workspaceName = :workspaceName AND nodeevent.parentEvent IS NULL)')
+            ->setParameter('workspaceName', $workspaceName);
+        $query->getQueryBuilder()->setFirstResult($offset);
+        $query->getQueryBuilder()->setMaxResults($limit);
+
+        return $query->execute();
+    }
+
+    /**
      * Find all events which are "top-level", i.e. do not have a parent event.
+     *
      * @param integer $offset
      * @param integer $limit
      * @return \TYPO3\Flow\Persistence\QueryResultInterface
      * @throws \TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException
      */
     public function findRelevantEvents($offset, $limit)
+    {
+        $query = $this->prepareRelevantEventsQuery();
+
+        $query->getQueryBuilder()->setFirstResult($offset);
+        $query->getQueryBuilder()->setMaxResults($limit);
+
+        return $query->execute();
+    }
+
+    /**
+     * @return \TYPO3\Flow\Persistence\Doctrine\Query
+     */
+    protected function prepareRelevantEventsQuery()
     {
         $query = $this->createQuery();
         $queryBuilder = $query->getQueryBuilder();
@@ -47,10 +84,7 @@ class EventRepository extends Repository
 
         $queryBuilder->orderBy('e.uid', 'DESC');
 
-        $queryBuilder->setFirstResult($offset);
-        $queryBuilder->setMaxResults($limit);
-
-        return $query->execute();
+        return $query;
     }
 
     /**

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/History/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/History/Index.html
@@ -40,7 +40,7 @@
 
 <f:if condition="{nextPage}">
   <div class="loadMore" data-neos-history-nextpage="{nextPage}">
-	  <button>Load more</button>
+	  <button>{neos:backend.translate(id: 'history.loadMore.label', source: 'Modules', package: 'TYPO3.Neos')}</button>
   </div>
 </f:if>
 

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -255,7 +255,9 @@
 			<trans-unit id="history.eventDescription.account.deleted" xml:space="preserve">
 				<source>{0} deleted the account "{1}" of {2}.</source>
 			</trans-unit>
-
+			<trans-unit id="history.loadMore.label" xml:space="preserve">
+				<source>Load More</source>
+			</trans-unit>
 
 			<!-- Administration -->
 			<trans-unit id="administration.label" xml:space="preserve">


### PR DESCRIPTION
This fixes the following issue with the history module:

- The "load more" button label is now translateable
- The NodeEvent won't call the SiteRepository if there is no "site"
- The EventRepository allows to filter correctly by Events
- HistoryController will correctly paginate due to the fixed Repository

NEOS-1221 #comment some cleanup to the implementation