### PR TITLE
FEATURE: ``TYPO3.TypoScript:Debug`` TypoScript-Object

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/TypoScript/InsideTypoScript.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/TypoScript/InsideTypoScript.rst
@@ -501,6 +501,28 @@ a property using the ``@if`` meta-property::
 
 Multiple conditions can be used, and if one of them doesn't return ``true`` the condition stops evaluation.
 
+Debugging
+=========
+
+To show the result of TypoScript Expressions directly you can use the TYPO3.TypoScript:Debug TypoScript-Object::
+
+	debugObject = Debug {
+		# optional: set title for the debug output
+		# title = 'Debug'
+
+		# optional: show result as plaintext
+		# plaintext = TRUE
+
+		# If only the value-key is given it is debugged directly,
+		# otherwise all keys except title an plaintext are debugged.
+		value = "hello neos world"
+
+		# Additional values for debugging
+		documentTitle = ${q(documentNode).property('title')}
+		documentPath = ${documentNode.path}
+	}
+	# the value of this object is the formated debug output of all keys given to the object
+
 .. Important TypoScript objects and patterns
 .. =========================================
 .. - page, template, content collection, menu, value (TODO ChristianM)

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/DebugImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/DebugImplementation.php
@@ -1,0 +1,78 @@
+<?php
+namespace TYPO3\TypoScript\TypoScriptObjects;
+
+/*
+ * This file is part of the TYPO3.TypoScript package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A TypoScript object for debugging ts-values
+ *
+ * If only value is given it is debugged directly. Otherwise all keys except title an plaintext are debugged.
+ *
+ * //tsPath value The variable to display a dump of.
+ * //tsPath title $title optional custom title for the debug output
+ * //tsPath plaintext If TRUE, the dump is in plain text, if FALSE the debug output is in HTML format. If not specified, the mode is guessed from FLOW_SAPITYPE
+ * @api
+ */
+class DebugImplementation extends ArrayImplementation
+{
+    /**
+     * If you iterate over "properties" these in here should usually be ignored.
+     * For example additional properties in "Case" that are not "Matchers".
+     *
+     * @var array
+     */
+    protected $ignoreProperties = ['__meta', 'title', 'plaintext'];
+
+    /**
+     * @return mixed
+     */
+    public function getTitle()
+    {
+        return $this->tsValue('title');
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPlaintext()
+    {
+        return $this->tsValue('plaintext');
+    }
+
+    /**
+     * Return the values in a human readable form
+     *
+     * @return void|string
+     */
+    public function evaluate()
+    {
+        $title = $this->getTitle();
+        $plaintext = $this->getPlaintext();
+
+        $debugData = array();
+        foreach (array_keys($this->properties) as $key) {
+            if (in_array($key, $this->ignoreProperties)) {
+                continue;
+            }
+            $debugData[$key] = $this->tsValue($key);
+        }
+
+        if (count($debugData) === 0) {
+            $debugData = null;
+        } elseif (array_key_exists('value', $debugData) && count($debugData) === 1) {
+            $debugData = $debugData['value'];
+        }
+
+        return \TYPO3\Flow\var_dump($debugData, $title, true, $plaintext);
+    }
+}

--- a/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
@@ -5,6 +5,7 @@ prototype(TYPO3.TypoScript:Collection).@class = 'TYPO3\\TypoScript\\TypoScriptOb
 prototype(TYPO3.TypoScript:Case).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\CaseImplementation'
 prototype(TYPO3.TypoScript:Matcher).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\MatcherImplementation'
 prototype(TYPO3.TypoScript:Value).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\ValueImplementation'
+prototype(TYPO3.TypoScript:Debug).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\DebugImplementation'
 
 # Render an HTTP response header
 #

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/DebugTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/DebugTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace TYPO3\TypoScript\Tests\Functional\TypoScriptObjects;
+
+/*
+ * This file is part of the TYPO3.TypoScript package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Debug object
+ *
+ */
+class DebugTest extends AbstractTypoScriptObjectTest
+{
+    /**
+     * @test
+     */
+    public function debugEmptyValue()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/empty');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals($lines[1], 'NULL');
+    }
+
+    /**
+     * @test
+     */
+    public function debugNullValue()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/null');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals($lines[1], 'NULL');
+    }
+
+    /**
+     * @test
+     */
+    public function debugNullValueWithTitle()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/nullWithTitle');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals('Title', $lines[0]);
+        $this->assertEquals('NULL', $lines[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function debugEelExpression()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/eelExpression');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals('string "hello world" (11)', $lines[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function debugTsObjectExpression()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/tsObjectExpression');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals('string "hello world" (11)', $lines[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function debugMultipleValues()
+    {
+        $view = $this->buildView();
+        $view->setTypoScriptPath('debug/multipleValues');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals('array(2)', $lines[1]);
+        $this->assertEquals(' string "foo" (3) => string "foo" (3)', $lines[2]);
+        $this->assertEquals(' string "bar" (3) => string "bar" (3)', $lines[3]);
+    }
+}

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/Debug.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/Debug.ts2
@@ -1,0 +1,31 @@
+prototype(TYPO3.TypoScript:Value).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\ValueImplementation'
+prototype(TYPO3.TypoScript:Debug) {
+	@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\DebugImplementation'
+	plaintext = TRUE
+}
+
+debug.empty = Debug
+
+debug.null = Debug {
+	value = NULL
+}
+
+debug.nullWithTitle = Debug {
+	title = 'Title'
+	value = NULL
+}
+
+debug.eelExpression = Debug {
+	value = ${'hello' + ' ' + 'world'}
+}
+
+debug.tsObjectExpression = Debug {
+	value = Value {
+		value = 'hello world'
+	}
+}
+
+debug.multipleValues = Debug {
+  foo = 'foo'
+  bar = 'bar'
+}


### PR DESCRIPTION
A TypoScript Object "Debug" is added as an equivalent to the ``f:debug`` view helper.
The Object will display the value of all child-keys in a debug window.

```
tsPath = TYPO3.TypoScript:Debug {
    # optional: set title for the debug output
    # title = 'Debug'
  
    # optional: show result as plaintext
    # plaintext = TRUE

    # If only the value-key is given it is debugged directly,
    # otherwise all keys except title an plaintext are debugged.
    value = "hello neos world"

    # Additional values for debugging
    documentTitle = ${q(documentNode).property('title')}
    documentPath = ${documentNode.path}
}
```