### PR TITLE
TASK: Replace visible occurrences of www.typo3.org with www.neos.io

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/DomainRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/DomainRepository.php
@@ -47,7 +47,7 @@ class DomainRepository extends \TYPO3\Flow\Persistence\Repository
      *
      * Their order is determined by how well they match, best match first.
      *
-     * @param string $host Host the domain should match with (eg. "localhost" or "www.typo3.org")
+     * @param string $host Host the domain should match with (eg. "localhost" or "www.neos.io")
      * @param boolean $onlyActive Only include active domains
      * @return array An array of matching domains
      * @api
@@ -61,7 +61,7 @@ class DomainRepository extends \TYPO3\Flow\Persistence\Repository
     /**
      * Find the best matching active domain for the given host.
      *
-     * @param string $host Host the domain should match with (eg. "localhost" or "www.typo3.org")
+     * @param string $host Host the domain should match with (eg. "localhost" or "www.neos.io")
      * @param boolean $onlyActive Only include active domains
      * @return \TYPO3\Neos\Domain\Model\Domain
      * @api

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DomainMatchingStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DomainMatchingStrategy.php
@@ -28,7 +28,7 @@ class DomainMatchingStrategy
      * The domains are sorted by their match exactness.
      * If none really matches an empty array is returned.
      *
-     * @param string $host The host to match against (eg. "localhost" or "www.typo3.org")
+     * @param string $host The host to match against (eg. "localhost" or "www.neos.io")
      * @param array<\TYPO3\Neos\Domain\Model\Domain> $domains The domains to check
      * @return array The matching domains
      */

--- a/TYPO3.Neos/Resources/Private/Partials/Module/Shared/DomainForm.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Module/Shared/DomainForm.html
@@ -6,7 +6,7 @@
 		<div class="neos-control-group">
 			<label class="neos-control-label" for="host-pattern">Host pattern</label>
 			<div class="neos-controls">
-				<f:form.textfield property="hostPattern" value="{domain.hostPattern}" id="host-pattern" class="neos-span12" placeholder="e.g. www.typo3.org" />
+				<f:form.textfield property="hostPattern" value="{domain.hostPattern}" id="host-pattern" class="neos-span12" placeholder="e.g. www.neos.io" />
 			</div>
 		</div>
 		<div class="neos-control-group">

--- a/TYPO3.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -23,11 +23,11 @@ class DomainMatchingStrategyTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function getSortedMatchesReturnsOneGivenDomainIfItMatchesExactly()
     {
         $mockDomains = array($this->getMock('TYPO3\Neos\Domain\Model\Domain', array(), array(), '', false));
-        $mockDomains[0]->expects($this->any())->method('getHostPattern')->will($this->returnValue('www.typo3.org'));
+        $mockDomains[0]->expects($this->any())->method('getHostPattern')->will($this->returnValue('www.neos.io'));
         $expectedDomains = array($mockDomains[0]);
 
         $strategy = new \TYPO3\Neos\Domain\Service\DomainMatchingStrategy();
-        $actualDomains = $strategy->getSortedMatches('www.typo3.org', $mockDomains);
+        $actualDomains = $strategy->getSortedMatches('www.neos.io', $mockDomains);
         $this->assertSame($expectedDomains, $actualDomains);
     }
 


### PR DESCRIPTION
This change replaces www.typo3.org which is given as an example in the
"add new domain" dialog by www.neos.io, and also replaces it in a couple
of unit tests. The VIE namespace is not modified by this change.