### PR TITLE
BUGFIX: Do not automatically persist new thumbnails

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -184,7 +184,9 @@ class ThumbnailService
     {
         $thumbnail->refresh();
         $this->persistenceManager->whiteListObject($thumbnail);
-        $this->thumbnailRepository->update($thumbnail);
+        if (!$this->persistenceManager->isNewObject($thumbnail)) {
+            $this->thumbnailRepository->update($thumbnail);
+        }
     }
 
     /**


### PR DESCRIPTION
When an asset is uploaded and a thumbnail is generated for it,
the thumbnail object might not have been persisted already leading
to issues when the thumbnail is updated after rendering.

This fixes an issue in the asset list when uploading document assets.