### PR TITLE
BUGFIX: Node constraints for auto created node types in structure tree

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -63,8 +63,13 @@ define(
 			var page = InstanceWrapper.entities.get(InstanceWrapper.service('rdfa').getElementSubject($('#neos-document-metadata'))),
 				namespace = Configuration.get('TYPO3_NAMESPACE'),
 				pageTitle = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : this.get('pageNodePath'),
+				documentNodeType = page.get('typo3:_nodeType');
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
-			siteNode.fromDict({key: this.get('pageNodePath'), title: pageTitle});
+			siteNode.fromDict({
+				key: this.get('pageNodePath'),
+				title: pageTitle,
+				nodeType: documentNodeType
+			});
 			this.refresh();
 		}.observes('pageNodePath'),
 


### PR DESCRIPTION
The node type was not updated when a new page was loaded, leading to
incorrect constraints being applied to auto created child nodes.

NEOS-1728 #close