### PR TITLE
TASK: Ignore empty NodeType configurations

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeTypeManager.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeTypeManager.php
@@ -189,6 +189,9 @@ class NodeTypeManager
         $completeNodeTypeConfiguration = $this->configurationManager->getConfiguration('NodeTypes');
 
         foreach (array_keys($completeNodeTypeConfiguration) as $nodeTypeName) {
+            if (!is_array($completeNodeTypeConfiguration[$nodeTypeName])) {
+                continue;
+            }
             $nodeType = $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration, (isset($this->fullNodeTypeConfigurations[$nodeTypeName]) ? $this->fullNodeTypeConfigurations[$nodeTypeName] : null));
             if ($fillFullConfigurationCache) {
                 $this->fullNodeTypeConfigurations[$nodeTypeName] = $nodeType->getFullConfiguration();


### PR DESCRIPTION
When a NodeType is unset using ```'My.Package:NodeType': ~``` the
NodeTypeManager complains the NodeType is undefined.

This change makes the NodeTypeManager ignore NodeType configurations
which are no array. This way the NodeType does not end up in the schema
definitions at all meaning a more lightweight UI.