### PR TITLE
BUGFIX: Add autoload to composer again

### DIFF
--- a/TYPO3.Neos.NodeTypes/composer.json
+++ b/TYPO3.Neos.NodeTypes/composer.json
@@ -11,5 +11,10 @@
         "neos": {
             "package-key": "TYPO3.Neos.NodeTypes"
         }
+    },
+    "autoload": {
+        "psr-0": {
+            "TYPO3\\Neos\\NodeTypes": "Classes"
+        }
     }
 }


### PR DESCRIPTION
In a86591d459cb9a0f87daae72839019415b6fb1a6 the autoload
section was removed, as there had been no classes at that time.