### PR TITLE
BUGFIX: Node property can be null in removeProperty

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
@@ -256,7 +256,7 @@ abstract class AbstractNodeData
     public function removeProperty($propertyName)
     {
         if (!is_object($this->contentObjectProxy)) {
-            if (isset($this->properties[$propertyName])) {
+            if (array_key_exists($propertyName, $this->properties)) {
                 unset($this->properties[$propertyName]);
                 $this->addOrUpdate();
             } else {


### PR DESCRIPTION
The ``AbstractNodeData::removeProperty()`` method checked
the existence of the given property with ``isset`` but that
leads to an exception if the property has a ``null`` value.
The check has been changed to ``array_key_exists``.

NEOS-1719 #close