### PR TITLE
TASK: Streamline generated Site packages

### DIFF
--- a/TYPO3.Neos.Kickstarter/Resources/Private/Generator/Content/Sites.xml
+++ b/TYPO3.Neos.Kickstarter/Resources/Private/Generator/Content/Sites.xml
@@ -24,18 +24,6 @@
       </dimensions>
       <accessRoles __type="array"/>
      </variant>
-     <node nodeName="text1">
-      <variant workspace="live" nodeType="TYPO3.Neos.NodeTypes:Text" sortingIndex="100" version="1" removed="" hidden="" hiddenInIndex="">
-       <dimensions>
-       <f:for each="{dimensions}" as="dimension">
-        <{dimension.identifier}>{dimension.default}</{dimension.identifier}>
-       </f:for>
-       </dimensions>
-       <accessRoles __type="array"/>
-       <properties>
-        <text __type="string">&lt;p&gt;This is the homepage&lt;/p&gt;</text>
-       </properties>
-      </variant>
      </node>
     </node>
    </node>

--- a/TYPO3.Neos.Kickstarter/Resources/Private/Generator/Template/SiteTemplate.html
+++ b/TYPO3.Neos.Kickstarter/Resources/Private/Generator/Template/SiteTemplate.html
@@ -15,9 +15,6 @@
 	<nav class="menu">
 		{parts.menu -> f:format.raw()}
 	</nav>
-	<nav class="breadcrumb">
-		{parts.breadcrumb -> f:format.raw()}
-	</nav>
 	<div class="content">
 		{content.main -> f:format.raw()}
 	</div>

--- a/TYPO3.Neos.Kickstarter/Resources/Private/Generator/TypoScript/Root.ts2
+++ b/TYPO3.Neos.Kickstarter/Resources/Private/Generator/TypoScript/Root.ts2
@@ -1,7 +1,7 @@
 /**
  * Root TypoScript template for the {siteName} site
  */
-page = Page {
+page = TYPO3.Neos:Page {
 	head {
 		stylesheets.site = TYPO3.TypoScript:Template {
 			templatePath = 'resource://{packageKey}/Private/Templates/Page/Default.html'
@@ -18,13 +18,13 @@ page = Page {
 		templatePath = 'resource://{packageKey}/Private/Templates/Page/Default.html'
 		sectionName = 'body'
 		parts {
-			menu = Menu
-			breadcrumb = Breadcrumb
+			menu = TYPO3.Neos:Menu
 		}
+
 		// These are your content areas, you can define as many as you want, just name them and the nodePath.
 		content {
 			// The default content section
-			main = PrimaryContent {
+			main = TYPO3.Neos:PrimaryContent {
 				nodePath = 'main'
 			}
 		}


### PR DESCRIPTION
Removes useless text node to prevent complications with dimensions,
the breadcrumb that these days is seldom used and uses fully qualified
prototype names for all used TypoScript objects to make understanding
easier.