### PR TITLE
BUGFIX: Allow ``tel:`` and ``callto:`` link protocols in inline editing

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/aloha.js
@@ -228,7 +228,7 @@ function(
 						'th': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'scope']
 					},
 					protocols: {
-						'a': {'href': ['ftp', 'http', 'https', 'mailto', '__relative__', 'node', 'asset']},
+						'a': {'href': ['ftp', 'http', 'https', 'mailto', '__relative__', 'node', 'asset', 'tel', 'callto']},
 						'blockquote': {'cite': ['http', 'https', '__relative__']},
 						'q': {'cite': ['http', 'https', '__relative__']}
 					}


### PR DESCRIPTION
Allows the user to link telephone numbers and Skype usernames with Aloha.

NEOS-512 #close