### PR TITLE
TASK: Remove display of unpublished changes count

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -160,7 +160,6 @@ class WorkspacesController extends AbstractModuleController
             'baseWorkspaceName' => $workspace->getBaseWorkspace()->getName(),
             'baseWorkspaceLabel' => $workspace->getBaseWorkspace()->getTitle() ?: $workspace->getBaseWorkspace()->getName(),
             'canPublishToBaseWorkspace' => $this->userService->currentUserCanPublishToWorkspace($workspace->getBaseWorkspace()),
-            'changesCounts' => $this->computeChangesCount($workspace),
             'siteChanges' => $this->computeSiteChanges($workspace)
         ]);
     }

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
@@ -69,13 +69,12 @@
 										</f:if>
 									</div>
 								</span>
-								<f:link.action action="show" arguments="{workspace: workspace}" class="neos-button neos-button-primary">
+								<f:if condition="{changesCounts.total} != 0">
+									<f:link.action action="show" arguments="{workspace: workspace}" class="neos-button neos-button-primary">
 									<i class="icon-review"></i>
-									<f:if condition="{changesCounts.total} != 0">
-										<f:then>{neos:backend.translate(id: 'workspaces.reviewChanges', source: 'Modules', package: 'TYPO3.Neos', arguments: {0: changesCounts.total})}</f:then>
-										<f:else>{neos:backend.translate(id: 'workspaces.noChanges', source: 'Modules', package: 'TYPO3.Neos')}</f:else>
-									</f:if>
-								</f:link.action>
+									{neos:backend.translate(id: 'workspaces.review', source: 'Modules', package: 'TYPO3.Neos')}
+									</f:link.action>
+								</f:if>
 							</f:if>
 						</td>
 						<td class="neos-action">

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -10,7 +10,7 @@
 		<f:then>
 			<f:form action="publishOrDiscardNodes">
 				<f:form.hidden name="selectedWorkspace" value="{selectedWorkspace}"/>
-				<legend title="{neos:backend.translate(id: 'workspaces.changesCounts', source: 'Modules', package: 'TYPO3.Neos', arguments: changesCounts)}">{changesCounts.total} {neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'TYPO3.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
+				<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'TYPO3.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
 				<br />
 				<div class="neos-row-fluid">
 					<table class="neos-table">

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -122,8 +122,8 @@
 			<trans-unit id="workspaces.changesCounts" xml:space="preserve">
 				<source>additions: {new}, changes: {changed}, removals: {removed}</source>
 			</trans-unit>
-			<trans-unit id="workspaces.reviewChanges" xml:space="preserve">
-				<source>Review {0} changes</source>
+			<trans-unit id="workspaces.review" xml:space="preserve">
+				<source>Review</source>
 			</trans-unit>
 			<trans-unit id="workspaces.noChanges" xml:space="preserve">
 				<source>No changes</source>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -117,7 +117,7 @@
 				<source>This module contains the overview of all elements within the current workspace and it enables to continue the review and publishing workflow for them.</source>
 			</trans-unit>
 			<trans-unit id="workspaces.unpublishedChanges" xml:space="preserve">
-				<source>unpublished changes in workspace "{0}"</source>
+				<source>Unpublished changes in workspace "{0}"</source>
 			</trans-unit>
 			<trans-unit id="workspaces.changesCounts" xml:space="preserve">
 				<source>additions: {new}, changes: {changed}, removals: {removed}</source>


### PR DESCRIPTION
Following up on https://github.com/neos/neos-development-collection/pull/298 this change
removes the display of the number of unpublished changes again from the review button and the
change overview page.
