### PR TITLE
BUGFIX: Use stable identifier for auto-created child nodes in repair

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -25,6 +25,7 @@ use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Exception\NodeTypeNotFoundException;
+use TYPO3\TYPO3CR\Utility;
 
 /**
  * Plugin for the TYPO3CR NodeCommandController which provides functionality for creating missing child nodes.
@@ -259,7 +260,8 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
                         $childNodeMissing = $node->getNode($childNodeName) ? false : true;
                         if ($childNodeMissing) {
                             if ($dryRun === false) {
-                                $node->createNode($childNodeName, $childNodeType);
+                                $childNodeIdentifier = Utility::buildAutoCreatedChildNodeIdentifier($childNodeName, $node->getIdentifier());
+                                $node->createNode($childNodeName, $childNodeType, $childNodeIdentifier);
                                 $this->output->outputLine('Auto created node named "%s" in "%s"', array($childNodeName, $node->getPath()));
                             } else {
                                 $this->output->outputLine('Missing node named "%s" in "%s"', array($childNodeName, $node->getPath()));

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -19,6 +19,7 @@ use TYPO3\TYPO3CR\Domain\Service\Context;
 use TYPO3\TYPO3CR\Exception\NodeConstraintException;
 use TYPO3\TYPO3CR\Exception\NodeException;
 use TYPO3\TYPO3CR\Exception\NodeExistsException;
+use TYPO3\TYPO3CR\Utility;
 
 /**
  * This is the main API for storing and retrieving content in the system.
@@ -963,7 +964,7 @@ class Node implements NodeInterface, CacheAwareInterface
             }
 
             foreach ($nodeType->getAutoCreatedChildNodes() as $childNodeName => $childNodeType) {
-                $childNodeIdentifier = $this->buildAutoCreatedChildNodeIdentifier($childNodeName, $newNode->getIdentifier());
+                $childNodeIdentifier = Utility::buildAutoCreatedChildNodeIdentifier($childNodeName, $newNode->getIdentifier());
                 $alreadyPresentChildNode = $newNode->getNode($childNodeName);
                 if ($alreadyPresentChildNode === null) {
                     $newNode->createNode($childNodeName, $childNodeType, $childNodeIdentifier);
@@ -976,22 +977,6 @@ class Node implements NodeInterface, CacheAwareInterface
         $this->emitAfterNodeCreate($newNode);
 
         return $newNode;
-    }
-
-    /**
-     * Generate a stable identifier for auto-created child nodes
-     *
-     * This is needed if multiple node variants are created through "createNode" with different dimension values. If
-     * child nodes with the same path and different identifiers exist, bad things can happen.
-     *
-     * @param string $childNodeName
-     * @param string $identifier
-     * @return string The generated UUID like identifier
-     */
-    protected function buildAutoCreatedChildNodeIdentifier($childNodeName, $identifier)
-    {
-        $hex = md5($identifier . '-' . $childNodeName);
-        return substr($hex, 0, 8) . '-' . substr($hex, 8, 4) . '-' . substr($hex, 12, 4) . '-' . substr($hex, 16, 4) . '-' . substr($hex, 20, 12);
     }
 
     /**

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
@@ -120,4 +120,21 @@ class Utility
         // trim leftover dashes, lowercase and return
         return strtolower(trim($name, '-'));
     }
+
+    /**
+     * Generate a stable identifier for auto-created child nodes
+     *
+     * This is needed if multiple node variants are created through "createNode" with different dimension values. If
+     * child nodes with the same path and different identifiers exist, bad things can happen.
+     *
+     * @param string $childNodeName
+     * @param string $identifier Identifier of the node where the child node should be created
+     * @return string The generated UUID like identifier
+     */
+    public static function buildAutoCreatedChildNodeIdentifier($childNodeName, $identifier)
+    {
+        $hex = md5($identifier . '-' . $childNodeName);
+
+        return substr($hex, 0, 8) . '-' . substr($hex, 8, 4) . '-' . substr($hex, 12, 4) . '-' . substr($hex, 16, 4) . '-' . substr($hex, 20, 12);
+    }
 }


### PR DESCRIPTION
If auto-created child nodes are added via `node:repair`, the generated identifiers are not the same across different variants. This will cause problems when publishing these node variants later.

This change synchronizes the behavior between `node:repair` and regular node creation.

Running `node:repair` will now check identifiers of auto-created child nodes and adjust them accordingly. This is potentially breaking if a child node was referenced from another node but that should very rarely happen.

NEOS-1783 #close