### PR TITLE
BUGFIX: SVG Thumbnail Generator should keep track of width / height

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/SvgThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/SvgThumbnailGenerator.php
@@ -55,9 +55,14 @@ class SvgThumbnailGenerator extends AbstractThumbnailGenerator
     public function refresh(Thumbnail $thumbnail)
     {
         try {
+            $width = $thumbnail->getConfigurationValue('width') ?: $thumbnail->getConfigurationValue('maximumWidth');
+            $height = $thumbnail->getConfigurationValue('height') ?: $thumbnail->getConfigurationValue('maximumHeight');
+
             /** @var AssetInterface $asset */
             $asset = $thumbnail->getOriginalAsset();
             $thumbnail->setStaticResource($this->resourceManager->getPublicPersistentResourceUri($asset->getResource()));
+            $thumbnail->setWidth($width);
+            $thumbnail->setHeight($height);
         } catch (\Exception $exception) {
             $filename = $thumbnail->getOriginalAsset()->getResource()->getFilename();
             $sha1 = $thumbnail->getOriginalAsset()->getResource()->getSha1();


### PR DESCRIPTION
Every generator should update the requested width and height of the generated thumbnail.

NEOS-1165