### PR TITLE
TASK: Media browser fixes and improvements

### DIFF
--- a/TYPO3.Media/Resources/Public/Scripts/edit.js
+++ b/TYPO3.Media/Resources/Public/Scripts/edit.js
@@ -1,8 +1,9 @@
 (function($) {
 	$(function() {
 		if (window.parent !== window && window.parent.Typo3MediaBrowserCallbacks) {
-			$('.neos-footer .neos-button-primary').on('click', function(e) {
-				if(window.parent.Typo3MediaBrowserCallbacks && typeof window.parent.Typo3MediaBrowserCallbacks.close === 'function') {
+			$('.neos-action-cancel, .neos-button-primary', '.neos-footer').on('click', function(e) {
+				if (window.parent.Typo3MediaBrowserCallbacks && typeof window.parent.Typo3MediaBrowserCallbacks.close === 'function') {
+					console.log('close');
 					window.parent.Typo3MediaBrowserCallbacks.close();
 				}
 			});

--- a/TYPO3.Media/Resources/Public/Scripts/edit.js
+++ b/TYPO3.Media/Resources/Public/Scripts/edit.js
@@ -3,7 +3,6 @@
 		if (window.parent !== window && window.parent.Typo3MediaBrowserCallbacks) {
 			$('.neos-action-cancel, .neos-button-primary', '.neos-footer').on('click', function(e) {
 				if (window.parent.Typo3MediaBrowserCallbacks && typeof window.parent.Typo3MediaBrowserCallbacks.close === 'function') {
-					console.log('close');
 					window.parent.Typo3MediaBrowserCallbacks.close();
 				}
 			});

--- a/TYPO3.Media/Resources/Public/Scripts/new.js
+++ b/TYPO3.Media/Resources/Public/Scripts/new.js
@@ -1,6 +1,7 @@
 (function($) {
 	$(function() {
-		$('#resource').change(function(e) {
+		var $resource = $('#resource');
+		$resource.change(function(e) {
 			var filename = $(this).val().split('\\').pop();
 			$('label[for="resource"]').text(filename);
 			var filesize = $(this).get(0).files[0].size;
@@ -19,7 +20,7 @@
 				} else {
 					alert(message);
 				}
-				$(this.form).submit(function(e) {
+				$(this.form).on('submit.invalidfile', function(e) {
 					e.preventDefault();
 					var message = 'Cannot upload the file';
 					if (window.Typo3Neos) {
@@ -30,8 +31,24 @@
 					}
 				});
 			} else {
-				$(this.form).unbind('submit');
+				$(this.form).off('submit.invalidfile');
 			}
 		});
+		// Fallback validation for Safaris missing required attribute validation
+		var isSafari = navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1;
+		if (isSafari) {
+			$resource.closest('form').on('submit.safari', function(e) {
+				if (!$resource.val()) {
+					e.preventDefault();
+					var message = 'No file selected';
+					if (window.Typo3Neos) {
+						message = window.Typo3Neos.I18n.translate('media.noFileSelected', message, 'TYPO3.Neos', 'Modules');
+						window.Typo3Neos.Notification.warning(message);
+					} else {
+						alert(message);
+					}
+				}
+			});
+		}
 	});
 })(jQuery);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -134,7 +134,9 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
             $this->assetService->getRepository($asset)->remove($asset);
             $this->addFlashMessage('assetHasBeenDeleted', '', Message::SEVERITY_OK, [$asset->getLabel()], 1412375050);
         } catch (AssetServiceException $exception) {
-            $this->addFlashMessage('media.deleteRelatedNodes', '', Message::SEVERITY_WARNING, [], 1412422767);
+            $message = $this->translator->translateById('media.deleteRelatedNodes', [], null, null, 'Modules', 'TYPO3.Neos');
+
+            $this->addFlashMessage($message, '', Message::SEVERITY_WARNING, [], 1412422767);
         }
 
         $this->redirect('index');

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
@@ -84,7 +84,7 @@
 							<a class="dropdown-toggle neos-button neos-button-mini" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
 								<i class="icon-ellipsis-horizontal"></i>
 							</a>
-							<div class="neos-dropdown-menu-list" role="menu">
+							<div class="neos-dropdown-menu-list neos-pull-right" role="menu">
 								<ul>
 									<li>
 										<f:link.action action="edit" arguments="{asset: asset}" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}">

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
@@ -70,7 +70,7 @@
 							<m:thumbnail asset="{asset}" preset="TYPO3.Neos:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
 						</div>
 					</td>
-					<td class="asset-label"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
+					<td class="asset-label" data-neos-toggle="tooltip" title="{asset.label}"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
 					<td><span title="{asset.lastModified -> f:format.date(format: 'd-m-Y H:i')}" data-neos-toggle="tooltip">{asset.lastModified -> m:format.relativeDate()}</span></td>
 					<td>{asset.resource.fileSize -> f:format.bytes()}</td>
 					<td><span class="neos-label">{asset.resource.mediatype}</span></td>

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ListView.html
@@ -70,7 +70,7 @@
 							<m:thumbnail asset="{asset}" preset="TYPO3.Neos:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
 						</div>
 					</td>
-					<td class="asset-label" data-neos-toggle="tooltip" title="{asset.label}"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></td>
+					<td class="asset-label"><span data-neos-toggle="tooltip" title="{asset.label}"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></span></td>
 					<td><span title="{asset.lastModified -> f:format.date(format: 'd-m-Y H:i')}" data-neos-toggle="tooltip">{asset.lastModified -> m:format.relativeDate()}</span></td>
 					<td>{asset.resource.fileSize -> f:format.bytes()}</td>
 					<td><span class="neos-label">{asset.resource.mediatype}</span></td>

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
@@ -17,7 +17,7 @@
 							<a class="dropdown-toggle neos-button neos-button-small" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
 								<i class="icon-ellipsis-horizontal"></i>
 							</a>
-							<div class="neos-dropdown-menu-list" role="menu">
+							<div class="neos-dropdown-menu-list neos-pull-right" role="menu">
 								<ul>
 									<li>
 										<f:link.action action="edit" arguments="{asset: asset}" title="{neos:backend.translate(id: 'media.tooltip.editAsset', source: 'Modules', package: 'TYPO3.Neos')}">

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
@@ -14,7 +14,7 @@
 						<m:fileTypeIcon file="{asset}" height="32" />
 
 						<div class="neos-dropdown neos-pull-right" id="neos-asset-actionmenu-{asset -> f:format.identifier()}">
-							<a class="dropdown-toggle neos-button neos-button-small" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
+							<a class="dropdown-toggle neos-button" href="#" data-neos-toggle="dropdown" data-target="#neos-asset-actionmenu-{asset -> f:format.identifier()}">
 								<i class="icon-ellipsis-horizontal"></i>
 							</a>
 							<div class="neos-dropdown-menu-list neos-pull-right" role="menu">

--- a/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Media/ThumbnailView.html
@@ -40,7 +40,7 @@
 							</div>
 						</div>
 
-						<span class="neos-caption asset-label" title="{asset.label}"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
+						<span class="neos-caption asset-label" title="{asset.label}" data-neos-toggle="tooltip"><f:format.crop maxCharacters="100">{asset.label}</f:format.crop></span>
 					</div>
 				</li>
 			</f:for>

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -942,10 +942,18 @@
 		display: none;
 	}
 
-	#resource {
-		visibility: hidden;
-		position: absolute;
-		left: -9999px;
+	.neos-file-input {
+		position: relative;
+
+		#resource {
+			opacity: 0;
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			cursor: pointer;
+		}
 	}
 
 	.fold-toggle {

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -599,7 +599,6 @@
 				.neos-button.dropdown-toggle {
 					width: $unit;
 					padding: 0;
-					text-align: center;
 
 					.icon-ellipsis-horizontal {
 						line-height: $unit;

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -552,7 +552,6 @@
 					position: relative;
 					padding-bottom: 100%;
 					height: 0;
-					margin-bottom: $relatedMargin * 1.5;
 					background-color: $grayDarker;
 					background-image: url('../Images/ajax-preloader-222222.gif');
 					background-position: center center;
@@ -578,6 +577,7 @@
 					box-shadow: none;
 					position: relative;
 					padding: 0;
+					z-index: 2;
 
 					&:hover {
 						box-shadow: none;
@@ -596,27 +596,26 @@
 					}
 				}
 
-				.neos-button-small {
-					height: $wideMargin;
-					width: $wideMargin;
+				.neos-button.dropdown-toggle {
+					width: $unit;
+					padding: 0;
+					text-align: center;
 
 					.icon-ellipsis-horizontal {
-						line-height: $wideMargin;
+						line-height: $unit;
 					}
 				}
 
 				.neos-img-label {
-					padding: 0 0 $defaultMargin $tightMargin;
 					position: relative;
+					background-color: $grayMedium;
+					height: $unit;
 
 					.neos-caption {
-						margin-right: $wideMargin;
-						padding-left: 4px;
 						padding-right: 4px;
 						display: block;
 						font-size: 12px;
-						line-height: $wideMargin;
-						color: $textSubtleLight;
+						line-height: $unit;
 						overflow: hidden;
 						text-overflow: ellipsis;
 						white-space: nowrap;
@@ -628,6 +627,7 @@
 
 					> img {
 						float: left;
+						padding: 4px;
 					}
 				}
 			}

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -959,4 +959,12 @@
 	.fold-toggle {
 		cursor: pointer;
 	}
+
+	.icon-ok-sign {
+		color: $green;
+	}
+
+	.icon-exclamation-sign {
+		color: $orange;
+	}
 }

--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -608,18 +608,22 @@
 				.neos-img-label {
 					padding: 0 0 $defaultMargin $tightMargin;
 					position: relative;
-					font-size: 12px;
 
 					.neos-caption {
 						margin-right: $wideMargin;
 						padding-left: 4px;
 						padding-right: 4px;
 						display: block;
+						font-size: 12px;
 						line-height: $wideMargin;
 						color: $textSubtleLight;
 						overflow: hidden;
 						text-overflow: ellipsis;
 						white-space: nowrap;
+					}
+
+					.neos-dropdown {
+						font-size: 14px;
 					}
 
 					> img {
@@ -836,7 +840,7 @@
 
 			.neos-dropdown {
 				display: inline-block;
-				font-size: 12px;
+				font-size: 14px;
 			}
 
 			.neos-modal {

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
@@ -73,7 +73,7 @@
 			</div>
 		</div>
 		<div class="neos-footer">
-			<f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
+			<f:link.action action="index" class="neos-button neos-action-cancel">{neos:backend.translate(id: 'media.cancel', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
 			<f:security.ifAccess privilegeTarget="TYPO3.Neos:Backend.Module.Media.ReplaceAssetResource">
 				<f:link.action action="replaceAssetResource" arguments="{asset: asset}" class="neos-button">{neos:backend.translate(id: 'media.replaceAssetResource', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
 			</f:security.ifAccess>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/New.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/New.html
@@ -8,8 +8,12 @@
 		<fieldset>
 			<div class="neos-span6 neos-image-inputs">
 				<legend>{neos:backend.translate(id: 'media.basics', source: 'Modules', package: 'TYPO3.Neos')}</legend>
-				<label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'media.chooseFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i></label>
-				<f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
+				<span class="neos-file-input">
+					<label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">
+						{neos:backend.translate(id: 'media.chooseFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i>
+					</label>
+					<f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
+				</span>
 				<label for="title">{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}</label>
 				<f:form.textfield property="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}" />
 				<label for="caption">{neos:backend.translate(id: 'media.field.caption', source: 'Modules', package: 'TYPO3.Neos')}</label>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -133,6 +133,9 @@
 		<a href="javascript:window.history.back(1);" class="neos-button">{neos:backend.translate(id: 'back', source: 'Modules')}</a>
 	</div>
 
+</f:section>
+
+<f:section name="Scripts">
 	<script>
 		(function($) {
 			$('.fold-toggle').click(function() {

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -37,13 +37,13 @@
                     <legend>{neos:backend.translate(id: 'media.relatedNodes.referencesTo', source: 'Modules', arguments: {asset: asset.label})}</legend>
                     <f:if condition="{asset.inUse}">
                         <f:then>
-                            <p class="neos-buffer-below">{neos:backend.translate(id: 'media.replace.usageCount', arguments: {usageCount: asset.usageCount}, source: 'Modules', package: 'TYPO3.Neos')}</p>
+                            <p class="neos-buffer-below"><i class="icon-exclamation-sign"></i> {neos:backend.translate(id: 'media.replace.usageCount', arguments: {usageCount: asset.usageCount}, source: 'Modules', package: 'TYPO3.Neos')}</p>
                             <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
                                 {neos:backend.translate(id: 'media.replace.allUsages', source: 'Modules', package: 'TYPO3.Neos')}
                             </f:link.action>
                         </f:then>
                         <f:else>
-                            <p>{neos:backend.translate(id: 'media.replace.notUsed', source: 'Modules', package: 'TYPO3.Neos')}</p>
+                            <p><i class="icon-ok-sign"></i> {neos:backend.translate(id: 'media.replace.notUsed', source: 'Modules', package: 'TYPO3.Neos')}</p>
                         </f:else>
                     </f:if>
                 </fieldset>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -14,8 +14,10 @@
                         {neos:backend.translate(id: 'media.replaceAsset.description', source: 'Modules', package: 'TYPO3.Neos')}<br/>
                         <b>{neos:backend.translate(id: 'media.replaceAsset.note', source: 'Modules', package: 'TYPO3.Neos')}: </b> {neos:backend.translate(id: 'media.replaceAsset.noteText', source: 'Modules', package: 'TYPO3.Neos')}
                     </p>
-                    <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'media.replaceAsset.chooseNewFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i></label>
-                    <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}" />
+                    <span class="neos-file-input">
+                        <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'media.replaceAsset.chooseNewFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i></label>
+                        <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}" />
+                    </span>
                 </fieldset>
                 <fieldset>
                     <div>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -52,7 +52,8 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" title="Cancel editing" class="neos-button">{neos:backend.translate(id: 'cancel', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
+            <!-- TODO: Find a nicer way to send the referer for a get request -->
+            <a href="javascript:window.history.back(1);" class="neos-button">{neos:backend.translate(id: 'cancel', source: 'Modules')}</a>
             <f:form.submit id="replace" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'media.replaceAssetResource', source: 'Modules', package: 'TYPO3.Neos')}" />
         </div>
     </f:form>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -891,6 +891,9 @@
 			<trans-unit id="media.cannotUploadFile" xml:space="preserve">
 				<source>Cannot upload the file</source>
 			</trans-unit>
+			<trans-unit id="media.noFileSelected" xml:space="preserve">
+				<source>No file selected</source>
+			</trans-unit>
 			<trans-unit id="media.fileSizeExceedsAllowedLimit" xml:space="preserve">
 				<source>The file size of {0} exceeds the allowed limit of {1}</source>
 			</trans-unit>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
@@ -329,8 +329,15 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 						});
 					}
 				},
-				onLoad: function() {
+				onLoad: function(event, iframe) {
 					this._frameLoaded = true;
+					var notifications = $(iframe).contents().find('#neos-notifications-inline');
+					if (notifications.length > 0) {
+						$('li', notifications).each(function(index, notification) {
+							var title = $(notification).data('title');
+							Notification[$(notification).data('type')](title ? title : $(notification).text(), title ? $(notification).html() : '');
+						});
+					}
 				},
 				refreshThumbnail: function() {
 					if (this._frameLoaded) {
@@ -358,7 +365,7 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 				didInsertElement: function() {
 					this.$().find('iframe').on('load', function(event) {
 						if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.onLoad) {
-							window.Typo3MediaBrowserCallbacks.onLoad(event);
+							window.Typo3MediaBrowserCallbacks.onLoad(event, this);
 						}
 					});
 				}
@@ -1072,7 +1079,7 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 				didInsertElement: function() {
 					this.$().find('iframe').on('load', function(event) {
 						if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.onLoad) {
-							window.Typo3MediaBrowserCallbacks.onLoad(event);
+							window.Typo3MediaBrowserCallbacks.onLoad(event, this);
 						}
 					});
 				}

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/SecondaryInspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/SecondaryInspectorController.js
@@ -62,9 +62,6 @@ function(Ember, Button) {
 		 * Always hide the given view class
 		 */
 		hide: function() {
-			if (window.Typo3MediaBrowserCallbacks && window.Typo3MediaBrowserCallbacks.close) {
-				window.Typo3MediaBrowserCallbacks.close();
-			}
 			this.set('_visible', false);
 		}
 	}).create();

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13929,10 +13929,17 @@
 .neos.media-browser #uploader .plupload {
   display: none;
 }
-.neos.media-browser #resource {
-  visibility: hidden;
+.neos.media-browser .neos-file-input {
+  position: relative;
+}
+.neos.media-browser .neos-file-input #resource {
+  opacity: 0;
   position: absolute;
-  left: -9999px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
 }
 .neos.media-browser .fold-toggle {
   cursor: pointer;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13591,7 +13591,6 @@
   position: relative;
   padding-bottom: 100%;
   height: 0;
-  margin-bottom: 12px;
   background-color: #141414;
   background-image: url("../Images/ajax-preloader-222222.gif");
   background-position: center center;
@@ -13616,6 +13615,7 @@
   box-shadow: none;
   position: relative;
   padding: 0;
+  z-index: 2;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li > a:hover {
   box-shadow: none;
@@ -13635,25 +13635,24 @@
   max-height: 100%;
   max-width: 100%;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button-small {
-  height: 32px;
-  width: 32px;
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button.dropdown-toggle {
+  width: 40px;
+  padding: 0;
+  text-align: center;
 }
-.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button-small .icon-ellipsis-horizontal {
-  line-height: 32px;
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button.dropdown-toggle .icon-ellipsis-horizontal {
+  line-height: 40px;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label {
-  padding: 0 0 16px 4px;
   position: relative;
+  background-color: #323232;
+  height: 40px;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label .neos-caption {
-  margin-right: 32px;
-  padding-left: 4px;
   padding-right: 4px;
   display: block;
   font-size: 12px;
-  line-height: 32px;
-  color: #adadad;
+  line-height: 40px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13663,6 +13662,7 @@
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label > img {
   float: left;
+  padding: 4px;
 }
 @media (max-width: 540px) {
   .neos.media-browser .neos-media-assets .page-navigation ul li {

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13645,18 +13645,21 @@
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label {
   padding: 0 0 16px 4px;
   position: relative;
-  font-size: 12px;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label .neos-caption {
   margin-right: 32px;
   padding-left: 4px;
   padding-right: 4px;
   display: block;
+  font-size: 12px;
   line-height: 32px;
   color: #adadad;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label .neos-dropdown {
+  font-size: 14px;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-img-label > img {
   float: left;
@@ -13849,7 +13852,7 @@
 }
 .neos.media-browser table.neos-table.asset-list .neos-action .neos-dropdown {
   display: inline-block;
-  font-size: 12px;
+  font-size: 14px;
 }
 .neos.media-browser table.neos-table.asset-list .neos-action .neos-modal, .neos.media-browser table.neos-table.asset-list .neos-action .neos-modal-content {
   text-align: left;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13638,7 +13638,6 @@
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button.dropdown-toggle {
   width: 40px;
   padding: 0;
-  text-align: center;
 }
 .neos.media-browser .neos-media-assets .neos-thumbnails > li .neos-button.dropdown-toggle .icon-ellipsis-horizontal {
   line-height: 40px;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13944,6 +13944,12 @@
 .neos.media-browser .fold-toggle {
   cursor: pointer;
 }
+.neos.media-browser .icon-ok-sign {
+  color: #00a338;
+}
+.neos.media-browser .icon-exclamation-sign {
+  color: #ff8700;
+}
 .neos #neos-notification-container.neos-notification-top {
   position: fixed;
   z-index: 999999;


### PR DESCRIPTION
Fixes and improves a bunch of different issues related to the media browser.

- Dropdown menu overflow
- Dropdown font size
- Notifications not shown inside media browser (iframe)
- Missing jQuery library when showing asset usages in media browser (iframe)
- Clicking image thumbnail again to close leads to an error
- Clicking image thumbnail and then usages and then cancel goes to overview instead of details
- Clicking image thumbnail in inspector and then clicking the close button leads to an error (fixes #1135)
- Translate labels
- No file selected in upload / replace doesn't display any error
- Make "Asset in use / not in use more clear"
- Clicking image thumbnail and then cancel goes to overview and then clicking an asset leads to an error
- Adjust styling of asset details in thumbnail view
- Translate flash message when deleting used asset