### PR TITLE
BUGFIX: Translate dimension label in dimension choice dialog

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
@@ -8,7 +8,8 @@ define(
 	'Shared/EventDispatcher',
 	'Shared/HttpRestClient',
 	'vie',
-	'Content/Application'
+	'Content/Application',
+	'Shared/I18n'
 ],
 function(
 	Ember,
@@ -19,7 +20,8 @@ function(
 	EventDispatcher,
 	HttpRestClient,
 	vie,
-	ContentModule
+	ContentModule,
+	I18n
 ) {
 	var Dimension, Preset;
 
@@ -190,7 +192,8 @@ function(
 		currentDimensionChoiceText: function() {
 			var dimensionText = [];
 			$.each(this.get('dimensions'), function(index, dimension) {
-				dimensionText.push(dimension.get('label') + ' ' + dimension.get('selected.label'));
+				var translatedLabel = I18n.translate(dimension.get('label'));
+				dimensionText.push(translatedLabel + ' ' + dimension.get('selected.label'));
 			});
 			return dimensionText.join(', ');
 		}.property('dimensions.@each.selected'),


### PR DESCRIPTION
The demo site specifies an i18n label but the implementation didn't use
any client-side translation for the dimension label yet.