### PR TITLE
TASK: Avoid workspace not found after flushing doctrine states

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -1188,7 +1188,10 @@ class NodeDataRepository extends Repository
             $nodeDimensions = $node->getDimensionValues();
 
             // Find the position of the workspace, a smaller value means more priority
-            $workspacePosition = array_search($node->getWorkspace(), $workspaces);
+            $workspaceNames = array_map(function (Workspace $workspace) {
+                return $workspace->getName();
+            }, $workspaces);
+            $workspacePosition = array_search($node->getWorkspace()->getName(), $workspaceNames);
             if ($workspacePosition === false) {
                 throw new Exception\NodeException('Node workspace not found in allowed workspaces, this could result from a detached workspace entity in the context.', 1413902143);
             }


### PR DESCRIPTION
When flushing doctrine state, the method ```node::getWorkpace``` can return
a proxy or $workspace can contains unresolved proxy, depend on the current application state, so array_search will return false. This change don't search for the workspace object, but just for the workspace name so it's should a bit more performant and force resolving proxy.

This change does not mean it's completely safe to flush doctrine states, you must be aware when you do this kind of low level stuff, but at least now you can try to do it.