### PR TITLE
FEATURE: Load ``LastVisitedNode.js`` asynchronously

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
@@ -158,6 +158,7 @@ prototype(TYPO3.Neos:Page) < prototype(TYPO3.TypoScript:Http.Message) {
 			src = TYPO3.TypoScript:ResourceUri {
 				path = 'resource://TYPO3.Neos/Public/JavaScript/LastVisitedNode.js'
 			}
+			async = true
 		}
 	}
 


### PR DESCRIPTION
`LastVisitedNode.js` should run asynchronously as soon as it is available, since some speed testing tools consider it to be render blocking.