### PR TITLE
BUGFIX: Allow installation of typo3/media into Flow 2.x project

### DIFF
--- a/TYPO3.Media/Migrations/Mysql/Version20110925123120.php
+++ b/TYPO3.Media/Migrations/Mysql/Version20110925123120.php
@@ -18,7 +18,13 @@ class Version20110925123120 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
         $this->addSql("CREATE TABLE typo3_media_domain_model_image (flow3_persistence_identifier VARCHAR(40) NOT NULL, resource VARCHAR(40) DEFAULT NULL, title VARCHAR(255) DEFAULT NULL, width INT DEFAULT NULL, height INT DEFAULT NULL, type INT DEFAULT NULL, imagevariants LONGTEXT DEFAULT NULL COMMENT '(DC2Type:array)', INDEX IDX_7FA2358DBC91F416 (resource), PRIMARY KEY(flow3_persistence_identifier)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
-        $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT typo3_media_domain_model_image_ibfk_1 FOREIGN KEY (resource) REFERENCES typo3_flow3_resource_resource(flow3_persistence_identifier)");
+
+        $tableNames = $this->sm->listTableNames();
+        if (array_search('typo3_flow3_resource_resource', $tableNames) !== false) {
+            $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT typo3_media_domain_model_image_ibfk_1 FOREIGN KEY (resource) REFERENCES typo3_flow3_resource_resource(flow3_persistence_identifier)");
+        } elseif (array_search('typo3_flow_resource_resource', $tableNames) !== false) {
+            $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT typo3_media_domain_model_image_ibfk_1 FOREIGN KEY (resource) REFERENCES typo3_flow_resource_resource(persistence_object_identifier)");
+        }
     }
 
     /**

--- a/TYPO3.Media/Migrations/Postgresql/Version20120412194612.php
+++ b/TYPO3.Media/Migrations/Postgresql/Version20120412194612.php
@@ -20,7 +20,13 @@ class Version20120412194612 extends AbstractMigration
         $this->addSql("CREATE TABLE typo3_media_domain_model_image (flow3_persistence_identifier VARCHAR(40) NOT NULL, resource VARCHAR(40) DEFAULT NULL, title VARCHAR(255) NOT NULL, width INT NOT NULL, height INT NOT NULL, type INT NOT NULL, imagevariants TEXT NOT NULL, PRIMARY KEY(flow3_persistence_identifier))");
         $this->addSql("CREATE INDEX IDX_7FA2358DBC91F416 ON typo3_media_domain_model_image (resource)");
         $this->addSql("COMMENT ON COLUMN typo3_media_domain_model_image.imagevariants IS '(DC2Type:array)'");
-        $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT FK_7FA2358DBC91F416 FOREIGN KEY (resource) REFERENCES typo3_flow3_resource_resource (flow3_persistence_identifier) NOT DEFERRABLE INITIALLY IMMEDIATE");
+
+        $tableNames = $this->sm->listTableNames();
+        if (array_search('typo3_flow3_resource_resource', $tableNames) !== false) {
+            $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT FK_7FA2358DBC91F416 FOREIGN KEY (resource) REFERENCES typo3_flow3_resource_resource (flow3_persistence_identifier) NOT DEFERRABLE INITIALLY IMMEDIATE");
+        } elseif (array_search('typo3_flow_resource_resource', $tableNames) !== false) {
+            $this->addSql("ALTER TABLE typo3_media_domain_model_image ADD CONSTRAINT FK_7FA2358DBC91F416 FOREIGN KEY (resource) REFERENCES typo3_flow_resource_resource (persistence_object_identifier) NOT DEFERRABLE INITIALLY IMMEDIATE");
+        }
     }
 
     /**


### PR DESCRIPTION
When installing ``typo3/media`` into an existing Flow 2.x project, a schema
migration relies on an old table name, which does not exist anymore.

This change fixes that by checking for the table name and target the
FK to create on the correct table.

NEOS-1341 #close