### PR TITLE
BUGFIX: Fixed a typo in ``_InlineEditing.scss``

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/_InlineEditing.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/_InlineEditing.scss
@@ -67,5 +67,5 @@
 &.neos-empty-contentcollection-overlay {
 	height: 20px;
 	outline: 2px solid rgba(0, 0, 0, .2);
-	inline-offset: 2px;
+	outline-offset: 2px;
 }


### PR DESCRIPTION
The css property ``inline-offset`` doesn't exist, it should be
``outline-offset``.