### PR TITLE
BUGFIX: Incompatible constructor in Video model

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Video.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Video.php
@@ -13,6 +13,7 @@ namespace TYPO3\Media\Domain\Model;
 
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\Resource as FlowResource;
 
 /**
  * A Video asset
@@ -35,10 +36,12 @@ class Video extends Asset
 
     /**
      * Constructs the object and sets default values for width and height
+     *
+     * @param FlowResource $resource
      */
-    public function __construct()
+    public function __construct(FlowResource $resource)
     {
-        parent::__construct();
+        parent::__construct($resource);
 
         $this->width = -1;
         $this->height = -1;

--- a/TYPO3.Media/Tests/Unit/Domain/Model/VideoTest.php
+++ b/TYPO3.Media/Tests/Unit/Domain/Model/VideoTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace TYPO3\Media\Tests\Unit\Domain\Model;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\Video;
+
+/**
+ * Test case for the Video model
+ */
+class VideoTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function dimensionsDefaultToMinusOneOnConstruct()
+    {
+        $mockResource = $this->getMock('TYPO3\Flow\Resource\Resource');
+
+        $video = new Video($mockResource);
+
+        $this->assertEquals(-1, $video->getWidth());
+        $this->assertEquals(-1, $video->getHeight());
+    }
+}


### PR DESCRIPTION
The Video model has an incompatible constructor as the Asset
model require a $resource argument. This change adds the argument
to the constructor and adds a test to prevent regressions.