### PR TITLE
BUGFIX: Values not selected in select box editor when added asynchronously

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/SelectBoxEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/SelectBoxEditor.js
@@ -160,11 +160,15 @@ define([
 			if (this.get('multiple') || (value !== (valuePath ? this.get('selection.' + valuePath) : this.get('selection')))) {
 				this.set('selection', this.get('multiple') ? selection : selection[0]);
 				Ember.run.next(function() {
-					if (that.$() && that.get('multiple')) {
-						var data = value.length > 0 ? value.map(function(val) {
-							return {id: val, text: selection.findBy('value', val).label};
-						}) : null;
-						that.$().select2('data', data);
+					if (that.$()) {
+						if (that.get('multiple')) {
+							var data = value.length > 0 ? value.map(function (val) {
+								return {id: val, text: selection.length > 0 ? selection.findBy('value', val).label : val};
+							}) : null;
+							that.$().select2('data', data);
+						} else {
+							that.$().trigger('change');
+						}
 					}
 				});
 			}


### PR DESCRIPTION
When options are populated asynchronously to the select box editor (e.g.
when using data source or in the plugin view editors) the value wasn't
updated properly.

Regression introduced in 2b79b585b63f3d07153af404721a77798e47cf3a