### PR TITLE
BUGFIX: Reenable the nodeTypes properties.ui configuration validation

### DIFF
--- a/TYPO3.Neos/Documentation/Appendixes/ChangeLogs/2011.rst
+++ b/TYPO3.Neos/Documentation/Appendixes/ChangeLogs/2011.rst
@@ -1,0 +1,59 @@
+`2.0.11 (2016-05-09) <https://github.com/neos/neos-development-collection/releases/tag/2.0.11>`_
+================================================================================================
+
+Overview of merged pull requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`BUGFIX: Incompatible constructor in Video model <https://github.com/neos/neos-development-collection/pull/499>`_
+-----------------------------------------------------------------------------------------------------------------
+
+The Video model has an incompatible constructor as the Asset
+model require a $resource argument. This change adds the argument
+to the constructor and adds a test to prevent regressions.
+
+* Packages: ``Media``
+
+`BUGFIX: Exclude initialize*Actions from Testing Policy <https://github.com/neos/neos-development-collection/pull/492>`_
+------------------------------------------------------------------------------------------------------------------------
+
+We should always exclude initialize*Actions from method policy
+matchers and this didn't happen in the Testing ``Policy.yaml``.
+For unit and functional tests this does not pose a big problem
+but behat tests fail when trying to call the backend login for
+example.
+
+* Packages: ``Neos``
+
+`BUGFIX: Editing asset collection <https://github.com/neos/neos-development-collection/pull/476>`_
+--------------------------------------------------------------------------------------------------
+
+Prevents an exception thrown while property mapping for the title constructor parameter.
+
+* Packages: ``Media`` ``TYPO3CR``
+
+`BUGFIX: Free index space at target position if no free index space is available <https://github.com/neos/neos-development-collection/pull/462>`_
+-------------------------------------------------------------------------------------------------------------------------------------------------
+
+If a node is inserted at a given position between nodes and no free sorting index is available, the sortindices on
+that level are renumbered. The previous code for that could lead to unexpected node reordering and sortingindex
+value escalation if workspaces or dimensions were used.
+
+The following steps reproduce the error:
+* In dimension A create nodes between other nodes until there are no free sortindices available
+* Create a variant of those nodes in dimension B
+* In dimension B add a new node in a place where no free sort index is available
+
+Since the previous code is only repositioning one item of a given index and does not take workspaces and dimensions
+into account this results in the following unwanted effects:
+* Unwanted reordering of the nodes in dimension A
+* In dimension B two nodes with identical sortingindex occur which makes the order of the nodes random
+* If this is repeated multiple times the sorting indices in dimension A escalate quickly to very high values
+
+This patch resolves this behavior by freeing index space at the target position instead of renumbering the
+whole level by modifying all nodes on the given path and incrementing all sort indices above the reference position
+a consistent behavior across workspaces and dimensions is ensured.
+
+* Packages: ``Neos`` ``TYPO3CR``
+
+`Detailed log <https://github.com/neos/neos-development-collection/compare/2.0.10...2.0.11>`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -4,7 +4,7 @@ additionalProperties:
   type: dictionary
   properties:
     'properties':
-      type: ['dictionary', 'null']
+      type: 'dictionary'
       additionalProperties:
         # for each property...
         type: dictionary

--- a/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -19,6 +19,7 @@ use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
@@ -77,6 +78,11 @@ class PublishingServiceTest extends UnitTestCase
      */
     protected $mockSite;
 
