### PR TITLE
BUGFIX: Fix schema error that prevented the validation of aloha configurations

### DIFF
--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -4,7 +4,7 @@ additionalProperties:
   type: dictionary
   properties:
     'properties':
-      type: ['dictionary', 'null']
+      type: dictionary
       additionalProperties:
         # for each property...
         type: dictionary


### PR DESCRIPTION
The schema was altered before to allow setting the properties to NULL in a derived nodeType. This was done incompletely and lead the situation where the schema validation only validates that the
value of properties was a dictionary or null.

The ``additionalProperties`` were ignored because that property is only evaluated inside
a dictionary schema.

The underlying intent to allow resetting the properties in derived node types by setting ``NodeType.properties: null`` is not supported any more. The correct syntax to achieve this
is instead ``NodeType.properties: []``.

This is not marked as breaking since it will not break functionality. Nevertheless it alters
what is marked as a defect configuration.