### PR TITLE
TASK: Make nodes selectable in context structure tree

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -106,6 +106,7 @@ define(
 				return;
 			}
 			selectedNode.activate();
+			selectedNode.select();
 			this.scrollToCurrentNode();
 		}.observes('nodeSelection.selectedNode'),
 
@@ -144,9 +145,9 @@ define(
 						isFolder: true,
 						expand: false,
 						isLazy: true,
-						select: false,
+						select: true,
 						active: false,
-						unselectable: true,
+						unselectable: false,
 						nodeType: nodeType,
 						nodeTypeLabel: nodeTypeConfiguration ? nodeTypeConfiguration.label : '',
 						addClass: 'typo3-neos-page',
@@ -155,6 +156,7 @@ define(
 				],
 
 				onClick: function(node, event) {
+					node.select();
 					if (node.getEventTargetType(event) === 'title' || node.getEventTargetType(event) === null) {
 						this.options.parent._selectNode(node);
 					}
@@ -231,6 +233,7 @@ define(
 					currentNode = tree.getNodeByKey(NodeSelection.get('selectedNode').$element.attr('about'));
 				if (currentNode) {
 					currentNode.activate();
+					currentNode.select();
 					this.scrollToCurrentNode();
 				}
 			}


### PR DESCRIPTION
This makes it more clear which structure node is selected and more in sync with the document node tree.

Visually the title is blue instead of just the background being color being lighter.
This corresponds with the blue outline the selected inline element has.