### PR TITLE
FEATURE: Replace existing assets with new version

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Imagine\Image\Box;
 use Imagine\Image\Point;
 use Imagine\Image\ImageInterface as ImagineImageInterface;
+use TYPO3\Media\Domain\Model\ImageInterface;
 
 /**
  * An adjustment for cropping an image
@@ -176,5 +177,27 @@ class CropImageAdjustment extends AbstractImageAdjustment
         $point = new Point($this->x, $this->y);
         $box = new Box($this->width, $this->height);
         return $image->crop($point, $box);
+    }
+
+    /**
+     * Refits the crop proportions to be the maximum size within the image boundaries.
+     *
+     * @param ImageInterface $image
+     * @return void
+     */
+    public function refit(ImageInterface $image)
+    {
+        $this->x = 0;
+        $this->y = 0;
+
+        $ratio = $this->getWidth() / $image->getWidth();
+        $this->setWidth($image->getWidth());
+        $this->setHeight($this->getHeight() / $ratio);
+
+        if ($this->getHeight() > $image->getHeight()) {
+            $ratio = $this->getHeight() / $image->getHeight();
+            $this->setWidth($this->getWidth() / $ratio);
+            $this->setHeight($image->getHeight());
+        }
     }
 }

--- a/TYPO3.Media/Configuration/Policy.yaml
+++ b/TYPO3.Media/Configuration/Policy.yaml
@@ -7,7 +7,7 @@ privilegeTargets:
   'TYPO3\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
 
     'TYPO3.Media:ManageAssets':
-      matcher: 'method(TYPO3\Media\Controller\AssetController->(index|new|edit|update|initializeCreate|create|initializeUpload|upload|tagAsset|delete|createTag|editTag|updateTag|deleteTag|addAssetToCollection)Action())'
+      matcher: 'method(TYPO3\Media\Controller\AssetController->(index|new|edit|update|initializeCreate|create|replaceAssetResource|updateResource|initializeUpload|upload|tagAsset|delete|createTag|editTag|updateTag|deleteTag|addAssetToCollection)Action())'
 
     'TYPO3.Media:ManageAssetCollections':
       matcher: 'method(TYPO3\Media\Controller\AssetController->(createAssetCollection|editAssetCollection|updateAssetCollection|deleteAssetCollection)Action())'

--- a/TYPO3.Media/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Media/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -1,0 +1,59 @@
+{namespace m=TYPO3\Media\ViewHelpers}
+<f:layout name="UploadImage" />
+
+<f:section name="Title">Replace view of AssetController</f:section>
+
+<f:section name="Content">
+    <h2>Replace "{asset.resource.filename}"</h2>
+    <f:form method="post" arguments="{asset: asset}" action="updateResource" enctype="multipart/form-data">
+        <div class="neos-row-fluid">
+            <div class="neos-span8">
+                <fieldset>
+                    <legend>New file</legend>
+                    <label class="neos-button neos-button-primary" for="resource" title="Max. upload size {humanReadableMaximumFileUploadSize} per file" data-neos-toggle="tooltip">Choose a new file <i class="icon-file"></i></label>
+                    <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}" />
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <label class="neos-checkbox neos-inline">
+                            <f:form.checkbox name="options[keepOriginalFilename]" value="1" /><span></span> {f:translate(id: 'media.replace.options.keepOriginalFilename', arguments: {0: asset.resource.filename}, source: 'Modules', package: 'TYPO3.Neos')}
+                        </label>
+                    </div>
+                    <f:if condition="{redirectPackageEnabled}">
+                        <div>
+                            <label class="neos-checkbox neos-inline">
+                                <f:form.checkbox name="options[generateRedirects]" value="1" checked="true" /><span></span> {neos:backend.translate(id: 'media.replace.options.generateRedirects', source: 'Main', package: 'TYPO3.Media')}
+                            </label>
+                        </div>
+                    </f:if>
+                </fieldset>
+            </div>
+
+            <div class="neos-span4 neos-image-example">
+                <f:render section="ContentImage" arguments="{_all}" />
+            </div>
+        </div>
+        <div class="neos-footer">
+            <f:link.action action="index" title="Cancel editing" class="neos-button">Cancel</f:link.action>
+            <f:form.submit id="import" class="neos-button neos-button-primary" value="Replace" />
+        </div>
+    </f:form>
+</f:section>
+
+<f:section name="ContentImage">
+    <label>Preview current file</label>
+    <div class="neos-preview-image">
+        <a href="{f:uri.resource(resource: asset.resource)}" target="_blank">
+            <m:thumbnail asset="{asset}" maximumWidth="1000" maximumHeight="1000" alt="{asset.label}" class="img-polaroid" />
+        </a>
+    </div>
+</f:section>
+
+<f:section name="Scripts">
+    <script type="text/javascript">
+        var maximumFileUploadSize = {maximumFileUploadSize};
+    </script>
+    <script type="text/javascript" src="{f:uri.resource(package: 'TYPO3.Media', path: 'Scripts/new.js')}"></script>
+</f:section>
+
+

--- a/TYPO3.Media/Resources/Private/Translations/en/Main.xlf
+++ b/TYPO3.Media/Resources/Private/Translations/en/Main.xlf
@@ -20,6 +20,9 @@
 			<trans-unit id="assetCouldNotBeDeleted" xml:space="preserve">
 				<source>Asset could not be deleted.</source>
 			</trans-unit>
