### PR TITLE
BUGFIX: Thumbnail migration should clear thumbnails

### DIFF
--- a/TYPO3.Media/Migrations/Mysql/Version20151216144408.php
+++ b/TYPO3.Media/Migrations/Mysql/Version20151216144408.php
@@ -17,6 +17,7 @@ class Version20151216144408 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        $this->addSql("TRUNCATE TABLE typo3_media_domain_model_thumbnail");
         $this->addSql("DROP INDEX originalasset_configurationhash ON typo3_media_domain_model_thumbnail");
         $this->addSql("CREATE UNIQUE INDEX originalasset_configurationhash ON typo3_media_domain_model_thumbnail (originalasset, configurationhash)");
     }

--- a/TYPO3.Media/Migrations/Postgresql/Version20151216144435.php
+++ b/TYPO3.Media/Migrations/Postgresql/Version20151216144435.php
@@ -17,6 +17,7 @@ class Version20151216144435 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
+        $this->addSql("TRUNCATE TABLE typo3_media_domain_model_thumbnail");
         $this->addSql("DROP INDEX originalasset_configurationhash");
         $this->addSql("CREATE UNIQUE INDEX originalasset_configurationhash ON typo3_media_domain_model_thumbnail (originalasset, configurationhash)");
     }


### PR DESCRIPTION
To avoid unique constraint errors on applying the new index the
thumbnail table should be cleared beforehand.

Any left over resources can be cleared by executing::

    ./flow resource:clean