### PR TITLE
TASK: Adjust configuration to render the neos-viewhelper reference automatically

### DIFF
--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -527,6 +527,7 @@ TYPO3:
           - 'Neos:FormViewHelpers'
           - 'Neos:NeosViewHelpers'
           - 'Neos:Typo3CrViewHelpers'
+          - 'Neos:TypoScriptViewHelpers'
           - 'Neos:FlowValidators'
           - 'Neos:PartyValidators'
           - 'Neos:MediaValidators'


### PR DESCRIPTION
In 6cc5ad24997a55cc31fceacb62188e5c6feec640 the configuration for the rendering of the neos-viewhelpers was added. This commit adds this configuration to the list of references that is automatically updated for neos.