### PR TITLE
TASK: Make personal workspace names explicit domain knowledge

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/WorkspaceCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/WorkspaceCommandController.php
@@ -236,7 +236,7 @@ class WorkspaceCommandController extends CommandController
             $this->quit(1);
         }
 
-        if (substr($workspaceName, 0, 5) === 'user-') {
+        if ($workspace->isPersonalWorkspace()) {
             $this->outputLine('Did not delete workspace "%s" because it is a personal workspace. Personal workspaces cannot be deleted manually.', [$workspaceName]);
             $this->quit(2);
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -120,7 +120,7 @@ class WorkspacesController extends AbstractModuleController
     public function indexAction()
     {
         $currentAccount = $this->securityContext->getAccount();
-        $userWorkspace = $this->workspaceRepository->findOneByName('user-' . UserUtility::slugifyUsername($currentAccount->getAccountIdentifier()));
+        $userWorkspace = $this->workspaceRepository->findOneByName(UserUtility::getPersonalWorkspaceNameForUsername($currentAccount->getAccountIdentifier()));
         /** @var Workspace $userWorkspace */
 
         $workspacesAndCounts = [
@@ -250,7 +250,7 @@ class WorkspacesController extends AbstractModuleController
      */
     public function deleteAction(Workspace $workspace)
     {
-        if (substr($workspace->getName(), 0, 5) === 'user-') {
+        if ($workspace->isPersonalWorkspace()) {
             $this->redirect('index');
         }
 
@@ -297,7 +297,7 @@ class WorkspacesController extends AbstractModuleController
     public function rebaseAndRedirectAction(NodeInterface $targetNode, Workspace $targetWorkspace)
     {
         $currentAccount = $this->securityContext->getAccount();
-        $personalWorkspace = $this->workspaceRepository->findOneByName('user-' . UserUtility::slugifyUsername($currentAccount->getAccountIdentifier()));
+        $personalWorkspace = $this->workspaceRepository->findOneByName(UserUtility::getPersonalWorkspaceNameForUsername($currentAccount->getAccountIdentifier()));
         /** @var Workspace $personalWorkspace */
 
         if ($personalWorkspace !== $targetWorkspace) {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -750,7 +750,7 @@ class UserService
      */
     protected function createPersonalWorkspace(User $user, Account $account)
     {
-        $userWorkspaceName = 'user-' . UserUtility::slugifyUsername($account->getAccountIdentifier());
+        $userWorkspaceName = UserUtility::getPersonalWorkspaceNameForUsername($account->getAccountIdentifier());
         $userWorkspace = $this->workspaceRepository->findByIdentifier($userWorkspaceName);
         if ($userWorkspace === null) {
             $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
@@ -775,7 +775,7 @@ class UserService
      */
     protected function deletePersonalWorkspace($accountIdentifier)
     {
-        $userWorkspace = $this->workspaceRepository->findByIdentifier('user-' . UserUtility::slugifyUsername($accountIdentifier));
+        $userWorkspace = $this->workspaceRepository->findByIdentifier(UserUtility::getPersonalWorkspaceNameForUsername($accountIdentifier));
         if ($userWorkspace instanceof Workspace) {
             $this->publishingService->discardAllNodes($userWorkspace);
             $this->workspaceRepository->remove($userWorkspace);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/UserService.php
@@ -90,7 +90,7 @@ class UserService
         }
 
         $username = $this->userDomainService->getUsername($currentUser);
-        return 'user-' . UserUtility::slugifyUsername($username);
+        return ($username === null ? null : UserUtility::getPersonalWorkspaceNameForUsername($username));
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/User.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/User.php
@@ -1,11 +1,24 @@
 <?php
 namespace TYPO3\Neos\Utility;
 
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
+
 /**
- *
+ * Utility functions for dealing with users in the Content Repository.
  */
 class User
 {
+    /**
+     * Constructs a personal workspace name for the user with the given username.
+     *
+     * @param string $username
+     * @return string
+     */
+    public static function getPersonalWorkspaceNameForUsername($username)
+    {
+        return Workspace::PERSONAL_WORKSPACE_PREFIX . static::slugifyUsername($username);
+    }
+
     /**
      * Will reduce the username to ascii alphabet and numbers.
      *

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -28,6 +28,10 @@ use TYPO3\TYPO3CR\Exception\WorkspaceException;
  */
 class Workspace
 {
+    /**
+     * This prefix determines if a given workspace (name) is a user workspace.
+     */
+    const PERSONAL_WORKSPACE_PREFIX = 'user-';
 
     /**
      * @var string
@@ -267,7 +271,7 @@ class Workspace
      */
     public function isPersonalWorkspace()
     {
-        return strpos($this->name, 'user-') === 0;
+        return strpos($this->name, static::PERSONAL_WORKSPACE_PREFIX) === 0;
     }
 
     /**


### PR DESCRIPTION
Just moves code around to avoid string concatentation all over
the place. Also uses the ``isPersonalWorkspace()`` in appropriate
places.