### PR TITLE
TASK: Add signals to notify on asset add / update / remove

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
@@ -412,6 +412,8 @@ class Asset implements AssetInterface
 
     /**
      * Signals that an asset was created.
+     * @deprecated Will be removed with next major version of TYPO3.Media.
+     * Use AssetService::emitAssetCreated signal instead.
      *
      * @Flow\Signal
      * @param AssetInterface $asset

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Thumbnail.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Thumbnail.php
@@ -197,6 +197,8 @@ class Thumbnail implements ImageInterface
 
     /**
      * Signals that a thumbnail was created.
+     * @deprecated Will be removed with next major version of TYPO3.Media.
+     * Use ThumbnailService::emitThumbnailCreated signal instead.
      *
      * @Flow\Signal
      * @param Thumbnail $thumbnail

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -286,6 +286,7 @@ class AssetRepository extends Repository
             ->getQuery()->iterate();
     }
 
+
     /**
      * Remove an asset while first validating if the object can be removed or
      * if removal is blocked because the asset is still in use.
@@ -297,6 +298,7 @@ class AssetRepository extends Repository
     {
         $this->assetService->validateRemoval($object);
         parent::remove($object);
+        $this->emitAssetRemoved($object);
     }
 
     /**
@@ -310,5 +312,59 @@ class AssetRepository extends Repository
     public function removeWithoutUsageChecks($object)
     {
         parent::remove($object);
+        $this->emitAssetRemoved($object);
+    }
+
+    /**
+     * @param AssetInterface $object
+     * @throws \TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException
+     */
+    public function add($object)
+    {
+        parent::add($object);
+        $this->emitAssetAdded($object);
+    }
+
+    /**
+     * @param AssetInterface $object
+     * @throws \TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException
+     */
+    public function update($object)
+    {
+        parent::update($object);
+        $this->emitAssetUpdated($object);
+    }
+
+    /**
+     * Signals that an asset was added.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetAdded(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * Signals that an asset was removed.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetRemoved(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * Signals that an asset was updated.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetUpdated(AssetInterface $asset)
+    {
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -316,7 +316,6 @@ class AssetRepository extends Repository
 
     /**
      * @param AssetInterface $object
-     * @throws \TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function add($object)
     {
@@ -326,7 +325,6 @@ class AssetRepository extends Repository
 
     /**
      * @param AssetInterface $object
-     * @throws \TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function update($object)
     {

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -286,7 +286,6 @@ class AssetRepository extends Repository
             ->getQuery()->iterate();
     }
 
-
     /**
      * Remove an asset while first validating if the object can be removed or
      * if removal is blocked because the asset is still in use.
@@ -298,7 +297,7 @@ class AssetRepository extends Repository
     {
         $this->assetService->validateRemoval($object);
         parent::remove($object);
-        $this->emitAssetRemoved($object);
+        $this->assetService->emitAssetRemoved($object);
     }
 
     /**
@@ -312,7 +311,7 @@ class AssetRepository extends Repository
     public function removeWithoutUsageChecks($object)
     {
         parent::remove($object);
-        $this->emitAssetRemoved($object);
+        $this->assetService->emitAssetRemoved($object);
     }
 
     /**
@@ -322,7 +321,7 @@ class AssetRepository extends Repository
     public function add($object)
     {
         parent::add($object);
-        $this->emitAssetAdded($object);
+        $this->assetService->emitAssetCreated($object);
     }
 
     /**
@@ -332,39 +331,6 @@ class AssetRepository extends Repository
     public function update($object)
     {
         parent::update($object);
-        $this->emitAssetUpdated($object);
-    }
-
-    /**
-     * Signals that an asset was added.
-     *
-     * @Flow\Signal
-     * @param AssetInterface $asset
-     * @return void
-     */
-    public function emitAssetAdded(AssetInterface $asset)
-    {
-    }
-
-    /**
-     * Signals that an asset was removed.
-     *
-     * @Flow\Signal
-     * @param AssetInterface $asset
-     * @return void
-     */
-    public function emitAssetRemoved(AssetInterface $asset)
-    {
-    }
-
-    /**
-     * Signals that an asset was updated.
-     *
-     * @Flow\Signal
-     * @param AssetInterface $asset
-     * @return void
-     */
-    public function emitAssetUpdated(AssetInterface $asset)
-    {
+        $this->assetService->emitAssetUpdated($object);
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -290,6 +290,39 @@ class AssetService
     }
 
     /**
+     * Signals that an asset was added.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetCreated(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * Signals that an asset was removed.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetRemoved(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * Signals that an asset was updated.
+     *
+     * @Flow\Signal
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function emitAssetUpdated(AssetInterface $asset)
+    {
+    }
+
+    /**
      * Signals that a resource on an asset has been replaced
      *
      * @param AssetInterface $asset

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -114,6 +114,7 @@ class ThumbnailService
         if ($thumbnail === null) {
             try {
                 $thumbnail = new Thumbnail($asset, $configuration, $async);
+                $this->emitThumbnailCreated($thumbnail);
 
                 // If the thumbnail strategy failed to generate a valid thumbnail
                 if ($async === false && $thumbnail->getResource() === null && $thumbnail->getStaticResource() === null) {
@@ -210,5 +211,16 @@ class ThumbnailService
         }
 
         return $this->resourceManager->getPublicPackageResourceUriByPath($staticResource);
+    }
+
+    /**
+     * Signals that a thumbnail was created.
+     *
+     * @Flow\Signal
+     * @param Thumbnail $thumbnail
+     * @return void
+     */
+    protected function emitThumbnailCreated(Thumbnail $thumbnail)
+    {
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Package.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Package.php
@@ -13,6 +13,8 @@ namespace TYPO3\Media;
 
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\Package as BasePackage;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Media\Domain\Service\ThumbnailGenerator;
 
 /**
  * The Media Package
@@ -26,6 +28,6 @@ class Package extends BasePackage
     public function boot(Bootstrap $bootstrap)
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
-        $dispatcher->connect('TYPO3\Media\Domain\Model\Asset', 'assetCreated', 'TYPO3\Media\Domain\Service\ThumbnailGenerator', 'createThumbnails');
+        $dispatcher->connect(AssetService::class, 'assetCreated', ThumbnailGenerator::class, 'createThumbnails');
     }
 }


### PR DESCRIPTION
In order to implement additional tasks for asset handling,
like meta data management, these new signals in the
central point of asset handling - the meta data repository -
notify on asset created / updated / removed.

Moved assetCreated and thumbnailCreated to the corresponding
services for consistency.