### PR TITLE
TASK: Show target dimension in review module for changes

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -472,6 +472,11 @@ class WorkspacesController extends AbstractModuleController
                             'node' => $node,
                             'contentChanges' => $this->renderContentChanges($node),
                         ];
+
+                        if (!empty($node->getContext()->getTargetDimensions())) {
+                            $change['targetDimensions'] = $node->getContext()->getTargetDimensions();
+                        }
+
                         if ($node->getNodeType()->isOfType('TYPO3.Neos:Node')) {
                             $change['configuration'] = $node->getNodeType()->getFullConfiguration();
                         }

--- a/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -10,6 +10,20 @@
                 {f:if(condition: change.node.nodeType.label, then: '{neos:backend.translate(id: change.node.nodeType.label)}', else: '{change.node.nodeType.name}')}
             </th>
         </tr>
+        <f:if condition="{change.targetDimensions}">
+            <tr>
+                <th>Dimensions</th>
+            </tr>
+            <tr>
+                <td>
+                    <ul>
+                        <f:for each="{change.targetDimensions}" key="name" as="dimension">
+                            <li>{name}: {dimension}</li>
+                        </f:for>
+                    </ul>
+                </td>
+            </tr>
+        </f:if>
         <f:for each="{change.contentChanges}" key="propertyName" as="contentChanges">
             <tr>
                 <th>{neos:backend.translate(id: contentChanges.propertyLabel)}</th>


### PR DESCRIPTION
This change will display the target dimension beside the content changes for nodes in the workspace
module when changes are reviewed.

NEOS-1801 #close