### PR TITLE
BUGFIX: Multi-line links in inline editing

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Editors/Aloha/LinkPlugin/lib/neos-link-plugin.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Editors/Aloha/LinkPlugin/lib/neos-link-plugin.js
@@ -55,15 +55,7 @@ define([
 				require({context: 'neos'}, ['Shared/Utility'], function(Utility) {
 					if (!Utility.isValidLink(value)) {
 						var url = 'http://' + value;
-						$(that.hrefField.getTargetObject()).attr('href', url);
-						if (that.target) {
-							that.hrefField.setAttribute(
-								'target',
-								that.target,
-								that.targetregex,
-								url
-							);
-						}
+						that.hrefField.setAttribute('href', url);
 					}
 				});
 			}

--- a/TYPO3.Neos/Resources/Public/Library/aloha/aloha.js
+++ b/TYPO3.Neos/Resources/Public/Library/aloha/aloha.js
@@ -34987,7 +34987,7 @@ define('ui/port-helper-attribute-field',[
 				// store the value to be the "reference" value for the currently selected resource item
 				resourceValue = v;
 				setAttribute(targetAttribute, item[valueField]);
-				RepositoryManager.markObject(targetObject, item);
+				executeForTargets(function (target) { RepositoryManager.markObject(target, item); });
 			} else {
 				resourceValue = null;
 			}

--- a/TYPO3.Neos/Scripts/Gruntfile.js
+++ b/TYPO3.Neos/Scripts/Gruntfile.js
@@ -129,6 +129,9 @@ module.exports = function (grunt) {
 						src = src.replace(/var componentNameByElement = {\n/, "var componentNameByElement = { 'code': 'code'," + "\n");
 						src = src.replace("availableButtons: [ 'u',", "availableButtons: [ 'code', 'u',");
 
+						// fix https://github.com/alohaeditor/Aloha-Editor/issues/1525
+						src = src.replace('RepositoryManager.markObject(targetObject, item);', 'executeForTargets(function (target) { RepositoryManager.markObject(target, item); });');
+
 						return src;
 					}
 				}


### PR DESCRIPTION
When creating a multi-line link to using inline editing, only the
first link is created correctly unless a whole URL is specified.

The issue lies in Aloha and an issue with a fix has been pushed to
their backlog. Until that is merged it is hotfixed in Neos.

https://github.com/alohaeditor/Aloha-Editor/issues/1525