### PR TITLE
FEATURE: Filetype icon view helper

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/IconThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/IconThumbnailGenerator.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Domain\Service\FileTypeIconService;
 use TYPO3\Media\Domain\Service\ImageService;
 use TYPO3\Media\Exception;
 
@@ -50,58 +51,13 @@ class IconThumbnailGenerator extends AbstractThumbnailGenerator
 
             /** @var AssetInterface $asset */
             $asset = $thumbnail->getOriginalAsset();
-            $icon = $this->getAssetIcon($asset, $width, $height);
+            $icon = FileTypeIconService::getIcon($asset, $width, $height);
             $thumbnail->setStaticResource($icon['src']);
             $thumbnail->setWidth($icon['width']);
             $thumbnail->setHeight($icon['height']);
         } catch (\Exception $exception) {
             $message = sprintf('Unable to generate thumbnail for the given image (filename: %s, SHA1: %s)', $thumbnail->getOriginalAsset()->getResource()->getFilename(), $thumbnail->getOriginalAsset()->getResource()->getSha1());
             throw new Exception\NoThumbnailAvailableException($message, 1433109654, $exception);
-        }
-    }
-
-    /**
-     * @param AssetInterface $asset
-     * @param integer $maximumWidth
-     * @param integer $maximumHeight
-     * @return array
-     */
-    protected function getAssetIcon(AssetInterface $asset, $maximumWidth, $maximumHeight)
-    {
-        // TODO: Could be configurable at some point
-        $iconPackage = 'TYPO3.Media';
-
-        $iconSize = $this->getDocumentIconSize($maximumWidth, $maximumHeight);
-
-        if (is_file('resource://' . $iconPackage . '/Public/Icons/16px/' . $asset->getResource()->getFileExtension() . '.png')) {
-            $icon = sprintf('Icons/%spx/' . $asset->getResource()->getFileExtension() . '.png', $iconSize);
-        } else {
-            $icon = sprintf('Icons/%spx/_blank.png', $iconSize);
-        }
-
-        return [
-            'width' => $iconSize,
-            'height' => $iconSize,
-            'src' => 'resource://' . $iconPackage . '/Public/' . $icon
-        ];
-    }
-
-    /**
-     * @param integer $maximumWidth
-     * @param integer $maximumHeight
-     * @return integer
-     */
-    protected function getDocumentIconSize($maximumWidth, $maximumHeight)
-    {
-        $size = max($maximumWidth, $maximumHeight);
-        if ($size <= 16) {
-            return 16;
-        } elseif ($size <= 32) {
-            return 32;
-        } elseif ($size <= 48) {
-            return 48;
-        } else {
-            return 512;
         }
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/FileTypeIconService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/FileTypeIconService.php
@@ -1,0 +1,68 @@
+<?php
+namespace TYPO3\Media\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Media\Domain\Model\AssetInterface;
+
+/**
+ * Service that retrieves an icon for the filetype of a given asset
+ */
+class FileTypeIconService
+{
+    /**
+     * Returns an icon for a filetype within given dimensions
+     *
+     * @param AssetInterface $asset
+     * @param integer $maximumWidth
+     * @param integer $maximumHeight
+     * @return array
+     */
+    public static function getIcon(AssetInterface $asset, $maximumWidth, $maximumHeight)
+    {
+        // TODO: Could be configurable at some point
+        $iconPackage = 'TYPO3.Media';
+
+        $iconSize = self::getDocumentIconSize($maximumWidth, $maximumHeight);
+
+        if (is_file('resource://' . $iconPackage . '/Public/Icons/16px/' . $asset->getResource()->getFileExtension() . '.png')) {
+            $icon = sprintf('Icons/%spx/' . $asset->getResource()->getFileExtension() . '.png', $iconSize);
+        } else {
+            $icon = sprintf('Icons/%spx/_blank.png', $iconSize);
+        }
+
+        return [
+            'width' => $iconSize,
+            'height' => $iconSize,
+            'src' => 'resource://' . $iconPackage . '/Public/' . $icon,
+            'alt' => $asset->getResource()->getFileExtension()
+        ];
+    }
+
+    /**
+     * @param integer $maximumWidth
+     * @param integer $maximumHeight
+     * @return integer
+     */
+    protected function getDocumentIconSize($maximumWidth, $maximumHeight)
+    {
+        $size = max($maximumWidth, $maximumHeight);
+        if ($size <= 16) {
+            return 16;
+        } elseif ($size <= 32) {
+            return 32;
+        } elseif ($size <= 48) {
+            return 48;
+        } else {
+            return 512;
+        }
+    }
+}

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/FileTypeIconViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/FileTypeIconViewHelper.php
@@ -1,0 +1,82 @@
+<?php
+namespace TYPO3\Media\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Service\FileTypeIconService;
+
+/**
+ * Renders an <img> HTML tag for a filetype icon for a given TYPO3.Media's asset instance
+ *
+ * = Examples =
+ *
+ * <code title="Rendering an asset filetype icon">
+ * <typo3.media:fileTypeIcon asset="{assetObject}" alt="a filetype icon" height="16" />
+ * </code>
+ * <output>
+ * (depending on the asset, no scaling applied)
+ * <img src="_Resources/Static/Packages/TYPO3/Media/Icons/16px/jpg.png" height="16" alt="a filetype icon" />
+ * </output>
+ *
+ */
+class FileTypeIconViewHelper extends AbstractTagBasedViewHelper
+{
+    /**
+     * @Flow\Inject
+     * @var ResourceManager
+     */
+    protected $resourceManager;
+
+    /**
+     * name of the tag to be created by this view helper
+     *
+     * @var string
+     */
+    protected $tagName = 'img';
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerUniversalTagAttributes();
+    }
+
+    /**
+     * Renders an <img> HTML tag for a filetype icon for a given TYPO3.Media's asset instance
+     *
+     * @param AssetInterface $file
+     * @param integer|null $width
+     * @param integer|null $height
+     * @return string
+     */
+    public function render(AssetInterface $file, $width = null, $height = null)
+    {
+        $icon = FileTypeIconService::getIcon($file, $width, $height);
+        $this->tag->addAttribute('src', $this->resourceManager->getPublicPackageResourceUriByPath($icon['src']));
+        $this->tag->addAttribute('alt', $icon['alt']);
+
+        if ($width !== null) {
+            $this->tag->addAttribute('width', $width);
+        }
+
+        if ($height !== null) {
+            $this->tag->addAttribute('height', $height);
+        }
+
+        return $this->tag->render();
+    }
+}


### PR DESCRIPTION
This change introduces a Filetype icon viewhelper
that renders a simple image tag with an icon for the
type of a given asset based on it's mediatypes and
given maximum dimensions.

Besides that it moves the logic for retrieving the icon
to a service that can be used outside of the thumbnail
generator service too.