### PR TITLE
BUGFIX: Support empty dimension values for default fallbacks

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
@@ -60,6 +60,7 @@ class ParentsOperation extends AbstractOperation
         $output = array();
         $outputNodePaths = array();
         foreach ($flowQuery->getContext() as $contextNode) {
+            /** @var NodeInterface $contextNode */
             $siteNode = $contextNode->getContext()->getCurrentSiteNode();
             while ($contextNode !== $siteNode && $contextNode->getParent() !== null) {
                 $contextNode = $contextNode->getParent();

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -1708,7 +1708,13 @@ class Node implements NodeInterface, CacheAwareInterface
         $contextDimensions = $this->context->getDimensions();
         foreach ($this->context->getTargetDimensions() as $dimensionName => $targetDimensionValue) {
             if (!isset($dimensions[$dimensionName])) {
-                return false;
+                if ($targetDimensionValue === null) {
+                    continue;
+                } else {
+                    return false;
+                }
+            } elseif ($targetDimensionValue === null && $dimensions[$dimensionName] === array()) {
+                continue;
             } elseif (!in_array($targetDimensionValue, $dimensions[$dimensionName], true)) {
                 $contextDimensionValues = $contextDimensions[$dimensionName];
                 $targetPositionInContext = array_search($targetDimensionValue, $contextDimensionValues, true);

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -802,7 +802,7 @@ class NodeData extends AbstractNodeData
         if ($dimensions !== null) {
             $nodeDimensionValues = $this->dimensionValues;
             foreach ($dimensions as $dimensionName => $dimensionValues) {
-                if (!isset($nodeDimensionValues[$dimensionName]) || array_intersect($nodeDimensionValues[$dimensionName], $dimensionValues) === []) {
+                if (isset($nodeDimensionValues[$dimensionName]) && $nodeDimensionValues[$dimensionName] !== [] && array_intersect($nodeDimensionValues[$dimensionName], $dimensionValues) === []) {
                     return false;
                 }
             }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/Context.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/Context.php
@@ -461,7 +461,9 @@ class Context
      */
     public function getTargetDimensionValues()
     {
-        return array_map(function ($value) { return array($value); }, $this->getTargetDimensions());
+        return array_map(function ($value) {
+            return $value === null ? array() : array($value);
+        }, $this->getTargetDimensions());
     }
 
     /**

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/Context.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/Context.php
@@ -462,7 +462,7 @@ class Context
     public function getTargetDimensionValues()
     {
         return array_map(function ($value) {
-            return $value === null ? array() : array($value);
+            return $value === null ? [] : [ $value ];
         }, $this->getTargetDimensions());
     }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContextFactory.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContextFactory.php
@@ -228,8 +228,8 @@ class ContextFactory implements ContextFactoryInterface
             if (!isset($contextProperties['dimensions'][$dimensionName])) {
                 throw new InvalidNodeContextException(sprintf('Failed creating a %s because the specified target dimension "%s" does not exist', $this->contextImplementation, $dimensionName), 1391340781);
             }
-            if (!in_array($dimensionValue, $contextProperties['dimensions'][$dimensionName])) {
-                throw new InvalidNodeContextException(sprintf('Failed creating a %s because the specified target dimension value %s for dimension %s is not in the list of dimension values (%s)', $this->contextImplementation, $dimensionValue, $dimensionName, implode(', ', $contextProperties['dimensions'][$dimensionName])), 1391340741);
+            if ($dimensionValue !== null && !in_array($dimensionValue, $contextProperties['dimensions'][$dimensionName])) {
+                throw new InvalidNodeContextException(sprintf('Failed creating a %s because the specified target dimension value "%s" for dimension "%s" is not in the list of dimension values (%s)', $this->contextImplementation, $dimensionValue, $dimensionName, implode(', ', $contextProperties['dimensions'][$dimensionName])), 1391340741);
             }
         }
     }

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -320,6 +320,34 @@ trait NodeOperationsTrait
     }
 
     /**
+     * @When /^I run getNode with the path "([^"]*)" on the current node$/
+     */
+    public function iRunGetNodeWithThePathOnTheCurrentNode($path)
+    {
+        if ($this->isolated === true) {
+            $this->callStepInSubProcess(__METHOD__);
+        } else {
+            $node = $this->iShouldHaveOneNode();
+            $retrievedNode = $node->getNode($path);
+            $this->currentNodes = $retrievedNode ? [ $retrievedNode ] : [];
+        }
+    }
+
+    /**
+     * @When /^I retrieve the current site node$/
+     */
+    public function iRetrieveTheCurrentSiteNode()
+    {
+        if ($this->isolated === true) {
+            $this->callStepInSubProcess(__METHOD__);
+        } else {
+            $node = $this->iShouldHaveOneNode();
+            $retrievedNode = $node->getContext()->getCurrentSiteNode();
+            $this->currentNodes = $retrievedNode ? [ $retrievedNode ] : [];
+        }
+    }
+
+    /**
      * @When /^I publish the node$/
      */
     public function iPublishNodeToWorkspaceWithTheFollowingContext()

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -908,7 +908,11 @@ trait NodeOperationsTrait
                     $contextProperties['dimensions'][substr($propertyName, strlen('Dimension: '))] = Arrays::trimExplode(',', $propertyValue);
                 }
 
+                // FIXME We lack a good API to manipulate dimension values explicitly or assign multiple values, so we are doing this via target dimension values
                 if (strpos($propertyName, 'Target dimension: ') === 0) {
+                    if ($propertyValue === '') {
+                        $propertyValue = null;
+                    }
                     $contextProperties['targetDimensions'][substr($propertyName, strlen('Target dimension: '))] = $propertyValue;
                 }
             }

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/EmptyDimensionValues.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/EmptyDimensionValues.feature
@@ -1,0 +1,45 @@
+Feature: Empty dimension values act as a fallback
+  In order to have nodes without knowledge about particular dimensions
+  As an API user of the content repository
+  I need a way to access nodes without dimension values
+
+  Background:
+    Given I have the following content dimensions:
+      | Identifier | Default   |
+      | language   | en_US     |
+      | personas   | everybody |
+    And I have the following nodes:
+      | Identifier                           | Path           | Node Type                  | Properties        | Dimension: language | Target dimension: language | Dimension: personas | Target dimension: personas |
+      # Intentionally the /sites node should not have any dimension value assigned!
+      | 0befa678-79ad-11e5-b465-14109fd7a2dd | /sites         | unstructured               |                   |                     |                            |                     |                            |
+      | 17046dc8-79ad-11e5-9fef-14109fd7a2dd | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | en_US               | en_US                      | specialist          | specialist                 |
+
+  @fixtures
+  Scenario: Node variant with empty dimension values is found
+    When I get a node by path "/sites" with the following context:
+      | Dimension: language | Dimension: personas |
+      | de_DE               | everybody           |
+    Then I should have one node
+
+    When I get a node by path "/sites/typo3cr" with the following context:
+      | Dimension: language | Dimension: personas |
+      | de_DE               | everybody           |
+    Then I should have 0 nodes
+
+  @fixtures
+  Scenario: Node variant with empty dimension values has least priority
+    Given I have the following nodes:
+      | Identifier                           | Path           | Node Type                  | Properties                | Target dimension: language | Target dimension: personas |
+      | 17046dc8-79ad-11e5-9fef-14109fd7a2dd | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Default Home"} |                            |                            |
+
+    When I get a node by path "/sites/typo3cr" with the following context:
+      | Dimension: language | Dimension: personas |
+      | de_DE               | everybody           |
+    Then I should have one node
+    And the node property "title" should be "Default Home"
+
+    When I get a node by path "/sites/typo3cr" with the following context:
+      | Dimension: language | Dimension: personas   |
+      | de_DE, en_US        | specialist, everybody |
+    Then I should have one node
+    And the node property "title" should be "Home"

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/FindSiteNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/FindSiteNode.feature
@@ -1,0 +1,66 @@
+Feature: Find site node in non-default content dimension context
+  In order to determine the full path leading to a node with non-default dimension values
+  As an API user of the content repository
+  I need a way to access the site node regardless of the current dimension value context
+
+  Background:
+    Given I have the following content dimensions:
+      | Identifier | Default | Presets                                                                                        |
+      | language   | en      | de=de; fr=fr; nl=nl; es=es; it=it                                                              |
+      | country    | int     | be=be,int; de=de,int; fr=fr,int lu=lu,int; nl=nl,int; ch=ch,int; gb=gb,int; us=us,int; int=int |
+
+    And I have the following nodes:
+      | Identifier                           | Path                                    | Node Type                  | Properties                         | Dimension: language | Target dimension: language | Dimension: country | Target dimension: country |
+      | 0befa678-79ad-11e5-b465-14109fd7a2dd | /sites                                  | unstructured               |                                    |                     |                            |                    |                           |
+      | 8f9b7036-17b7-b7e0-c3e0-844ffd82aace | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home DE DE"}            | de                  | de                         | de                 | de                        |
+      | a00bf041-6939-172f-5a71-c29495301c7a | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home DE INT"}           | de                  | de                         | int                | int                       |
+      | b02c29d2-bf3d-1092-44a7-43a92834fa72 | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home EN FR"}            | en                  | en                         | fr                 | fr                        |
+      | c6499b0c-f9a2-e94b-860a-6ac7e57bbbb7 | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home EN INT"}           | en                  | en                         | int                | int                       |
+      | 56b1c647-4a08-ab32-0995-ab452222ec70 | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home NL BE"}            | nl                  | nl                         | be                 | be                        |
+      | 6b4a6b39-5a49-fa66-b0a2-b312b02183a1 | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home NL LU"}            | nl                  | nl                         | lu                 | lu                        |
+      | 1f46a576-20bb-225e-a517-682e07b4a046 | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home FR FR"}            | fr                  | fr                         | fr                 | fr                        |
+      | 61eb69ba-de68-4ec2-079c-b1d04fc2719a | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home ES INT"}           | es                  | es                         | int                | int                       |
+      | e3424a9b-f5cc-f294-2366-2764187e5c4f | /sites/wwwexamplecom                    | TYPO3.TYPO3CR.Testing:Page | {"title": "Home IT INT"}           | it                  | it                         | int                | int                       |
+      | a616c868-67dd-4c30-83ef-e14893bc7bb9 | /sites/wwwexamplecom/shop               | TYPO3.TYPO3CR.Testing:Page | {"title": "Shop DE INT"}           | de                  | de                         | int                | int                       |
+      | fcc8f596-c358-4fc1-8ba4-efe864e07e0b | /sites/wwwexamplecom/shop               | TYPO3.TYPO3CR.Testing:Page | {"title": "Shop EN INT"}           | en                  | en                         | int                | int                       |
+      | 92d9ca30-c769-4660-94e0-dc93bcfcbb7a | /sites/wwwexamplecom/shop               | TYPO3.TYPO3CR.Testing:Page | {"title": "Shop ES INT"}           | es                  | es                         | int                | int                       |
+      | affba0f6-52d8-4456-93ea-d208cad6c97e | /sites/wwwexamplecom/shop               | TYPO3.TYPO3CR.Testing:Page | {"title": "Shop IT INT"}           | it                  | it                         | int                | int                       |
+      | e2dba764-27c8-4279-aadf-e060f0b6621d | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine DE DE"}  | de                  | de                         | de                 | de                        |
+      | bbde4a73-ec71-40de-8dc0-fc1beae9accd | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine DE INT"} | de                  | de                         | int                | int                       |
+      | 723a5937-5429-45c6-ac8a-7ac55b6c91d5 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine EN FR"}  | en                  | en                         | fr                 | fr                        |
+      | 0f7071ab-4a4f-403c-9503-68f7bf34d8cc | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine EN INT"} | en                  | en                         | int                | int                       |
+      | 397b9558-bac7-46d2-bf7a-13249cec1195 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine NL BE"}  | nl                  | nl                         | be                 | be                        |
+      | 607d28e4-8e5c-4746-9f02-ab85a07c1b97 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine NL LU"}  | nl                  | nl                         | lu                 | lu                        |
+      | 0d80f01c-1234-4b73-9c0f-d1ec6f4592ed | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine FR FR"}  | fr                  | fr                         | fr                 | fr                        |
+      | 46c505c2-fb5f-46f5-aba1-37fe17a1a000 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine ES INT"} | es                  | es                         | int                | int                       |
+      | ebd4bef1-5f51-4348-9d31-f221cc8cc1d7 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine IT INT"} | it                  | it                         | int                | int                       |
+
+  @fixtures
+  Scenario: Retrieve site node from a node which is connected to the site node through a node with the same dimension values
+    When I get a node by path "/sites/wwwexamplecom/shop" with the following context:
+      | Dimension: language | Dimension: country |
+      | de                  | int                |
+    Then I should have one node
+    And the node property "title" should be "Shop DE INT"
+
+    When I get a node by path "/sites/wwwexamplecom/shop/coffeemachine" with the following context:
+      | Dimension: language | Dimension: country |
+      | de                  | int                |
+    Then I should have one node
+    And the node property "title" should be "Coffee Machine DE INT"
+
+    When I run getNode with the path "../../" on the current node
+    Then I should have one node
+    And the node property "title" should be "Home DE INT"
+
+  @fixtures
+  Scenario: Retrieve site node from a node which is NOT connected to the site node through a node with the same dimension values
+    When I get a node by identifier "e2dba764-27c8-4279-aadf-e060f0b6621d" with the following context:
+      | Dimension: language | Dimension: country |
+      | de                  | de                 |
+    Then I should have one node
+    And the node property "title" should be "Coffee Machine DE DE"
+
+    When I run getNode with the path "../../" on the current node
+    Then I should have one node
+    And the node property "title" should be "Home DE DE"


### PR DESCRIPTION
Implement support for empty dimension values (for any number of dimensions) of a node variant.
This allows to have nodes like ``/sites`` that will always be found, independent from the dimensions
of the context.

Another case is the transition to new dimensions that will be much easier because existing nodes
are already visible.

NEOS-1633 #close