### PR TITLE
BUGFIX: ImageVariant can be reused

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -177,7 +177,9 @@ class ContentController extends ActionController
      */
     public function createImageVariantAction(ImageVariant $asset)
     {
-        $this->assetRepository->add($asset);
+        if ($this->persistenceManager->isNewObject($asset)) {
+            $this->assetRepository->add($asset);
+        }
 
         $propertyMappingConfiguration = new PropertyMappingConfiguration();
         // This will not be sent as "application/json" as we need the JSON string and not the single variables.


### PR DESCRIPTION
This fix a bug when the editor choose two times the same settings for an
image variant of the same image. In this condition, the $asset object is
not new, and should not be passed to the add method.