### PR TITLE
BUGFIX: Free index space at target position if no free index space is available

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -337,8 +337,8 @@ class NodeDataRepository extends Repository
                     // there is free space left between $referenceNode and preceding sibling.
                     $newIndex = (integer)round($nextLowerIndex + (($referenceIndex - $nextLowerIndex) / 2));
                 } else {
-                    // there is no free space left between $referenceNode and following sibling -> we need to re-number!
-                    $this->renumberIndexesInLevel($parentPath);
+                    // there is no free space left between $referenceNode and following sibling -> we have to make room!
+                    $this->createFreeIndexSpace($parentPath, $referenceIndex);
                     $referenceIndex = $referenceNode->getIndex();
                     $nextLowerIndex = $this->findNextLowerIndex($parentPath, $referenceIndex);
                     if ($nextLowerIndex === null) {
@@ -362,9 +362,8 @@ class NodeDataRepository extends Repository
                     // $referenceNode is not last node, but there is free space left between $referenceNode and following sibling.
                     $newIndex = (integer)round($referenceIndex + (($nextHigherIndex - $referenceIndex) / 2));
                 } else {
-                    // $referenceNode is not last node, and no free space is left -> we need to re-number!
-                    $this->renumberIndexesInLevel($parentPath);
-                    $referenceIndex = $referenceNode->getIndex();
+                    // $referenceNode is not last node, and no free space is left -> we have to make room after the reference node!
+                    $this->createFreeIndexSpace($parentPath, $referenceIndex + 1);
                     $nextHigherIndex = $this->findNextHigherIndex($parentPath, $referenceIndex);
                     if ($nextHigherIndex === null) {
                         $newIndex = $referenceIndex + 100;
@@ -612,21 +611,16 @@ class NodeDataRepository extends Repository
     }
 
     /**
-     * Renumbers the indexes of all nodes directly below the node specified by the
-     * given path.
+     * Make room in the sortindex-index space of a given path in preparation to inserting a node.
+     * All indices that are greater or equal to the given referenceIndex are incremented by 100
      *
-     * Note that renumbering must happen in-memory and can't be optimized by a clever
-     * query executed directly by the database because sorting indexes of new or
-     * modified nodes need to be considered.
-     *
-     * @param string $parentPath Path to the parent node
-     * @return void
+     * @param string $parentPath
+     * @param integer $referenceIndex
      * @throws Exception\NodeException
      */
-    protected function renumberIndexesInLevel($parentPath)
+    protected function createFreeIndexSpace ($parentPath, $referenceIndex)
     {
-        $parentPath = strtolower($parentPath);
-        $this->systemLogger->log(sprintf('Renumbering nodes in level below %s.', $parentPath), LOG_INFO);
+        $this->systemLogger->log(sprintf('Opening sortindex space after index %s at path %s.', $referenceIndex, $parentPath), LOG_INFO);
 
         /** @var Query $query */
         $query = $this->entityManager->createQuery('SELECT n.Persistence_Object_Identifier identifier, n.index, n.path FROM TYPO3\TYPO3CR\Domain\Model\NodeData n WHERE n.parentPathHash = :parentPathHash ORDER BY n.index ASC');
@@ -635,33 +629,30 @@ class NodeDataRepository extends Repository
         $nodesOnLevel = array();
         /** @var $node NodeData */
         foreach ($query->getArrayResult() as $node) {
-            $nodesOnLevel[$node['index']] = array(
+            $nodesOnLevel[] = array(
                 'identifier' => $node['identifier'],
-                'path' => $node['path']
+                'path' => $node['path'],
+                'index' => $node['index']
             );
         }
 
         /** @var $node NodeData */
         foreach ($this->addedNodes as $node) {
             if ($node->getParentPath() === $parentPath) {
-                $index = $node->getIndex();
-                if (isset($nodesOnLevel[$index])) {
-                    throw new Exception\NodeException(sprintf('Index conflict for nodes %s and %s: both have index %s', $nodesOnLevel[$index]->getPath(), $node->getPath(), $index), 1317140401);
-                }
-                $nodesOnLevel[$index] = array(
+                $nodesOnLevel[] = array(
                     'addedNode' => $node,
-                    'path' => $node->getPath()
+                    'path' => $node->getPath(),
+                    'index' => $node->getIndex()
                 );
             }
         }
 
-            // We need to sort the nodes now, to take unpersisted node orderings into account.
-            // This fixes bug #34291
-        ksort($nodesOnLevel);
-
-        $newIndex = 100;
         $query = $this->entityManager->createQuery('UPDATE TYPO3\TYPO3CR\Domain\Model\NodeData n SET n.index = :index WHERE n.Persistence_Object_Identifier = :identifier');
         foreach ($nodesOnLevel as $node) {
+            if ($node['index'] < $referenceIndex) {
+                continue;
+            }
+            $newIndex = $node['index'] + 100;
             if ($newIndex > self::INDEX_MAXIMUM) {
                 throw new Exception\NodeException(sprintf('Reached maximum node index of %s while setting index of node %s.', $newIndex, $node['path']), 1317140402);
             }
@@ -675,7 +666,6 @@ class NodeDataRepository extends Repository
                 $query->setParameter('identifier', $node['identifier']);
                 $query->execute();
             }
-            $newIndex += 100;
         }
     }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -338,7 +338,7 @@ class NodeDataRepository extends Repository
                     $newIndex = (integer)round($nextLowerIndex + (($referenceIndex - $nextLowerIndex) / 2));
                 } else {
                     // there is no free space left between $referenceNode and following sibling -> we have to make room!
-                    $this->createFreeIndexSpace($parentPath, $referenceIndex);
+                    $this->openIndexSpace($parentPath, $referenceIndex);
                     $referenceIndex = $referenceNode->getIndex();
                     $nextLowerIndex = $this->findNextLowerIndex($parentPath, $referenceIndex);
                     if ($nextLowerIndex === null) {
@@ -363,7 +363,7 @@ class NodeDataRepository extends Repository
                     $newIndex = (integer)round($referenceIndex + (($nextHigherIndex - $referenceIndex) / 2));
                 } else {
                     // $referenceNode is not last node, and no free space is left -> we have to make room after the reference node!
-                    $this->createFreeIndexSpace($parentPath, $referenceIndex + 1);
+                    $this->openIndexSpace($parentPath, $referenceIndex + 1);
                     $nextHigherIndex = $this->findNextHigherIndex($parentPath, $referenceIndex);
                     if ($nextHigherIndex === null) {
                         $newIndex = $referenceIndex + 100;
@@ -618,7 +618,7 @@ class NodeDataRepository extends Repository
      * @param integer $referenceIndex
      * @throws Exception\NodeException
      */
-    protected function createFreeIndexSpace ($parentPath, $referenceIndex)
+    protected function openIndexSpace($parentPath, $referenceIndex)
     {
         $this->systemLogger->log(sprintf('Opening sortindex space after index %s at path %s.', $referenceIndex, $parentPath), LOG_INFO);
 


### PR DESCRIPTION
If a node is inserted at a given position between nodes and no free sorting index is available, the sortindices on
that level are renumbered. The previous code for that could lead to unexpected node reordering and sortingindex
value escalation if workspaces or dimensions were used.

The following steps reproduce the error:
* In dimension A create nodes between other nodes until there are no free sortindices available
* Create a variant of those nodes in dimension B
* In dimension B add a new node in a place where no free sort index is available

Since the previous code is only repositioning one item of a given index and does not take workspaces and dimensions
into account this results in the following unwanted effects:
* Unwanted reordering of the nodes in dimension A
* In dimension B two nodes with identical sortingindex occur which makes the order of the nodes random
* If this is repeated multiple times the sorting indices in dimension A escalate quickly to very high values

This patch resolves this behavior by freeing index space at the target position instead of renumbering the
whole level by modifying all nodes on the given path and incrementing all sort indices above the reference position
a consistent behavior across workspaces and dimensions is ensured.