### PR TITLE
BUGFIX: Add missing default configuration

### DIFF
--- a/TYPO3.TYPO3CR/Configuration/Objects.yaml
+++ b/TYPO3.TYPO3CR/Configuration/Objects.yaml
@@ -6,6 +6,10 @@
   className: TYPO3\TYPO3CR\Service\PublishingService
 'TYPO3\TYPO3CR\Domain\Model\NodeInterface':
   className: TYPO3\TYPO3CR\Domain\Model\Node
+'TYPO3\TYPO3CR\Domain\Service\ConfigurationContentDimensionPresetSource':
+  properties:
+    configuration:
+      setting: 'TYPO3.TYPO3CR.contentDimensions'
 'TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface':
   className: TYPO3\TYPO3CR\Domain\Service\ConfigurationContentDimensionPresetSource
 'TYPO3\TYPO3CR\Domain\Model\NodeLabelGeneratorInterface':


### PR DESCRIPTION
The ConfigurationContentDimensionPresetSource in TYPO3CR did not have its
configuration set by default (as opposed to the Neos implementation).