### PR TITLE
BUGFIX: Avoid fetching meta data when ``AssetEditor`` is empty

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
@@ -85,11 +85,9 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 
 			var that = this;
 
-			var assetIdentifiers;
-			if (this.multiple) {
-				assetIdentifiers = $.parseJSON(value);
-			} else {
-				assetIdentifiers = [$.parseJSON(value)];
+			var assetIdentifiers = JSON.parse(value);
+			if (!this.multiple) {
+				assetIdentifiers = assetIdentifiers !== null ? [assetIdentifiers] : [];
 			}
 
 			if (assetIdentifiers.length > 0) {


### PR DESCRIPTION
If the ``AssetInspector`` is used for a single asset used and the asset is removed the inspector will call the ``assetMetadataEndpoint`` without any asset identifier. This changes it to only call the fetch the meta data if there is an asset.