### PR TITLE
BUGFIX: Content Collection nodes vanish when publishing to nested workspace

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -413,6 +413,11 @@ class Workspace
         if ($node->getWorkspace() !== $this) {
             return;
         }
+        // Might happen if a node which has been published during an earlier call of publishNode() is attempted to
+        // be published again:
+        if ($node->getWorkspace() === $targetWorkspace) {
+            return;
+        }
         $this->verifyPublishingTargetWorkspace($targetWorkspace);
         $this->emitBeforeNodePublishing($node, $targetWorkspace);
         if ($node->getPath() === '/') {
@@ -560,7 +565,7 @@ class Workspace
      * @return void
      * @Flow\Signal
      */
-    protected function emitBaseWorkspaceChanged(Workspace $workspace, Workspace $oldBaseWorkspace, Workspace $newBaseWorkspace)
+    protected function emitBaseWorkspaceChanged(Workspace $workspace, Workspace $oldBaseWorkspace = null, Workspace $newBaseWorkspace = null)
     {
     }
 

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -81,6 +81,27 @@ class WorkspaceTest extends UnitTestCase
     }
 
     /**
+     * Bug NEOS-1769: Content Collections disappear when publishing to other workspace than "live"
+     *
+     * Under certain circumstances, content collection nodes will be deleted when publishing a document to a workspace which is based on another workspace.
+     *
+     * @test
+     */
+    public function publishNodeReturnsIfTheTargetWorkspaceIsTheSameAsTheSourceWorkspace()
+    {
+        $liveWorkspace = new Workspace('live');
+        $workspace = new Workspace('some-campaign');
+        $workspace->setBaseWorkspace($liveWorkspace);
+
+        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->disableOriginalConstructor()->getMock();
+        $mockNode->expects($this->any())->method('getWorkspace')->will($this->returnValue($workspace));
+
+        $mockNode->expects($this->never())->method('emitBeforeNodePublishing');
+
+        $workspace->publishNode($mockNode, $workspace);
+    }
+
+    /**
      * @test
      */
     public function verifyPublishingTargetWorkspaceDoesNotThrowAnExceptionIfTargetWorkspaceIsABaseWorkspace()


### PR DESCRIPTION
This fixes an issue with the publishing mechanism which can result in
removed Content Collection nodes when documents are published to a
workspace other than the live workspace.

The root cause for this issue is that during publishing Neos will publish
Content Collection nodes twice (the first time because they may exist
in the personal workspace and the second time because all Content
Collection nodes are published automatically when a Document node is
published). Because the workspace of the Content Collection node is
changed to the target workspace on the first publish iteration, the
source and target workspace will be the same on the second publish
iteration. That results in `replaceNodeData()` to remove the "existing"
Content Collection node, which is actually the very same object like
the "new" one.

NEOS-1769 #resolve