### PR TITLE
BUGFIX: Accept ``ImageInterface`` in ``getUriForThumbnail``

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -188,11 +188,11 @@ class ThumbnailService
     }
 
     /**
-     * @param Thumbnail $thumbnail
+     * @param ImageInterface $thumbnail
      * @return string
      * @throws ThumbnailServiceException
      */
-    public function getUriForThumbnail(Thumbnail $thumbnail)
+    public function getUriForThumbnail(ImageInterface $thumbnail)
     {
         $resource = $thumbnail->getResource();
         if ($resource) {


### PR DESCRIPTION
Allow using the return value of ``thumbnailService->getThumbnail`` of type
``ImageInterface`` in the ``thumbnailService->getUriForThumbnail`` for
convenience.

This occurs when uploading an image in a image property that doesn't need to be
scaled.