+    /**
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $mockContentDimensionPresetSource;
+
     public function setUp()
     {
         $this->publishingService = new PublishingService();
@@ -100,6 +106,10 @@ class PublishingServiceTest extends UnitTestCase
         $this->mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
         $this->mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue($this->mockSite));
         $this->inject($this->publishingService, 'siteRepository', $this->mockSiteRepository);
+
+        $this->mockContentDimensionPresetSource = $this->getMockBuilder(ContentDimensionPresetSourceInterface::class)->disableOriginalConstructor()->getMock();
+        $this->mockContentDimensionPresetSource->expects($this->any())->method('findPresetsByTargetValues')->will($this->returnArgument(0));
+        $this->inject($this->publishingService, 'contentDimensionPresetSource', $this->mockContentDimensionPresetSource);
 
         $this->mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
         $this->mockWorkspace->expects($this->any())->method('getName')->with()->will($this->returnValue('workspace-name'));

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ConfigurationContentDimensionPresetSource.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ConfigurationContentDimensionPresetSource.php
@@ -54,8 +54,10 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
         if (isset($this->configuration[$dimensionName]['defaultPreset']) && isset($this->configuration[$dimensionName]['presets'][$this->configuration[$dimensionName]['defaultPreset']])) {
             $preset = $this->configuration[$dimensionName]['presets'][$this->configuration[$dimensionName]['defaultPreset']];
             $preset['identifier'] = $this->configuration[$dimensionName]['defaultPreset'];
+
             return $preset;
         }
+
         return null;
     }
 
@@ -68,10 +70,12 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
             foreach ($this->configuration[$dimensionName]['presets'] as $presetIdentifier => $presetConfiguration) {
                 if (isset($presetConfiguration['values']) && $presetConfiguration['values'] === $dimensionValues) {
                     $presetConfiguration['identifier'] = $presetIdentifier;
+
                     return $presetConfiguration;
                 }
             }
         }
+
         return null;
     }
 
@@ -89,7 +93,7 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
             return null;
         }
 
-        $dimensionConfiguration = array($dimensionName => $this->configuration[$dimensionName]);
+        $dimensionConfiguration = [$dimensionName => $this->configuration[$dimensionName]];
         $sorter = new PositionalArraySorter($dimensionConfiguration[$dimensionName]['presets']);
         $dimensionConfiguration[$dimensionName]['presets'] = $sorter->toArray();
 
@@ -130,6 +134,7 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
                 }
             }
         }
+
         return true;
     }
 
@@ -155,6 +160,7 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
         if (array_key_exists('*', $constraints[$dimensionName])) {
             return (boolean)$constraints[$dimensionName]['*'];
         }
+
         return true;
     }
 
@@ -172,5 +178,63 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
             }
         }
         $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findPresetsByTargetValues(array $targetValues)
+    {
+        $matchingPresets = [];
+        $allPresets = $this->getAllPresets();
+
+        foreach ($targetValues as $dimensionName => $dimensionValues) {
+            $matchingPresets[$dimensionName] = array_reduce($allPresets[$dimensionName]['presets'], function ($primaryPreset, $presetForDimension) use ($dimensionValues) {
+                return $this->comparePresetsForTargetValue($presetForDimension, $dimensionValues, $primaryPreset);
+            }, null);
+
+            if ($matchingPresets[$dimensionName] !== null) {
+                continue;
+            }
+
+            $matchingPresets[$dimensionName] = [
+                'label' => reset($dimensionValues),
+                'values' =>  $dimensionValues
+            ];
+        }
+
+        return $matchingPresets;
+    }
+
+    /**
+     * Compares the given $possibleBetterPreset to the $targetValues (based on the position of the contained values)
+     * and returns either $possibleBetterPreset or the $currentBestPreset, depending on the result.
+     *
+     * @param array $possibleBetterPreset
+     * @param array $targetValues
+     * @param array $currentBestPreset
+     * @return array
+     */
+    protected function comparePresetsForTargetValue(array $possibleBetterPreset, array $targetValues, array $currentBestPreset = null)
+    {
+        if (!isset($possibleBetterPreset['values'][0])) {
+            return $currentBestPreset;
+        }
+
+        if ($possibleBetterPreset['values'] === $targetValues) {
+            return $possibleBetterPreset;
+        }
+
+        if ($possibleBetterPreset['values'][0] === reset($targetValues)) {
+            return $possibleBetterPreset;
+        }
+
+        foreach ($targetValues as $targetValue) {
+            if ($currentBestPreset === null && in_array($targetValue, $possibleBetterPreset['values'])) {
+                return $possibleBetterPreset;
+            }
+        }
+
+        return $currentBestPreset;
     }
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
@@ -86,4 +86,14 @@ interface ContentDimensionPresetSourceInterface
      * @return boolean
      */
     public function isPresetCombinationAllowedByConstraints(array $dimensionsNamesAndPresetIdentifiers);
+
+    /**
+     * Finds for each configured dimension the best matching preset based on given target value for that dimension.
+     *
+     * The $targetValues array should have the dimension as key and the target value (single value) as value.
+     *
+     * @param array $targetValues
+     * @return array
+     */
+    public function findPresetsByTargetValues(array $targetValues);
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\Context;
 use TYPO3\TYPO3CR\Exception\WorkspaceException;
 use TYPO3\TYPO3CR\Service\Utility\NodePublishingDependencySolver;
@@ -50,6 +51,12 @@ class PublishingService implements PublishingServiceInterface
      * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
      */
     protected $contextFactory;
+
+    /**
+     * @Flow\Inject
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $contentDimensionPresetSource;
 
     /**
      * Returns a list of nodes contained in the given workspace which are not yet published
@@ -225,12 +232,17 @@ class PublishingService implements PublishingServiceInterface
      */
     protected function createContext(Workspace $workspace, array $dimensionValues, array $contextProperties = array())
     {
+        $presetsMatchingDimensionValues = $this->contentDimensionPresetSource->findPresetsByTargetValues($dimensionValues);
+        $dimensions = array_map(function ($preset) {
+            return $preset['values'];
+        }, $presetsMatchingDimensionValues);
+
         $contextProperties += array(
             'workspaceName' => $workspace->getName(),
             'inaccessibleContentShown' => true,
             'invisibleContentShown' => true,
             'removedContentShown' => true,
-            'dimensions' => $dimensionValues
+            'dimensions' => $dimensions
         );
 
         return $this->contextFactory->create($contextProperties);

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
@@ -106,11 +106,11 @@ Feature: Move node with dimension support
 
     And I get a node by path "/sites/typo3cr/company/service" with the following context:
       | Workspace | Language |
-      | admin     | en       |
+      | live      | en       |
     Then I should have one node
     And I get a node by path "/sites/typo3cr/company/service" with the following context:
       | Workspace | Language |
-      | admin     | de       |
+      | live      | de       |
     Then I should have one node
 
   @fixtures


### PR DESCRIPTION
The configuration of the single properties was altered to support null or dictionary types. Since the both schemas were written as an array of simple types the validator did not use the additionalProperties section any more and only checked wether the property was null or a dictionary.

This change alteres the notation of both types to add make use of the dictionary subvalidation again.