### PR TITLE
BUGFIX: Migration for workspaces with empty owners

### DIFF
--- a/TYPO3.Neos/Migrations/Mysql/Version20160104121311.php
+++ b/TYPO3.Neos/Migrations/Mysql/Version20160104121311.php
@@ -1,0 +1,50 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+use TYPO3\Neos\Utility\User as UserUtility;
+
+/**
+ * Set the Workspace "owner" field for all personal workspaces with special characters in the username
+ */
+class Version20160104121311 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+        $workspacesWithoutOwnerQuery = $this->connection->executeQuery("SELECT name FROM typo3_typo3cr_domain_model_workspace t0 WHERE t0.name LIKE 'user-%' AND t0.owner = ''");
+        $workspacesWithoutOwner = $workspacesWithoutOwnerQuery->fetchAll(\PDO::FETCH_ASSOC);
+        if ($workspacesWithoutOwner === []) {
+            return;
+        }
+
+        $neosAccountQuery = $this->connection->executeQuery('SELECT t0.party_abstractparty, t1.accountidentifier FROM typo3_party_domain_model_abstractparty_accounts_join t0 JOIN typo3_flow_security_account t1 ON t0.flow_security_account = t1.persistence_object_identifier WHERE t1.authenticationprovidername = \'Typo3BackendProvider\'');
+        while ($account = $neosAccountQuery->fetch(\PDO::FETCH_ASSOC)) {
+            $normalizedUsername = UserUtility::slugifyUsername($account['accountidentifier']);
+
+            foreach ($workspacesWithoutOwner as $workspaceWithoutOwner) {
+                if ($workspaceWithoutOwner['name'] === 'user-' . $normalizedUsername) {
+                    $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = \'' . $account['party_abstractparty'] . '\' WHERE name = \'user-' . $normalizedUsername . '\'');
+                    continue 2;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = NULL');
+    }
+}

--- a/TYPO3.Neos/Migrations/Postgresql/Version20160104121413.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20160104121413.php
@@ -1,0 +1,50 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+use TYPO3\Neos\Utility\User as UserUtility;
+
+/**
+ * Set the Workspace "owner" field for all personal workspaces with special characters in the username
+ */
+class Version20160104121413 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $workspacesWithoutOwnerQuery = $this->connection->executeQuery("SELECT name FROM typo3_typo3cr_domain_model_workspace t0 WHERE t0.name LIKE 'user-%' AND t0.owner = ''");
+        $workspacesWithoutOwner = $workspacesWithoutOwnerQuery->fetchAll(\PDO::FETCH_ASSOC);
+        if ($workspacesWithoutOwner === []) {
+            return;
+        }
+
+        $neosAccountQuery = $this->connection->executeQuery('SELECT t0.party_abstractparty, t1.accountidentifier FROM typo3_party_domain_model_abstractparty_accounts_join t0 JOIN typo3_flow_security_account t1 ON t0.flow_security_account = t1.persistence_object_identifier WHERE t1.authenticationprovidername = \'Typo3BackendProvider\'');
+        while ($account = $neosAccountQuery->fetch(\PDO::FETCH_ASSOC)) {
+            $normalizedUsername = UserUtility::slugifyUsername($account['accountidentifier']);
+
+            foreach ($workspacesWithoutOwner as $workspaceWithoutOwner) {
+                if ($workspaceWithoutOwner['name'] === 'user-' . $normalizedUsername) {
+                    $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = \'' . $account['party_abstractparty'] . '\' WHERE name = \'user-' . $normalizedUsername . '\'');
+                    continue 2;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+        $this->addSql('UPDATE typo3_typo3cr_domain_model_workspace SET owner = NULL');
+    }
+}


### PR DESCRIPTION
The fixes issued for NEOS-1740 didn't consider the case of an installation
were previous migrations ran and set the owner of workspaces to an
empty string instead of NULL which made the first bugfix migration ignore
those workspaces. This migration now targets those specifically, together
migrating all workspaces to having the correct ownership.

NEOS-1740 #close