### PR TITLE
TASK: Reintroduce PublishingService

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
@@ -1,0 +1,23 @@
+<?php
+namespace TYPO3\TYPO3CR\Service;
+
+/*
+ * This file is part of the TYPO3.TYPO3CR package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ *
+ * @Flow\Scope("singleton")
+ * @deprecated since 2.1, use \TYPO3\TYPO3CR\Domain\Service\PublishingService instead
+ */
+class PublishingService extends \TYPO3\TYPO3CR\Domain\Service\PublishingService
+{
+}


### PR DESCRIPTION
The PublishingService was moved from TYPO3\TYPO3CR\Service to
the TYPO3\TYPO3CR\Domain\Service namespace in commit
23b162fa737cd56eb065b71e76a11ee823cdec7a. As the class was annotated
with @api that change was actually breaking and should not have been
released in a minor release.

This change introduces the class again and immediately deprecates it
to be removed in a later version.