### PR TITLE
BUGFIX: Translate title attribute on module widget action buttons

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Module/Widget.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Widget.html
@@ -18,7 +18,7 @@
 	<f:if condition="{submoduleConfiguration.actions}">
 		<div class="widget-footer">
 			<f:for each="{submoduleConfiguration.actions}" as="actionConfiguration" key="submoduleAction">
-				<neos:link.module title="{actionConfiguration.title}" class="neos-button neos-button-primary" path="{f:if(condition: actionConfiguration.path, then: actionConfiguration.path, else: '{moduleConfiguration.path}/{submoduleIdentifier}/{submoduleAction -> f:format.case(mode: \'lower\')}')}">
+				<neos:link.module title="{neos:backend.translate(id: actionConfiguration.title, source: 'Modules')}" class="neos-button neos-button-primary" path="{f:if(condition: actionConfiguration.path, then: actionConfiguration.path, else: '{moduleConfiguration.path}/{submoduleIdentifier}/{submoduleAction -> f:format.case(mode: \'lower\')}')}">
 					<neos:backend.translate source="Modules" id="{actionConfiguration.label}" />
 				</neos:link.module>
 			</f:for>


### PR DESCRIPTION
Enables translation of the title attribute used for action buttons in module widgets.

NEOS-1536 #close