### PR TITLE
FEATURE: Custom label for auto created child nodes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
@@ -68,14 +68,20 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
     /**
      * Render a node label based on an eel expression or return the expression if it is not valid eel.
      *
-     * @param \Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node
-     * @return string
      * @throws \Neos\Eel\Exception
      */
     public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node): string
     {
-        if (Utility::parseEelExpression($this->getExpression()) === null) {
-            return $this->getExpression();
+        $expression = $this->getExpression();
+        if ($node->isAutoCreated()) {
+            $parentNode = $node->getParent();
+            $property = 'childNodes.' . $node->getName() . '.label';
+            if ($parentNode?->getNodeType()->hasConfiguration($property)) {
+                $expression = $parentNode->getNodeType()->getConfiguration($property);
+            }
+        }
+        if (Utility::parseEelExpression($expression) === null) {
+            return $expression;
         }
         return (string)Utility::evaluateEelExpression($this->getExpression(), $this->eelEvaluator, ['node' => $node], $this->defaultContextConfiguration);
     }

--- a/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
@@ -205,3 +205,13 @@
 
 'Neos.ContentRepository.Testing:NodeTypeWithEelExpressionLabel':
   label: '${"Test" + " " + "nodetype"}'
+
+'Neos.ContentRepository.Testing:NodeTypeWithPlainLabelInChildNode':
+  childNodes:
+    child:
+      label: 'Test child node'
+
+'Neos.ContentRepository.Testing:NodeTypeWithEelExpressionLabelInChildNode':
+  childNodes:
+    child:
+      label: '${"Test" + " child " + "node"}'

--- a/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -19,7 +19,7 @@ additionalProperties:
 
     'label':
       type: ['string', 'array']
-      description: "An EEL expression for generating a node's of this node type's label. Alternatively an array with the key generatorClass and optional options."
+      description: "An EEL expression for generating a node's of this node type's label. Alternatively an array with the key generatorClass and optional generator options."
 
     'constraints': &constraints
       type: dictionary
@@ -42,6 +42,7 @@ additionalProperties:
             type: dictionary
             additionalProperties: false
             properties:
+              'label': { type: string, description: "A string or an EEL expression for generating a node's of this node type's label. Alternatively an array with the key generatorClass and optional generator options." }
               'type': { type: string, description: "Node Type of this child node." }
               'position':
                 type: ['string', 'null']

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -1080,6 +1080,23 @@ class NodesTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function getChildNodeLabelReturnsParsedEelExpressionOrFallback()
+    {
+        $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $nodeTypeWithPlainLabelInChildNode = $nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithPlainLabelInChildNode');
+        $nodeTypeWithEelExpressionLabelInChildNode = $nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithEelExpressionLabelInChildNode');
+
+        $rootNode = $this->context->getNode('/');
+        $nodeWithPlainLabelInChildNode = $rootNode->createNode('node-plain', $nodeTypeWithPlainLabelInChildNode, '30e893c1-caef-0ca5-b53d-e5699bb8e506');
+        $nodeWithEelExpressionLabelInChildNode = $rootNode->createNode('node-eel', $nodeTypeWithEelExpressionLabelInChildNode, '81c848ed-abb5-7608-a5db-7eea0331ccfa');
+
+        self::assertEquals('Test child node', $nodeWithPlainLabelInChildNode->getLabel());
+        self::assertEquals('Test child node', $nodeWithEelExpressionLabelInChildNode->getLabel());
+    }
+
+    /**
+     * @test
+     */
     public function nodesCanBeCopiedAfterAndBeforeAndKeepProperties()
     {
         $rootNode = $this->context->getNode('/');

--- a/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/FourColumn.yaml
+++ b/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/FourColumn.yaml
@@ -6,12 +6,16 @@
     position: 400
   childNodes:
     column0:
+      label: 'Left Column'
       type: 'Neos.Neos:ContentCollection'
     column1:
+      label: 'Middle Left Column'
       type: 'Neos.Neos:ContentCollection'
     column2:
+      label: 'Middle Right Column'
       type: 'Neos.Neos:ContentCollection'
     column3:
+      label: 'Right Column'
       type: 'Neos.Neos:ContentCollection'
   properties:
     layout:

--- a/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/ThreeColumn.yaml
+++ b/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/ThreeColumn.yaml
@@ -6,10 +6,13 @@
     position: 300
   childNodes:
     column0:
+      label: 'Left Column'
       type: 'Neos.Neos:ContentCollection'
     column1:
+      label: 'Middle Column'
       type: 'Neos.Neos:ContentCollection'
     column2:
+      label: 'Right Column'
       type: 'Neos.Neos:ContentCollection'
   properties:
     layout:

--- a/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/TwoColumn.yaml
+++ b/Neos.NodeTypes.ColumnLayouts/NodeTypes/Content/TwoColumn.yaml
@@ -6,8 +6,10 @@
     position: 200
   childNodes:
     column0:
+      label: 'Left Column'
       type: 'Neos.Neos:ContentCollection'
     column1:
+      label: 'Right Column'
       type: 'Neos.Neos:ContentCollection'
   properties:
     layout:


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-development-collection/issues/2276

This change add a node type configuration to generate a custom node label
for auto created child nodes:

```
'Neos.Neos.NodeTypes:Page':
  superTypes:
    'Neos.Neos:Document': TRUE
  childNodes:
    main:
      label: 'Main Content Collection'
      type: 'Neos.Neos:ContentCollection'
```

This allow to have a less technical content tree. This change include the
schema validation and default label for default node types.

The label can be a string or an EEL expression. Inside the
expression you can access the parent node in the variable `parentNode`.
