### PR TITLE
TASK: Remove "CreateNodes" from documentation

### DIFF
--- a/TYPO3.Neos/Documentation/References/NodeMigrations.rst
+++ b/TYPO3.Neos/Documentation/References/NodeMigrations.rst
@@ -15,7 +15,6 @@ The Content Repository comes with a number of common transformations:
 - ``AddNewProperty``
 - ``ChangeNodeType``
 - ``ChangePropertyValue``
-- ``CreateNodes``
 - ``RemoveNode``
 - ``RemoveProperty``
 - ``RenameDimension``


### PR DESCRIPTION
The node migration transformation "CreateNodes" does not exist,
so it is removed from the documentation.