### PR TITLE
BUGFIX: Exclude initialize*Actions from Testing Policy

### DIFF
--- a/TYPO3.Neos/Configuration/Testing/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Testing/Policy.yaml
@@ -5,4 +5,4 @@
 privilegeTargets:
   'TYPO3\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
     'TYPO3.Neos:AllControllerActions':
-      matcher: 'within(TYPO3\Flow\Mvc\Controller\AbstractController) && method(public .*->.*Action()) &&! method(public .*\Tests\.*\Fixtures\.*->.*Action())'
+      matcher: 'within(TYPO3\Flow\Mvc\Controller\AbstractController) && method(public .*->.(?!initialize).*Action()) &&! method(public .*\Tests\.*\Fixtures\.*->.(?!initialize).*Action())'


### PR DESCRIPTION
We should always exclude initialize*Actions from method policy
matchers and this didn't happen in the Testing ``Policy.yaml``.
For unit and functional tests this does not pose a big problem
but behat tests fail when trying to call the backend login for
example.