### PR TITLE
BUGFIX: Adjust index names to match Doctrine DBAL 2.5

### DIFF
--- a/TYPO3.Neos/Migrations/Mysql/Version20160212141523.php
+++ b/TYPO3.Neos/Migrations/Mysql/Version20160212141523.php
@@ -35,15 +35,15 @@ class Version20160212141523 extends AbstractMigration {
 	public function down(Schema $schema) {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY FK_8E49A537694309E4");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY typo3_neos_domain_model_domain_ibfk_1");
 		$this->addSql("DROP INDEX idx_8e49a537694309e4 ON typo3_neos_domain_model_domain");
 		$this->addSql("CREATE INDEX IDX_F227E8F6694309E4 ON typo3_neos_domain_model_domain (site)");
-		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT FK_8E49A537694309E4 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT typo3_neos_domain_model_domain_ibfk_1 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
 		$this->addSql("DROP INDEX flow_identity_typo3_neos_domain_model_site ON typo3_neos_domain_model_site");
 		$this->addSql("CREATE UNIQUE INDEX flow3_identity_typo3_typo3_domain_model_site ON typo3_neos_domain_model_site (nodename)");
-		$this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY FK_FC846DAAE931A6F5");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY typo3_neos_domain_model_user_ibfk_1");
 		$this->addSql("DROP INDEX uniq_fc846daae931a6f5 ON typo3_neos_domain_model_user");
 		$this->addSql("CREATE UNIQUE INDEX UNIQ_E3F98B13E931A6F5 ON typo3_neos_domain_model_user (preferences)");
-		$this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT FK_FC846DAAE931A6F5 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
 	}
 }

--- a/TYPO3.Neos/Migrations/Mysql/Version20160212141523.php
+++ b/TYPO3.Neos/Migrations/Mysql/Version20160212141523.php
@@ -1,0 +1,49 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212141523 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY typo3_neos_domain_model_domain_ibfk_1");
+		$this->addSql("DROP INDEX idx_f227e8f6694309e4 ON typo3_neos_domain_model_domain");
+		$this->addSql("CREATE INDEX IDX_8E49A537694309E4 ON typo3_neos_domain_model_domain (site)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT typo3_neos_domain_model_domain_ibfk_1 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
+		$this->addSql("DROP INDEX flow3_identity_typo3_typo3_domain_model_site ON typo3_neos_domain_model_site");
+		$this->addSql("CREATE UNIQUE INDEX flow_identity_typo3_neos_domain_model_site ON typo3_neos_domain_model_site (nodename)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY typo3_neos_domain_model_user_ibfk_1");
+		$this->addSql("DROP INDEX uniq_e3f98b13e931a6f5 ON typo3_neos_domain_model_user");
+		$this->addSql("CREATE UNIQUE INDEX UNIQ_FC846DAAE931A6F5 ON typo3_neos_domain_model_user (preferences)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY FK_8E49A537694309E4");
+		$this->addSql("DROP INDEX idx_8e49a537694309e4 ON typo3_neos_domain_model_domain");
+		$this->addSql("CREATE INDEX IDX_F227E8F6694309E4 ON typo3_neos_domain_model_domain (site)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT FK_8E49A537694309E4 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
+		$this->addSql("DROP INDEX flow_identity_typo3_neos_domain_model_site ON typo3_neos_domain_model_site");
+		$this->addSql("CREATE UNIQUE INDEX flow3_identity_typo3_typo3_domain_model_site ON typo3_neos_domain_model_site (nodename)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY FK_FC846DAAE931A6F5");
+		$this->addSql("DROP INDEX uniq_fc846daae931a6f5 ON typo3_neos_domain_model_user");
+		$this->addSql("CREATE UNIQUE INDEX UNIQ_E3F98B13E931A6F5 ON typo3_neos_domain_model_user (preferences)");
+		$this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT FK_FC846DAAE931A6F5 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
+	}
+}

--- a/TYPO3.Neos/Migrations/Postgresql/Version20160212141533.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20160212141533.php
@@ -1,0 +1,45 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212141533 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		// typo3_neos_domain_model_domain
+		$this->addSql("ALTER INDEX idx_f227e8f6694309e4 RENAME TO IDX_8E49A537694309E4");
+
+		// typo3_neos_domain_model_site
+		$this->addSql("ALTER INDEX flow3_identity_typo3_typo3_domain_model_site RENAME TO flow_identity_typo3_neos_domain_model_site");
+
+		// typo3_neos_domain_model_user
+		$this->addSql("ALTER INDEX uniq_e3f98b13e931a6f5 RENAME TO UNIQ_FC846DAAE931A6F5");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		// typo3_neos_domain_model_domain
+		$this->addSql("ALTER INDEX IDX_8E49A537694309E4 RENAME TO idx_f227e8f6694309e4");
+
+		// typo3_neos_domain_model_site
+		$this->addSql("ALTER INDEX flow_identity_typo3_neos_domain_model_site RENAME TO flow3_identity_typo3_typo3_domain_model_site");
+
+		// typo3_neos_domain_model_user
+		$this->addSql("ALTER INDEX UNIQ_FC846DAAE931A6F5 RENAME TO uniq_e3f98b13e931a6f5");
+	}
+}

