### PR TITLE
BUGFIX: Allow translation of dimension label

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionSelector.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionSelector.html
@@ -6,7 +6,7 @@
 <div class="neos-content-dimension-selector-dimensions">
 	{{#each dimension in dimensions}}
 		<div class="neos-content-dimension-selector-dimension">
-			<label for="neos-content-dimension-{{unbound dimension.identifier}}"><i class="{{unbound dimension.icon}}"></i> {{unbound dimension.label}}</label>
+			<label for="neos-content-dimension-{{unbound dimension.identifier}}"><i class="{{unbound dimension.icon}}"></i> {{boundTranslate idBinding="dimension.label"}}</label>
 			<select name="{{unbound dimension.identifier}}" id="neos-content-dimension-{{unbound dimension.identifier}}">
 				{{#each preset in dimension.presets}}
 					<option value="{{unbound preset.identifier}}" {{bind-attr selected=preset.selected}} {{bind-attr disabled=preset.disabled}}>{{unbound preset.label}}</option>


### PR DESCRIPTION
The dimension label could not be translated, because the translate
helper was used incorrect.