### PR TITLE
TASK: Adjust unit tests mocks to new errors

### DIFF
--- a/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
+++ b/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
@@ -57,7 +57,7 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->mockContext = $this->getMock('TYPO3\Neos\Domain\Service\ContentContext', array(), array(), '', false);
 
         $mockNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeData', array(), array(), '', false);
-        $this->mockContextualizedNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Node', null, array($mockNode, $this->mockContext));
+        $this->mockContextualizedNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Node', array('getContext'), array($mockNode, $this->mockContext));
         $mockSiteNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
 
         $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($mockSiteNode));
@@ -147,7 +147,7 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
         $mockContext = $this->getMock('TYPO3\Neos\Domain\Service\ContentContext', array(), array(), '', false);
 
         $mockNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeData', array(), array(), '', false);
-        $mockContextualizedNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Node', null, array($mockNode, $mockContext));
+        $mockContextualizedNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Node', array('getContext'), array($mockNode, $mockContext));
         $mockSiteNode = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
 
         $mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($mockSiteNode));

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/NextOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/NextOperationTest.php
@@ -57,7 +57,6 @@ class NextOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
             $this->thirdNodeInLevel
         )));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstNodeInLevel->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstNodeInLevel->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
@@ -49,7 +49,6 @@ class ParentOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->siteNode->expects($this->any())->method('getPath')->will($this->returnValue('/site'));
         $this->siteNode->expects($this->any())->method('getChildNodes')->will($this->returnValue(array($this->firstLevelNode)));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstLevelNode->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstLevelNode->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
@@ -57,7 +57,6 @@ class PrevOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
             $this->thirdNodeInLevel
         )));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstNodeInLevel->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstNodeInLevel->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
@@ -59,7 +59,6 @@ class SiblingsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
             $this->thirdNodeInLevel
         )));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstNodeInLevel->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstNodeInLevel->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));


### PR DESCRIPTION
Since ``phpunit-mock-objects`` 3.1.0 errors are thrown when a mocked
method is not allowed, non-existing, final or private.

This change adjusts to that change by getting rid of such mistakes in
the tests, which are made visible due to the change.