+			<trans-unit id="assetHasBeenReplaced" xml:space="preserve">
+				<source>Asset "{0}" has been replaced.</source>
+			</trans-unit>
 			<trans-unit id="tagAlreadyExistsAndAddedToCollection" xml:space="preserve">
 				<source>Tag "{0}" already exists and was added to collection.</source>
 			</trans-unit>
@@ -40,6 +43,9 @@
 			</trans-unit>
 			<trans-unit id="collectionHasBeenDeleted" xml:space="preserve">
 				<source>Collection "{0}" has been deleted.</source>
+			</trans-unit>
+			<trans-unit id="media.replace.options.generateRedirects" xml:space="preserve">
+				<source>Generate redirects from original file url to the new url</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/TYPO3.Media/Resources/Public/Scripts/edit.js
+++ b/TYPO3.Media/Resources/Public/Scripts/edit.js
@@ -1,7 +1,6 @@
 (function($) {
 	$(function() {
 		if (window.parent !== window && window.parent.Typo3MediaBrowserCallbacks) {
-			$('.neos-footer a, .neos-footer button').hide();
 			$('.neos-footer .neos-button-primary').on('click', function(e) {
 				window.parent.Typo3MediaBrowserCallbacks.close();
 			});

--- a/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
+++ b/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace TYPO3\Media\Tests\Unit\Domain\Model\Adjustment;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Imagine\Image\Box;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\Adjustment\CropImageAdjustment;
+use TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
+use TYPO3\Media\Domain\Model\ImageInterface;
+
+/**
+ * Test case for the Crop Image Adjustment
+ */
+class CropImageAdjustmentTest extends UnitTestCase
+{
+    /**
+     * @return array
+     */
+    public function imageCropRefitDataProvider()
+    {
+        return [
+            [
+                0, 0, 100, 100,
+                1000, 1000,
+                0, 0, 1000, 1000
+            ],
+            [
+                10, 10, 100, 100,
+                1000, 1000,
+                0, 0, 1000, 1000
+            ],
+            [
+                50, 40, 300, 400,
+                3000, 4000,
+                0, 0, 3000, 4000
+            ],
+            [
+                0, 0, 300, 400,
+                3000, 8000,
+                0, 0, 3000, 4000
+            ],
+            [
+                0, 0, 400, 300,
+                8000, 3000,
+                0, 0, 4000, 3000
+            ],
+            [
+                0, 0, 300, 400,
+                8000, 3000,
+                0, 0, 2250, 3000
+            ],
+            [
+                0, 0, 400, 300,
+                3000, 8000,
+                0, 0, 3000, 2250
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider imageCropRefitDataProvider
+     */
+    public function refitFitsCropPropertionWithinImageSizeConstraints($cropX, $cropY, $cropWidth, $cropHeight, $newImageWidth, $newImageHeight, $expectedX, $expectedY, $expectedWidth, $expectedHeight)
+    {
+        $mockImage = $this->getMock('TYPO3\Media\Domain\Model\Image', [], [], '', false);
+        $mockImage->expects($this->any())->method('getWidth')->will($this->returnValue($newImageWidth));
+        $mockImage->expects($this->any())->method('getHeight')->will($this->returnValue($newImageHeight));
+
+        $mockCropImageAdjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\CropImageAdjustment', ['dummy'], [], '', false);
+        $mockCropImageAdjustment->_set('x', $cropX);
+        $mockCropImageAdjustment->_set('y', $cropY);
+        $mockCropImageAdjustment->_set('width', $cropWidth);
+        $mockCropImageAdjustment->_set('height', $cropHeight);
+
+        $mockCropImageAdjustment->refit($mockImage);
+
+        $this->assertEquals($expectedX, $mockCropImageAdjustment->getX());
+        $this->assertEquals($expectedY, $mockCropImageAdjustment->getY());
+        $this->assertEquals($expectedWidth, $mockCropImageAdjustment->getWidth());
+        $this->assertEquals($expectedHeight, $mockCropImageAdjustment->getHeight());
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -60,6 +60,8 @@ class Package extends BasePackage
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodeMove', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
+        $dispatcher->connect('TYPO3\Media\Domain\Service\AssetService', 'assetResourceReplaced', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerAssetResourceChange');
+
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePropertyChanged', function (NodeInterface $node, $propertyName) use ($bootstrap) {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
@@ -12,6 +12,9 @@ namespace TYPO3\Neos\TypoScript\Cache;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TypoScript\Core\Cache\ContentCache;
@@ -45,6 +48,12 @@ class ContentCacheFlusher
     protected $tagsToFlush = array();
 
     /**
+     * @Flow\Inject
+     * @var AssetService
+     */
+    protected $assetService;
+
+    /**
      * Register a node change for a later cache flush. This method is triggered by a signal sent via TYPO3CR's Node
      * model or the Neos Publishing Service.
      *
@@ -72,6 +81,27 @@ class ContentCacheFlusher
             }
             $tagName = 'DescendantOf_' . $node->getIdentifier();
             $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $originalNode->getPath());
+        }
+    }
+
+    /**
+     * Fetches possible usages of the asset and registers nodes that use the asset as changed.
+     *
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function registerAssetResourceChange(AssetInterface $asset)
+    {
+        if (!$asset->isInUse()) {
+            return;
+        }
+
+        foreach ($this->assetService->getUsageReferences($asset) as $reference) {
+            if (!$reference instanceof AssetUsageInNodeProperties) {
+                continue;
+            }
+
+            $this->registerNodeChange($reference->getNode());
         }
     }
 

--- a/TYPO3.Neos/Configuration/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Policy.yaml
@@ -106,6 +106,9 @@ privilegeTargets:
     'TYPO3.Neos:Backend.Module.Media.ManageAssets':
       matcher: 'method(TYPO3\Neos\Controller\(Module\Management\Asset|Backend\MediaBrowser|Backend\ImageBrowser)Controller->(index|new|edit|update|initializeCreate|create|initializeUpload|upload|tagAsset|delete|createTag|editTag|updateTag|deleteTag|addAssetToCollection|relatedNodes)Action())'
 
+    'TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource':
+      matcher: 'method(TYPO3\Neos\Controller\(Module\Management\Asset|Backend\MediaBrowser|Backend\ImageBrowser)Controller->(replaceAssetResource|updateResource)Action())'
+
     'TYPO3.Neos:Backend.Module.Media.ManageAssetCollections':
       matcher: 'method(TYPO3\Neos\Controller\(Module\Management\Asset|Backend\MediaBrowser|Backend\ImageBrowser)Controller->(createAssetCollection|editAssetCollection|updateAssetCollection|deleteAssetCollection)Action())'
 
@@ -166,6 +169,10 @@ roles:
 
       -
         privilegeTarget: 'TYPO3.Neos:Backend.PublishAllToLiveWorkspace'
+        permission: GRANT
+
+      -
+        privilegeTarget: 'TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource'
         permission: GRANT
 
   'TYPO3.Neos:AbstractEditor':

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
@@ -62,14 +62,13 @@
 			</tr>
 		</thead>
 		<tbody>
-		<f:alias map="{'dragAndDropOnTagOrCollectionLabel': '{neos:backend.translate(id: \'media.tooltip.dragAndDropOnTagOrCollection\', source: \'Modules\', package: \'TYPO3.Neos\')}', 'editAsset': '{neos:backend.translate(id: \'media.tooltip.editAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
+		<f:alias map="{'dragAndDropOnTagOrCollectionLabel': '{neos:backend.translate(id: \'media.tooltip.dragAndDropOnTagOrCollection\', source: \'Modules\', package: \'TYPO3.Neos\')}', 'editAsset': '{neos:backend.translate(id: \'media.tooltip.editAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}', 'replaceAssetResource': '{neos:backend.translate(id: \'media.tooltip.replaceAssetResource\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
 			<f:for each="{paginatedAssets}" as="asset" iteration="iterator">
 				<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
 					<td>
 						<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{f:if(condition: asset.width, then: '{asset.width} x {asset.height}')}" data-html="true" data-content="{m:thumbnail(asset: asset, preset: 'TYPO3.Neos:Thumbnail', alt: asset.label, async: settings.asyncThumbnails) -> f:format.htmlentities()}">
 							<m:thumbnail asset="{asset}" preset="TYPO3.Neos:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
 						</div>
-						<i class="icon-move" title="{dragAndDropOnTagOrCollectionLabel}" data-neos-toggle="tooltip"></i>
 					</td>
 					<td class="asset-label"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
 					<td><span title="{asset.lastModified -> f:format.date(format: 'd-m-Y H:i')}" data-neos-toggle="tooltip">{asset.lastModified -> m:format.relativeDate()}</span></td>
@@ -81,8 +80,32 @@
 						</f:for>
 					</td>
 					<td class="neos-action">
-						<f:link.action action="edit" title="{editAsset}" class="neos-button neos-button-mini" arguments="{asset: asset}" data="{neos-toggle: 'tooltip'}"><i class="icon-pencil"></i></f:link.action>
-						<button class="neos-button neos-button-mini neos-button-danger" title="{neos:backend.translate(id: 'media.tooltip.deleteAsset', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
+						<div class="neos-dropdown" id="neos-asset-actionmenu-{asset -> f:format.identifier()}">
+							<a class="dropdown-toggle neos-button neos-button-mini" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
+								<i class="icon-ellipsis-horizontal"></i>
+							</a>
+							<div class="neos-dropdown-menu-list" role="menu">
+								<ul>
+									<li>
+										<f:link.action action="edit" arguments="{asset: asset}" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}">
+											<i class="icon-edit icon-white"></i> Edit
+										</f:link.action>
+									</li>
+									<f:security.ifAccess privilegeTarget="TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource">
+										<li>
+											<f:link.action action="replaceAssetResource" arguments="{asset: asset}" title="{replaceAssetResourceLabel}">
+												<i class="icon-random icon-white"></i> Replace
+											</f:link.action>
+										</li>
+									</f:security.ifAccess>
+									<li>
+										<a href="#" class="neos-media-delete" title="{deleteAssetLabel}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}">
+											<i class="icon-trash icon-white"></i> Delete
+										</a>
+									</li>
+								</ul>
+							</div>
+						</div>
 					</td>
 				</tr>
 			</f:for>

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
@@ -2,16 +2,46 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
 <f:widget.paginate objects="{assets}" as="paginatedAssets" configuration="{itemsPerPage: 30, maximumNumberOfLinks: 5}">
 	<ul class="neos-thumbnails asset-list">
-		<f:alias map="{'deleteAssetLabel': '{neos:backend.translate(id: \'media.tooltip.deleteAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
+		<f:alias map="{'deleteAssetLabel': '{neos:backend.translate(id: \'media.tooltip.deleteAsset\', source: \'Modules\', package: \'TYPO3.Neos\')}', 'replaceAssetResourceLabel': '{neos:backend.translate(id: \'media.tooltip.replaceAssetResource\', source: \'Modules\', package: \'TYPO3.Neos\')}'}">
 			<f:for each="{paginatedAssets}" as="asset">
 				<li class="asset">
 					<f:link.action action="edit" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}" class="neos-thumbnail" arguments="{asset: asset}">
 						<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
 							<m:thumbnail asset="{asset}" preset="TYPO3.Neos:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
-							<button class="neos-button neos-media-delete" title="{deleteAssetLabel}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}"><i class="icon-trash icon-white"></i></button>
 						</div>
-						<span class="neos-caption asset-label"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
 					</f:link.action>
+					<div class="neos-img-label">
+						<m:fileTypeIcon file="{asset}" height="16" />
+
+						<div class="neos-dropdown neos-pull-right" id="neos-asset-actionmenu-{asset -> f:format.identifier()}">
+							<a class="dropdown-toggle neos-button neos-button-small" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
+								<i class="icon-ellipsis-horizontal"></i>
+							</a>
+							<div class="neos-dropdown-menu-list" role="menu">
+								<ul>
+									<li>
+										<f:link.action action="edit" arguments="{asset: asset}" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}">
+											<i class="icon-edit icon-white"></i> Edit
+										</f:link.action>
+									</li>
+									<f:security.ifAccess privilegeTarget="TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource">
+										<li>
+											<f:link.action action="replaceAssetResource" arguments="{asset: asset}" title="{replaceAssetResourceLabel}">
+												<i class="icon-random icon-white"></i> Replace
+											</f:link.action>
+										</li>
+									</f:security.ifAccess>
+									<li>
+										<a href="#" class="neos-media-delete" title="{deleteAssetLabel}" data-neos-toggle="tooltip" data-modal="delete-asset-modal" data-label="{asset.label -> f:format.crop(maxCharacters: 50)}" data-object-identifier="{asset -> f:format.identifier()}">
+											<i class="icon-trash icon-white"></i> Delete
+										</a>
+									</li>
+								</ul>
+							</div>
+						</div>
+
+						<span class="neos-caption asset-label" title="{asset.label}"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
+					</div>
 				</li>
 			</f:for>
 		</f:alias>

--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_utilities.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_utilities.scss
@@ -43,3 +43,7 @@
 .neos-input-block-level {
   @include input-block-level();
 }
+
+.neos-buffer-below {
+  margin-bottom: 1em;
+}

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -486,7 +486,7 @@
 			font-size: 0;
 			margin-left: 0;
 
-			li {
+			> li {
 				margin-left: 0;
 				margin-right: $defaultMargin;
 				@include box-sizing(border-box);
@@ -560,13 +560,6 @@
 					overflow: hidden;
 					@include box-sizing(border-box);
 
-					&:hover {
-						.neos-media-delete,
-						&::after {
-							opacity: .9;
-						}
-					}
-
 					&.ui-draggable-dragging {
 						width: 250px;
 						height: 250px;
@@ -576,47 +569,6 @@
 						background-color: $grayDarker;
 						outline: 3px solid $grayDarker;
 					}
-
-					.neos-media-delete {
-						position: absolute;
-						bottom: 0;
-						right: 0;
-						background-color: $grayDark;
-						opacity: .5;
-
-						&:hover {
-							background-color: $warning;
-						}
-					}
-
-					&::after {
-						@include fa-icon();
-						content: $fa-var-arrows;
-						display: block;
-						position: absolute;
-						left: 0;
-						bottom: 0;
-						width: $unit;
-						height: $unit;
-						background-color: $grayDark;
-						opacity: .5;
-						color: #fff;
-						font-size: 16px;
-						text-align: center;
-						line-height: $unit;
-						cursor: move;
-					}
-				}
-
-				.neos-caption {
-					padding: 0;
-					display: block;
-					font-size: 12px;
-					line-height: 1.2;
-					color: $textSubtleLight;
-					overflow: hidden;
-					text-overflow: ellipsis;
-					white-space: nowrap;
 				}
 
 				> a {
@@ -632,7 +584,7 @@
 						text-decoration: none;
 					}
 
-					img {
+					.neos-img-container > img {
 						position: absolute;
 						top: 50%;
 						left: 50%;
@@ -641,6 +593,27 @@
 						width: auto;
 						max-height: 100%;
 						max-width: 100%;
+					}
+				}
+
+				.neos-img-label {
+					padding: 0 0 1rem .5rem;
+					position: relative;
+					font-size: 12px;
+
+					.neos-caption {
+						padding: 0 0 0 .5rem;
+						margin-right: 2rem;
+						display: block;
+						line-height: 1.2;
+						color: $textSubtleLight;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+					}
+
+					> img {
+						float: left;
 					}
 				}
 			}
@@ -706,6 +679,11 @@
 			margin-right: $relatedMargin;
 			margin-bottom: $wideMargin;
 		}
+	}
+
+	.neos-media-content-help {
+		font-style: italic;
+		padding-bottom: 1em;
 	}
 
 	//Styles for image preview in edit mode
@@ -841,16 +819,15 @@
 			}
 		}
 
-		.icon-move {
-			float: left;
-			line-height: $unit;
-			padding-left: $relatedMargin + $tightMargin;
-		}
-
 		.neos-action {
 			width: 10%;
 			font-size: 0;
 			text-align: right;
+
+			.neos-dropdown {
+				display: inline-block;
+				font-size: 12px;
+			}
 
 			.neos-modal {
 				text-align: left;
@@ -862,12 +839,8 @@
 		vertical-align: baseline;
 	}
 
-	.draggable-asset {
-		cursor: move;
-	}
-
 	&:not(.media-module) {
-		table.neos-table {
+		table.neos-table:not(.neos-no-hover) {
 			tbody tr:hover td {
 				background-color: $blue;
 				cursor: pointer;

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
@@ -74,6 +74,9 @@
 		</div>
 		<div class="neos-footer">
 			<f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
+			<f:security.ifAccess privilegeTarget="TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource">
+				<f:link.action action="replaceAssetResource" arguments="{asset: asset}" class="neos-button">{neos:backend.translate(id: 'media.replaceAssetResource', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
+			</f:security.ifAccess>
 			<f:if condition="{asset.inUse}">
 				<f:then>
 					<a title="{neos:backend.translate(id: 'media.deleteRelatedNodes', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip" class="neos-button neos-button-danger neos-disabled">{neos:backend.translate(id: 'media.delete', source: 'Modules', package: 'TYPO3.Neos')}</a>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Index.html
@@ -238,6 +238,9 @@
 	</div>
 	<f:if condition="{assets}">
 		<f:then>
+			<div class="neos-media-content-help">
+				<i class="icon-info-circle"></i> {neos:backend.translate(id: 'media.dragHelp', source: 'Modules', package: 'TYPO3.Neos')}
+			</div>
 			<f:render partial="{view}View" arguments="{assets: assets, sortBy: sortBy, sortDirection: sortDirection}" />
 			<div class="neos-hide" id="delete-asset-modal">
 				<div class="neos-modal-centered">
@@ -278,6 +281,10 @@
 	<script type="text/javascript">
 		var uploadUrl = '<f:uri.action action="upload" additionalParams="{__csrfToken: \"{f:security.csrfToken()}\"}" absolute="true" />';
 		var maximumFileUploadSize = {maximumFileUploadSize};
+
+		if (window.parent !== window && window.parent.Typo3MediaBrowserCallbacks && window.parent.Typo3MediaBrowserCallbacks.refreshThumbnail) {
+			window.parent.Typo3MediaBrowserCallbacks.refreshThumbnail();
+		}
 	</script>
 	<f:form action="tagAsset" id="tag-asset-form" format="json">
 		<f:form.hidden name="asset[__identity]" id="tag-asset-form-asset" />

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -7,11 +7,12 @@
 <f:section name="Content">
 	<legend>{neos:backend.translate(id: 'media.relatedNodes.referencesTo', source: 'Modules', arguments: {asset: asset.label})}</legend>
 
-	<table class="neos-table">
+	<table class="neos-table neos-no-hover">
 		<thead>
 			<tr>
 				<th>{neos:backend.translate(id: 'document')}</th>
 				<th>{neos:backend.translate(id: 'reference')}</th>
+				<th>&nbsp;</th>
 				<f:if condition="{contentDimensions}">
 					<th>{neos:backend.translate(id: 'contentDimensions')}</th>
 				</f:if>
@@ -48,12 +49,10 @@
 									<li>
 										<f:if condition="{relatedNode.accessible}">
 											<f:then>
-												<neos:link.node node="{relatedNode.contextDocumentNode}">
-													<f:if condition="{relatedNode.node.nodeType.ui.icon}">
-														<i class="{relatedNode.node.nodeType.ui.icon}" title="{f:if(condition: relatedNode.node.nodeType.label, then: '{neos:backend.translate(id: relatedNode.node.nodeType.label)}', else: '{relatedNode.node.nodeType.name}')}" data-neos-toggle="tooltip" data-placement="left"></i>
-													</f:if>
-													<span title="{relatedNode.node.path}" data-neos-toggle="tooltip" data-placement="left">{relatedNode.node.label}</span>
-												</neos:link.node>
+												<f:if condition="{relatedNode.node.nodeType.ui.icon}">
+													<i class="{relatedNode.node.nodeType.ui.icon}" title="{f:if(condition: relatedNode.node.nodeType.label, then: '{neos:backend.translate(id: relatedNode.node.nodeType.label)}', else: '{relatedNode.node.nodeType.name}')}" data-neos-toggle="tooltip" data-placement="left"></i>
+												</f:if>
+												<span title="{relatedNode.node.path}" data-neos-toggle="tooltip" data-placement="left">{relatedNode.node.label}</span>
 											</f:then>
 											<f:else>
 												<f:if condition="{relatedNode.node.nodeType.ui.icon}">
@@ -62,6 +61,15 @@
 												<span title="{relatedNode.node.path}" data-neos-toggle="tooltip" data-placement="left">{relatedNode.node.label}</span>
 											</f:else>
 										</f:if>
+									</li>
+								</f:for>
+							</ul>
+						</td>
+						<td>
+							<ul>
+								<f:for each="{documentNode.nodes}" as="relatedNode">
+									<li>
+										<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank"><i class="icon-external-link"></i></neos:link.node>
 									</li>
 								</f:for>
 							</ul>
@@ -124,7 +132,8 @@
 	</table>
 
 	<div class="neos-footer">
-		<f:link.action action="edit" arguments="{asset:asset}" class="neos-button">{neos:backend.translate(id: 'back', source: 'Modules')}</f:link.action>
+		<!-- TODO: Find a nicer way to send the referer for a get request -->
+		<a href="javascript:window.history.back(1);" class="neos-button">{neos:backend.translate(id: 'back', source: 'Modules')}</a>
 	</div>
 
 	<script>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -1,0 +1,77 @@
+{namespace m=TYPO3\Media\ViewHelpers}
+{namespace neos=TYPO3\Neos\ViewHelpers}
+<f:layout name="UploadImage" />
+
+<f:section name="Title">Replace view of AssetController</f:section>
+
+<f:section name="Content">
+    <f:form method="post" arguments="{asset: asset}" action="updateResource" enctype="multipart/form-data">
+        <div class="neos-row-fluid">
+            <div class="neos-span8">
+                <fieldset>
+                    <legend>Replace "{asset.resource.filename}"</legend>
+                    <p class="neos-buffer-below">
+                        You can replace this asset by uploading a new file. Once replaced, the new asset will be used on all places where the asset is used on your website.<br/>
+                        <b>Note:</b> This operation will replace the asset in all published or unpublished workspaces, including the live website.
+                    </p>
+                    <label class="neos-button neos-button-primary" for="resource" title="Max. upload size {humanReadableMaximumFileUploadSize} per file" data-neos-toggle="tooltip">Choose a new file <i class="icon-file"></i></label>
+                    <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}" />
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <label class="neos-checkbox neos-inline">
+                            <f:form.checkbox name="options[keepOriginalFilename]" value="1" /><span></span> {neos:backend.translate(id: 'media.replace.options.keepOriginalFilename', arguments: {0: asset.resource.filename}, source: 'Modules', package: 'TYPO3.Neos')}
+                        </label>
+                    </div>
+                    <f:if condition="{redirectPackageEnabled}">
+                        <div>
+                            <label class="neos-checkbox neos-inline">
+                                <f:form.checkbox name="options[generateRedirects]" value="1" checked="true" /><span></span> {neos:backend.translate(id: 'media.replace.options.generateRedirects', source: 'Main', package: 'TYPO3.Media')}
+                            </label>
+                        </div>
+                    </f:if>
+                </fieldset>
+                <fieldset>
+                    <legend>Usage</legend>
+                    <f:if condition="{asset.inUse}">
+                        <f:then>
+                            <p class="neos-buffer-below">Currently the asset is used {asset.usageCount} times.</p>
+                            <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
+                                Show all usages
+                            </f:link.action>
+                        </f:then>
+                        <f:else>
+                            <p>Currently the asset is not in used anywhere on the website</p>
+                        </f:else>
+                    </f:if>
+                </fieldset>
+            </div>
+
+            <div class="neos-span4 neos-image-example">
+                <f:render section="ContentImage" arguments="{_all}" />
+            </div>
+        </div>
+        <div class="neos-footer">
+            <f:link.action action="index" title="Cancel editing" class="neos-button">Cancel</f:link.action>
+            <f:form.submit id="replace" class="neos-button neos-button-primary" value="Replace" />
+        </div>
+    </f:form>
+</f:section>
+
+<f:section name="ContentImage">
+    <label>Preview current file</label>
+    <div class="neos-preview-image">
+        <a href="{f:uri.resource(resource: asset.resource)}" target="_blank">
+            <m:thumbnail asset="{asset}" maximumWidth="1000" maximumHeight="1000" alt="{asset.label}" class="img-polaroid" />
+        </a>
+    </div>
+</f:section>
+
+<f:section name="Scripts">
+    <script type="text/javascript">
+        var maximumFileUploadSize = {maximumFileUploadSize};
+    </script>
+    <script type="text/javascript" src="{f:uri.resource(package: 'TYPO3.Media', path: 'Scripts/new.js')}"></script>
+</f:section>
+
+

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -209,6 +209,13 @@
 				<source>All changes from workspace "{0}" have been discarded.</source>
 			</trans-unit>
 
+			<trans-unit id="media.dragHelp" xml:space="preserve">
+				<source>Drag and drop image on a collection / tag to add them to it.</source>
+			</trans-unit>
+			<trans-unit id="media.replace.options.keepOriginalFilename" xml:space="preserve">
+				<source>Keep the filename "{0}"</source>
+			</trans-unit>
+
 			<trans-unit id="media.label" xml:space="preserve">
 				<source>Media</source>
 			</trans-unit>
@@ -674,6 +681,9 @@
 			<trans-unit id="media.tooltip.editAsset" xml:space="preserve">
 				<source>Edit asset</source>
 			</trans-unit>
+			<trans-unit id="media.tooltip.replaceAssetResource" xml:space="preserve">
+				<source>Replace</source>
+			</trans-unit>
 			<trans-unit id="media.tooltip.deleteAsset" xml:space="preserve">
 				<source>Delete asset</source>
 			</trans-unit>
@@ -700,6 +710,9 @@
 			</trans-unit>
 			<trans-unit id="media.cancel" xml:space="preserve">
 				<source>Cancel</source>
+			</trans-unit>
+			<trans-unit id="media.replaceAssetResource" xml:space="preserve">
+				<source>Replace</source>
 			</trans-unit>
 			<trans-unit id="media.saveEditing" xml:space="preserve">
 				<source>Save</source>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
@@ -34,7 +34,14 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 
 			// Create new instance per asset editor to avoid side effects
 			this.set('_mediaBrowserView', Ember.View.extend({
-				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-media-browser"]').attr('href') + '"></iframe>')
+				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-media-browser"]').attr('href') + '"></iframe>'),
+				didInsertElement: function() {
+					this.$().find('iframe').on('load', function(event) {
+						if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.onLoad) {
+							window.Typo3MediaBrowserCallbacks.onLoad(event);
+						}
+					});
+				}
 			}));
 
 			this.set('assets', Ember.A());

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
@@ -267,7 +267,6 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 		 * and reads the image if possible
 		 */
 		didInsertElement: function () {
-			var that = this;
 			this._super();
 
 			this.$().find('.neos-inspector-image-thumbnail-inner').css({
@@ -298,19 +297,52 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 		_mediaBrowserView: null,
 
 		_beforeMediaBrowserIsShown: function () {
-			var that = this;
+			var that = this,
+				value = null;
+
+			try {
+				if (this.get('value')) {
+					value = JSON.parse(this.get('value'));
+				}
+			} catch (exception) {
+				console.log('Invalid JSON value in image editor', this.get('value'));
+			}
+
 			window.Typo3MediaBrowserCallbacks = {
-				assetChosen: function (assetIdentifier) {
+				_assetIdentifier: value && '__identity' in value ? value.__identity : null,
+				_frameLoaded: false,
+				_reloadPreviewImage: function() {
+					var originalPreviewImageResourceUri = that.get('_previewImageUri');
+
 					that._displayImageLoader();
 
 					that.set('_loadPreviewImageHandler', HttpClient.getResource(
-						that.get('_imageServiceEndpointUri') + '?image=' + assetIdentifier,
+						that.get('_imageServiceEndpointUri') + '?image=' + this._assetIdentifier,
 						{dataType: 'json'}
 					));
 					that.get('_loadPreviewImageHandler').then(function (result) {
-						that.fileUploaded(result);
+						if (originalPreviewImageResourceUri !== result.previewImageResourceUri) {
+							that.fileUploaded(result);
+						}
 						that._hideImageLoader();
 					});
+				},
+				onLoad: function() {
+					this._frameLoaded = true;
+				},
+				refreshThumbnail: function() {
+					if (this._frameLoaded) {
+						this._reloadPreviewImage();
+					}
+				},
+				assetChosen: function(assetIdentifier) {
+					if (assetIdentifier) {
+						this._assetIdentifier = assetIdentifier;
+						this._reloadPreviewImage();
+					}
+					that.set('mediaBrowserShown', false);
+				},
+				close: function() {
 					that.set('mediaBrowserShown', false);
 				}
 			};
@@ -320,7 +352,14 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 
 		_initializeMediaBrowserEditView: function () {
 			this.set('_mediaBrowserEditView', Ember.View.extend({
-				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-image-browser-edit"]').attr('href') + '?asset[__identity]=' + this.get("_object").__identity + '"></iframe>')
+				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-image-browser-edit"]').attr('href') + '?asset[__identity]=' + this.get("_object").__identity + '"></iframe>'),
+				didInsertElement: function() {
+					this.$().find('iframe').on('load', function(event) {
+						if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.onLoad) {
+							window.Typo3MediaBrowserCallbacks.onLoad(event);
+						}
+					});
+				}
 			}));
 		},
 
@@ -1027,7 +1066,14 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 
 		_initializeMediaView: function () {
 			this.set('_mediaBrowserView', Ember.View.extend({
-				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-image-browser"]').attr('href') + '"></iframe>')
+				template: Ember.Handlebars.compile('<iframe style="width:100%; height: 100%" src="' + $('link[rel="neos-image-browser"]').attr('href') + '"></iframe>'),
+				didInsertElement: function() {
+					this.$().find('iframe').on('load', function(event) {
+						if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.onLoad) {
+							window.Typo3MediaBrowserCallbacks.onLoad(event);
+						}
+					});
+				}
 			}));
 		},
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/SecondaryInspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/SecondaryInspectorController.js
@@ -62,6 +62,9 @@ function(Ember, Button) {
 		 * Always hide the given view class
 		 */
 		hide: function() {
+			if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.close) {
+				window.Typo3MediaBrowserCallbacks.close();
+			}
 			this.set('_visible', false);
 		}
 	}).create();

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -6229,6 +6229,9 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
+.neos .neos-buffer-below {
+  margin-bottom: 1em;
+}
 @media (min-width: 1200px) {
   .neos .neos-row {
     margin-left: -30px;
@@ -13467,7 +13470,7 @@
   font-size: 0;
   margin-left: 0;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li {
   margin-left: 0;
   margin-right: 16px;
   -webkit-box-sizing: border-box;
@@ -13478,108 +13481,108 @@
   vertical-align: top;
 }
 @media (max-width: 479px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px) / 2);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(2n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(2n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(2n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(2n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(2n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(2n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(2n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(2n):after {
     clear: both;
   }
 }
 @media (min-width: 480px) and (max-width: 767px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px * 2) / 3);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):after {
     clear: both;
   }
 }
 @media (min-width: 768px) and (max-width: 1023px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px * 2) / 3);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(3n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(3n):after {
     clear: both;
   }
 }
 @media (min-width: 1024px) and (max-width: 1199px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px * 3) / 4);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(4n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(4n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(4n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(4n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(4n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(4n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(4n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(4n):after {
     clear: both;
   }
 }
 @media (min-width: 1200px) and (max-width: 1599px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px * 4) / 5);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(5n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(5n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(5n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(5n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(5n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(5n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(5n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(5n):after {
     clear: both;
   }
 }
 @media (min-width: 1600px) {
-  .neos.media-browser .neos-media-assets .neos-thumbnails li {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li {
     width: calc((100% - 16px * 5) / 6);
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(6n) {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(6n) {
     margin-right: 0;
     *zoom: 1;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(6n):before, .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(6n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(6n):before, .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(6n):after {
     display: table;
     content: "";
     line-height: 0;
   }
-  .neos.media-browser .neos-media-assets .neos-thumbnails li:nth-child(6n):after {
+  .neos.media-browser .neos-media-assets .neos-thumbnails > li:nth-child(6n):after {
     clear: both;
   }
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-container {
   position: relative;
   padding-bottom: 100%;
   height: 0;
@@ -13593,60 +13596,15 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container:hover .neos-media-delete, .neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container:hover::after {
-  opacity: .9;
-}
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container.ui-draggable-dragging {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-container.ui-draggable-dragging {
   width: 250px;
   height: 250px;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container img {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-container img {
   background-color: #141414;
   outline: 3px solid #141414;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container .neos-media-delete {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  background-color: #222;
-  opacity: .5;
-}
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container .neos-media-delete:hover {
-  background-color: #ff460d;
-}
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-img-container::after {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome;
-  font-size: inherit;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  content: "";
-  display: block;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 40px;
-  height: 40px;
-  background-color: #222;
-  opacity: .5;
-  color: #fff;
-  font-size: 16px;
-  text-align: center;
-  line-height: 40px;
-  cursor: move;
-}
-.neos.media-browser .neos-media-assets .neos-thumbnails li .neos-caption {
-  padding: 0;
-  display: block;
-  font-size: 12px;
-  line-height: 1.2;
-  color: #adadad;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.neos.media-browser .neos-media-assets .neos-thumbnails li > a {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li > a {
   border: 0;
   border-radius: 0;
   display: block;
@@ -13654,11 +13612,11 @@
   position: relative;
   padding: 0;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li > a:hover {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li > a:hover {
   box-shadow: none;
   text-decoration: none;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails li > a img {
+.neos.media-browser .neos-media-assets .neos-thumbnails > li > a .neos-img-container > img {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -13671,6 +13629,24 @@
   width: auto;
   max-height: 100%;
   max-width: 100%;
+}
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label {
+  padding: 0 0 1rem .5rem;
+  position: relative;
+  font-size: 12px;
+}
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label .neos-caption {
+  padding: 0 0 0 .5rem;
+  margin-right: 2rem;
+  display: block;
+  line-height: 1.2;
+  color: #adadad;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label > img {
+  float: left;
 }
 @media (max-width: 540px) {
   .neos.media-browser .neos-media-assets .page-navigation ul li {
@@ -13722,6 +13698,10 @@
 .neos.media-browser .neos-row-fluid .neos-image-inputs .neos-button {
   margin-right: 8px;
   margin-bottom: 32px;
+}
+.neos.media-browser .neos-media-content-help {
+  font-style: italic;
+  padding-bottom: 1em;
 }
 .neos.media-browser .neos-row-fluid [class*="neos-span"].neos-image-example label {
   text-align: right;
@@ -13849,15 +13829,14 @@
 .neos.media-browser table.neos-table.asset-list .neos-popover.neos-bottom .neos-arrow {
   border-bottom-color: #222;
 }
-.neos.media-browser table.neos-table.asset-list .icon-move {
-  float: left;
-  line-height: 40px;
-  padding-left: 12px;
-}
 .neos.media-browser table.neos-table.asset-list .neos-action {
   width: 10%;
   font-size: 0;
   text-align: right;
+}
+.neos.media-browser table.neos-table.asset-list .neos-action .neos-dropdown {
+  display: inline-block;
+  font-size: 12px;
 }
 .neos.media-browser table.neos-table.asset-list .neos-action .neos-modal, .neos.media-browser table.neos-table.asset-list .neos-action .neos-modal-content {
   text-align: left;
@@ -13865,22 +13844,19 @@
 .neos.media-browser table.neos-info-table i {
   vertical-align: baseline;
 }
-.neos.media-browser .draggable-asset {
-  cursor: move;
-}
-.neos.media-browser:not(.media-module) table.neos-table tbody tr:hover td {
+.neos.media-browser:not(.media-module) table.neos-table:not(.neos-no-hover) tbody tr:hover td {
   background-color: #00b5ff;
   cursor: pointer;
 }
-.neos.media-browser:not(.media-module) table.neos-table tbody tr:hover td .neos-label {
+.neos.media-browser:not(.media-module) table.neos-table:not(.neos-no-hover) tbody tr:hover td .neos-label {
   background-color: #fff;
   color: #00b5ff;
   text-shadow: none;
 }
-.neos.media-browser:not(.media-module) table.neos-table .icon-move {
+.neos.media-browser:not(.media-module) table.neos-table:not(.neos-no-hover) .icon-move {
   cursor: move;
 }
-.neos.media-browser:not(.media-module) table.neos-table .neos-action {
+.neos.media-browser:not(.media-module) table.neos-table:not(.neos-no-hover) .neos-action {
   display: none;
 }
 .neos.media-browser .neos-upload-area {


### PR DESCRIPTION
Introduce replacement of files in Neos. When an asset
is replaced the content cache for nodes that use the
asset or a variant is flushed. Also a 301 redirect from
the old resource url to the new url is created.

Because the changes are applied to the asset model directly
the changes will be live immediately. For this reason
the replace functionality is restricted to live publishers
in Neos.

In case image variants have cropping instructions they
will be reset to the maximum bounds for the new image.