### PR TITLE
BUGFIX: Aloha list style class not sanitized

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
@@ -225,7 +225,9 @@ function(
 						'h6': ['style'],
 						'p': ['class', 'style', 'id'],
 						'td': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'style'],
-						'th': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'scope']
+						'th': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'scope'],
+						'ul': ['class'],
+						'ol': ['class']
 					},
 					protocols: {
 						'a': {'href': ['ftp', 'http', 'https', 'mailto', '__relative__', 'node', 'asset']},


### PR DESCRIPTION
When using Aloha list styles, the class attribute was sanitized automatically making the feature unusable.

NEOS-854