### PR TITLE
BUGFIX: Do not automatically persist thumbnails for new asset objects

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -121,7 +121,9 @@ class ThumbnailService
                     return null;
                 }
 
-                $this->thumbnailRepository->add($thumbnail);
+                if (!$this->persistenceManager->isNewObject($asset)) {
+                    $this->thumbnailRepository->add($thumbnail);
+                }
                 $asset->addThumbnail($thumbnail);
 
                 // Allow thumbnails to be persisted even if this is a "safe" HTTP request:


### PR DESCRIPTION
Prevents issues with database constraints caused by new assets being added to persistence, since
the asset would be added through the thumbnail as a related object as well.

Due to the automatic creation of thumbnails on asset creation, this caused problems for the site import.

NEOS-1671