### PR TITLE
BUGFIX: requireJs loading timeout for editors

### DIFF
--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -130,6 +130,12 @@ TYPO3:
       # Content Module, this should be set to FALSE.
       loadMinifiedJavascript: TRUE
 
+      # The number of seconds to wait before giving up on loading a script.
+      # The default in requireJs is 7 seconds but on slow clients with slow internetconnections
+      # in combination with big Document Nodes it can happen that the Inspector Editors and Aloha
+      # can not be loaded. http://requirejs.org/docs/api.html#config-waitSeconds
+      requireJsWaitSeconds: 30
+
       # Switch on to see all translated labels getting scrambled. You now can localize
       # everything that is still readable.
       scrambleTranslatedLabels: FALSE

--- a/TYPO3.Neos/Resources/Public/JavaScript/ContentModuleBootstrap.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/ContentModuleBootstrap.js
@@ -15,7 +15,9 @@ require(
 		baseUrl: window.T3Configuration.neosJavascriptBasePath,
 		urlArgs: window.T3Configuration.neosJavascriptVersion ? 'bust=' +  window.T3Configuration.neosJavascriptVersion : '',
 		paths: requirePaths,
-		context: 'neos'
+		context: 'neos',
+		waitSeconds: window.T3Configuration.UserInterface.requireJsWaitSeconds
+
 	},
 	[
 		'Library/jquery-with-dependencies',

--- a/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
@@ -235,12 +235,12 @@ function(
 				}
 			}
 		};
-
 		require(
 			{
 				context: 'aloha',
 				baseUrl: alohaBaseUrl,
-				urlArgs: Configuration.get('neosJavascriptVersion') ? 'bust=' +  Configuration.get('neosJavascriptVersion') : ''
+				urlArgs: Configuration.get('neosJavascriptVersion') ? 'bust=' +  Configuration.get('neosJavascriptVersion') : '',
+				waitSeconds: Configuration.get('UserInterface.requireJsWaitSeconds')
 			},
 			['aloha']
 		);


### PR DESCRIPTION
On slow internet connections in combination with 
big Document Nodes it can happen that the 
Inspector Editors and Aloha can not be loaded. The 
default value of require is 7.