### PR TITLE
TASK: Adjust unit tests mocks to new errors

### DIFF
--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -461,7 +461,7 @@ class NodeDataTest extends UnitTestCase
 
         $workspace = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Workspace', array(), array(), '', false);
 
-        $nodeDataRepository = $this->getAccessibleMock('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', array('setRemoved', 'update'), array(), '', false);
+        $nodeDataRepository = $this->getAccessibleMock('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', array('setRemoved', 'update', 'remove'), array(), '', false);
         $this->inject($nodeDataRepository, 'entityClassName', 'TYPO3\TYPO3CR\Domain\Model\NodeData');
         $this->inject($nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
 

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
@@ -57,7 +57,6 @@ class NextAllOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
             $this->thirdNodeInLevel
         )));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstNodeInLevel->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstNodeInLevel->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));

--- a/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
@@ -57,7 +57,6 @@ class PrevAllOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
             $this->thirdNodeInLevel
         )));
         $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($this->siteNode));
 
         $this->firstNodeInLevel->expects($this->any())->method('getParent')->will($this->returnValue($this->siteNode));
         $this->firstNodeInLevel->expects($this->any())->method('getPath')->will($this->returnValue('/site/first'));


### PR DESCRIPTION
Since ``phpunit-mock-objects`` 3.1.0 errors are thrown when a mocked
method is not allowed, non-existing, final or private.

This change adjusts to that change by getting rid of such mistakes in
the tests, which are made visible due to the change.