### PR TITLE
BUGFIX: Publishable Node Context considers dimension fallbacks

### DIFF
--- a/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -19,6 +19,7 @@ use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
@@ -77,6 +78,11 @@ class PublishingServiceTest extends UnitTestCase
      */
     protected $mockSite;
 
+    /**
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $mockContentDimensionPresetSource;
+
     public function setUp()
     {
         $this->publishingService = new PublishingService();
@@ -100,6 +106,10 @@ class PublishingServiceTest extends UnitTestCase
         $this->mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
         $this->mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue($this->mockSite));
         $this->inject($this->publishingService, 'siteRepository', $this->mockSiteRepository);
+
+        $this->mockContentDimensionPresetSource = $this->getMockBuilder(ContentDimensionPresetSourceInterface::class)->disableOriginalConstructor()->getMock();
+        $this->mockContentDimensionPresetSource->expects($this->any())->method('findPresetsByTargetValues')->will($this->returnArgument(0));
+        $this->inject($this->publishingService, 'contentDimensionPresetSource', $this->mockContentDimensionPresetSource);
 
         $this->mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
         $this->mockWorkspace->expects($this->any())->method('getName')->with()->will($this->returnValue('workspace-name'));

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ConfigurationContentDimensionPresetSource.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ConfigurationContentDimensionPresetSource.php
@@ -207,12 +207,15 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
     }
 
     /**
+     * Compares the given $possibleBetterPreset to the $targetValues (based on the position of the contained values)
+     * and returns either $possibleBetterPreset or the $currentBestPreset, depending on the result.
+     *
      * @param array $possibleBetterPreset
      * @param array $targetValues
      * @param array $currentBestPreset
      * @return array
      */
-    protected function comparePresetsForTargetValue(array $possibleBetterPreset, $targetValues, array $currentBestPreset = null)
+    protected function comparePresetsForTargetValue(array $possibleBetterPreset, array $targetValues, array $currentBestPreset = null)
     {
         if (!isset($possibleBetterPreset['values'][0])) {
             return $currentBestPreset;

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
@@ -86,4 +86,14 @@ interface ContentDimensionPresetSourceInterface
      * @return boolean
      */
     public function isPresetCombinationAllowedByConstraints(array $dimensionsNamesAndPresetIdentifiers);
+
+    /**
+     * Finds for each configured dimension the best matching preset based on given target value for that dimension.
+     *
+     * The $targetValues array should habe the dimension as key and the target value (single value) as value.
+     *
+     * @param array $targetValues
+     * @return array
+     */
+    public function findPresetsByTargetValues(array $targetValues);
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ContentDimensionPresetSourceInterface.php
@@ -90,7 +90,7 @@ interface ContentDimensionPresetSourceInterface
     /**
      * Finds for each configured dimension the best matching preset based on given target value for that dimension.
      *
-     * The $targetValues array should habe the dimension as key and the target value (single value) as value.
+     * The $targetValues array should have the dimension as key and the target value (single value) as value.
      *
      * @param array $targetValues
      * @return array

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Service/PublishingService.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Domain\Service\Context;
 use TYPO3\TYPO3CR\Exception\WorkspaceException;
 use TYPO3\TYPO3CR\Service\Utility\NodePublishingDependencySolver;
@@ -50,6 +51,12 @@ class PublishingService implements PublishingServiceInterface
      * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
      */
     protected $contextFactory;
+
+    /**
+     * @Flow\Inject
+     * @var ContentDimensionPresetSourceInterface
+     */
+    protected $contentDimensionPresetSource;
 
     /**
      * Returns a list of nodes contained in the given workspace which are not yet published
@@ -225,12 +232,17 @@ class PublishingService implements PublishingServiceInterface
      */
     protected function createContext(Workspace $workspace, array $dimensionValues, array $contextProperties = array())
     {
+        $presetsMatchingDimensionValues = $this->contentDimensionPresetSource->findPresetsByTargetValues($dimensionValues);
+        $dimensions = array_map(function ($preset) {
+            return $preset['values'];
+        }, $presetsMatchingDimensionValues);
+
         $contextProperties += array(
             'workspaceName' => $workspace->getName(),
             'inaccessibleContentShown' => true,
             'invisibleContentShown' => true,
             'removedContentShown' => true,
-            'dimensions' => $dimensionValues
+            'dimensions' => $dimensions
         );
 
         return $this->contextFactory->create($contextProperties);

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
@@ -106,11 +106,11 @@ Feature: Move node with dimension support
 
     And I get a node by path "/sites/typo3cr/company/service" with the following context:
       | Workspace | Language |
-      | admin     | en       |
+      | live      | en       |
     Then I should have one node
     And I get a node by path "/sites/typo3cr/company/service" with the following context:
       | Workspace | Language |
-      | admin     | de       |
+      | live      | de       |
     Then I should have one node
 
   @fixtures


### PR DESCRIPTION
The Context created for Nodes in a workspace in the ``PublishingService``
was derived from the ``NodeData`` entities dimension values, which should only
be the target values of the context but (wrongly) doesn't consider fallbacks
configured in presets.

To solve this a new method in the PresetSource allows to find best matching
presets based on target values for dimensions. Those are then used to
get a ``Context`` with fallback rules for dimensions, avoiding errors with
missing nodes in the root path as these might only exist within a ``Context``
that considers fallback rules.

The ``ContentDimensionPresetSourceInterface`` is not declared public ``@api``
so the change is not marked breaking.