### PR TITLE
BUGFIX: Service NodeController does not set all context properties

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
@@ -91,6 +91,12 @@ class NodeController extends AbstractServiceController
     protected $nodeOperations;
 
     /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     */
+    protected $domainRepository;
+
+    /**
      * Select special error action
      *
      * @return void
@@ -372,6 +378,7 @@ class NodeController extends AbstractServiceController
     /**
      * Search a page, needed for internal links.
      *
+     * @deprecated will be removed with 3.0, use Service/NodesController->indexAction() instead
      * @param string $query
      * @return void
      */
@@ -437,6 +444,12 @@ class NodeController extends AbstractServiceController
         $contextProperties = array(
             'workspaceName' => $workspaceName
         );
+
+        $currentDomain = $this->domainRepository->findOneByActiveRequest();
+        if ($currentDomain !== null) {
+            $contextProperties['currentSite'] = $currentDomain->getSite();
+            $contextProperties['currentDomain'] = $currentDomain;
+        }
 
         return $this->contextFactory->create($contextProperties);
     }


### PR DESCRIPTION
The service `NodeController` does not add the `currentSite` and `currentDomain` properties to the node context if a page is searched with `searchPageAction()`. Without them the uri can not be resolved.
This methos is also marked as deprecated with this change since it is never used and will be removed with 3.0