### PR TITLE
BUGFIX: Fix default expression to generate node labels

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -1,6 +1,6 @@
 # Base node, which just configures the "removed" property of the node.
 'TYPO3.Neos:Node':
-  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '\/<br\\W*?\\/?>|\\x{00a0}|[[^:print:]]|\\s+\/u', ' '))), 100, '...')}"
+  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[[^:print:]]|\\s+/u', ' '))), 100, '...')}"
   abstract: TRUE
   ui:
     inspector:


### PR DESCRIPTION
The PR #448 changed the default expression used to generate the label by
adding a preg_replace. The way the pattern is specified breaks with the
php-yaml extension.

This changes fixes it by removing the backslash characters before the
slashes delimiting the pattern.

NEOS-1818 #close