### PR TITLE
FEATURE: Use data source to list forms in inspector

### DIFF
--- a/TYPO3.Neos.NodeTypes/Classes/TYPO3/Neos/NodeTypes/Service/DataSource/FormDefinitionDataSource.php
+++ b/TYPO3.Neos.NodeTypes/Classes/TYPO3/Neos/NodeTypes/Service/DataSource/FormDefinitionDataSource.php
@@ -1,0 +1,48 @@
+<?php
+namespace TYPO3\Neos\NodeTypes\Service\DataSource;
+
+/*
+ * This file is part of the TYPO3.Neos.NodeTypes package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Neos\Service\DataSource\AbstractDataSource;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\Flow\Annotations as Flow;
+
+class FormDefinitionDataSource extends AbstractDataSource
+{
+
+    /**
+     * @var string
+     */
+    protected static $identifier = 'neos-nodetypes-form-definitions';
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Form\Persistence\YamlPersistenceManager
+     */
+    protected $yamlPersistenceManager;
+
+    /**
+     * @param NodeInterface|null $node
+     * @param array $arguments
+     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     */
+    public function getData(NodeInterface $node = null, array $arguments)
+    {
+        $formDefinitions['']['label'] = '';
+        $forms = $this->yamlPersistenceManager->listForms();
+
+        foreach ($forms as $form) {
+            $formDefinitions[$form['identifier']]['label'] = $form['name'];
+        }
+
+        return $formDefinitions;
+    }
+}

--- a/TYPO3.Neos.NodeTypes/Configuration/NodeTypes.Content.yaml
+++ b/TYPO3.Neos.NodeTypes/Configuration/NodeTypes.Content.yaml
@@ -283,9 +283,7 @@
           editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             placeholder: i18n
-            values:
-              '':
-                label: ''
+            dataSourceIdentifier: 'neos-nodetypes-form-definitions'
 
 'TYPO3.Neos.NodeTypes:AssetList':
   superTypes:

--- a/TYPO3.Neos/Documentation/HowTos/AddingSimpleContactForm.rst
+++ b/TYPO3.Neos/Documentation/HowTos/AddingSimpleContactForm.rst
@@ -12,21 +12,7 @@ Yaml (Sites/Vendor.Site/Configuration/Settings.yaml) ::
       yamlPersistenceManager:
         savePath: 'resource://Vendor.Site/Private/Form/'
 
-Yaml (Sites/Vendor.Site/Configuration/NodeTypes.yaml) ::
-
-  'TYPO3.Neos.NodeTypes:Form':
-    properties:
-      formIdentifier:
-        ui:
-          inspector:
-            editorOptions:
-              values:
-                '': ~
-                # Maps to the file Sites/Vendor.Site/Resources/Private/Form/contact-form.yaml
-                'contact-form':
-                  label: 'contact-form'
-
-Now place a valid TYPO3.Form Yaml configuration the Private/Form folder. Then add a Form Element where
+Now place a valid TYPO3.Form Yaml configuration in the Private/Form folder. Then add a Form Element where
 you wish the form to be displayed and select it from the dropdown in the Inspector.
 
 Yaml (Sites/Vendor.Site/Resources/Private/Form/contact-form.yaml) ::


### PR DESCRIPTION
Currently form identifiers need to be defined manually extending
the properties of ``TYPO3.Neos.NodeTypes:Form`` .
This change adds a data source which uses the
`TYPO3\Form\Persistence\YamlPersistenceManager::listForms`
to list all available forms automatically.