### PR TITLE
BUGFIX: Show installed version of packages in package manager backend module

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
@@ -44,7 +44,7 @@ class PackagesController extends \TYPO3\Neos\Controller\Module\AbstractModuleCon
             $packageGroup = substr($packagePath, 0, strpos($packagePath, '/'));
             $packageGroups[$packageGroup][$package->getPackageKey()] = array(
                 'sanitizedPackageKey' => str_replace('.', '', $package->getPackageKey()),
-                'version' => $package->getPackageMetaData()->getVersion(),
+                'version' => $package->getInstalledVersion(),
                 'name' => $package->getComposerManifest('name'),
                 'type' => $package->getComposerManifest('type'),
                 'description' => $package->getPackageMetaData()->getDescription(),

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
@@ -44,7 +44,7 @@ class PackagesController extends \TYPO3\Neos\Controller\Module\AbstractModuleCon
             $packageGroup = substr($packagePath, 0, strpos($packagePath, '/'));
             $packageGroups[$packageGroup][$package->getPackageKey()] = array(
                 'sanitizedPackageKey' => str_replace('.', '', $package->getPackageKey()),
-                'version' => $package->getInstalledVersion() ? $package->getInstalledVersion() : $package->getPackageMetaData()->getVersion(),
+                'version' => $package->getInstalledVersion(),
                 'name' => $package->getComposerManifest('name'),
                 'type' => $package->getComposerManifest('type'),
                 'description' => $package->getPackageMetaData()->getDescription(),

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
@@ -44,7 +44,7 @@ class PackagesController extends \TYPO3\Neos\Controller\Module\AbstractModuleCon
             $packageGroup = substr($packagePath, 0, strpos($packagePath, '/'));
             $packageGroups[$packageGroup][$package->getPackageKey()] = array(
                 'sanitizedPackageKey' => str_replace('.', '', $package->getPackageKey()),
-                'version' => $package->getInstalledVersion(),
+                'version' => $package->getInstalledVersion() ? $package->getInstalledVersion() : $package->getPackageMetaData()->getVersion(),
                 'name' => $package->getComposerManifest('name'),
                 'type' => $package->getComposerManifest('type'),
                 'description' => $package->getPackageMetaData()->getDescription(),


### PR DESCRIPTION
Show the actually installed version of each package instead of the defined version in the composer manifest.

NEOS-1826 #close