### PR TITLE
BUGFIX: Initialize variable $language

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
@@ -59,9 +59,11 @@ class NodeUriPathSegmentGenerator
      * @param NodeInterface $node Optional node to determine language dimension
      * @param string $text Optional text
      * @return string
+     * @throws \TYPO3\Neos\Exception
      */
     public function generateUriPathSegment(NodeInterface $node = null, $text = null)
     {
+        $language = null;
         if ($node) {
             $text = $text ?: $node->getLabel() ?: $node->getName();
             $dimensions = $node->getContext()->getDimensions();


### PR DESCRIPTION
The uninitialized variable $language results in an exception
when the user tries to add a page on PHP 7 due to the
Notice: Undefined variable: language