### PR TITLE
TASK: Add better help text for ``site:export`` command

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -115,7 +115,7 @@ class SiteCommandController extends CommandController
     }
 
     /**
-     * Export sites content
+     * Export sites content (e.g. site:export --package-key "TYPO3.NeosDemoTypo3Org")
      *
      * This command exports all or one specific site with all its content into an XML format.
      *


### PR DESCRIPTION
Adds a better help text for the `site:export` command when calling `help`