### PR TITLE
TASK: node:repair doesn't mix internal node properties

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -140,6 +140,8 @@ The following options are allowed:
 ``properties``
   A list of named properties for this node type. For each property the following settings are available.
 
+  .. note:: Your own property names should never start with an underscore ``_`` as we use that as an internal prefix.
+
   ``type``
     Data type of this property. This may be a simple type (like in PHP), a fully qualified PHP class name, or one of
     these three special types: ``DateTime``, ``references``, or ``reference``. Use ``DateTime`` to store dates / time as a

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -140,7 +140,8 @@ The following options are allowed:
 ``properties``
   A list of named properties for this node type. For each property the following settings are available.
 
-  .. note:: Your own property names should never start with an underscore ``_`` as we use that as an internal prefix.
+  .. note:: Your own property names should never start with an underscore ``_`` as that is used for internal
+            properties or as an internal prefix.
 
   ``type``
     Data type of this property. This may be a simple type (like in PHP), a fully qualified PHP class name, or one of

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -345,6 +345,10 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
                     continue;
                 }
                 foreach ($defaultValues as $propertyName => $defaultValue) {
+                    if ($propertyName[0] === '_') {
+                        continue;
+                    }
+
                     if (!$node->hasProperty($propertyName)) {
                         $addedMissingDefaultValuesCount++;
                         if (!$dryRun) {


### PR DESCRIPTION
The ``node:repair`` command would currently apply any configured default
value as node property value if the property did not exist. This is
wrong for properties prefixed with an underscore as we use this
prefix for internal properties.
This is now changed so that any property starting with underscore
is ignored.

As this prefix is currently implicit knowledge a small note was added
to the documentation, stating that property names should not start
with underscores as we use them internally.

NEOS-1721 #close