### PR TITLE
TASK: Display node label instead of node type label in workspace overview

### DIFF
--- a/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -3,11 +3,11 @@
 <div class="neos-content-diff">
     <table class="neos-content-diff">
         <tr>
-            <th>
+            <th title="{f:if(condition: change.node.nodeType.label, then: '{neos:backend.translate(id: change.node.nodeType.label)}', else: '{change.node.nodeType.name}')}">
                 <f:if condition="{change.configuration.ui.icon}">
-                    <i class="{change.configuration.ui.icon}" title="{change.node.nodeType.name}"></i>
+                    <i class="{change.configuration.ui.icon}"></i>
                 </f:if>
-                {f:if(condition: change.node.nodeType.label, then: '{neos:backend.translate(id: change.node.nodeType.label)}', else: '{change.node.nodeType.name}')}
+                {change.node.label}
             </th>
         </tr>
         <f:for each="{change.contentChanges}" key="propertyName" as="contentChanges">


### PR DESCRIPTION
The node type label doesn't really represent the actual node making it difficult to identity,
instead the node label is used and the node type label is available on hover.