### PR TITLE
TASK: ``LoginController`` respects JSON on authentication failure

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -147,7 +147,11 @@ class LoginController extends AbstractAuthenticationController
      */
     protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
     {
-        $this->addFlashMessage('The entered username or password was wrong', 'Wrong credentials', Message::SEVERITY_ERROR, array(), ($exception === null ? 1347016771 : $exception->getCode()));
+        if ($this->view instanceof JsonView) {
+            $this->view->assign('value', array('success' => false));
+        } else {
+            $this->addFlashMessage('The entered username or password was wrong', 'Wrong credentials', Message::SEVERITY_ERROR, array(), ($exception === null ? 1347016771 : $exception->getCode()));
+        }
     }
 
     /**


### PR DESCRIPTION
Adds a JSON output of ``"success" => false`` if authentication failed.

NEOS-1510 #close