### PR TITLE
BUGFIX: User workspace names should be deterministic

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -34,6 +34,7 @@ use TYPO3\Party\Domain\Repository\PartyRepository;
 use TYPO3\Party\Domain\Service\PartyService;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\Neos\Utility\User as UserUtility;
 
 /**
  * A service for managing users
@@ -749,7 +750,7 @@ class UserService
      */
     protected function createPersonalWorkspace(User $user, Account $account)
     {
-        $userWorkspaceName = 'user-' . $account->getAccountIdentifier();
+        $userWorkspaceName = 'user-' . UserUtility::slugifyUsername($account->getAccountIdentifier());
         $userWorkspace = $this->workspaceRepository->findByIdentifier($userWorkspaceName);
         if ($userWorkspace === null) {
             $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
@@ -774,7 +775,7 @@ class UserService
      */
     protected function deletePersonalWorkspace($accountIdentifier)
     {
-        $userWorkspace = $this->workspaceRepository->findByIdentifier('user-' . $accountIdentifier);
+        $userWorkspace = $this->workspaceRepository->findByIdentifier('user-' . UserUtility::slugifyUsername($accountIdentifier));
         if ($userWorkspace instanceof Workspace) {
             $this->publishingService->discardAllNodes($userWorkspace);
             $this->workspaceRepository->remove($userWorkspace);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Neos\Domain\Model\User;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\Neos\Utility\User as UserUtility;
 
 /**
  * The user service provides general context information about the currently
@@ -89,7 +90,7 @@ class UserService
         }
 
         $username = $this->userDomainService->getUsername($currentUser);
-        return 'user-' . preg_replace('/[^a-z0-9]/i', '', $username);
+        return 'user-' . UserUtility::slugifyUsername($username);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/User.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/User.php
@@ -1,0 +1,19 @@
+<?php
+namespace TYPO3\Neos\Utility;
+
+/**
+ *
+ */
+class User
+{
+    /**
+     * Will reduce the username to ascii alphabet and numbers.
+     *
+     * @param string $username
+     * @return string
+     */
+    public static function slugifyUsername($username)
+    {
+        return preg_replace('/[^a-z0-9]/i', '', $username);
+    }
+}

--- a/TYPO3.Neos/Migrations/Mysql/Version20151223125909.php
+++ b/TYPO3.Neos/Migrations/Mysql/Version20151223125909.php
@@ -1,0 +1,50 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+use TYPO3\Neos\Utility\User as UserUtility;
+
+/**
+ * Set the Workspace "owner" field for all personal workspaces with special characters in the username
+ */
+class Version20151223125909 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+        $workspacesWithoutOwnerQuery = $this->connection->executeQuery('SELECT name FROM typo3_typo3cr_domain_model_workspace t0 WHERE t0.name LIKE \'user-%\' AND t0.owner IS NULL');
+        $workspacesWithoutOwner = $workspacesWithoutOwnerQuery->fetchAll(\PDO::FETCH_ASSOC);
+        if ($workspacesWithoutOwner === []) {
+            return;
+        }
+
+        $neosAccountQuery = $this->connection->executeQuery('SELECT t0.party_abstractparty, t1.accountidentifier FROM typo3_party_domain_model_abstractparty_accounts_join t0 JOIN typo3_flow_security_account t1 ON t0.flow_security_account = t1.persistence_object_identifier WHERE t1.authenticationprovidername = \'Typo3BackendProvider\'');
+        while ($account = $neosAccountQuery->fetch(\PDO::FETCH_ASSOC)) {
+            $normalizedUsername = UserUtility::slugifyUsername($account['accountidentifier']);
+
+            foreach ($workspacesWithoutOwner as $workspaceWithoutOwner) {
+                if ($workspaceWithoutOwner['name'] === 'user-' . $normalizedUsername) {
+                    $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = \'' . $account['party_abstractparty'] . '\' WHERE name = \'user-' . $normalizedUsername . '\'');
+                    continue 2;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = NULL');
+    }
+}

--- a/TYPO3.Neos/Migrations/Postgresql/Version20151223125946.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20151223125946.php
@@ -1,0 +1,50 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+use TYPO3\Neos\Utility\User as UserUtility;
+
+/**
+ * Set the Workspace "owner" field for all personal workspaces with special characters in the username
+ */
+class Version20151223125946 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $workspacesWithoutOwnerQuery = $this->connection->executeQuery('SELECT name FROM typo3_typo3cr_domain_model_workspace t0 WHERE t0.name LIKE \'user-%\' AND t0.owner IS NULL');
+        $workspacesWithoutOwner = $workspacesWithoutOwnerQuery->fetchAll(\PDO::FETCH_ASSOC);
+        if ($workspacesWithoutOwner === []) {
+            return;
+        }
+
+        $neosAccountQuery = $this->connection->executeQuery('SELECT t0.party_abstractparty, t1.accountidentifier FROM typo3_party_domain_model_abstractparty_accounts_join t0 JOIN typo3_flow_security_account t1 ON t0.flow_security_account = t1.persistence_object_identifier WHERE t1.authenticationprovidername = \'Typo3BackendProvider\'');
+        while ($account = $neosAccountQuery->fetch(\PDO::FETCH_ASSOC)) {
+            $normalizedUsername = UserUtility::slugifyUsername($account['accountidentifier']);
+
+            foreach ($workspacesWithoutOwner as $workspaceWithoutOwner) {
+                if ($workspaceWithoutOwner['name'] === 'user-' . $normalizedUsername) {
+                    $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = \'' . $account['party_abstractparty'] . '\' WHERE name = \'user-' . $normalizedUsername . '\'');
+                    continue 2;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+        $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = NULL');
+    }
+}


### PR DESCRIPTION
This fixes some inconsistencies with the naming of user workspaces,
which resulted in duplicate workspaces being created for users with
special characters in their username.

Additionally a migration that can correctly set the owner for users
with usernames containing special characters was added.

NEOS-1740 #close Fixes the issue with a new migration