### PR TITLE
FEATURE: Add ``TYPO3.Neos:ContentElementEditable`` TypoScript-Object

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementEditableService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementEditableService.php
@@ -1,0 +1,75 @@
+<?php
+namespace TYPO3\Neos\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Service\AuthorizationService;
+
+/**
+ * The content element editable service adds the necessary markup around
+ * a content element such that it can be edited using the inline editing
+ * of the Neos Backend.
+ *
+ * @Flow\Scope("singleton")
+ */
+class ContentElementEditableService
+{
+
+    /**
+     * @Flow\Inject
+     * @var PrivilegeManagerInterface
+     */
+    protected $privilegeManager;
+
+    /**
+     * @Flow\Inject
+     * @var AuthorizationService
+     */
+    protected $nodeAuthorizationService;
+
+    /**
+     * @Flow\Inject
+     * @var HtmlAugmenter
+     */
+    protected $htmlAugmenter;
+
+    /**
+     * Wrap the $content identified by $node with the needed markup for the backend.
+     *
+     * @param NodeInterface $node
+     * @param string $property
+     * @param string $content
+     * @return string
+     */
+    public function wrapContentProperty(NodeInterface $node, $property, $content)
+    {
+        /** @var $contentContext ContentContext */
+        $contentContext = $node->getContext();
+        if ($contentContext->getWorkspaceName() === 'live' || !$this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess')) {
+            return $content;
+        }
+
+        if (!$this->nodeAuthorizationService->isGrantedToEditNode($node)) {
+            return $content;
+        }
+
+        $attributes = array();
+        $attributes['class'] = 'neos-inline-editable';
+        $attributes['property'] = 'typo3:' . $property ;
+        $attributes['data-neos-node-type'] = $node->getNodeType()->getName();
+
+        return $this->htmlAugmenter->addAttributes($content, $attributes, 'span');
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementEditableImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementEditableImplementation.php
@@ -1,0 +1,82 @@
+<?php
+namespace TYPO3\Neos\TypoScript;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Service\ContentElementEditableService;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TypoScript\TypoScriptObjects\AbstractTypoScriptObject;
+
+/**
+ * Adds meta data attributes to the processed Property to enable in place editing
+ */
+class ContentElementEditableImplementation extends AbstractTypoScriptObject
+{
+    /**
+     * @Flow\Inject
+     * @var PrivilegeManagerInterface
+     */
+    protected $privilegeManager;
+
+    /**
+     * @Flow\Inject
+     * @var ContentElementEditableService
+     */
+    protected $contentElementEditableService;
+
+    /**
+     * The string to be processed
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->tsValue('value');
+    }
+
+    /**
+     * Evaluate this TypoScript object and return the result
+     *
+     * @return mixed
+     * @throws \TYPO3\Neos\Domain\Exception
+     */
+    public function evaluate()
+    {
+        $content = $this->getValue();
+
+        /** @var $node NodeInterface */
+        $node = $this->tsValue('node');
+        if (!$node instanceof NodeInterface) {
+            return $content;
+        }
+
+        /** @var $property string */
+        $property = $this->tsValue('property');
+
+        /** @var $contentContext ContentContext */
+        $contentContext = $node->getContext();
+        if ($contentContext->getWorkspaceName() === 'live') {
+            return $content;
+        }
+
+        if (!$this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess')) {
+            return $content;
+        }
+
+        if ($node->isRemoved()) {
+            $content = '';
+        }
+        return $this->contentElementEditableService->wrapContentProperty($node, $property, $content);
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementEditableImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementEditableImplementation.php
@@ -49,7 +49,6 @@ class ContentElementEditableImplementation extends AbstractTypoScriptObject
      * Evaluate this TypoScript object and return the result
      *
      * @return mixed
-     * @throws \TYPO3\Neos\Domain\Exception
      */
     public function evaluate()
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
@@ -49,7 +49,6 @@ class ContentElementWrappingImplementation extends AbstractTypoScriptObject
      * Evaluate this TypoScript object and return the result
      *
      * @return mixed
-     * @throws \TYPO3\Neos\Domain\Exception
      */
     public function evaluate()
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -19,6 +19,7 @@ use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Service\AuthorizationService;
 use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
+use TYPO3\Neos\Service\ContentElementEditableService;
 
 /**
  * Renders a wrapper around the inner contents of the tag to enable frontend editing.
@@ -47,6 +48,12 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
      * @var AuthorizationService
      */
     protected $nodeAuthorizationService;
+
+    /**
+     * @Flow\Inject
+     * @var ContentElementEditableService
+     */
+    protected $contentElementEditableService;
 
     /**
      * @return void
@@ -89,20 +96,7 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
         }
         $this->tag->setContent($content);
 
-        /** @var $contentContext ContentContext */
-        $contentContext = $node->getContext();
-        if ($contentContext->getWorkspaceName() === 'live' || !$this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess')) {
-            return $this->tag->render();
-        }
-
-        if (!$this->nodeAuthorizationService->isGrantedToEditNode($node)) {
-            return $this->tag->render();
-        }
-
-        $this->tag->addAttribute('property', 'typo3:' . $property);
-        $this->tag->addAttribute('data-neos-node-type', $node->getNodeType()->getName());
-        $this->tag->addAttribute('class', $this->tag->hasAttribute('class') ? 'neos-inline-editable ' . $this->tag->getAttribute('class') : 'neos-inline-editable');
-        return $this->tag->render();
+        return $this->contentElementEditableService->wrapContentProperty($node, $property, $this->tag->render());
     }
 
     /**

--- a/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
@@ -16,6 +16,7 @@ include: Prototypes/ConvertUris.ts2
 include: Prototypes/ConvertNodeUris.ts2
 include: Prototypes/DocumentMetadata.ts2
 include: Prototypes/ContentElementWrapping.ts2
+include: Prototypes/ContentElementEditable.ts2
 include: Prototypes/NodeUri.ts2
 include: Prototypes/ImageUri.ts2
 include: Prototypes/FallbackNode.ts2

--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ContentElementEditable.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ContentElementEditable.ts2
@@ -1,0 +1,11 @@
+# ContentElementEditable implementation
+#
+# Used as processor this adds metadata attributes to the corresponding TypoScript object
+# This is used to render required attributes to enable inline editing in the backend
+#
+prototype(TYPO3.Neos:ContentElementEditable) {
+	@class = 'TYPO3\\Neos\\TypoScript\\ContentElementEditableImplementation'
+	node = ${node}
+	property = ${property}
+	value = ${value}
+}

--- a/TYPO3.Neos/Tests/Unit/Service/ContentElementEditableServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/ContentElementEditableServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+namespace TYPO3\Neos\Tests\Unit\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Service\HtmlAugmenter;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Service\AuthorizationService;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TypoScript\Core\Runtime;
+use TYPO3\Neos\Service\ContentElementEditableService;
+
+/**
+ * Test for the ContentElementEditableService
+ */
+class ContentElementEditableServiceTest extends UnitTestCase
+{
+    /**
+     * @var ContentElementEditableService
+     */
+    protected $contentElementEditableService;
+
+    /**
+     * @var PrivilegeManagerInterface
+     */
+    protected $mockPrivilegeManager;
+
+    /**
+     * @var AuthorizationService
+     */
+    protected $mockNodeAuthorizationService;
+
+    /**
+     * @var HtmlAugmenter
+     */
+    protected $mockHtmlAugmenter;
+
+    /**
+     * @var Runtime
+     */
+    protected $mockTsRuntime;
+
+    /**
+     * @var array
+     */
+    protected $mockTsContext;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $mockNode;
+
+    /**
+     * @var ContentContext
+     */
+    protected $mockContentContext;
+
+    /**
+     * @var array
+     */
+    protected $templateVariables = array();
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->contentElementEditableService = new ContentElementEditableService();
+
+        $this->mockPrivilegeManager = $this->getMockBuilder(PrivilegeManagerInterface::class)->getMock();
+        $this->inject($this->contentElementEditableService, 'privilegeManager', $this->mockPrivilegeManager);
+
+        $this->mockNodeAuthorizationService = $this->getMockBuilder(AuthorizationService::class)->getMock();
+        $this->inject($this->contentElementEditableService, 'nodeAuthorizationService', $this->mockNodeAuthorizationService);
+
+        $this->mockHtmlAugmenter = $this->getMockBuilder(HtmlAugmenter::class)->getMock();
+        $this->inject($this->contentElementEditableService, 'htmlAugmenter', $this->mockHtmlAugmenter);
+
+        $this->mockTsRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $this->mockContentContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
+
+        $this->mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContentContext));
+        $this->mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue(new NodeType('Acme.Test:Headline', [], [])));
+
+        $this->mockTsContext = array('node' => $this->mockNode);
+        $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
+    }
+
+    /**
+     * @test
+     */
+    public function wrapContentPropertyDoesNotAddEditingMetaDataAttributesIfInLiveWorkspace()
+    {
+        $this->mockContentContext->expects($this->atLeastOnce())->method('getWorkspaceName')->will($this->returnValue('live'));
+        $this->mockHtmlAugmenter->expects($this->never())->method('addAttributes');
+        $this->contentElementEditableService->wrapContentProperty($this->mockNode, 'someProperty', '<div>someRenderedPropertyValue</div>');
+    }
+
+    /**
+     * @test
+     */
+    public function wrapContentPropertyDoesNotAddEditingMetaDataAttributesIfUserHasNoAccessToBackend()
+    {
+        $this->mockContentContext->expects($this->atLeastOnce())->method('getWorkspaceName')->will($this->returnValue('not-live'));
+        $this->mockPrivilegeManager->expects($this->atLeastOnce())->method('isPrivilegeTargetGranted')->with('TYPO3.Neos:Backend.GeneralAccess')->will($this->returnValue(false));
+        $this->mockHtmlAugmenter->expects($this->never())->method('addAttributes');
+        $this->contentElementEditableService->wrapContentProperty($this->mockNode, 'someProperty', '<div>someRenderedPropertyValue</div>');
+    }
+
+    /**
+     * @test
+     */
+    public function wrapContentPropertyAddsEditingMetaDataAttributesIfInUserWorkspaceAndUserHasAccessToBackendAndEditNodePrivilegeIsGranted()
+    {
+        $this->mockContentContext->expects($this->atLeastOnce())->method('getWorkspaceName')->will($this->returnValue('not-live'));
+        $this->mockPrivilegeManager->expects($this->atLeastOnce())->method('isPrivilegeTargetGranted')->with('TYPO3.Neos:Backend.GeneralAccess')->will($this->returnValue(true));
+        $this->mockNodeAuthorizationService->expects($this->atLeastOnce())->method('isGrantedToEditNode')->will($this->returnValue(true));
+        $this->mockHtmlAugmenter->expects($this->atLeastOnce())->method('addAttributes');
+        $this->contentElementEditableService->wrapContentProperty($this->mockNode, 'someProperty', '<div>someRenderedPropertyValue</div>');
+    }
+
+    /**
+     * @test
+     */
+    public function wrapContentPropertyDoesNotAddEditingMetaDataIfEditNodePrivilegeIsNotGranted()
+    {
+        $this->mockContentContext->expects($this->atLeastOnce())->method('getWorkspaceName')->will($this->returnValue('not-live'));
+        $this->mockPrivilegeManager->expects($this->atLeastOnce())->method('isPrivilegeTargetGranted')->with('TYPO3.Neos:Backend.GeneralAccess')->will($this->returnValue(true));
+        $this->mockNodeAuthorizationService->expects($this->atLeastOnce())->method('isGrantedToEditNode')->will($this->returnValue(false));
+        $this->mockHtmlAugmenter->expects($this->never())->method('addAttributes');
+        $this->contentElementEditableService->wrapContentProperty($this->mockNode, 'someProperty', '<div>someRenderedPropertyValue</div>');
+    }
+}


### PR DESCRIPTION
This change extracts the functionality of the neos:contentElement.editable viewHelper into a service and adds an equivalent TypoScript-Prototype.

TypoScript Example:
```
element = TYPO3.TypoScript:Array {
	title = TYPO3.TypoScript:Tag {
		tagName = 'h1'
		content = ${q(node).property('title')}
		@process.contentElementEditable = TYPO3.Neos:ContentElementEditable
		@process.contentElementEditable.property = 'title'
	}
	@process.contentElementWrapping = TYPO3.Neos:ContentElementWrapping
}
```