### PR TITLE
BUGFIX: Fix unicode handling in help messages

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -382,7 +382,11 @@ class NodeTypeConfigurationEnrichmentAspect
     protected function addTargetAttribute($htmlString)
     {
         $document = new \DOMDocument();
-        $document->loadHTML($htmlString);
+
+        // Force correct unicode handling
+        $document->loadHTML('<?xml encoding="UTF-8">' . $htmlString);
+        $document->encoding = 'UTF-8';
+
         $links = $document->getElementsByTagName('a');
         /** @var \DOMElement $item */
         foreach ($links as $item) {


### PR DESCRIPTION
Currently help messages are broken with unicode strings, because
`DOMDocument::loadHTML` needs correct encoding declaration to handle
unicode correctly.

Append the encoding declaration to fix this issue.