### PR TITLE
BUGFIX: Verify DateTime parsing in nodeConverter

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
@@ -224,8 +224,7 @@ class NodeConverter extends AbstractTypeConverter
                     }
                 break;
                 case 'DateTime':
-                    if ($nodePropertyValue !== '') {
-                        $nodePropertyValue = \DateTime::createFromFormat(\DateTime::W3C, $nodePropertyValue);
+                    if ($nodePropertyValue !== '' && ($nodePropertyValue = \DateTime::createFromFormat(\DateTime::W3C, $nodePropertyValue)) !== false) {
                         $nodePropertyValue->setTimezone(new \DateTimeZone(date_default_timezone_get()));
                     } else {
                         $nodePropertyValue = null;


### PR DESCRIPTION
If a DateTime property is not parseable,
$nodePropertyValue->setTimezone() is called on a none-object.