### PR TITLE
BUGFIX: Load moved page if moving parent page

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
@@ -866,7 +866,17 @@ define(
 							// Update the pageNodePath if we moved the current page
 							if (that.get('pageNodePath') === sourceNode.data.key) {
 								that.set('pageNodePath', result.data.newNodePath);
+							} else {
+								// handle pageNodePath if we moved a parent node
+								var explodedParentPath = sourceNode.data.key.split('@');
+
+								if (that.get('pageNodePath').indexOf(explodedParentPath[0]) === 0) {
+									var newExplodedPath = result.data.newNodePath.split('@');
+
+									that.set('pageNodePath', that.get('pageNodePath').replace(explodedParentPath[0], newExplodedPath[0]))
+								}
 							}
+
 							// after we finished moving, update the node path/url
 							sourceNode.data.href = result.data.nextUri;
 							sourceNode.data.key = result.data.newNodePath;

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
@@ -275,7 +275,14 @@ define(
 				var isCurrentNode = node.data.key === this.get('pageNodePath');
 				if (isCurrentNode) {
 					ContentModule.loadPage(node.data.href);
+				} else {
+					// if the current viewed page is a children of the moved page load it
+					var explodedPath = node.data.key.split('@');
+					if (this.get('pageNodePath').indexOf(explodedPath[0]) === 0) {
+						ContentModule.loadPage(node.data.href);
+					}
 				}
+
 				EventDispatcher.trigger('nodeMoved', node);
 			},
 


### PR DESCRIPTION
If you move a parent node of the node in the NodeTree you are currently on the node tree
will break because the pageNodePath for your current node is not set to the new path.

NEOS-1752 #close