### PR TITLE
BUGFIX: RenameNode Transformation uses existing method

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Migration/Transformations/RenameNode.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Migration/Transformations/RenameNode.php
@@ -55,6 +55,7 @@ class RenameNode extends AbstractTransformation
      */
     public function execute(\TYPO3\TYPO3CR\Domain\Model\NodeData $node)
     {
-        $node->setName($this->newName);
+        $newNodePath = $node->getParentPath() . '/' . $this->newName;
+        $node->setPath($newNodePath);
     }
 }


### PR DESCRIPTION
The ``RenameNode`` transformation for node migrations used
the non existing method ``setName`` on the ``NodeData`` object.
It now uses ``setPath`` instead which exists.

NEOS-1727 #close fixed with this change