### PR TITLE
BUGFIX: Restrict global 404 handling in UI to page loads only

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Application.js
@@ -95,7 +95,7 @@ function(
 				}
 				if (xhr === undefined || xhr.status !== 404) {
 					Notification.error('Server communication ' + status + ': ' + message);
-				} else {
+				} else if (that.get('_isLoadingPage')) {
 					that._handlePageNotFoundError(that.getCurrentUri());
 				}
 				LoadingIndicator.done();


### PR DESCRIPTION
This fixes an issue that causes the backend UI to recursively find a valid URI
in the document tree and load it, whenever a 404 response occurs to the
HTTPClient or HTTPRestClient.

That behavior is now only applied, when an actual page load is requested
and remains silent for all other requests.

NEOS-1533 #close
NEOS-1831 #close