### PR TITLE
BUGFIX: Wrong label visibility inspector group

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -60,7 +60,7 @@
     inspector:
       groups:
         visibility:
-          label: 'i18n:TYPO3.Neos:Inspector:groups.visibility'
+          label: 'TYPO3.Neos:Inspector:groups.visibility'
           position: 100
           tab: meta
   properties:


### PR DESCRIPTION
This change remove the 'i18n' prefix from the inspector group label.