### PR TITLE
BUGFIX: Don't show error notification on cancelled page loads

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -441,10 +441,12 @@ function(
 						callback();
 					}
 				},
-				function() {
-					Notification.error('An error occurred.');
-					that.set('_isLoadingPage', false);
-					LoadingIndicator.done();
+				function(request) {
+					if (request.status !== 'abort') {
+						Notification.error('An error occurred.');
+						that.set('_isLoadingPage', false);
+						LoadingIndicator.done();
+					}
 				}
 			).fail(function(error) {
 				Notification.error('An error occurred.');


### PR DESCRIPTION
Due to the improved AJAX error handling an error was shown for
cancelled requests.