### PR TITLE
TASK: Only update changed model properties

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -456,8 +456,8 @@ define(
 				reloadPage = false,
 				selectedNode = this.get('selectedNode'),
 				propertyValuePostprocessPromises = [],
-				propertyPromise;
-
+				propertyPromise,
+				changedAttributes = {};
 
 			_.each(this.get('cleanProperties'), function(cleanPropertyValue, key) {
 				var valueOrPromise = that.get('nodeProperties').get(key);
@@ -473,7 +473,7 @@ define(
 
 				propertyValuePostprocessPromises.push(propertyPromise.then(function(value) {
 					if (value !== cleanPropertyValue) {
-						selectedNode.setAttribute(key, value, {validate: false});
+						changedAttributes[key] = value;
 						if (Ember.get(nodeTypeSchema, 'properties.' + key + '.ui.reloadPageIfChanged')) {
 							reloadPage = true;
 						} else if (Ember.get(nodeTypeSchema, 'properties.' + key + '.ui.reloadIfChanged')) {
@@ -484,6 +484,7 @@ define(
 			});
 
 			Ember.RSVP.all(propertyValuePostprocessPromises).then(function() {
+				selectedNode.setAttributes(changedAttributes, {validate: false});
 				var entity = that.get('selectedNode._vieEntity');
 				if (entity.isValid() !== true) {
 					return;
@@ -545,6 +546,8 @@ define(
 				that.set('cleanProperties', cleanProperties);
 				that.set('nodeProperties', Ember.Object.create(cleanProperties));
 				SecondaryInspectorController.hide();
+			}).fail(function(error) {
+				console.error(error);
 			});
 		},
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Model/Node.js
@@ -144,6 +144,26 @@ define([
 		},
 
 		/**
+		 * Set attributes on the underlying VIE entity
+		 *
+		 * @param {object} attributes
+		 * @param {object} options
+		 * @return {void}
+		 */
+		setAttributes: function(attributes, options) {
+			var prefixedAttributes = {};
+			_.each(attributes, function(value, key) {
+				var prefixedAttributeName = 'typo3:' + key;
+				prefixedAttributes[prefixedAttributeName] = value;
+				this.propertyWillChange(prefixedAttributeName);
+			}, this);
+			this.get('_vieEntity').set(prefixedAttributes, options);
+			_.each(prefixedAttributes, function(value, key) {
+				this.propertyDidChange(key);
+			}, this);
+		},
+
+		/**
 		 * Get an attribute on the underlying VIE entity
 		 *
 		 * @param {string} key

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InlineEditingHandles.js
@@ -167,7 +167,6 @@ function (
 			var node = this.get('_node'),
 				value = !node.getAttribute('_hidden');
 			this.set('_hidden', value);
-			node.setAttribute('_hidden', value);
 			InspectorController.set('nodeProperties._hidden', value);
 			InspectorController.apply();
 		},

--- a/TYPO3.Neos/Resources/Public/JavaScript/storage.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/storage.js
@@ -81,7 +81,7 @@ define(
 			},
 			_convertModelToJson: function(model) {
 				var contextPath = model.fromReference(model.id);
-				var attributes = Entity.extractAttributesFromVieEntity(model, null, function(k) {
+				var attributes = Entity.extractAttributesFromVieEntity(model, model.changed, function(k) {
 						// skip internal properties starting with __; and skip "content-collection" (which is collection-specific)
 					return !( (k[0] === '_' && k[1] === '_') || k === 'content-collection');
 				});


### PR DESCRIPTION
When updating a properties for a node, only post the properties
that have actually changed. This improves performance since
fewer ``setProperty`` calls are needed. The more node properties
the bigger the impact.