### PR TITLE
BUGFIX: Fix blurry insert panel (Table-cell approach)

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
@@ -21,29 +21,21 @@
 }
 
 // Base modal
-.neos-modal {
+.neos-modal-container {
+	width: 100%;
+	height: 100%;
+	display: table;
 	position: fixed;
-	z-index: $zindexModal;
-	color: $textOnGray;
-	background: $grayDark;
-	border: 1px solid $grayLight;
-	padding: 0px;
-	@include border-radius(0);
-	@include font();
-	// Remove focus outline from opened modal
-	outline: none;
-	width: calc(100vw - #{$unit * 2});
-	max-width: $unit * 16;
-	margin: auto;
 	top: 0;
 	left: 0;
-	bottom: 0;
 	right: 0;
-	display: inline-table;
+	bottom: 0;
+	z-index: $zindexModal;
+}
 
-	&.neos-modal-wide {
-		max-width: $unit * 24;
-	}
+.neos-modal {
+	display: table-cell;
+	vertical-align: middle;
 
 	&.neos-fade {
 		@include transition(opacity .3s linear, top .3s ease-out);
@@ -52,6 +44,24 @@
 
 	&.neos-fade.neos-in {
 		top: 10%;
+	}
+
+	.neos-modal-content {
+		margin: 0 auto;
+		color: $textOnGray;
+		background: $grayDark;
+		border: 1px solid $grayLight;
+		padding: 0px;
+		@include border-radius(0);
+		@include font();
+		// Remove focus outline from opened modal
+		outline: none;
+		width: calc(100vw - #{$unit * 2});
+		max-width: $unit * 16;
+
+		&.neos-modal-wide {
+			max-width: $unit * 24;
+		}
 	}
 
 	.neos-modal-header {

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_modals.scss
@@ -24,7 +24,6 @@
 .neos-modal {
 	position: fixed;
 	z-index: $zindexModal;
-	margin: 0;
 	color: $textOnGray;
 	background: $grayDark;
 	border: 1px solid $grayLight;
@@ -35,9 +34,12 @@
 	outline: none;
 	width: calc(100vw - #{$unit * 2});
 	max-width: $unit * 16;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+	margin: auto;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	display: inline-table;
 
 	&.neos-modal-wide {
 		max-width: $unit * 24;

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
@@ -1,43 +1,47 @@
-<div class="neos-modal neos-modal-wide neos-insert-node-panel">
-	<div class="neos-modal-header">
-		<button class="neos-close neos-button" title="{{translate id='close' fallback='Close'}}" {{action "cancel" target="view"}} data-neos-toggle></button>
-		<div class="neos-header">
-			{{translate id="createNew" fallback="Create new"}}
-			{{#if view._position}}
-				{{boundTranslate idBinding="view._position" fallbackBinding="view._position"}}
-				<i {{bindAttr class="view._positionIconClass"}}></i>
-			{{/if}}
-		</div>
-	</div>
-	<div class="neos-modal-body">
-		{{#each nodeTypeGroup in view.nodeTypeGroups}}
-			{{#if nodeTypeGroup.sortedNodeTypes}}
-				<div class="neos-subheader">
-					{{unbound nodeTypeGroup.label}}
-					{{view view.ToggleNodeTypeGroup nodeTypeGroupBinding="nodeTypeGroup"}}
+<div class="neos neos-modal-container">
+	<div class="neos-modal neos-insert-node-panel">
+		<div class="neos-modal-content neos-modal-wide">
+			<div class="neos-modal-header">
+				<button class="neos-close neos-button" title="{{translate id='close' fallback='Close'}}" {{action "cancel" target="view"}} data-neos-toggle></button>
+				<div class="neos-header">
+					{{translate id="createNew" fallback="Create new"}}
+					{{#if view._position}}
+						{{boundTranslate idBinding="view._position" fallbackBinding="view._position"}}
+						<i {{bindAttr class="view._positionIconClass"}}></i>
+					{{/if}}
 				</div>
-				<ul {{bindAttr class=":neos-clearfix"}}>
-					{{#each nodeTypeGroup.sortedNodeTypes}}
-						<li class="neos-content-new-selecttype-button">
-							<button class="neos-content-new" {{bindAttr title="nodeType"}} {{action "insertNode" nodeType icon target="view"}} data-neos-tooltip>
-								{{#if icon}}
-									<i class="{{unbound icon}}"></i>
-								{{else}}
-									<i class="icon-sign-blank"></i>
-								{{/if}}
-								{{unbound label}}
-							</button>
-							{{#if helpMessage}}
-								{{view view.HelpMessage titleBinding="label" contentBinding="helpMessage" popoverContainer=".neos-insert-node-panel"}}
-							{{/if}}
-						</li>
-					{{/each}}
-				</ul>
-			{{/if}}
-		{{/each}}
-	</div>
-	<div class="neos-modal-footer">
-		<button class="neos-button" {{action "cancel" target="view"}}>{{translate id="cancel" fallback="Cancel"}}</button>
+			</div>
+			<div class="neos-modal-body">
+				{{#each nodeTypeGroup in view.nodeTypeGroups}}
+					{{#if nodeTypeGroup.sortedNodeTypes}}
+						<div class="neos-subheader">
+							{{unbound nodeTypeGroup.label}}
+							{{view view.ToggleNodeTypeGroup nodeTypeGroupBinding="nodeTypeGroup"}}
+						</div>
+						<ul {{bindAttr class=":neos-clearfix"}}>
+							{{#each nodeTypeGroup.sortedNodeTypes}}
+								<li class="neos-content-new-selecttype-button">
+									<button class="neos-content-new" {{bindAttr title="nodeType"}} {{action "insertNode" nodeType icon target="view"}} data-neos-tooltip>
+										{{#if icon}}
+											<i class="{{unbound icon}}"></i>
+										{{else}}
+											<i class="icon-sign-blank"></i>
+										{{/if}}
+										{{unbound label}}
+									</button>
+									{{#if helpMessage}}
+										{{view view.HelpMessage titleBinding="label" contentBinding="helpMessage" popoverContainer=".neos-insert-node-panel"}}
+									{{/if}}
+								</li>
+							{{/each}}
+						</ul>
+					{{/if}}
+				{{/each}}
+			</div>
+			<div class="neos-modal-footer">
+				<button class="neos-button" {{action "cancel" target="view"}}>{{translate id="cancel" fallback="Cancel"}}</button>
+			</div>
+		</div>
 	</div>
 </div>
 <div class="neos-modal-backdrop neos-in"></div>

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -5600,9 +5600,33 @@ neos .icon-fw {
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=35);
   opacity: 0.35;
 }
-.neos .neos-modal {
+.neos .neos-modal-container {
+  width: 100%;
+  height: 100%;
+  display: table;
   position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 10050;
+}
+.neos .neos-modal {
+  display: table-cell;
+  vertical-align: middle;
+}
+.neos .neos-modal.neos-fade {
+  -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
+  -moz-transition: opacity 0.3s linear, top 0.3s ease-out;
+  -o-transition: opacity 0.3s linear, top 0.3s ease-out;
+  transition: opacity 0.3s linear, top 0.3s ease-out;
+  top: -25%;
+}
+.neos .neos-modal.neos-fade.neos-in {
+  top: 10%;
+}
+.neos .neos-modal .neos-modal-content {
+  margin: 0 auto;
   color: #fff;
   background: #222;
   border: 1px solid #3f3f3f;
@@ -5615,25 +5639,9 @@ neos .icon-fw {
   outline: none;
   width: calc(100vw - 80px);
   max-width: 640px;
-  margin: auto;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  display: inline-table;
 }
-.neos .neos-modal.neos-modal-wide {
+.neos .neos-modal .neos-modal-content.neos-modal-wide {
   max-width: 960px;
-}
-.neos .neos-modal.neos-fade {
-  -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
-  -moz-transition: opacity 0.3s linear, top 0.3s ease-out;
-  -o-transition: opacity 0.3s linear, top 0.3s ease-out;
-  transition: opacity 0.3s linear, top 0.3s ease-out;
-  top: -25%;
-}
-.neos .neos-modal.neos-fade.neos-in {
-  top: 10%;
 }
 .neos .neos-modal .neos-modal-header {
   padding: 0px;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -5603,7 +5603,6 @@ neos .icon-fw {
 .neos .neos-modal {
   position: fixed;
   z-index: 10050;
-  margin: 0;
   color: #fff;
   background: #222;
   border: 1px solid #3f3f3f;
@@ -5616,9 +5615,12 @@ neos .icon-fw {
   outline: none;
   width: calc(100vw - 80px);
   max-width: 640px;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  margin: auto;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: inline-table;
 }
 .neos .neos-modal.neos-modal-wide {
   max-width: 960px;


### PR DESCRIPTION
There is also a Flexbox approach for this: https://github.com/neos/neos-development-collection/pull/434

The node insert panel was centered with `transform: translate(x,y);` which caused the panel to become blurry in Chrome through special browser rendering techniques.

Tested on Windows
Chrome 49.0.2623
Firefox 45.0.1
Internet Explorer 10 / 11


Before:
![image](https://cloud.githubusercontent.com/assets/10533739/14330695/103bdb08-fc42-11e5-8524-e97344c86891.png)

After:
![image](https://cloud.githubusercontent.com/assets/10533739/14330703/1c2d6aa8-fc42-11e5-8afe-7a6dabcf6dbc.png)