### PR TITLE
BUGFIX: Fix ObjectAccess to overriden expression value in Fluid proxy

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/Helpers/TypoScriptPathProxy.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/Helpers/TypoScriptPathProxy.php
@@ -146,6 +146,8 @@ class TypoScriptPathProxy implements \TYPO3\Fluid\Core\Parser\SyntaxTree\Templat
             }
         } elseif (isset($this->partialTypoScriptTree['__eelExpression'])) {
             return $this->tsRuntime->evaluate($this->path, $this->templateImplementation);
+        } elseif (isset($this->partialTypoScriptTree['__value'])) {
+            return $this->partialTypoScriptTree['__value'];
         }
 
         return $this;

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/Templates/JsonEncodedValueTemplate.html
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/Templates/JsonEncodedValueTemplate.html
@@ -1,0 +1,1 @@
+{value -> f:format.json()}

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/Template.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/Template.ts2
@@ -31,3 +31,10 @@ template.offsetAccessException = TYPO3.TypoScript:Template {
 		@exceptionHandler = 'TYPO3\\TypoScript\\Core\\ExceptionHandlers\\PlainTextHandler'
 	}
 }
+
+template.overrideWithSimpleValueInTemplate = TYPO3.TypoScript:Template {
+	templatePath = ${fixtureDirectory + 'Templates/JsonEncodedValueTemplate.html'}
+	value = ${1 + 1}
+}
+// Overriding the expression with a simple value should still yield a number in the template
+template.overrideWithSimpleValueInTemplate.value = 3

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/TemplateTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/TemplateTest.php
@@ -66,4 +66,14 @@ class TemplateTest extends AbstractTypoScriptObjectTest
         $view->setTypoScriptPath('template/offsetAccessException');
         $this->assertStringStartsWith('Test TemplateException while rendering template', $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function expressionCanBeOverridenWithSimpleValueForTemplate()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('template/overrideWithSimpleValueInTemplate');
+        $this->assertSame('3', $view->render(), 'JSON encoded value should be a number');
+    }
 }


### PR DESCRIPTION
This will check for an overriden value when using object access in a
Fluid template on a TypoScript path proxy.

NEOS-1776 #close Fixes the issue