### PR TITLE
TASK: Adjust unit tests mocks to new errors

### DIFF
--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -90,13 +90,13 @@ class WorkspaceTest extends UnitTestCase
     public function publishNodeReturnsIfTheTargetWorkspaceIsTheSameAsTheSourceWorkspace()
     {
         $liveWorkspace = new Workspace('live');
-        $workspace = new Workspace('some-campaign');
+        $workspace = $this->getMock('TYPO3\TYPO3CR\Domain\Model\Workspace', array('emitBeforeNodePublishing'), array('some-campaign'));
         $workspace->setBaseWorkspace($liveWorkspace);
 
         $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->disableOriginalConstructor()->getMock();
         $mockNode->expects($this->any())->method('getWorkspace')->will($this->returnValue($workspace));
 
-        $mockNode->expects($this->never())->method('emitBeforeNodePublishing');
+        $workspace->expects($this->never())->method('emitBeforeNodePublishing');
 
         $workspace->publishNode($mockNode, $workspace);
     }


### PR DESCRIPTION
Since ``phpunit-mock-objects`` 3.1.0 errors are thrown when a mocked
method is not allowed, non-existing, final or private.

This change adjusts to that change by getting rid of such mistakes in
the tests, which are made visible due to the change.