### PR TITLE
FEATURE: Collapsible insert panel groups

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -182,7 +182,8 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
             }
             $settings[] = array(
                 'name' => $nodeTypeGroupName,
-                'label' => $nodeTypeGroupSettings['label']
+                'label' => $nodeTypeGroupSettings['label'],
+                'collapsed' => isset($nodeTypeGroupSettings['collapsed']) ? $nodeTypeGroupSettings['collapsed'] : true
             );
         }
 

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -122,12 +122,15 @@ TYPO3:
         general:
           position: 'start'
           label: 'TYPO3.Neos:Main:nodeTypes.groups.general'
+          collapsed: false
         structure:
           position: 100
           label: 'TYPO3.Neos:Main:nodeTypes.groups.structure'
+          collapsed: false
         plugins:
           position: 200
           label: 'TYPO3.Neos:Main:nodeTypes.groups.plugins'
+          collapsed: true
 
     userInterface:
       # should minified JavaScript be loaded? For developing the Neos

--- a/TYPO3.Neos/Documentation/CreatingASite/RenderingCustomMarkup/CustomContentElements.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/RenderingCustomMarkup/CustomContentElements.rst
@@ -263,6 +263,7 @@ Registering 2 new groups could look like::
 	        special:
 	          position: 50
 	          label: 'Special elements'
+	          collapsed: true
 
 The groups are ordered by the position argument.
 

