### PR TITLE
BUGFIX: Page creation without ``language`` dimension

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
@@ -72,7 +72,7 @@ class NodeUriPathSegmentGenerator
         } elseif (strlen($text) === 0) {
             throw new \TYPO3\Neos\Exception('Given text was empty.', 1457591815);
         }
-        $text = $this->transliterationService->transliterate($text, $language ?: null);
+        $text = $this->transliterationService->transliterate($text, isset($language) ? $language : null);
         return \Behat\Transliterator\Transliterator::urlize($text);
     }
 }


### PR DESCRIPTION
The uninitialized variable ``$language`` results in an exception
when the user tries to add a page on PHP 7 due to
``Notice: Undefined variable: language``.