### PR TITLE
BUGFIX: Show content element after copy paste inline

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
@@ -302,8 +302,8 @@ class NodeController extends AbstractServiceController
      */
     public function copyAndRenderAction(Node $node, Node $targetNode, $position, $typoScriptPath, $nodeName = null)
     {
-        $this->nodeOperations->copy($node, $targetNode, $position, $nodeName);
-        $this->redirectToRenderNode($targetNode, $typoScriptPath);
+        $copiedNode = $this->nodeOperations->copy($node, $targetNode, $position, $nodeName);
+        $this->redirectToRenderNode($copiedNode, $typoScriptPath);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
@@ -251,7 +251,7 @@ class NodeController extends AbstractServiceController
     public function moveAndRenderAction(Node $node, Node $targetNode, $position, $typoScriptPath)
     {
         $this->nodeOperations->move($node, $targetNode, $position);
-        $this->redirectToRenderNode($targetNode, $typoScriptPath);
+        $this->redirectToRenderNode($node, $typoScriptPath);
     }
 
     /**

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeActions.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeActions.js
@@ -141,23 +141,29 @@ define(
 				collection = referenceNodeEntity._enclosingCollectionWidget.options.collection,
 				typoScriptPath = collectionModel.get('typo3:__typoscriptPath'),
 				nodeType = clipboard.nodeType,
-				localXhr = this._prepareXhr();
+				localXhr = this._prepareXhr(),
+				action = 'moveAndRender',
+				args = [
+					clipboard.nodePath,
+					referenceNode.get('nodePath'),
+					position,
+					typoScriptPath
+				];
 
-			var action = clipboard.type === 'cut' ? 'moveAndRender' : 'copyAndRender';
-			LoadingIndicator.start();
-			NodeEndpoint[action].call(
-				that,
-				clipboard.nodePath,
-				referenceNode.get('nodePath'),
-				position,
-				typoScriptPath,
-				'',
-				{
-					xhr: function() {
-						return localXhr;
-					}
+			if (clipboard.type === 'copy') {
+				action = 'copyAndRender';
+				// Add empty node name argument
+				args.push('');
+			}
+
+			args.push({
+				xhr: function() {
+					return localXhr;
 				}
-			).then(
+			});
+
+			LoadingIndicator.start();
+			NodeEndpoint[action].apply(that, args).then(
 				function(result) {
 					if (clipboard.type === 'cut') {
 						that.set('clipboard', null);


### PR DESCRIPTION
Fixes copy pasting of content elements where the new element wouldn't be displayed until
reloading the page.

Additionally fixes an issue where cutting an element caused a page reload.

NEOS-1506 #close