### PR TITLE
BUGFIX: Handle missing node type group gracefully

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/InsertNodePanel.js
@@ -30,14 +30,21 @@ define(
 						helpMessage = nodeType.ui.help.message;
 					}
 
-					var groupName = nodeType.ui.group || 'general';
-					nodeTypeGroups.findBy('name', groupName).get('nodeTypes').pushObject({
-						'nodeType': nodeTypeName,
-						'label': I18n.translate(nodeType.ui.label),
-						'helpMessage': helpMessage,
-						'icon': nodeType.ui.icon || 'icon-file',
-						'position': nodeType.ui.position
-					});
+					var groupName = 'group' in nodeType.ui ? nodeType.ui.group : 'general';
+					if (groupName) {
+						var group = nodeTypeGroups.findBy('name', groupName);
+						if (group) {
+							group.get('nodeTypes').pushObject({
+								'nodeType': nodeTypeName,
+								'label': I18n.translate(nodeType.ui.label),
+								'helpMessage': helpMessage,
+								'icon': nodeType.ui.icon || 'icon-file',
+								'position': nodeType.ui.position
+							});
+						} else {
+							window.console.warn('Node type group "' + groupName + '" not found for node type "' + nodeTypeName + '", defined in "Settings" configuration "TYPO3.Neos.nodeTypes.groups"');
+						}
+					}
 				});
 			}
 		});

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/InsertNodePanel.js
@@ -62,14 +62,21 @@ function(
 					helpMessage = type.metadata.ui.help.message;
 				}
 
-				var groupName = type.metadata.ui.group || 'general';
-				nodeTypeGroups.findBy('name', groupName).get('nodeTypes').pushObject({
-					'nodeType': nodeTypeName,
-					'label': I18n.translate(type.metadata.ui.label),
-					'helpMessage': helpMessage,
-					'icon': 'icon' in type.metadata.ui ? type.metadata.ui.icon : 'icon-file',
-					'position': type.metadata.ui.position
-				});
+				var groupName = 'group' in type.metadata.ui ? type.metadata.ui.group : 'general';
+				if (groupName) {
+					var group = nodeTypeGroups.findBy('name', groupName);
+					if (group) {
+						group.get('nodeTypes').pushObject({
+							'nodeType': nodeTypeName,
+							'label': I18n.translate(type.metadata.ui.label),
+							'helpMessage': helpMessage,
+							'icon': 'icon' in type.metadata.ui ? type.metadata.ui.icon : 'icon-file',
+							'position': type.metadata.ui.position
+						});
+					} else {
+						window.console.warn('Node type group "' + groupName + '" not found for node type "' + nodeTypeName + '", defined in "Settings" configuration "TYPO3.Neos.nodeTypes.groups"');
+					}
+				}
 			});
 		},
 


### PR DESCRIPTION
Gracefully handle a node type configured configured with a non-existing
node type group.

Additionally changes the behavior when the group is set to null,
making it possible to hide the node type. If the group is not set,
it will default to the "general" group as previously.

Regression of 54aa91f19c8776a96003a631c23d8c1556fb33fe

NEOS-786 #comment Fix regression