### PR TITLE
BUGFIX: The AssetUsageInNodePropertiesStrategy breaks for non-site-nodes

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -28,6 +28,7 @@ use TYPO3\Media\Exception\AssetServiceException;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
 use TYPO3\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
+use TYPO3\Neos\Domain\Model\Dto\AssetUsageInSite;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
@@ -184,16 +185,23 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
 
         /** @var AssetUsageInNodeProperties $usage */
         foreach ($usageReferences as $usage) {
-            $documentNodeIdentifier = $usage->getDocumentNode() instanceof NodeInterface ? $usage->getDocumentNode()->getIdentifier() : null;
+            if ($usage instanceof AssetUsageInSite) {
+                $documentNodeIdentifier = $usage->getDocumentNode() instanceof NodeInterface ? $usage->getDocumentNode()->getIdentifier() : null;
 
-            $relatedNodes[$usage->getSite()->getNodeName()]['site'] = $usage->getSite();
-            $relatedNodes[$usage->getSite()->getNodeName()]['documentNodes'][$documentNodeIdentifier]['node'] = $usage->getDocumentNode();
-            $relatedNodes[$usage->getSite()->getNodeName()]['documentNodes'][$documentNodeIdentifier]['nodes'][] = [
-                'node' => $usage->getNode(),
-                'nodeData' => $usage->getNode()->getNodeData(),
-                'contextDocumentNode' => $usage->getDocumentNode(),
-                'accessible' => $usage->isAccessible()
-            ];
+                $relatedNodes[$usage->getSite()->getNodeName()]['site'] = $usage->getSite();
+                $relatedNodes[$usage->getSite()->getNodeName()]['documentNodes'][$documentNodeIdentifier]['node'] = $usage->getDocumentNode();
+                $relatedNodes[$usage->getSite()->getNodeName()]['documentNodes'][$documentNodeIdentifier]['nodes'][] = [
+                    'node' => $usage->getNode(),
+                    'nodeData' => $usage->getNode()->getNodeData(),
+                    'contextDocumentNode' => $usage->getDocumentNode(),
+                    'accessible' => $usage->isAccessible()
+                ];
+            } elseif ($usage instanceof AssetUsageInNodeProperties) {
+                $relatedNodes['cr']['site'] = ['name' => 'Content Repository'];
+                $relatedNodes['cr']['documentNodes']['cr']['nodes'][] = [
+                    'node' => $usage->getNode()
+                ];
+            }
         }
 
         $this->view->assignMultiple([

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Dto/AssetUsageInSite.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Dto/AssetUsageInSite.php
@@ -16,10 +16,21 @@ use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
- * A DTO for storing information related to a usage of an asset in node properties.
+ * A DTO for storing information related to a usage of an asset in node properties
+ * of site content.
  */
-class AssetUsageInNodeProperties extends UsageReference
+class AssetUsageInSite extends UsageReference
 {
+    /**
+     * @var Site
+     */
+    protected $site;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $documentNode;
+
     /**
      * @var NodeInterface
      */
@@ -32,14 +43,38 @@ class AssetUsageInNodeProperties extends UsageReference
 
     /**
      * @param AssetInterface $asset
+     * @param Site $site
+     * @param NodeInterface $documentNode
      * @param NodeInterface $node
      * @param boolean $accessible
      */
-    public function __construct(AssetInterface $asset, NodeInterface $node, $accessible)
+    public function __construct(AssetInterface $asset, Site $site, NodeInterface $documentNode = null, NodeInterface $node, $accessible)
     {
         parent::__construct($asset);
+        $this->site = $site;
+        $this->documentNode = $documentNode;
         $this->node = $node;
         $this->accessible = $accessible;
+    }
+
+    /**
+     * Returns the Site object of the site where the asset is in use.
+     *
+     * @return Site
+     */
+    public function getSite()
+    {
+        return $this->site;
+    }
+
+    /**
+     * Returns the parent document node of the node where the asset is used.
+     *
+     * @return NodeInterface
+     */
+    public function getDocumentNode()
+    {
+        return $this->documentNode;
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -19,6 +19,7 @@ use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Strategy\AbstractAssetUsageStrategy;
 use TYPO3\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\Service\UserService;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
@@ -92,6 +93,10 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
 
         $relatedNodes = [];
         foreach ($this->getRelatedNodes($asset) as $relatedNodeData) {
+            if (substr($relatedNodeData->getPath(), 0, strlen(SiteService::SITES_ROOT_PATH)) !== SiteService::SITES_ROOT_PATH) {
+                continue;
+            }
+
             $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());
             if ($accessible) {
                 $context = $this->createContextMatchingNodeData($relatedNodeData);

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -40,7 +40,10 @@
 								<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label)}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
 							</f:if>
 							<f:if condition="{documentNode.node}">
-								<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
+								<f:then>
+									<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
+								</f:then>
+								<f:else>---</f:else>
 							</f:if>
 						</td>
 						<td>
@@ -69,7 +72,9 @@
 							<ul>
 								<f:for each="{documentNode.nodes}" as="relatedNode">
 									<li>
-										<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank"><i class="icon-external-link"></i></neos:link.node>
+										<f:if condition="{relatedNode.contextDocumentNode}">
+											<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank"><i class="icon-external-link"></i></neos:link.node>
+										</f:if>
 									</li>
 								</f:for>
 							</ul>


### PR DESCRIPTION
The AssetUsageInNodePropertiesStrategy gathers the usage of assets
in site nodes. It uses the method
`NodePaths::getRelativePathBetween(SiteService::SITES_ROOT_PATH, $nodePath));`
to build the path between the site root and the node referencing the
asset. This method throws an exception when the asset is refernced
in a node wich is not under the site tree.
