### PR TITLE
BUGFIX: Reset ``backendOptions`` for TypoScript content cache in testing context

### DIFF
--- a/TYPO3.TypoScript/Configuration/Testing/Caches.yaml
+++ b/TYPO3.TypoScript/Configuration/Testing/Caches.yaml
@@ -1,2 +1,3 @@
 TYPO3_TypoScript_Content:
   backend: TYPO3\Flow\Cache\Backend\TransientMemoryBackend
+  backendOptions: ~


### PR DESCRIPTION
Fixes a bug that occurs if there is a custom configuration for ``TYPO3_TypoScript_Content`` cache with ``backendOptions`` set. This fix will unset the ``backendOptions`` in testing context which are not allowed for the ``TYPO3\Flow\Cache\Backend\TransientMemoryBackend`` backend.

NEOS-1781 #close