### PR TITLE
TASK: Use node label in inspector breadcrumb

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
@@ -142,6 +142,7 @@ class ContentElementWrappingService
         $attributes['data-node-_identifier'] = $node->getIdentifier();
         $attributes['data-node-__workspace-name'] = $node->getWorkspace()->getName();
         $attributes['data-node-__typoscript-path'] = $typoScriptPath;
+        $attributes['data-node-__label'] = $node->getLabel();
 
         // these properties are needed together with the current NodeType to evaluate Node Type Constraints
         // TODO: this can probably be greatly cleaned up once we do not use CreateJS or VIE anymore.

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
@@ -331,7 +331,14 @@ class NodeController extends AbstractServiceController
         $q = new FlowQuery(array($node));
         $closestDocumentNode = $q->closest('[instanceof TYPO3.Neos:Document]')->get(0);
         $nextUri = $this->uriBuilder->reset()->setFormat('html')->setCreateAbsoluteUri(true)->uriFor('show', array('node' => $closestDocumentNode), 'Frontend\Node', 'TYPO3.Neos');
-        $this->view->assign('value', array('data' => array('workspaceNameOfNode' => $node->getWorkspace()->getName(), 'nextUri' => $nextUri), 'success' => true));
+        $this->view->assign('value', array(
+            'data' => array(
+                'workspaceNameOfNode' => $node->getWorkspace()->getName(),
+                'labelOfNode' => $node->getLabel(),
+                'nextUri' => $nextUri
+            ),
+            'success' => true
+        ));
     }
 
     /**

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -442,10 +442,14 @@ function(
 					}
 				},
 				function() {
+					Notification.error('An error occurred.');
 					that.set('_isLoadingPage', false);
 					LoadingIndicator.done();
 				}
-			)
+			).fail(function(error) {
+				Notification.error('An error occurred.');
+				console.error('An error occurred:', error);
+			});
 		}
 
 	}).create();

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Breadcrumb.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Breadcrumb.html
@@ -1,7 +1,7 @@
 <div>
 	<span>
 		<i {{bindAttr class="view.currentNode.nodeTypeSchema.ui.icon::icon-sign-blank view.currentNode.nodeTypeSchema.ui.icon"}}></i>
-		{{boundTranslate fallbackBinding="view.currentNode.nodeTypeLabel" idBinding="view.currentNode.nodeTypeLabel"}}
+		{{view.currentNode.nodeLabel}}
 		{{#if view.currentNode.status}}({{view.currentNode.status}}){{/if}}
 	</span>
 </div>
@@ -11,7 +11,7 @@
 			<li>
 				<a href="#" {{action "selectNode" node bubbles=false target="view.nodeSelection"}}>
 				<i {{bindAttr class="node.nodeTypeSchema.ui.icon::icon-sign-blank node.nodeTypeSchema.ui.icon"}}></i>
-				{{boundTranslate fallbackBinding="node.nodeTypeLabel" idBinding="node.nodeTypeLabel"}}
+				{{node.nodeLabel}}
 				{{#if status}}<span class="neos-breadcrumbitem-status">({{status}})</span>{{/if}}
 				</a>
 			</li>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -513,7 +513,7 @@ define(
 						} else if (reloadElement === true) {
 							if (result && result.data && result.data.collectionContent) {
 								LoadingIndicator.done();
-								var id = entity.id.substring(1, entity.id.length - 1),
+								var id = entity.id.slice(1, -1);
 									$element = $('[about="' + id + '"]').first(),
 									content = $(result.data.collectionContent).find('[about="' + xhr.getResponseHeader('X-Neos-AffectedNodePath') + '"]').first();
 								if (content.length === 0) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -134,6 +134,15 @@ define([
 		},
 
 		/**
+		 * @param {string} key
+		 * @return {object}
+		 */
+		getPreviousAttribute: function(key) {
+			var vieEntity = this.get('_vieEntity');
+			return Entity.extractAttributesFromVieEntity(vieEntity, vieEntity.previousAttributes())[key];
+		},
+
+		/**
 		 * @return {string}
 		 */
 		nodePath: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -163,7 +163,7 @@ define([
 		nodePath: function() {
 			var subject = this.get('_vieEntity').getSubject();
 			return subject.slice(1, -1);
-		}.property('_vieEntity'),
+		}.property('_vieEntity').volatile(),
 
 		/**
 		 * @return {boolean}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -186,7 +186,6 @@ define([
 		}.property()
 	});
 
-	var namespace = Configuration.get('TYPO3_NAMESPACE');
 	Entity.reopenClass({
 		/**
 		 * @param {object} vieEntity
@@ -195,7 +194,8 @@ define([
 		 * @return {object}
 		 */
 		extractAttributesFromVieEntity: function(vieEntity, attributes, filterFn) {
-			var cleanAttributes = {};
+			var cleanAttributes = {},
+				namespace = vieEntity.vie.namespaces.get('typo3');
 			attributes = _.isEmpty(attributes) ? vieEntity.attributes : attributes;
 			_.each(attributes, function(value, subject) {
 				var property = vieEntity.fromReference(subject);
@@ -215,7 +215,8 @@ define([
 		 */
 		extractNodeTypeFromVieEntity: function(vieEntity) {
 			var types = vieEntity.get('@type'),
-				type;
+				type,
+				namespace = vieEntity.vie.namespaces.get('typo3');
 			if (!_.isArray(types)) {
 				types = [types];
 			}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -108,6 +108,17 @@ define([
 		}.property('_vieEntity').volatile(),
 
 		/**
+		 * Check if an attribute exists on the underlying VIE entity
+		 *
+		 * @param {string} key
+		 * @return {void}
+		 */
+		hasAttribute: function(key) {
+			var attributeName = 'typo3:' + key;
+			return this.get('_vieEntity').has(attributeName);
+		},
+
+		/**
 		 * Set an attribute on the underlying VIE entity
 		 *
 		 * @param {string} key

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -165,25 +165,21 @@ define([
 		 * @return {boolean}
 		 */
 		isHideable: function() {
-			return this.get('_vieEntity').has('typo3:_hidden');
+			return this.hasAttribute('_hidden');
 		},
 
 		/**
 		 * @return {boolean}
 		 */
 		isHidden: function() {
-			return this.get('_vieEntity').get('typo3:_hidden');
+			return this.getAttribute('_hidden');
 		},
 
 		/**
 		 * @return {string}
 		 */
 		nodeLabel: function() {
-			if (this.get('_vieEntity').get('typo3:title') !== undefined) {
-				return this.get('_vieEntity').get('typo3:title');
-			}
-
-			return '';
+			return this.getAttribute('title') || '';
 		}.property('_vieEntity'),
 
 		/**

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -194,7 +194,7 @@ define([
 		nodeTypeSchema: function() {
 			var schema = Configuration.get('Schema');
 			return schema[this.get('nodeType')];
-		}.property()
+		}.property('nodeType')
 	});
 
 	Entity.reopenClass({

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -76,21 +76,22 @@ define([
 		 */
 		init: function() {
 			var that = this,
-				vieEntity = this.get('_vieEntity'),
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+				vieEntity = this.get('_vieEntity');
 
 			this.set('modified', !$.isEmptyObject(vieEntity.changed));
-			this.set('publishable', vieEntity.get(namespace + '__workspaceName') !== 'live');
+			this.set('publishable', this.getAttribute('__workspaceName') !== 'live');
 
 			var $entityElement = vieInstance.service('rdfa').getElementBySubject(vieEntity.getSubject(), $(document));
-				// this event fires if inline content changes
+
+			// this event fires if inline content changes
 			$entityElement.bind('midgardeditablechanged', function(event, data) {
 				that.set('modified', !$.isEmptyObject(vieEntity.changed));
 			});
-				// this event fires if content changes through the property inspector
+
+			// this event fires if content changes through the property inspector
 			vieEntity.on('change', function() {
 				that.set('modified', !$.isEmptyObject(vieEntity.changed));
-				that.set('publishable', vieEntity.get(namespace + '__workspacename') !== 'live');
+				that.set('publishable', that.getAttribute('__workspacename') !== 'live');
 			});
 
 			this.set('$element', $entityElement);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -158,7 +158,7 @@ define([
 		 */
 		nodePath: function() {
 			var subject = this.get('_vieEntity').getSubject();
-			return subject.substring(1, subject.length - 1);
+			return subject.slice(1, -1);
 		}.property('_vieEntity'),
 
 		/**
@@ -238,7 +238,7 @@ define([
 
 			if (type) {
 				type = type.substr(namespace.length + 1);
-				type = type.substr(0, type.length - 1);
+				type = type.slice(0, -1);
 			}
 			return type;
 		}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -177,6 +177,7 @@ define([
 		}.property()
 	});
 
+	var namespace = Configuration.get('TYPO3_NAMESPACE');
 	Entity.reopenClass({
 		/**
 		 * @param {object} vieEntity
@@ -185,8 +186,7 @@ define([
 		 * @return {object}
 		 */
 		extractAttributesFromVieEntity: function(vieEntity, attributes, filterFn) {
-			var cleanAttributes = {},
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+			var cleanAttributes = {};
 			attributes = _.isEmpty(attributes) ? vieEntity.attributes : attributes;
 			_.each(attributes, function(value, subject) {
 				var property = vieEntity.fromReference(subject);
@@ -206,8 +206,7 @@ define([
 		 */
 		extractNodeTypeFromVieEntity: function(vieEntity) {
 			var types = vieEntity.get('@type'),
-				type,
-				namespace = Configuration.get('TYPO3_NAMESPACE');
+				type;
 			if (!_.isArray(types)) {
 				types = [types];
 			}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -92,6 +92,10 @@ define([
 			vieEntity.on('change', function() {
 				that.set('modified', !$.isEmptyObject(vieEntity.changed));
 				that.set('publishable', that.getAttribute('__workspacename') !== 'live');
+				var changedAttributes = Entity.extractAttributesFromVieEntity(vieEntity, vieEntity.changed);
+				_.each(changedAttributes, function(value, key) {
+					that.notifyPropertyChange('typo3:' + key);
+				});
 			});
 
 			this.set('$element', $entityElement);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/NodeSelection.js
@@ -324,7 +324,17 @@ define(
 		},
 
 		getNode: function(contextPath) {
-			return this._entitiesBySubject['<' + contextPath + '>'];
+			var node = this._entitiesBySubject['<' + contextPath + '>'];
+			if (node) {
+				return node;
+			}
+
+			var element = $('[about="' + contextPath + '"]');
+			if (element) {
+				return this._createEntityWrapper(element);
+			}
+
+			return null;
 		},
 
 		selectedNode: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
@@ -82,7 +82,7 @@ define(
         vie.entities.forEach(function (entity) {
           if (this._isEntityPublishable(entity)) {
             var entitySubject = entity.id,
-              nodeContextPath = entitySubject.slice(1, entitySubject.length - 1);
+              nodeContextPath = entitySubject.slice(1, -1);
             if (!this.get('workspaceWidePublishableEntitySubjects').findBy('nodeContextPath', nodeContextPath)) {
               this.get('workspaceWidePublishableEntitySubjects').addObject({
                 nodeContextPath: nodeContextPath,
@@ -164,7 +164,7 @@ define(
           entity.set('typo3:__workspaceName', workspaceOverride, {silent: true});
         }
 
-        var nodeContextPath = entitySubject.slice(1, entitySubject.length - 1),
+        var nodeContextPath = entitySubject.slice(1, -1),
           node = that.get('workspaceWidePublishableEntitySubjects').findBy('nodeContextPath', nodeContextPath);
         if (node) {
           that.get('workspaceWidePublishableEntitySubjects').removeObject(node);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
@@ -9,6 +9,7 @@ define(
     'Library/jquery-with-dependencies',
     'vie',
     'Content/Model/Node',
+    'Content/Model/NodeSelection',
     'Content/Components/TargetWorkspaceController',
     'Shared/EventDispatcher',
     'Shared/NodeTypeService',
@@ -22,6 +23,7 @@ define(
                $,
                vie,
                EntityWrapper,
+               NodeSelection,
                TargetWorkspaceController,
                EventDispatcher,
                NodeTypeService,
@@ -131,11 +133,10 @@ define(
               if (autoPublish !== true) {
                 var documentMetadata = $('#neos-document-metadata'),
                   nodeType = documentMetadata.data('node-_node-type'),
-                  page = vie.entities.get(vie.service('rdfa').getElementSubject(documentMetadata)),
-                  namespace = Configuration.get('TYPO3_NAMESPACE'),
-                  title = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : '',
-                  nodeTypeDefinition = NodeTypeService.getNodeTypeDefinition(nodeType);
-                Notification.ok('Published changes for ' + I18n.translate(nodeTypeDefinition.ui.label) + ' "' + $('<a />').html(title).text() + '"');
+                  page = NodeSelection.getNode(documentMetadata.attr('about')),
+                  pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || '',
+                  nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
+                Notification.ok('Published changes for ' + I18n.translate(nodeTypeConfiguration.ui.label) + ' "' + $('<a />').html(pageTitle).text() + '"');
               }
               that.set('publishRunning', false);
             },
@@ -205,11 +206,10 @@ define(
               );
               var documentMetadata = $('#neos-document-metadata'),
                 nodeType = documentMetadata.data('node-_node-type'),
-                page = vie.entities.get(vie.service('rdfa').getElementSubject(documentMetadata)),
-                namespace = Configuration.get('TYPO3_NAMESPACE'),
-                title = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : '',
-                nodeTypeDefinition = NodeTypeService.getNodeTypeDefinition(nodeType);
-              Notification.ok('Discarded changes for ' + nodeTypeDefinition.ui.label + ' "' + title + '"');
+                page = NodeSelection.getNode(documentMetadata.attr('about')),
+                pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || '',
+                nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
+              Notification.ok('Discarded changes for ' + I18n.translate(nodeTypeConfiguration.ui.label) + ' "' + $('<a />').html(pageTitle).text() + '"');
               that.set('discardRunning', false);
             },
             function (error) {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/PublishableNodes.js
@@ -144,7 +144,10 @@ define(
               that.set('publishRunning', false);
               Notification.error('Unexpected error while publishing changes: ' + JSON.stringify(error));
             }
-          );
+          ).fail(function(error) {
+              Notification.error('An error occurred.');
+              console.error('An error occurred:', error);
+          });
         }
       },
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
@@ -444,6 +444,9 @@ define(
 					entityWrapper.addObserver('typo3:_hiddenAfterDateTime', function() {
 						that.synchronizeNodeVisibility(this);
 					});
+					entityWrapper.addObserver('typo3:__label', function() {
+						that.synchronizeNodeLabel(this);
+					});
 				});
 			},
 
@@ -479,7 +482,16 @@ define(
 			synchronizeNodeTitle: function(entityWrapper) {
 				var node = this.getNodeByEntityWrapper(entityWrapper);
 				if (node) {
-					node.setTitle(entityWrapper.getAttribute('title'));
+					var title = entityWrapper.getAttribute('title');
+					node.data.title = title
+					node.data.fullTitle = title;
+				}
+			},
+
+			synchronizeNodeLabel: function(entityWrapper) {
+				var node = this.getNodeByEntityWrapper(entityWrapper);
+				if (node) {
+					node.setTitle(entityWrapper.getAttribute('__label'));
 				}
 			},
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -114,7 +114,7 @@ define(
 
 			var that = this;
 			PublishableNodes.get('publishableEntitySubjects').forEach(function(entitySubject) {
-				var treeNode = that.$nodeTree.dynatree('getTree').getNodeByKey(entitySubject.slice(1, entitySubject.length - 1));
+				var treeNode = that.$nodeTree.dynatree('getTree').getNodeByKey(entitySubject.slice(1, -1));
 				if (treeNode) {
 					$(treeNode.span).addClass('neos-dynatree-dirty');
 				}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -78,9 +78,10 @@ define(
 		},
 
 		_onPageNodePathChanged: function() {
-			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
+			var documentMetadata = $('#neos-document-metadata'),
+				page = NodeSelection.getNode(documentMetadata.attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
-				documentNodeType = page.get('typo3:_nodeType'),
+				documentNodeType = documentMetadata.data('node-_node-type'),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(documentNodeType),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
@@ -131,7 +132,7 @@ define(
 
 			var page = NodeSelection.getNode(documentMetadata.attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
-				nodeType = documentMetadata.attr('typeof').substr(6),
+				nodeType = documentMetadata.data('node-_node-type'),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
 
 			this.set('treeConfiguration', $.extend(true, this.get('treeConfiguration'), {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -81,11 +81,13 @@ define(
 			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
 				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
 				documentNodeType = page.get('typo3:_nodeType'),
+				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(documentNodeType),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
 				key: this.get('pageNodePath'),
 				title: pageTitle,
-				nodeType: documentNodeType
+				nodeType: documentNodeType,
+				nodeTypeLabel: nodeTypeConfiguration ? nodeTypeConfiguration.label : ''
 			});
 			this.refresh();
 		}.observes('pageNodePath'),

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -7,8 +7,6 @@ define(
 	'Library/jquery-with-dependencies',
 	'./AbstractNodeTree',
 	'Content/Application',
-	'Content/Model/Node',
-	'vie',
 	'Shared/Configuration',
 	'Shared/Notification',
 	'Shared/EventDispatcher',
@@ -23,8 +21,6 @@ define(
 	$,
 	AbstractNodeTree,
 	ContentModule,
-	EntityWrapper,
-	InstanceWrapper,
 	Configuration,
 	Notification,
 	EventDispatcher,
@@ -82,10 +78,9 @@ define(
 		},
 
 		_onPageNodePathChanged: function() {
-			var page = InstanceWrapper.entities.get(InstanceWrapper.service('rdfa').getElementSubject($('#neos-document-metadata'))),
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
-				pageTitle = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : this.get('pageNodePath'),
-				documentNodeType = page.get('typo3:_nodeType');
+			var page = NodeSelection.getNode($('#neos-document-metadata').attr('about')),
+				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
+				documentNodeType = page.get('typo3:_nodeType'),
 				siteNode = this.$nodeTree.dynatree('getRoot').getChildren()[0];
 			siteNode.fromDict({
 				key: this.get('pageNodePath'),
@@ -132,9 +127,8 @@ define(
 				return;
 			}
 
-			var page = InstanceWrapper.entities.get(InstanceWrapper.service('rdfa').getElementSubject(documentMetadata)),
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
-				pageTitle = typeof page !== 'undefined' && typeof page.get(namespace + 'title') !== 'undefined' ? page.get(namespace + 'title') : this.pageNodePath,
+			var page = NodeSelection.getNode(documentMetadata.attr('about')),
+				pageTitle = (typeof page !== 'undefined' ? page.getAttribute('title') : null) || this.get('pageNodePath'),
 				nodeType = documentMetadata.attr('typeof').substr(6),
 				nodeTypeConfiguration = NodeTypeService.getNodeTypeDefinition(nodeType);
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/CreateJs/jquery.typo3.collectionWidget.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/CreateJs/jquery.typo3.collectionWidget.js
@@ -47,7 +47,7 @@ define(
 				vie.entities.get(vie.service('rdfa').getElementSubject(this.element))._enclosingCollectionWidget = that;
 				_.each(this.options.collection.models, function(entity, iterator) {
 					entity._enclosingCollectionWidget = that;
-					var id = entity.id.substring(1, entity.id.length - 1),
+					var id = entity.id.slice(1, -1),
 						$element = $('[about="' + id + '"]').first();
 					if ($element.hasClass('neos-not-inline-editable')) {
 						NotInlineEditableOverlay.create({$element: $element, entity: entity}).appendTo($element);

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Dialogs/DeleteNodeDialog.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Dialogs/DeleteNodeDialog.js
@@ -17,10 +17,6 @@ define(
 			template: Ember.Handlebars.compile(template),
 			_node: null,
 
-			strippedLabel: function() {
-				return $('<span>' + this.get('_node.nodeLabel') + '</span>').text().trim();
-			}.property('_node.nodeLabel'),
-
 			'delete': function() {
 				this.get('_node').$element.remove();
 				NodeActions.remove(this.get('_node'));

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -190,10 +190,10 @@ function (
 		}.property('nodeActions.clipboard', '_node'),
 
 		toggleHidden: function() {
-			var entity = this.get('_node._vieEntity'),
-				value = !entity.get('typo3:_hidden');
+			var node = this.get('_node'),
+				value = !node.getAttribute('_hidden');
 			this.set('_hidden', value);
-			entity.set('typo3:_hidden', value);
+			node.setAttribute('_hidden', value);
 			InspectorController.set('nodeProperties._hidden', value);
 			InspectorController.apply();
 		},

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -159,7 +159,7 @@ function (
 		}.property('nodeSelection.selectedNode', 'nodeActions.clipboard'),
 
 		_entityChanged: function() {
-			this.set('_hidden', this.get('_node._vieEntity').get('typo3:_hidden'));
+			this.set('_hidden', this.get('_node').getAttribute('_hidden'));
 		},
 
 		/** Content element actions **/

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -85,23 +85,25 @@ function (
 
 		_onNodeSelectionChange: function() {
 			this.$().find('.action-new').trigger('hidePopover');
-			var selectedNode = this.get('nodeSelection.selectedNode'),
-				entity = selectedNode.get('_vieEntity');
-
-			if (selectedNode && entity) {
-				this.set('_node', selectedNode);
-
-				entity.on('change', this._entityChanged, this);
-				this._entityChanged();
-
-				if (selectedNode.isHideable()) {
-					this.set('_showHide', true);
-					this.set('_hidden', selectedNode.isHidden());
-				} else {
-					this.set('_showHide', false);
-					this.set('_hidden', false);
-				}
+			var selectedNode = NodeSelection.get('selectedNode');
+			if (!selectedNode) {
+				return;
 			}
+
+			this.set('_node', selectedNode);
+
+			if (selectedNode.isHideable()) {
+				this.set('_showHide', true);
+				this.set('_hidden', selectedNode.isHidden());
+			} else {
+				this.set('_showHide', false);
+				this.set('_hidden', false);
+			}
+
+			var that = this;
+			selectedNode.addObserver('typo3:_hidden', function() {
+				that.set('_hidden', selectedNode.isHidden());
+			});
 		}.observes('nodeSelection.selectedNode'),
 
 		currentFocusedNodeCanBeModified: function() {
@@ -157,10 +159,6 @@ function (
 			}
 			return positions;
 		}.property('nodeSelection.selectedNode', 'nodeActions.clipboard'),
-
-		_entityChanged: function() {
-			this.set('_hidden', this.get('_node').getAttribute('_hidden'));
-		},
 
 		/** Content element actions **/
 		remove: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -30,7 +30,6 @@ function(
 
 		nodeTypeGroups: function() {
 			var groups = {},
-				namespace = Configuration.get('TYPO3_NAMESPACE'),
 				node = this.get('_node'),
 				position = this.get('_position'),
 				types;
@@ -53,7 +52,7 @@ function(
 					return;
 				}
 
-				var nodeTypeName = type.id.substring(1, type.id.length - 1).replace(namespace, '');
+				var nodeTypeName = type.id.substring(1, type.id.length - 1).replace(type.metadata.url, '');
 				if (!contentTypes.hasOwnProperty(nodeTypeName)) {
 					return;
 				}

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -52,7 +52,7 @@ function(
 					return;
 				}
 
-				var nodeTypeName = type.id.substring(1, type.id.length - 1).replace(type.metadata.url, '');
+				var nodeTypeName = type.id.slice(1, -1).replace(type.metadata.url, '');
 				if (!contentTypes.hasOwnProperty(nodeTypeName)) {
 					return;
 				}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Configuration.js
@@ -12,8 +12,6 @@ function(Ember, $) {
 	 * @singleton
 	 */
 	return Ember.Object.extend({
-		TYPO3_NAMESPACE: 'http://www.typo3.org/ns/2012/Flow/Packages/Neos/Content/',
-
 		_data: {},
 
 		init: function() {

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/ResourceCache.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/ResourceCache.js
@@ -35,7 +35,10 @@ function(Ember, SessionStorage, HttpClient) {
 					function() {
 						resourceRequests[resourceUri].reject(arguments);
 					}
-				);
+				).fail(function(error) {
+					Notification.error('An error occurred.');
+					console.error('An error occurred:', error);
+				});
 			} else {
 				resourceRequests[resourceUri].resolve(data);
 			}

--- a/TYPO3.Neos/Resources/Public/JavaScript/storage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/storage.js
@@ -3,7 +3,6 @@ define(
 	'Library/jquery-with-dependencies',
 	'Content/Model/Node',
 	'Library/backbone',
-	'Content/Model/PublishableNodes',
 	'Shared/Endpoint/NodeEndpoint',
 	'Shared/EventDispatcher',
 	'Shared/Notification'
@@ -11,7 +10,6 @@ define(
 	$,
 	Entity,
 	Backbone,
-	PublishableNodes,
 	NodeEndpoint,
 	EventDispatcher,
 	Notification
@@ -43,16 +41,15 @@ define(
 						//
 						// Furthermore, we do not want event listeners to be fired, as otherwise the content element
 						// would be redrawn leading to a loss of the current editing cursor position.
-						//
-						// The PublishableNodes are explicitly updated, as changes from the backbone models
-						// workspace name attribute are suppressed and our entity wrapper would not notice.
 						NodeEndpoint.set('_saveRunning', false);
 						EventDispatcher.trigger('contentSaved');
 
 						if (result !== undefined && (result.success === true || options.render)) {
 							if (!options.render) {
 								model.set('typo3:__workspaceName', result.data.workspaceNameOfNode, {silent: true});
-								PublishableNodes._updatePublishableEntities();
+								// The PublishableNodes are explicitly updated through the ``nodesUpdated`` event, as changes from
+								// the backbone models workspace name attribute are suppressed and our entity wrapper would not notice.
+								EventDispatcher.trigger('nodeUpdated');
 							}
 
 							NodeEndpoint.set('_lastSuccessfulTransfer', new Date());

--- a/TYPO3.Neos/Resources/Public/JavaScript/storage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/storage.js
@@ -65,7 +65,10 @@ define(
 							NodeUpdateFailureDialog.create();
 						});
 					}
-				);
+				).fail(function(error) {
+					Notification.error('An error occurred.');
+					console.error('An error occurred:', error);
+				});
 			},
 			'delete': function(model, options) {
 				console.log('DELETE', arguments);

--- a/TYPO3.Neos/Resources/Public/JavaScript/storage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/storage.js
@@ -2,6 +2,7 @@ define(
 [
 	'Library/jquery-with-dependencies',
 	'Content/Model/Node',
+	'Content/Model/NodeSelection',
 	'Library/backbone',
 	'Shared/Endpoint/NodeEndpoint',
 	'Shared/EventDispatcher',
@@ -9,6 +10,7 @@ define(
 ], function(
 	$,
 	Entity,
+	NodeSelection,
 	Backbone,
 	NodeEndpoint,
 	EventDispatcher,
@@ -51,6 +53,8 @@ define(
 								// the backbone models workspace name attribute are suppressed and our entity wrapper would not notice.
 								EventDispatcher.trigger('nodeUpdated');
 							}
+
+							NodeSelection.getNode(model.id.slice(1, -1)).setAttribute('__label', result.data.labelOfNode, {silent: true});
 
 							NodeEndpoint.set('_lastSuccessfulTransfer', new Date());
 							if (options && options.success) {

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/FallbackNodeDataLabelGenerator.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/FallbackNodeDataLabelGenerator.php
@@ -41,7 +41,7 @@ class FallbackNodeDataLabelGenerator implements NodeDataLabelGeneratorInterface
             return $label;
         }
 
-        $croppedLabel = \TYPO3\Flow\Utility\Unicode\Functions::substr($label, 0, 30);
+        $croppedLabel = trim(\TYPO3\Flow\Utility\Unicode\Functions::substr($label, 0, 30));
         return $croppedLabel . (strlen($croppedLabel) < strlen($label) ? ' …' : '');
     }
 }


### PR DESCRIPTION
Instead of using the node type name the label of the node is used instead. This helps avoid confusing the breadcrumb in the inspector from a node type selector.

Additionally the label is now updated using the server side rendered label in the inspector breadcrumb, context structure tree and node tree.

NEOS-1141 #comment replaced the node type name with the node label, which should help a little