### PR TITLE
BUGFIX: Fix issues with PostgreSQL migrations

### DIFF
--- a/TYPO3.Neos/Migrations/Postgresql/Version20151120170812.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20151120170812.php
@@ -18,9 +18,9 @@ class Version20151120170812 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues TYPE jsonb");
+        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues TYPE jsonb USING dimensionvalues::jsonb");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER dimensionvalues DROP DEFAULT");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles TYPE jsonb");
+        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles TYPE jsonb USING accessroles::jsonb");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ALTER accessroles DROP DEFAULT");
     }
 

--- a/TYPO3.Neos/Migrations/Postgresql/Version20151126122252.php
+++ b/TYPO3.Neos/Migrations/Postgresql/Version20151126122252.php
@@ -21,6 +21,8 @@ class Version20151126122252 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
+        $this->addSql("TRUNCATE TABLE typo3_neos_eventlog_domain_model_event");
+
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data TYPE jsonb USING data::jsonb");
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data DROP DEFAULT");
 
@@ -35,6 +37,8 @@ class Version20151126122252 extends AbstractMigration
     public function down(Schema $schema)
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $this->addSql("TRUNCATE TABLE typo3_neos_eventlog_domain_model_event");
 
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data TYPE TEXT");
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ALTER data DROP DEFAULT");


### PR DESCRIPTION
This fixes issues when migrating to 2.1 that affect some, but not all, running PostgreSQL:

- JSON to JSONB column type change not possible
- column type change on event log not possible

NEOS-1763 #close