--- a/TYPO3.Neos/Migrations/Postgresql/Version20160212141533.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20160212141533.php
@@ -14,7 +14,7 @@ class Version20160212141533 extends AbstractMigration {
 	 * @return void
 	 */
 	public function up(Schema $schema) {
-		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
 		// typo3_neos_domain_model_domain
 		$this->addSql("ALTER INDEX idx_f227e8f6694309e4 RENAME TO IDX_8E49A537694309E4");
@@ -31,7 +31,7 @@ class Version20160212141533 extends AbstractMigration {
 	 * @return void
 	 */
 	public function down(Schema $schema) {
-		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
 		// typo3_neos_domain_model_domain
 		$this->addSql("ALTER INDEX IDX_8E49A537694309E4 RENAME TO idx_f227e8f6694309e4");

--- a/TYPO3.TYPO3CR/Migrations/Mysql/Version20160212141524.php
+++ b/TYPO3.TYPO3CR/Migrations/Mysql/Version20160212141524.php
@@ -34,12 +34,12 @@ class Version20160212141524 extends AbstractMigration {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
 		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
-		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B94930C33C");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY typo3_typo3cr_domain_model_nodedata_ibfk_2");
 		$this->addSql("DROP INDEX idx_60a956b98d940019 ON typo3_typo3cr_domain_model_nodedata");
 		$this->addSql("CREATE INDEX IDX_820CADC88D940019 ON typo3_typo3cr_domain_model_nodedata (workspace)");
 		$this->addSql("DROP INDEX idx_60a956b94930c33c ON typo3_typo3cr_domain_model_nodedata");
 		$this->addSql("CREATE INDEX IDX_820CADC84930C33C ON typo3_typo3cr_domain_model_nodedata (contentobjectproxy)");
 		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B98D940019 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace (name) ON DELETE SET NULL");
-		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B94930C33C FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT typo3_typo3cr_domain_model_nodedata_ibfk_2 FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");
 	}
 }

--- a/TYPO3.TYPO3CR/Migrations/Mysql/Version20160212141524.php
+++ b/TYPO3.TYPO3CR/Migrations/Mysql/Version20160212141524.php
@@ -1,0 +1,45 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212141524 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY typo3_typo3cr_domain_model_nodedata_ibfk_2");
+		$this->addSql("DROP INDEX idx_820cadc88d940019 ON typo3_typo3cr_domain_model_nodedata");
+		$this->addSql("CREATE INDEX IDX_60A956B98D940019 ON typo3_typo3cr_domain_model_nodedata (workspace)");
+		$this->addSql("DROP INDEX idx_820cadc84930c33c ON typo3_typo3cr_domain_model_nodedata");
+		$this->addSql("CREATE INDEX IDX_60A956B94930C33C ON typo3_typo3cr_domain_model_nodedata (contentobjectproxy)");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B98D940019 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace (name) ON DELETE SET NULL");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT typo3_typo3cr_domain_model_nodedata_ibfk_2 FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B94930C33C");
+		$this->addSql("DROP INDEX idx_60a956b98d940019 ON typo3_typo3cr_domain_model_nodedata");
+		$this->addSql("CREATE INDEX IDX_820CADC88D940019 ON typo3_typo3cr_domain_model_nodedata (workspace)");
+		$this->addSql("DROP INDEX idx_60a956b94930c33c ON typo3_typo3cr_domain_model_nodedata");
+		$this->addSql("CREATE INDEX IDX_820CADC84930C33C ON typo3_typo3cr_domain_model_nodedata (contentobjectproxy)");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B98D940019 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace (name) ON DELETE SET NULL");
+		$this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B94930C33C FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");
+	}
+}

--- a/TYPO3.TYPO3CR/Migrations/Postgresql/Version20160212141534.php
+++ b/TYPO3.TYPO3CR/Migrations/Postgresql/Version20160212141534.php
@@ -1,0 +1,35 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+	Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212141534 extends AbstractMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function up(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		// typo3_typo3cr_domain_model_nodedata
+		$this->addSql("ALTER INDEX idx_820cadc88d940019 RENAME TO IDX_60A956B98D940019");
+		$this->addSql("ALTER INDEX idx_820cadc84930c33c RENAME TO IDX_60A956B94930C33C");
+	}
+
+	/**
+	 * @param Schema $schema
+	 * @return void
+	 */
+	public function down(Schema $schema) {
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+		// typo3_typo3cr_domain_model_nodedata
+		$this->addSql("ALTER INDEX IDX_60A956B98D940019 RENAME TO idx_820cadc88d940019");
+		$this->addSql("ALTER INDEX IDX_60A956B94930C33C RENAME TO idx_820cadc84930c33c");
+	}
+}

--- a/TYPO3.TYPO3CR/Migrations/Postgresql/Version20160212141534.php
+++ b/TYPO3.TYPO3CR/Migrations/Postgresql/Version20160212141534.php
@@ -14,7 +14,7 @@ class Version20160212141534 extends AbstractMigration {
 	 * @return void
 	 */
 	public function up(Schema $schema) {
-		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
 		// typo3_typo3cr_domain_model_nodedata
 		$this->addSql("ALTER INDEX idx_820cadc88d940019 RENAME TO IDX_60A956B98D940019");
@@ -26,7 +26,7 @@ class Version20160212141534 extends AbstractMigration {
 	 * @return void
 	 */
 	public function down(Schema $schema) {
-		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
 		// typo3_typo3cr_domain_model_nodedata
 		$this->addSql("ALTER INDEX IDX_60A956B98D940019 RENAME TO idx_820cadc88d940019");


### PR DESCRIPTION
The use of Doctrine 2.5 (instead of 2.4) exposes the fact that some
(old) index names in the Neos database schema do not match the names
that are generated currently.

This adjusts those index names, something that is a one-time adjustment.