### PR TITLE
BUGFIX: Remove site logic from parents operation

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Neos\Eel\FlowQueryOperations;
 
 /*
- * This file is part of the TYPO3.TYPO3CR package.
+ * This file is part of the TYPO3.Neos package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
@@ -1,5 +1,5 @@
 <?php
-namespace TYPO3\TYPO3CR\Eel\FlowQueryOperations;
+namespace TYPO3\Neos\Eel\FlowQueryOperations;
 
 /*
  * This file is part of the TYPO3.TYPO3CR package.
@@ -35,7 +35,7 @@ class ParentsOperation extends AbstractOperation
      *
      * @var integer
      */
-    protected static $priority = 0;
+    protected static $priority = 100;
 
     /**
      * {@inheritdoc}
@@ -60,7 +60,8 @@ class ParentsOperation extends AbstractOperation
         $output = array();
         $outputNodePaths = array();
         foreach ($flowQuery->getContext() as $contextNode) {
-            while ($contextNode->getParent() !== null) {
+            $siteNode = $contextNode->getContext()->getCurrentSiteNode();
+            while ($contextNode !== $siteNode && $contextNode->getParent() !== null) {
                 $contextNode = $contextNode->getParent();
                 if (!isset($outputNodePaths[$contextNode->getPath()])) {
                     $output[] = $contextNode;

--- a/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace TYPO3\TYPO3CR\Tests\Unit\FlowQueryOperations;
+namespace TYPO3\Neos\Tests\Unit\FlowQueryOperations;
 
 /*
- * This file is part of the TYPO3.TYPO3CR package.
+ * This file is part of the TYPO3.Neos package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -37,7 +37,7 @@ class ParentsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
         $context = array($secondLevelNode);
         $q = new \TYPO3\Eel\FlowQuery\FlowQuery($context);
 
-        $operation = new \TYPO3\TYPO3CR\Eel\FlowQueryOperations\ParentsOperation();
+        $operation = new \TYPO3\Neos\Eel\FlowQueryOperations\ParentsOperation();
         $operation->evaluate($q, array());
 
         $output = $q->getContext();


### PR DESCRIPTION
There is site logic within the parents operation inside the TYPO3.CR package. There is a seperate operation especially for Neos now.

NEOS-1628 #resolve