### PR TITLE
BUGFIX: Editing asset collection

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
@@ -43,6 +43,9 @@ class AssetCollection
      */
     protected $tags;
 
+    /**
+     * @param string $title
+     */
     public function __construct($title)
     {
         $this->title = $title;


### PR DESCRIPTION
Prevents an exception thrown while property mapping for the title constructor parameter.