### PR TITLE
FEATURE: Make position selector appear on hover

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractPositionSelectorButton.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractPositionSelectorButton.js
@@ -39,7 +39,7 @@ function (
 
 		hoverTimer: null,
 
-		mouseInside: false,
+		isMouseInside: false,
 
 		toggleSelectorOption: function(newPosition) {
 			this.set('desiredPosition', newPosition);
@@ -74,10 +74,10 @@ function (
 		mouseEnter: function(event) {
 			if (this.get('isDisabled') === false) {
 				var that = this;
-				that.set('mouseInside', true);
+				that.set('isMouseInside', true);
 				clearTimeout(this.get('hoverTimer'));
 				this.set('hoverTimer', setTimeout(function() {
-					if (that.get('mouseInside') === true) {
+					if (that.get('isMouseInside') === true) {
 						that.set('isExpanded', true);
 					}
 				}, 700));
@@ -85,7 +85,7 @@ function (
 		},
 
 		mouseLeave: function() {
-			this.set('mouseInside', false);
+			this.set('isMouseInside', false);
 			this.set('isExpanded', false);
 		},
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractPositionSelectorButton.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractPositionSelectorButton.js
@@ -37,6 +37,10 @@ function (
 
 		downTimer: null,
 
+		hoverTimer: null,
+
+		mouseInside: false,
+
 		toggleSelectorOption: function(newPosition) {
 			this.set('desiredPosition', newPosition);
 		},
@@ -67,7 +71,21 @@ function (
 			}
 		},
 
+		mouseEnter: function(event) {
+			if (this.get('isDisabled') === false) {
+				var that = this;
+				that.set('mouseInside', true);
+				clearTimeout(this.get('hoverTimer'));
+				this.set('hoverTimer', setTimeout(function() {
+					if (that.get('mouseInside') === true) {
+						that.set('isExpanded', true);
+					}
+				}, 700));
+			}
+		},
+
 		mouseLeave: function() {
+			this.set('mouseInside', false);
 			this.set('isExpanded', false);
 		},
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
@@ -156,7 +156,7 @@ define(
 
 			NewPositionSelectorButton: AbstractPositionSelectorButton.extend({
 				allowedPositionsBinding: 'parentView.allowedNewPositions',
-				title: 'Create (hold to select position)',
+				title: 'Create (hover to select position)',
 				iconClass: 'icon-plus',
 
 				mouseUp: function(event) {
@@ -172,7 +172,7 @@ define(
 
 			PastePositionSelectorButton: AbstractPositionSelectorButton.extend({
 				allowedPositionsBinding: 'parentView.allowedPastePositions',
-				title: 'Paste (hold to select position)',
+				title: 'Paste (hover to select position)',
 				iconClass: 'icon-paste',
 
 				mouseUp: function(event) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -45,7 +45,7 @@ function (
 
 		NewPositionSelectorButton: AbstractPositionSelectorButton.extend({
 			allowedPositionsBinding: 'parentView.allowedNewPositions',
-			title: 'Create (hold to select position)',
+			title: 'Create (hover to select position)',
 			iconClass: 'icon-plus',
 
 			mouseUp: function(event) {
@@ -61,7 +61,7 @@ function (
 
 		PastePositionSelectorButton: AbstractPositionSelectorButton.extend({
 			allowedPositionsBinding: 'parentView.allowedPastePositions',
-			title: 'Paste (hold to select position)',
+			title: 'Paste (hover to select position)',
 			iconClass: 'icon-paste',
 
 			mouseUp: function(event) {


### PR DESCRIPTION
The position selector for creating or pasting elements used to appear when click-and-holding the button for 300ms. This is not very intuitive for a web interface. Now the option menu will appear on hover after 700ms. The click-and-hold behaviour will still work, so touch support is still given.

NEOS-1691 #close