### PR TITLE
BUGFIX: Travis builds fail because RedirectStorageInterface is not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - composer install --no-progress --no-interaction
   - composer update --no-progress --no-interaction
+  - composer require neos/redirecthandler-databasestorage
   - rm -rf Packages/Neos
   - mv ../neos-development-collection Packages/Neos
 before_script:


### PR DESCRIPTION
Since the redirect packages were removed from the Flow development repository
the Travis build fail on master because the Neos adapter package is still in
the Neos development repository.
This leads to an error because the RedirectStorageInterface is injected into
``Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService``.

This change installs the neos/redirecthandler-databasestorage package so the
redirect handler package and a storage implementation is available during the build.