### PR TITLE
BUGFIX: Image crop selection incorrect on small screens

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Inspector/_SecondaryInspector.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Inspector/_SecondaryInspector.scss
@@ -48,13 +48,24 @@
 }
 
 .neos-secondary-inspector-image-crop {
-	.jcrop-holder {
-		margin: $defaultMargin auto;
+	overflow: auto;
+
+	.neos-image-editor-crop-area {
+		padding: 0 $defaultMargin;
+
+		> img {
+			max-width: none;
+		}
+
+		.jcrop-holder {
+			margin: 0 auto;
+		}
 	}
 
 	.neos-image-editor-crop-aspect-ratio {
-		margin: $unit auto 0;
 		width: 600px;
+		margin: 0 auto;
+		padding: $unit $defaultMargin $defaultMargin;
 
 		> span {
 			line-height: $unit;

--- a/TYPO3.Neos/Resources/Private/Styles/Inspector/_SecondaryInspector.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Inspector/_SecondaryInspector.scss
@@ -60,6 +60,11 @@
 		.jcrop-holder {
 			margin: 0 auto;
 		}
+
+		.jcrop-vline,
+		.jcrop-hline {
+			background: url('../Library/jcrop/css/Jcrop.gif') #fff;
+		}
 	}
 
 	.neos-image-editor-crop-aspect-ratio {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditorCrop.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditorCrop.html
@@ -20,4 +20,6 @@
 		{{/if}}
 	{{/unless}}
 </div>
-<img />
+<div class="neos-image-editor-crop-area">
+	<img />
+</div>

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -7030,12 +7030,22 @@
 .neos .neos-secondary-inspector > div > div {
   height: 100%;
 }
-.neos .neos-secondary-inspector-image-crop .jcrop-holder {
-  margin: 16px auto;
+.neos .neos-secondary-inspector-image-crop {
+  overflow: auto;
+}
+.neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area {
+  padding: 0 16px;
+}
+.neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area > img {
+  max-width: none;
+}
+.neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area .jcrop-holder {
+  margin: 0 auto;
 }
 .neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-aspect-ratio {
-  margin: 40px auto 0;
   width: 600px;
+  margin: 0 auto;
+  padding: 40px 16px 16px;
 }
 .neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-aspect-ratio > span {
   line-height: 40px;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -7042,6 +7042,10 @@
 .neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area .jcrop-holder {
   margin: 0 auto;
 }
+.neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area .jcrop-vline,
+.neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-area .jcrop-hline {
+  background: url("../Library/jcrop/css/Jcrop.gif") #fff;
+}
 .neos .neos-secondary-inspector-image-crop .neos-image-editor-crop-aspect-ratio {
   width: 600px;
   margin: 0 auto;


### PR DESCRIPTION
When the cropping area in the secondary inspector isn't wide enough,
the coordinates of the cropping area are miscalculated. To solve this
the cropping area now has a minimum width and scroll is added, when
the area is too small.

NEOS-1787 #close