### PR TITLE
BUGFIX: Cancel previous load page requests

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -79,6 +79,7 @@ function(
 		vie: null,
 
 		_activeEntity: null,
+		_loadPageRequest: null,
 
 		_vieOptions: {
 			stanbolUrl: null,
@@ -438,7 +439,10 @@ function(
 			}
 
 			var currentlyActiveContentElementNodePath = $('.neos-contentelement-active').attr('about');
-			HttpClient.getResource(
+			if (this.get('_loadPageRequest')) {
+				this.get('_loadPageRequest').abort();
+			}
+			this.set('_loadPageRequest', HttpClient.getResource(
 				uri,
 				{
 					xhr: function() {
@@ -456,70 +460,72 @@ function(
 						};
 						return xhr;
 					}
-				}).then(
-					function(htmlString) {
-						var $htmlDom = $($.parseHTML(htmlString)),
-							$documentMetadata = $htmlDom.filter('#neos-document-metadata');
-						if ($documentMetadata.length === 0) {
-							Notification.error('Could not read document metadata from response. Please open the location ' + uri + ' outside the Neos backend.');
-							that.set('_isLoadingPage', false);
-							LoadingIndicator.done();
-							return;
-						}
-
-						pushUriToHistory();
-
-						// Extract the HTML from the page, starting at (including) #neos-document-metadata until #neos-application.
-						var $newContent = $htmlDom.filter('#neos-document-metadata').nextUntil('#neos-application').andSelf();
-
-						// remove the current HTML content
-						var $neosApplication = $('#neos-application');
-						$neosApplication.prevAll().remove();
-						$('body').prepend($newContent);
-						that.set('_isLoadingPage', false);
-
-						var $insertedContent = $neosApplication.prevAll();
-						var $links = $insertedContent.find('a').add($insertedContent.filter('a'));
-						that._linkInterceptionHandler($links);
-						LoadingIndicator.done();
-
-						$('title').html($htmlDom.filter('title').html());
-						$('link[rel="neos-site"]').attr('href', $htmlDom.filter('link[rel="neos-site"]').attr('href'));
-
-						// TODO: transfer body classes and other possibly important tags from the head section
-
-						that._setPagePosition();
-
-						// Update node selection (will update VIE)
-						NodeSelection.initialize();
-						that.trigger('pageLoaded');
-
-						// Send external event so site JS can act on it
-						EventDispatcher.triggerExternalEvent('Neos.PageLoaded', 'Page is refreshed.');
-
-						if (EditPreviewPanelController.get('currentlyActiveMode.isPreviewMode') !== true) {
-							// Refresh CreateJS, renders the button bars f.e.
-							CreateJS.enableEdit();
-						}
-
-						// If doing a reload, we highlight the currently active content element again
-						var $currentlyActiveContentElement = $('[about="' + currentlyActiveContentElementNodePath + '"]');
-						if ($currentlyActiveContentElement.length === 1) {
-							NodeSelection.updateSelection($currentlyActiveContentElement);
-						}
-
+				}
+			));
+			this.get('_loadPageRequest').then(
+				function(htmlString) {
+					var $htmlDom = $($.parseHTML(htmlString)),
+						$documentMetadata = $htmlDom.filter('#neos-document-metadata');
+					if ($documentMetadata.length === 0) {
+						Notification.error('Could not read document metadata from response. Please open the location ' + uri + ' outside the Neos backend.');
 						that.set('_isLoadingPage', false);
 						LoadingIndicator.done();
-
-						if (typeof callback === 'function') {
-							callback();
-						}
-					},
-					function() {
-						that.set('_isLoadingPage', false);
-						LoadingIndicator.done();
+						return;
 					}
-				);
+
+					pushUriToHistory();
+
+					// Extract the HTML from the page, starting at (including) #neos-document-metadata until #neos-application.
+					var $newContent = $htmlDom.filter('#neos-document-metadata').nextUntil('#neos-application').andSelf();
+
+					// remove the current HTML content
+					var $neosApplication = $('#neos-application');
+					$neosApplication.prevAll().remove();
+					$('body').prepend($newContent);
+					that.set('_isLoadingPage', false);
+
+					var $insertedContent = $neosApplication.prevAll();
+					var $links = $insertedContent.find('a').add($insertedContent.filter('a'));
+					that._linkInterceptionHandler($links);
+					LoadingIndicator.done();
+
+					$('title').html($htmlDom.filter('title').html());
+					$('link[rel="neos-site"]').attr('href', $htmlDom.filter('link[rel="neos-site"]').attr('href'));
+
+					// TODO: transfer body classes and other possibly important tags from the head section
+
+					that._setPagePosition();
+
+					// Update node selection (will update VIE)
+					NodeSelection.initialize();
+					that.trigger('pageLoaded');
+
+					// Send external event so site JS can act on it
+					EventDispatcher.triggerExternalEvent('Neos.PageLoaded', 'Page is refreshed.');
+
+					if (EditPreviewPanelController.get('currentlyActiveMode.isPreviewMode') !== true) {
+						// Refresh CreateJS, renders the button bars f.e.
+						CreateJS.enableEdit();
+					}
+
+					// If doing a reload, we highlight the currently active content element again
+					var $currentlyActiveContentElement = $('[about="' + currentlyActiveContentElementNodePath + '"]');
+					if ($currentlyActiveContentElement.length === 1) {
+						NodeSelection.updateSelection($currentlyActiveContentElement);
+					}
+
+					that.set('_isLoadingPage', false);
+					LoadingIndicator.done();
+
+					if (typeof callback === 'function') {
+						callback();
+					}
+				},
+				function() {
+					that.set('_isLoadingPage', false);
+					LoadingIndicator.done();
+				}
+			)
 		}
 
 	}).create();


### PR DESCRIPTION
When a page takes long to load it can happen that a new page is requested instead.
If the new page loads before the previous slow request, the new page is loaded
first and then replaced with the old request once it finishes. This is a confusing
to the user and thus the last request should always take precedence.