### PR TITLE
TASK: Respect caption field for asset search

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -55,7 +55,8 @@ class AssetRepository extends Repository
 
         $constraints = array(
             $query->like('title', '%' . $searchTerm . '%'),
-            $query->like('resource.filename', '%' . $searchTerm . '%')
+            $query->like('resource.filename', '%' . $searchTerm . '%'),
+            $query->like('caption', '%' . $searchTerm . '%')
         );
         foreach ($tags as $tag) {
             $constraints[] = $query->contains('tags', $tag);


### PR DESCRIPTION
The caption field is not respected, when you are searching for assets.

NEOS-1837 #close