### PR TITLE
BUGFIX: Use correct value in ``StringLengthValidator`` error message

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Validation/StringLengthValidator.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Validation/StringLengthValidator.js
@@ -38,7 +38,7 @@ define(
 					} else if (minimum > 0) {
 						this.addError(I18n.translate('content.inspector.validators.stringLength.smallerThanMinimum', null, null, null, {minimum: minimum}));
 					} else {
-						this.addError(I18n.translate('content.inspector.validators.stringLength.greaterThanMaximum', null, null, null, {minimum: minimum}));
+						this.addError(I18n.translate('content.inspector.validators.stringLength.greaterThanMaximum', null, null, null, {maximum: maximum}));
 					}
 				}
 			}


### PR DESCRIPTION
Fixed maximum string length validation error message