### PR TITLE
TASK: Set the application key and name to Neos

### DIFF
--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -14,6 +14,10 @@ TYPO3:
       globalObjects:
         userInformation: TYPO3\Neos\Service\UserService
 
+    core:
+      applicationPackageKey: 'TYPO3.Neos'
+      applicationName: 'Neos'
+
     security:
       authentication:
         providers:


### PR DESCRIPTION
This change sets the application key and application name to TYPO3.Neos
and Neos respectively.