### PR TITLE
[TASK] Display error if no argument was specified to site:export

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -120,6 +120,10 @@ class SiteCommandController extends CommandController
      */
     public function exportCommand($siteNode = null, $tidy = false, $filename = null, $packageKey = null)
     {
+        if ($packageKey === null && $filename === null) {
+            $this->outputLine('Please specify either a package key or path and filename using --package-key or --filename respectively.');
+            $this->quit(2);
+        }
         if ($siteNode === null) {
             $sites = $this->siteRepository->findAll()->toArray();
         } else {


### PR DESCRIPTION
This change provides a helpful error message to the user when neither
package key nor path / filename was specified to site:export.