### PR TITLE
BUGFIX: Avoid fetching meta data when ``AssetEditor`` is empty

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
@@ -134,7 +134,7 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 				assetIdentifiers = [$.parseJSON(value)];
 			}
 
-			if (assetIdentifiers.length > 0) {
+			if (assetIdentifiers.length > 0 && assetIdentifiers[0] != null) {
 				this.set('_showLoadingIndicator', true);
 				HttpClient.getResource(that.get('_assetMetadataEndpointUri') + '?' + $.param({assets: assetIdentifiers})).then(
 					function(result) {


### PR DESCRIPTION
If the ``AssetInspector`` is used for a single asset used and the asset is removed the inspector will call the ``assetMetadataEndpoint`` without any asset identifier. This changes it to only call the fetch the meta data if there is an asset.