### PR TITLE
BUGFIX: ContentController::getAssetProperties must use the new Thumbnail API

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -17,7 +17,6 @@ use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Resource\Exception;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Media\Domain\Model\AssetInterface;
-use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 use TYPO3\Media\Domain\Model\Thumbnail;
 use TYPO3\Media\Domain\Repository\ThumbnailRepository;
@@ -87,19 +86,6 @@ class ThumbnailService
      */
     public function getThumbnail(AssetInterface $asset, ThumbnailConfiguration $configuration)
     {
-        // Calculates the dimensions of the thumbnail to be generated and returns the thumbnail image if the new
-        // dimensions differ from the specified image dimensions, otherwise the original image is returned.
-        if ($asset instanceof ImageInterface) {
-            if ($asset->getWidth() === null && $asset->getHeight() === null) {
-                return $asset;
-            }
-            $maximumWidth = ($configuration->getMaximumWidth() > $asset->getWidth()) ? $asset->getWidth() : $configuration->getMaximumWidth();
-            $maximumHeight = ($configuration->getMaximumHeight() > $asset->getHeight()) ? $asset->getHeight() : $configuration->getMaximumHeight();
-            if ($configuration->isUpScalingAllowed() === false && $maximumWidth === $asset->getWidth() && $maximumHeight === $asset->getHeight()) {
-                return $asset;
-            }
-        }
-
         $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
         $configurationHash = $configuration->getHash();
         if (!isset($this->thumbnailCache[$assetIdentifier])) {
@@ -210,11 +196,7 @@ class ThumbnailService
             list($package, $path) = $this->resourceManager->getPackageAndPathByPublicPath($staticResource);
             return $this->resourceManager->getPublicPackageResourceUri($package, $path);
         } catch (Exception $exception) {
-            throw new ThumbnailServiceException(sprintf(
-                'Invalid static resource path "%s" for static thumbnail "%s".',
-                $staticResource,
-                $this->persistenceManager->getIdentifierByObject($thumbnail)
-            ), 1450188242, $exception);
+            return $staticResource;
         }
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -14,6 +14,7 @@ namespace TYPO3\Media\Domain\Service;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Resource\Exception;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
@@ -188,6 +189,7 @@ class ThumbnailService
     /**
      * @param Thumbnail $thumbnail
      * @return string
+     * @throws ThumbnailServiceException
      */
     public function getUriForThumbnail(Thumbnail $thumbnail)
     {
@@ -204,13 +206,15 @@ class ThumbnailService
             ), 1450178437);
         }
 
-        if (preg_match('#^resource://([^/]+)/Public/(.*)#', $staticResource, $matches) !== 1) {
+        try {
+            list($package, $path) = $this->resourceManager->getPackageAndPathByPublicPath($staticResource);
+            return $this->resourceManager->getPublicPackageResourceUri($package, $path);
+        } catch (Exception $exception) {
             throw new ThumbnailServiceException(sprintf(
                 'Invalid static resource path "%s" for static thumbnail "%s".',
                 $staticResource,
                 $this->persistenceManager->getIdentifierByObject($thumbnail)
-            ), 1450188242);
+            ), 1450188242, $exception);
         }
-        return $this->resourceManager->getPublicPackageResourceUri($matches[1], $matches[2]);
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -16,7 +16,6 @@ use TYPO3\Flow\I18n\EelHelper\TranslationHelper;
 use TYPO3\Flow\Property\PropertyMappingConfiguration;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Media\Domain\Model\Asset;
-use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Model\ImageInterface;
@@ -233,14 +232,23 @@ class ContentController extends ActionController
      */
     protected function getImagePreviewData(Image $image)
     {
-        $thumbnail = $this->thumbnailService->getThumbnail($image, $this->thumbnailService->getThumbnailConfigurationForPreset('TYPO3.Neos:Preview'));
-        $imageProperties = array(
+        $imageProperties = [
             'originalImageResourceUri' => $this->resourceManager->getPublicPersistentResourceUri($image->getResource()),
-            'previewImageResourceUri' => $this->resourceManager->getPublicPersistentResourceUri($thumbnail->getResource()),
-            'originalDimensions' => array('width' => $image->getWidth(), 'height' => $image->getHeight(), 'aspectRatio' => $image->getAspectRatio()),
-            'previewDimensions' => array('width' => $thumbnail->getWidth(), 'height' => $thumbnail->getHeight()),
+            'originalDimensions' => [
+                'width' => $image->getWidth(),
+                'height' => $image->getHeight(),
+                'aspectRatio' => $image->getAspectRatio()
+            ],
             'mediaType' => $image->getResource()->getMediaType()
-        );
+        ];
+        $thumbnail = $this->thumbnailService->getThumbnail($image, $this->thumbnailService->getThumbnailConfigurationForPreset('TYPO3.Neos:Preview'));
+        if ($thumbnail !== null) {
+            $imageProperties['previewImageResourceUri'] = $this->thumbnailService->getUriForThumbnail($thumbnail);
+            $imageProperties['previewDimensions'] = [
+                'width' => $thumbnail->getWidth(),
+                'height' => $thumbnail->getHeight()
+            ];
+        }
         return $imageProperties;
     }
 
@@ -287,13 +295,16 @@ class ContentController extends ActionController
      */
     protected function getAssetProperties(Asset $asset)
     {
-        $thumbnail = $this->thumbnailService->getStaticThumbnailForAsset($asset, 16, 16);
-        $assetProperties = array(
+        $assetProperties = [
             'assetUuid' => $this->persistenceManager->getIdentifierByObject($asset),
-            'filename' => $asset->getResource()->getFilename(),
-            'previewImageResourceUri' => $this->resourceManager->getPublicPackageResourceUri($thumbnail['package'], $thumbnail['src']),
-            'previewSize' => array('w' => $thumbnail['width'], 'h' => $thumbnail['height'])
-        );
+            'filename' => $asset->getResource()->getFilename()
+        ];
+        $thumbnail = $this->thumbnailService->getThumbnail($asset, $this->thumbnailService->getThumbnailConfigurationForPreset('TYPO3.Neos:IconPreview'));
+        if ($thumbnail !== null) {
+            $assetProperties['previewImageResourceUri'] = $this->thumbnailService->getUriForThumbnail($thumbnail);
+            $assetProperties['previewSize'] = ['w' => $thumbnail->getWidth(), 'h' => $thumbnail->getHeight()];
+        }
+
         return $assetProperties;
     }
 

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -423,6 +423,9 @@ TYPO3:
       'TYPO3.Neos:Preview':
         maximumWidth: 1000
         maximumHeight: 1000
+      'TYPO3.Neos:IconPreview':
+        maximumWidth: 16
+        maximumHeight: 16
     bodyClasses: 'neos neos-module media-browser'
     scripts:
       - resource://TYPO3.Neos/Public/Library/jquery/jquery-2.0.3.js


### PR DESCRIPTION
This change adapts ``ContentController::getAssetProperties`` to use the new Thumbnail API.

With this change the AssetList node type is fixed, the selection of a new asset would fail because the controller called a method that no longer existed existed.

NEOS-1165 #comment fixes a regression