### PR TITLE
BUGFIX: Prevent edit / preview rendering path from applying to front-end

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
@@ -40,7 +40,7 @@ root {
 	editPreviewMode {
 		@position = 'end 9996'
 		possibleEditPreviewModePath = ${documentNode.context.currentRenderingMode.typoScriptPath}
-		condition = ${this.possibleEditPreviewModePath != null && this.possibleEditPreviewModePath != ''}
+		condition = ${documentNode.context.inBackend && this.possibleEditPreviewModePath != null && this.possibleEditPreviewModePath != ''}
 		renderPath = ${'/' + this.possibleEditPreviewModePath}
 	}
 


### PR DESCRIPTION
When a edit / preview mode with a rendering path is selected it can affect the
front-end view for the logged in user. To prevent this edit / preview modes now
only apply in the backend.

NEOS-1758 #close