### PR TITLE
BUGFIX: Replace document stylesheets after loading a page

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendHeaderData.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendHeaderData.html
@@ -8,9 +8,9 @@
 
 <f:if condition="{neos:backend.shouldLoadMinifiedJavascript()}">
 	<f:then>
-		<link rel="stylesheet" type="text/css" href="{f:uri.resource(path: 'Styles/Includes-built.css', package: 'TYPO3.Neos')}?bust={neos:backend.cssBuiltVersion()}" />
+		<link rel="stylesheet" type="text/css" class="neos-ui-asset" href="{f:uri.resource(path: 'Styles/Includes-built.css', package: 'TYPO3.Neos')}?bust={neos:backend.cssBuiltVersion()}" />
 	</f:then>
 	<f:else>
-		<link rel="stylesheet" type="text/css" href="{f:uri.resource(path: 'Styles/Includes.css', package: 'TYPO3.Neos')}" />
+		<link rel="stylesheet" type="text/css" class="neos-ui-asset" href="{f:uri.resource(path: 'Styles/Includes.css', package: 'TYPO3.Neos')}" />
 	</f:else>
 </f:if>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -449,6 +449,15 @@ function(
 					$('title').html($htmlDom.filter('title').html());
 					$('link[rel="neos-site"]').attr('href', $htmlDom.filter('link[rel="neos-site"]').attr('href'));
 
+					// We cannot do this stylesheet change on IE < 11 (the user agent string changed with 11, so everything with MSIE in is below 11)
+					if (window.navigator.userAgent.indexOf('MSIE ') < 1) {
+						var $pageStylesheets = $('link[rel="stylesheet"]:not(.neos-ui-asset)');
+
+						var $loadedStylesheets = $htmlDom.filter('link[rel="stylesheet"]:not(.neos-ui-asset)');
+						$('head').append($loadedStylesheets);
+						$pageStylesheets.remove();
+					}
+
 					// TODO: transfer body classes and other possibly important tags from the head section
 
 					that._setPagePosition();


### PR DESCRIPTION
This change adds a marker class to the Neos CSS link tag and will remove
and append all stylesheets into the document after loading a page in
the content module. This solves issues with document dependent CSS
includes on a site as well as the initial rendering of shortcut documents.

NEOS-830 #close
NEOS-99 #close