### PR TITLE
BUGFIX: Additional styles for modules loaded after Neos

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -4,6 +4,17 @@
 <f:section name="head">
 	<title>{title}</title>
 
+	<f:if condition="{neos:backend.shouldLoadMinifiedJavascript()}">
+		<f:then>
+			<link rel="stylesheet" type="text/css"
+				  href="{f:uri.resource(path: 'Styles/Includes-built.css?bust={neos:backend.cssBuiltVersion()}', package: 'TYPO3.Neos')}"/>
+		</f:then>
+		<f:else>
+			<link rel="stylesheet" type="text/css"
+				  href="{f:uri.resource(path: 'Styles/Includes.css', package: 'TYPO3.Neos')}"/>
+		</f:else>
+	</f:if>
+
 	<f:if condition="{moduleConfiguration.additionalResources.styleSheets}">
 		<f:for each="{moduleConfiguration.additionalResources.styleSheets}" as="additionalResource">
 			<link rel="stylesheet" href="{f:uri.resource(path: additionalResource)}" />
@@ -27,15 +38,6 @@
 	<link rel="neos-vieschema" href="{f:uri.action(action: 'vieSchema', controller: 'Backend\Schema', package: 'TYPO3.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
 	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'TYPO3.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
 	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'TYPO3.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
-
-	<f:if condition="{neos:backend.shouldLoadMinifiedJavascript()}">
-		<f:then>
-			<link rel="stylesheet" type="text/css" href="{f:uri.resource(path: 'Styles/Includes-built.css?bust={neos:backend.cssBuiltVersion()}', package: 'TYPO3.Neos')}" />
-		</f:then>
-		<f:else>
-			<link rel="stylesheet" type="text/css" href="{f:uri.resource(path: 'Styles/Includes.css', package: 'TYPO3.Neos')}" />
-		</f:else>
-	</f:if>
 </f:section>
 
 <f:section name="body">


### PR DESCRIPTION
Via `additionalResources.styleSheets` a map of additional
stylesheet files can be defined that are loaded in the module
the configuration was made for. Unfortunately they were loaded
before the Neos default styles which makes overwriting of some of
those styles cumbersome and more difficult than necessary.

This change switches the loading order so that the Neos styles
are loaded before any additional resources.