--- a/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
@@ -50,7 +50,7 @@
 
 	.neos-modal-body {
 		border-bottom: 1px solid $grayLight;
-		max-height: $unit * 12;
+		max-height: calc(100vh - #{$unit * 2 + 52 + 72});
 		overflow-y: auto;
 	}
 

--- a/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
@@ -1,11 +1,50 @@
 .neos-insert-node-panel {
 	.neos-subheader {
-		padding: 0 $defaultMargin $relatedMargin;
+		height: $unit;
+		line-height: $unit;
+		padding-left: $defaultMargin;
 		margin: 0;
+		position: relative;
+		border-bottom: 1px solid $grayLight;
+		overflow: hidden;
 
-		~ .neos-subheader {
-			padding: $defaultMargin $defaultMargin $relatedMargin;
-			border-top: 1px solid $grayLight;
+		.neos-modal-collapse-group {
+			position: absolute;
+			right: 0;
+			top: 0;
+			width: $unit;
+			height: $unit;
+			cursor: pointer;
+			color: #fff;
+
+			&:focus {
+				outline: 1px dotted #fff;
+			}
+
+			&:hover {
+				background-color: $blue;
+				outline: none;
+			}
+
+			&::before {
+				content: "›";
+				font-size: 26px;
+				font-weight: normal;
+				display: inline-block;
+				position: relative;
+				top: 0;
+				line-height: $unit;
+			}
+
+			&.neos-collapsed::before {
+				@include rotate(90deg);
+				left: 19px;
+			}
+
+			&.neos-open::before {
+				@include rotate(-90deg);
+				left: 13px;
+			}
 		}
 	}
 

--- a/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
@@ -48,10 +48,18 @@
 		}
 	}
 
+	+ ul {
+		margin-bottom: 1px;
+	}
+
 	.neos-modal-body {
-		border-bottom: 1px solid $grayLight;
 		max-height: calc(100vh - #{$unit * 2 + 52 + 72});
 		overflow-y: auto;
+	}
+
+	.neos-modal-footer {
+		border-top: 1px solid $grayLight;
+		margin-top: -1px;
 	}
 
 	.neos-content-new-selecttype-button {

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
@@ -23,23 +23,24 @@
 // Base modal
 .neos-modal {
 	position: fixed;
-	top: 120px;
-	left: 50%;
 	z-index: $zindexModal;
-	margin: 0px 0px 0px -17.5%;
+	margin: 0;
 	color: $textOnGray;
 	background: $grayDark;
 	border: 1px solid $grayLight;
 	padding: 0px;
-	width: 35%;
 	@include border-radius(0);
 	@include font();
 	// Remove focus outline from opened modal
 	outline: none;
+	width: calc(100vw - #{$unit * 2});
+	max-width: $unit * 16;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 
 	&.neos-modal-wide {
-		width: 50%;
-		left: 42.5%;
+		max-width: $unit * 24;
 	}
 
 	&.neos-fade {
@@ -54,6 +55,7 @@
 	.neos-modal-header {
 		padding: 0px;
 		border: 0px;
+
 		// Heading
 		h3 {
 			margin: 0;

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
@@ -4,25 +4,30 @@
 		<div class="neos-header">{{translate id="createNew" fallback="Create new"}}</div>
 	</div>
 	<div class="neos-modal-body">
-		{{#each view.nodeTypeGroups}}
-			<div class="neos-subheader">{{unbound label}}</div>
-			<ul class="neos-clearfix">
-				{{#each nodeTypes}}
-					<li class="neos-content-new-selecttype-button">
-						<button class="neos-content-new" {{bindAttr title="nodeType"}} {{action "insertNode" nodeType icon target="view"}}>
-							{{#if icon}}
-								<i class="{{unbound icon}}"></i>
-							{{else}}
-								<i class="icon-sign-blank"></i>
+		{{#each nodeTypeGroup in view.nodeTypeGroups}}
+			{{#if nodeTypeGroup.sortedNodeTypes}}
+				<div class="neos-subheader">
+					{{unbound nodeTypeGroup.label}}
+					{{view view.ToggleNodeTypeGroup nodeTypeGroupBinding="nodeTypeGroup"}}
+				</div>
+				<ul {{bindAttr class=":neos-clearfix"}}>
+					{{#each nodeTypeGroup.sortedNodeTypes}}
+						<li class="neos-content-new-selecttype-button">
+							<button class="neos-content-new" {{bindAttr title="nodeType"}} {{action "insertNode" nodeType icon target="view"}}>
+								{{#if icon}}
+									<i class="{{unbound icon}}"></i>
+								{{else}}
+									<i class="icon-sign-blank"></i>
+								{{/if}}
+								{{unbound label}}
+							</button>
+							{{#if helpMessage}}
+								{{view view.HelpMessage titleBinding="label" contentBinding="helpMessage" popoverContainer=".neos-insert-node-panel"}}
 							{{/if}}
-							{{unbound label}}
-						</button>
-						{{#if helpMessage}}
-							{{view view.HelpMessage titleBinding="label" contentBinding="helpMessage" popoverContainer=".neos-insert-node-panel"}}
-						{{/if}}
-					</li>
-				{{/each}}
-			</ul>
+						</li>
+					{{/each}}
+				</ul>
+			{{/if}}
 		{{/each}}
 	</div>
 	<div class="neos-modal-footer">

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
@@ -1,18 +1,97 @@
 define([
 	'emberjs',
 	'Shared/AbstractModal',
+	'Shared/Configuration',
+	'Shared/I18n',
+	'Shared/LocalStorage',
 	'./HelpMessage',
 	'text!./AbstractInsertNodePanel.html'
 ], function(
 	Ember,
 	AbstractModal,
+	Configuration,
+	I18n,
+	LocalStorage,
 	HelpMessage,
 	template
 ) {
 	return AbstractModal.extend({
 		template: Ember.Handlebars.compile(template),
-		nodeTypeGroups: Ember.required,
+		configuration: null,
 		insertNode: Ember.required,
-		HelpMessage: HelpMessage
+		HelpMessage: HelpMessage,
+
+		init: function() {
+			this._super();
+			this.set('configuration', LocalStorage.getItem('insertNodePanelConfiguration') || {});
+			Ember.addObserver(this, 'configuration', function() {
+				var configuration = this.get('configuration');
+				LocalStorage.setItem('insertNodePanelConfiguration', configuration);
+			});
+		},
+
+		ToggleNodeTypeGroup: Ember.View.extend({
+			tagName: 'a',
+			href: '#',
+			nodeTypeGroup: Ember.required,
+			attributeBindings: ['href'],
+			classNames: ['neos-modal-collapse-group'],
+			classNameBindings: ['nodeTypeGroup.collapsed:neos-collapsed:neos-open'],
+
+			didInsertElement: function() {
+				if (this.get('nodeTypeGroup.collapsed') === true) {
+					this.$().parent().next().slideUp(0);
+				}
+			},
+
+			_collapsedDidChange: function() {
+				var $content = this.$().parent().next();
+				if (this.get('nodeTypeGroup.collapsed') === true) {
+					$content.slideUp(200);
+				} else {
+					$content.slideDown(200);
+				}
+			}.observes('nodeTypeGroup.collapsed'),
+
+			click: function(e) {
+				e.preventDefault();
+				this.get('nodeTypeGroup').toggleProperty('collapsed');
+			}
+		}),
+
+		nodeTypeGroups: function() {
+			var that = this,
+				nodeTypeGroups = Ember.A();
+
+			Configuration.get('nodeTypes.groups').forEach(function(group) {
+				nodeTypeGroups.pushObject(Ember.Object.extend({
+					name: group.name,
+					label: I18n.translate(group.label),
+					position: group.position,
+					collapsed: group.collapsed,
+					nodeTypes: Ember.A(),
+
+					init: function() {
+						var collapsed = that.get('configuration.' + this.get('name'));
+						if (typeof collapsed === 'boolean') {
+							this.set('collapsed', collapsed);
+						}
+					},
+
+					_collapsedDidChange: function() {
+						that.set('configuration.' + this.get('name'), this.get('collapsed'));
+						that.propertyDidChange('configuration');
+					}.observes('collapsed'),
+
+					sortedNodeTypes: function() {
+						return this.get('nodeTypes').sort(function(a, b) {
+							return (Ember.get(a, 'position') || 9999) - (Ember.get(b, 'position') || 9999);
+						});
+					}.property('nodeTypes.@each')
+				}).create());
+			});
+
+			return nodeTypeGroups;
+		}.property()
 	});
 });

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Menu/MenuPanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Menu/MenuPanel.js
@@ -2,12 +2,11 @@ define(
 	[
 		'emberjs',
 		'Library/jquery-with-dependencies',
-		'Shared/LocalStorage',
 		'./MenuPanelController',
 		'Shared/EventDispatcher',
 		'Shared/I18n',
 		'text!./MenuPanel.html'
-	], function(Ember, $, LocalStorage, MenuPanelController, EventDispatcher, I18n, template) {
+	], function(Ember, $, MenuPanelController, EventDispatcher, I18n, template) {
 
 		return Ember.View.extend({
 			elementId: 'neos-menu-panel',

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
@@ -1,17 +1,13 @@
 define(
 	[
 		'emberjs',
-		'Library/jquery-with-dependencies',
 		'Content/Components/AbstractInsertNodePanel',
-		'Shared/Configuration',
 		'Shared/NodeTypeService',
 		'Shared/I18n'
 	],
 	function(
 		Ember,
-		$,
 		AbstractInsertNodePanel,
-		Configuration,
 		NodeTypeService,
 		I18n
 	) {
@@ -19,54 +15,31 @@ define(
 			// List of allowed node types (strings); with constraints already evaluated.
 			allowedNodeTypes: Ember.required,
 
-			nodeTypeGroups: function() {
-				var groupedNodeTypes = {},
-					nodeTypeGroups = [];
-
-				$.each(this.get('allowedNodeTypes'), function(index, nodeTypeName) {
-					var nodeType = NodeTypeService.getNodeTypeDefinition(nodeTypeName),
-						groupName;
+			init: function() {
+				this._super();
+				var nodeTypeGroups = this.get('nodeTypeGroups');
+				this.get('allowedNodeTypes').forEach(function(nodeTypeName) {
+					var nodeType = NodeTypeService.getNodeTypeDefinition(nodeTypeName);
 
 					if (!nodeType || !nodeType.ui) {
 						return;
 					}
 
-					groupName = 'group' in nodeType.ui ? nodeType.ui.group : 'general';
-
-					if (!groupedNodeTypes[groupName]) {
-						groupedNodeTypes[groupName] = {
-							'name': groupName,
-							'label': '',
-							'nodeTypes': []
-						};
-					}
-					var helpMessage;
+					var helpMessage = '';
 					if (nodeType.ui.help && nodeType.ui.help.message) {
 						helpMessage = nodeType.ui.help.message;
-					} else {
-						helpMessage = '';
 					}
-					groupedNodeTypes[groupName].nodeTypes.push({
+
+					var groupName = nodeType.ui.group || 'general';
+					nodeTypeGroups.findBy('name', groupName).get('nodeTypes').pushObject({
 						'nodeType': nodeTypeName,
 						'label': I18n.translate(nodeType.ui.label),
 						'helpMessage': helpMessage,
-						'icon': 'icon' in nodeType.ui ? nodeType.ui.icon : 'icon-file',
+						'icon': nodeType.ui.icon || 'icon-file',
 						'position': nodeType.ui.position
 					});
 				});
-
-				Configuration.get('nodeTypes.groups').forEach(function(group) {
-					if (groupedNodeTypes[group.name]) {
-						groupedNodeTypes[group.name].nodeTypes.sort(function(a, b) {
-							return (Ember.get(a, 'position') || 9999) - (Ember.get(b, 'position') || 9999);
-						});
-						groupedNodeTypes[group.name].label = I18n.translate(group.label);
-						nodeTypeGroups.push(groupedNodeTypes[group.name]);
-					}
-				});
-
-				return nodeTypeGroups;
-			}.property('allowedNodeTypes')
+			}
 		});
 	}
 );

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -13,7 +13,6 @@ define(
 	'Shared/NodeTypeService',
 	'InlineEditing/ContentCommands',
 	'InlineEditing/Dialogs/DeleteNodeDialog',
-	'InlineEditing/InsertNodePanel',
 	'Shared/I18n'
 ],
 function (
@@ -30,7 +29,6 @@ function (
 	NodeTypeService,
 	ContentCommands,
 	DeleteNodeDialog,
-	InsertNodePanel,
 	I18n
 ) {
 	return Ember.View.extend({

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -1,7 +1,6 @@
 define(
 [
 	'emberjs',
-	'Library/underscore',
 	'vie',
 	'Content/Components/AbstractInsertNodePanel',
 	'Content/Application',
@@ -14,7 +13,6 @@ define(
 ],
 function(
 	Ember,
-	_,
 	vie,
 	AbstractInsertNodePanel,
 	ContentModule,
@@ -28,7 +26,8 @@ function(
 		_node: null,
 		_position: null,
 
-		nodeTypeGroups: function() {
+		init: function() {
+			this._super();
 			var groups = {},
 				namespace = Configuration.get('TYPO3_NAMESPACE'),
 				node = this.get('_node'),
@@ -41,14 +40,15 @@ function(
 				types = ContentCommands.getAllowedSiblingNodeTypesForNode(node);
 			}
 
-			types = _.map(types, function(nodeType) {
+			types = types.map(function(nodeType) {
 				return 'typo3:' + nodeType;
 			});
 
-			var contentTypes = NodeTypeService.getSubNodeTypes('TYPO3.Neos:Content');
-
-			_.each(types, function(nodeType) {
-				var type = this.get('_node._vieEntity._enclosingCollectionWidget').options.vie.types.get(nodeType);
+			var contentTypes = NodeTypeService.getSubNodeTypes('TYPO3.Neos:Content'),
+				nodeTypeGroups = this.get('nodeTypeGroups'),
+				vieTypes = this.get('_node._vieEntity._enclosingCollectionWidget').options.vie.types;
+			types.forEach(function(nodeType) {
+				var type = vieTypes.get(nodeType);
 				if (!type || !type.metadata || type.metadata.abstract === true) {
 					return;
 				}
@@ -58,44 +58,21 @@ function(
 					return;
 				}
 
-				if (type.metadata.ui && type.metadata.ui.group) {
-					if (!groups[type.metadata.ui.group]) {
-						groups[type.metadata.ui.group] = {
-							name: type.metadata.ui.group,
-							label: '',
-							nodeTypes: []
-						};
-					}
-					var helpMessage;
-					if (type.metadata.ui.help && type.metadata.ui.help.message) {
-						helpMessage = type.metadata.ui.help.message;
-					} else {
-						helpMessage = '';
-					}
-					groups[type.metadata.ui.group].nodeTypes.push({
-						'nodeType': nodeTypeName,
-						'label': I18n.translate(type.metadata.ui.label),
-						'helpMessage': helpMessage,
-						'icon': 'icon' in type.metadata.ui ? type.metadata.ui.icon : 'icon-file',
-						'position': type.metadata.ui.position
-					});
+				var helpMessage = '';
+				if (type.metadata.ui.help && type.metadata.ui.help.message) {
+					helpMessage = type.metadata.ui.help.message;
 				}
-			}, this);
 
-			// Make the data object an array for usage in #each helper
-			var data = [];
-			Configuration.get('nodeTypes.groups').forEach(function(group) {
-				if (groups[group.name]) {
-					groups[group.name].nodeTypes.sort(function(a, b) {
-						return (Ember.get(a, 'position') || 9999) - (Ember.get(b, 'position') || 9999);
-					});
-					groups[group.name].label = I18n.translate(group.label);
-					data.push(groups[group.name]);
-				}
+				var groupName = type.metadata.ui.group || 'general';
+				nodeTypeGroups.findBy('name', groupName).get('nodeTypes').pushObject({
+					'nodeType': nodeTypeName,
+					'label': I18n.translate(type.metadata.ui.label),
+					'helpMessage': helpMessage,
+					'icon': 'icon' in type.metadata.ui ? type.metadata.ui.icon : 'icon-file',
+					'position': type.metadata.ui.position
+				});
 			});
-
-			return data;
-		}.property(),
+		},
 
 		/**
 		 * @param {string} nodeType

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -5533,25 +5533,26 @@ neos .icon-fw {
 }
 .neos .neos-modal {
   position: fixed;
-  top: 120px;
-  left: 50%;
   z-index: 10050;
-  margin: 0px 0px 0px -17.5%;
+  margin: 0;
   color: #fff;
   background: #222;
   border: 1px solid #3f3f3f;
   padding: 0px;
-  width: 35%;
   -webkit-border-radius: 0;
   -moz-border-radius: 0;
   border-radius: 0;
   font-family: 'Noto Sans', sans-serif;
   -webkit-font-smoothing: antialiased;
   outline: none;
+  width: calc(100vw - 80px);
+  max-width: 640px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 .neos .neos-modal.neos-modal-wide {
-  width: 50%;
-  left: 42.5%;
+  max-width: 960px;
 }
 .neos .neos-modal.neos-fade {
   -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
@@ -12552,7 +12553,7 @@ neos .icon-fw {
 }
 .neos .neos-insert-node-panel .neos-modal-body {
   border-bottom: 1px solid #3f3f3f;
-  max-height: 480px;
+  max-height: calc(100vh - 204px);
   overflow-y: auto;
 }
 .neos .neos-insert-node-panel .neos-content-new-selecttype-button {

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -12551,10 +12551,16 @@ neos .icon-fw {
   transform: rotate(-90deg);
   left: 13px;
 }
+.neos .neos-insert-node-panel + ul {
+  margin-bottom: 1px;
+}
 .neos .neos-insert-node-panel .neos-modal-body {
-  border-bottom: 1px solid #3f3f3f;
   max-height: calc(100vh - 204px);
   overflow-y: auto;
+}
+.neos .neos-insert-node-panel .neos-modal-footer {
+  border-top: 1px solid #3f3f3f;
+  margin-top: -1px;
 }
 .neos .neos-insert-node-panel .neos-content-new-selecttype-button {
   position: relative;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -12501,12 +12501,54 @@ neos .icon-fw {
   margin-left: 8px;
 }
 .neos .neos-insert-node-panel .neos-subheader {
-  padding: 0 16px 8px;
+  height: 40px;
+  line-height: 40px;
+  padding-left: 16px;
   margin: 0;
+  position: relative;
+  border-bottom: 1px solid #3f3f3f;
+  overflow: hidden;
 }
-.neos .neos-insert-node-panel .neos-subheader ~ .neos-subheader {
-  padding: 16px 16px 8px;
-  border-top: 1px solid #3f3f3f;
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  color: #fff;
+}
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group:focus {
+  outline: 1px dotted #fff;
+}
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group:hover {
+  background-color: #00b5ff;
+  outline: none;
+}
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group::before {
+  content: "›";
+  font-size: 26px;
+  font-weight: normal;
+  display: inline-block;
+  position: relative;
+  top: 0;
+  line-height: 40px;
+}
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group.neos-collapsed::before {
+  -webkit-transform: rotate(90deg);
+  -moz-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+  -o-transform: rotate(90deg);
+  transform: rotate(90deg);
+  left: 19px;
+}
+.neos .neos-insert-node-panel .neos-subheader .neos-modal-collapse-group.neos-open::before {
+  -webkit-transform: rotate(-90deg);
+  -moz-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  -o-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+  left: 13px;
 }
 .neos .neos-insert-node-panel .neos-modal-body {
   border-bottom: 1px solid #3f3f3f;


### PR DESCRIPTION
Makes the node type groups in the insert node type panel collapsible.
The initial state can be configured using configuration::

    TYPO3.Neos.nodeTypes.groups.general.collapsed: true

When the user toggles a group it is remembered and stored in local storage,
so the user has to toggle the group again to reset it.

Additionally optimizes the sizes of modal windows.

NEOS-786 #close
NEOS-614 #comment Optimized modals windows