### PR TITLE
BUGFIX: Creating pages using non-latin characters

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -15,6 +15,7 @@ use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\ConsoleOutput;
 use TYPO3\Neos\Domain\Service\SiteService;
+use TYPO3\Neos\Utility\NodeUriPathSegmentGenerator;
 use TYPO3\TYPO3CR\Command\NodeCommandControllerPluginInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
@@ -23,7 +24,6 @@ use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContentDimensionCombinator;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TYPO3CR\Domain\Utility\NodePaths;
-use TYPO3\TYPO3CR\Utility;
 
 /**
  * A plugin for the TYPO3CR NodeCommandController which adds a task adding missing URI segments to the node:repair
@@ -56,6 +56,12 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
      * @Flow\Inject
      */
     protected $dimensionCombinator;
+
+    /**
+     * @Flow\Inject
+     * @var NodeUriPathSegmentGenerator
+     */
+    protected $nodeUriPathSegmentGenerator;
 
     /**
      * @var ConsoleOutput
@@ -162,7 +168,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
     {
         if ((string)$node->getProperty('uriPathSegment') === '') {
             $name = $node->getLabel() ?: $node->getName();
-            $uriPathSegment = Utility::renderValidNodeName($name);
+            $uriPathSegment = $this->nodeUriPathSegmentGenerator->generateUriPathSegment($node);
             if ($dryRun === false) {
                 $node->setProperty('uriPathSegment', $uriPathSegment);
                 $this->output->outputLine('Added missing URI path segment for "%s" (%s) => %s', array($node->getPath(), $name, $uriPathSegment));

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeOperations.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeOperations.php
@@ -12,12 +12,12 @@ namespace TYPO3\Neos\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Utility\NodeUriPathSegmentGenerator;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeServiceInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Domain\Utility\NodePaths;
 use TYPO3\TYPO3CR\Exception\NodeException;
-use TYPO3\TYPO3CR\Utility;
 
 /**
  * Centralizes common operations like moving and copying of Nodes with Neos specific additional handling.
@@ -39,6 +39,12 @@ class NodeOperations
     protected $nodeService;
 
     /**
+     * @Flow\Inject
+     * @var NodeUriPathSegmentGenerator
+     */
+    protected $nodeUriPathSegmentGenerator;
+
+    /**
      * Helper method for creating a new node.
      *
      * @param NodeInterface $referenceNode
@@ -55,7 +61,7 @@ class NodeOperations
         $nodeType = $this->nodeTypeManager->getNodeType($nodeData['nodeType']);
 
         if ($nodeType->isOfType('TYPO3.Neos:Document') && !isset($nodeData['properties']['uriPathSegment']) && isset($nodeData['properties']['title'])) {
-            $nodeData['properties']['uriPathSegment'] = Utility::renderValidNodeName($nodeData['properties']['title']);
+            $nodeData['properties']['uriPathSegment'] = $this->nodeUriPathSegmentGenerator->generateUriPathSegment($referenceNode, $nodeData['properties']['title']);
         }
 
         $proposedNodeName = isset($nodeData['nodeName']) ? $nodeData['nodeName'] : null;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/TransliterationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/TransliterationService.php
@@ -1,0 +1,59 @@
+<?php
+namespace TYPO3\Neos\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\I18n\Service as LocalizationService;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class TransliterationService
+{
+    /**
+     * @Flow\Inject
+     * @var LocalizationService
+     */
+    protected $localizationService;
+
+    /**
+     * @Flow\InjectConfiguration("transliterationRules")
+     * @var boolean
+     */
+    protected $transliterationRules;
+
+    /**
+     * Translaterates UTF-8 string to ASCII. (北京 to 'Bei Jing')
+     *
+     * Accepts language parameter that maps to a configurable array of special transliteration rules if present.
+     *
+     * @param string $text Text to transliterate
+     * @param string $language Optional language for specific rules (falls back to current locale if not provided)
+     * @return string
+     */
+    public function transliterate($text, $language = null)
+    {
+        $language = $language ?: $this->localizationService->getConfiguration()->getCurrentLocale()->getLanguage();
+
+        if (isset($this->transliterationRules[$language])) {
+            // Apply special transliteration (not supported in library)
+            $text = strtr($text, $this->transliterationRules[$language]);
+        }
+
+        // Transliterate (transform 北京 to 'Bei Jing')
+        if (preg_match('/[\x80-\xff]/', $text) && \Behat\Transliterator\Transliterator::validUtf8($text)) {
+            $text = \Behat\Transliterator\Transliterator::utf8ToAscii($text);
+        }
+
+        return $text;
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
@@ -11,15 +11,25 @@ namespace TYPO3\Neos\Utility;
  * source code.
  */
 
-use TYPO3\Flow\Annotations\After;
-use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\Eel\FlowQuery\FlowQuery;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\I18n\Locale;
+use TYPO3\Neos\Service\TransliterationService;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
- * Static Utility to generate a valid, non-conflicting uriPathSegment for Nodes.
+ * Utility to generate a valid, non-conflicting uriPathSegment for nodes.
+ *
+ * @Flow\Scope("singleton")
  */
 class NodeUriPathSegmentGenerator
 {
+    /**
+     * @Flow\Inject
+     * @var TransliterationService
+     */
+    protected $transliterationService;
+
     /**
      * Sets the best possible uriPathSegment for the given Node.
      * Will use an already set uriPathSegment or alternatively the node name as base,
@@ -41,5 +51,28 @@ class NodeUriPathSegmentGenerator
             }
             $node->setProperty('uriPathSegment', $possibleUriPathSegment);
         }
+    }
+
+    /**
+     * Generates a URI path segment for a given node taking it's language dimension into account
+     *
+     * @param NodeInterface $node Optional node to determine language dimension
+     * @param string $text Optional text
+     * @return string
+     */
+    public function generateUriPathSegment(NodeInterface $node = null, $text = null)
+    {
+        if ($node) {
+            $text = $text ?: $node->getLabel() ?: $node->getName();
+            $dimensions = $node->getContext()->getDimensions();
+            if (array_key_exists('language', $dimensions) && $dimensions['language'] !== array()) {
+                $locale = new Locale($dimensions['language'][0]);
+                $language = $locale->getLanguage();
+            }
+        } elseif (strlen($text) === 0) {
+            throw new \TYPO3\Neos\Exception('Given text was empty.', 1457591815);
+        }
+        $text = $this->transliterationService->transliterate($text, $language ?: null);
+        return \Behat\Transliterator\Transliterator::urlize($text);
     }
 }

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -397,6 +397,20 @@ TYPO3:
             authenticationProviderName: '${entity.authenticationProviderName}'
             name: '${entity.party.name.fullName}'
 
+    transliterationRules:
+      da:
+        'Å': 'Aa'
+        'Ø': 'Oe'
+        'å': 'aa'
+        'ø': 'oe'
+      de:
+        'Ä': 'Ae'
+        'Ö': 'Oe'
+        'Ü': 'Ue'
+        'ä': 'ae'
+        'ö': 'oe'
+        'ü': 'ue'
+
   Setup:
     stepOrder: ['neosRequirements', 'database', 'administrator', 'siteimport', 'final']
     steps:

--- a/TYPO3.Neos/composer.json
+++ b/TYPO3.Neos/composer.json
@@ -12,7 +12,8 @@
         "typo3/twitter-bootstrap": "~2.0",
         "typo3/typo3cr": "~2.1.0",
         "typo3/typoscript": "~2.1.0",
-        "league/commonmark": "^0.12.0"
+        "league/commonmark": "^0.12.0",
+        "behat/transliterator": "~1.0"
     },
     "suggest": {
         "typo3/neos-kickstarter": "Helps with creating new site packages for Neos."

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
@@ -21,7 +21,7 @@ use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 class Utility
 {
     /**
-     * Transforms a text (for example a node title) into a valid node name  by removing invalid characters and
+     * Transforms a text (for example a node title) into a valid node name by removing invalid characters and
      * transliterating special characters if possible.
      *
      * @param string $name The possibly invalid node name
@@ -34,93 +34,17 @@ class Utility
             return $name;
         }
 
-        $transliteration = array(
-            // Latin
-            'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'AA', 'Æ' => 'AE', 'Ç' => 'C',
-            'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I', 'Ï' => 'I',
-            'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' => 'O', 'Ő' => 'O',
-            'Ø' => 'OE', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U', 'Ý' => 'Y', 'Þ' => 'TH',
-            'ß' => 'ss',
-            'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' => 'a', 'å' => 'aa', 'æ' => 'ae', 'ç' => 'c',
-            'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e', 'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
-            'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o',
-            'ø' => 'oe', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th',
-            'ÿ' => 'y',
+        // Transliterate (transform 北京 to 'Bei Jing')
+        $name = \Behat\Transliterator\Transliterator::transliterate($name);
 
-            // Latin symbols, punctuation
-            '©' => '(c)', '#' => 'no', '&' => 'and', '.' => '-',
+        // Urlization (replace spaces with dash, special special characters)
+        $name = \Behat\Transliterator\Transliterator::urlize($name);
 
-            // Greek
-            'Α' => 'A', 'Β' => 'B', 'Γ' => 'G', 'Δ' => 'D', 'Ε' => 'E', 'Ζ' => 'Z', 'Η' => 'H', 'Θ' => '8',
-            'Ι' => 'I', 'Κ' => 'K', 'Λ' => 'L', 'Μ' => 'M', 'Ν' => 'N', 'Ξ' => '3', 'Ο' => 'O', 'Π' => 'P',
-            'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
-            'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
-            'Ϋ' => 'Y',
-            'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
-            'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
-            'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
-            'ά' => 'a', 'έ' => 'e', 'ί' => 'i', 'ό' => 'o', 'ύ' => 'y', 'ή' => 'h', 'ώ' => 'w', 'ς' => 's',
-            'ϊ' => 'i', 'ΰ' => 'y', 'ϋ' => 'y', 'ΐ' => 'i',
+        // Ensure only allowed characters are left
+        $name = preg_replace('/[^a-z0-9\-]/', '', $name);
 
-            // Turkish
-            'Ş' => 'S', 'İ' => 'I', 'Ç' => 'C', 'Ü' => 'U', 'Ö' => 'O', 'Ğ' => 'G',
-            'ş' => 's', 'ı' => 'i', 'ç' => 'c', 'ü' => 'u', 'ö' => 'o', 'ğ' => 'g',
-
-            // Russian
-            'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D', 'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh',
-            'З' => 'Z', 'И' => 'I', 'Й' => 'J', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N', 'О' => 'O',
-            'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C',
-            'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
-            'Я' => 'Ya',
-            'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
-            'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
-            'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
-            'ч' => 'ch', 'ш' => 'sh', 'щ' => 'sh', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'ю' => 'yu',
-            'я' => 'ya',
-
-            // Ukrainian
-            'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G',
-            'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g',
-
-            // Czech
-            'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T', 'Ů' => 'U',
-            'Ž' => 'Z',
-            'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
-            'ž' => 'z',
-
-            // Polish
-            'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'o', 'Ś' => 'S', 'Ź' => 'Z',
-            'Ż' => 'Z',
-            'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
-            'ż' => 'z',
-
-            // Latvian
-            'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i', 'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N',
-            'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z',
-            'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
-            'š' => 's', 'ū' => 'u', 'ž' => 'z'
-        );
-        $name = strtr($name, $transliteration);
-
-        // "transliterate" known HTML entities
-        $name = htmlentities($name, ENT_QUOTES, 'UTF-8');
-        $name = preg_replace(
-            '/&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);/iu',
-            '$1',
-            $name
-        );
-        $name = html_entity_decode($name, ENT_QUOTES, 'UTF-8');
-
-        // Replace non-alphanumeric characters with a dash
-        $name = preg_replace('/[^\p{L}\p{Nd}]+/u', '-', $name);
-
-        // Remove duplicate delimiters
-        $name = preg_replace('/(' . preg_quote('-', '/') . '){2,}/u', '$1', $name);
-
-        // trim leftover dashes, lowercase and return
-        return strtolower(trim($name, '-'));
+        return $name;
     }
-
 
     /**
      * Sorts the incoming $dimensionValues array to make sure that before hashing, the ordering is made deterministic.

--- a/TYPO3.TYPO3CR/Tests/Unit/UtilityTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/UtilityTest.php
@@ -25,11 +25,22 @@ class UtilityTest extends UnitTestCase
      */
     public function sourcesAndNodeNames()
     {
-        return array(
-            array('Überlandstraßen; adé', 'uberlandstrassen-ade'),
-            array('Что делать, если я не хочу, UTF-8?', 'chto-delat-esli-ya-ne-hochu-utf-8'),
-            array('TEST DRIVE: INFINITI Q50S 3.7', 'test-drive-infiniti-q50s-3-7')
-        );
+        return [
+            ['Überlandstraßen; adé', 'uberlandstrassen-ade'],
+            ['TEST DRIVE: INFINITI Q50S 3.7', 'test-drive-infiniti-q50s-3-7'],
+            ['汉语', 'yi-yu'],
+            ['日本語', 'ri-ben-yu'],
+            ['Việt', 'viet'],
+            ['ភាសាខ្មែរ', 'bhaasaakhmaer'],
+            ['ภาษาไทย', 'phaasaaaithy'],
+            ['العَرَبِية', 'l-arabiy'],
+            ['עברית', 'bryt'],
+            ['한국어', 'hangugeo'],
+            ['ελληνικά', 'ellenika'],
+            ['မြန်မာဘာသာ', 'm-n-maabhaasaa'],
+            [' हिन्दी', 'hindii'],
+            [' x- ', 'x']
+        ];
     }
 
     /**

--- a/TYPO3.TYPO3CR/composer.json
+++ b/TYPO3.TYPO3CR/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "typo3/flow": "~3.1",
         "typo3/eel": "~3.1",
-        "gedmo/doctrine-extensions": "2.3.*"
+        "gedmo/doctrine-extensions": "2.3.*",
+        "behat/transliterator": "~1.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "typo3/setup": "~2.0",
         "typo3/twitter-bootstrap": "~2.0",
         "league/commonmark": "^0.12.0",
+        "behat/transliterator": "~1.0",
         "typo3/eel": "~3.1",
         "gedmo/doctrine-extensions": "2.3.*"
     },


### PR DESCRIPTION
When a page is created in the node tree the title is automatically
transliterated to a valid URL. However when using non-latin characters,
the characters weren't transliterated. This lead to the pages having
special characters in their URL, making them inaccessible.

To fix this a new transliteration service is introduced which adds support for Chinese, Japanese,
Korean, Vietnamese, Khmer, Thai, Arabic, Hebrew, Hindi, Burmese and Greek.

NEOS-1791 #close
NEOS-1280 #close