### PR TITLE
BUGFIX: Call to getIdentifier on non object in usage references

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -28,6 +28,7 @@ use TYPO3\Neos\Domain\Service\UserService as DomainUserService;
 use TYPO3\Neos\Service\UserService;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\Node;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 
@@ -168,9 +169,10 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
             $flowQuery = new FlowQuery([$node]);
             /** @var Node $documentNode */
             $documentNode = $flowQuery->closest('[instanceof TYPO3.Neos:Document]')->get(0);
+            $documentNodeIdentifier = $documentNode instanceof NodeInterface ? $documentNode->getIdentifier() : null;
             $relatedNodes[$site->getNodeName()]['site'] = $site;
-            $relatedNodes[$site->getNodeName()]['documentNodes'][$documentNode->getIdentifier()]['node'] = $documentNode;
-            $relatedNodes[$site->getNodeName()]['documentNodes'][$documentNode->getIdentifier()]['nodes'][] = [
+            $relatedNodes[$site->getNodeName()]['documentNodes'][$documentNodeIdentifier]['node'] = $documentNode;
+            $relatedNodes[$site->getNodeName()]['documentNodes'][$documentNodeIdentifier]['nodes'][] = [
                 'node' => $node,
                 'nodeData' => $relatedNodeData,
                 'contextDocumentNode' => $documentNode,

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -38,7 +38,9 @@
 							<f:if condition="{documentNode.node.nodeType.ui.icon}">
 								<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label)}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
 							</f:if>
-							<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
+							<f:if condition="{documentNode.node}">
+								<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
+							</f:if>
 						</td>
 						<td>
 							<ul>


### PR DESCRIPTION
In the usages overview for assets in the media module a list is rendered
with a path to the node where an asset is still used. This leads to a
call to getIdentifier() on a non object if the parent document node
is removed in the live / current users workspace.

As we can not display the title of the document in the other users workspace
this change leaves out the breadcrumb to the node in the overview.