### PR TITLE
TASK: Document missing ``ConvertUris`` property ``absolute``

### DIFF
--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -751,7 +751,7 @@ overriding the target attribute for external links and resource links.
 :externalLinkTarget: (string) Override the target attribute for external links, defaults to ``_blank``. Can be disabled with an empty value.
 :resourceLinkTarget: (string) Override the target attribute for resource links, defaults to ``_blank``. Can be disabled with an empty value.
 :forceConversion: (boolean) Whether to convert URIs in a non-live workspace, defaults to ``FALSE``
-:absolute: (boolean) can be used to convert node uris to absolute links, defaults to ``FALSE``
+:absolute: (boolean) Can be used to convert node uris to absolute links, defaults to ``FALSE``
 
 Example::
 

--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -751,6 +751,7 @@ overriding the target attribute for external links and resource links.
 :externalLinkTarget: (string) Override the target attribute for external links, defaults to ``_blank``. Can be disabled with an empty value.
 :resourceLinkTarget: (string) Override the target attribute for resource links, defaults to ``_blank``. Can be disabled with an empty value.
 :forceConversion: (boolean) Whether to convert URIs in a non-live workspace, defaults to ``FALSE``
+:absolute: (boolean) can be used to convert node uris to absolute links, defaults to ``FALSE``
 
 Example::
 

--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -751,7 +751,7 @@ overriding the target attribute for external links and resource links.
 :externalLinkTarget: (string) Override the target attribute for external links, defaults to ``_blank``. Can be disabled with an empty value.
 :resourceLinkTarget: (string) Override the target attribute for resource links, defaults to ``_blank``. Can be disabled with an empty value.
 :forceConversion: (boolean) Whether to convert URIs in a non-live workspace, defaults to ``FALSE``
-:absolute: (boolean) Can be used to convert node uris to absolute links, defaults to ``FALSE``
+:absolute: (boolean) Can be used to convert node URIs to absolute links, defaults to ``FALSE``
 
 Example::
 


### PR DESCRIPTION
Documents a missing property ``absolute`` for the ``ConvertUris`` TypoScript object