### PR TITLE
BUGFIX: Prevent database constraint violation during site prune with existing domains

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
@@ -56,6 +56,12 @@ class SiteService
     protected $workspaceRepository;
 
     /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
      * Remove given site all nodes for that site and all domains associated.
      *
      * @param Site $site
@@ -74,6 +80,8 @@ class SiteService
         foreach ($domainsForSite as $domain) {
             $this->domainRepository->remove($domain);
         }
+        $this->persistenceManager->persistAll();
+
         $this->siteRepository->remove($site);
 
         $this->emitSitePruned($site);


### PR DESCRIPTION
Deleting a site, e.g. using the ``site:prune`` command, fails due a database constraint violation.
This is due to Doctrine delete ordering, the site is deleted before the domains.

NEOS-178