### PR TITLE
BUGFIX: Allow the deletion of the primary domain

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
@@ -345,9 +345,14 @@ class SitesController extends AbstractModuleController
      */
     public function deleteDomainAction(Domain $domain)
     {
+        $site = $domain->getSite();
+        if ($site->getPrimaryDomain() === $domain) {
+            $site->setPrimaryDomain(null);
+            $this->siteRepository->update($site);
+        }
         $this->domainRepository->remove($domain);
         $this->addFlashMessage('The domain "%s" has been deleted.', 'Domain deleted', Message::SEVERITY_OK, array(htmlspecialchars($domain)), 1412373310);
-        $this->unsetLastVisitedNodeAndRedirect('edit', null, null, array('site' => $domain->getSite()));
+        $this->unsetLastVisitedNodeAndRedirect('edit', null, null, array('site' => $site));
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Site.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Site.php
@@ -279,15 +279,21 @@ class Site
     /**
      * Sets (and adds if necessary) the primary domain of this site.
      *
-     * @param Domain $domain The domain
+     * @param Domain|null $domain The domain
      * @return void
      * @api
      */
-    public function setPrimaryDomain(Domain $domain)
+    public function setPrimaryDomain(Domain $domain = null)
     {
+        if ($domain === null) {
+            $this->primaryDomain = null;
+            return;
+        }
+
         if (!$domain->getActive()) {
             return;
         }
+
         $this->primaryDomain = $domain;
         if (!$this->domains->contains($domain)) {
             $this->domains->add($domain);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
@@ -76,6 +76,9 @@ class SiteService
             $this->nodeDataRepository->remove($siteNode);
         }
 
+        $site->setPrimaryDomain(null);
+        $this->siteRepository->update($site);
+
         $domainsForSite = $this->domainRepository->findBySite($site);
         foreach ($domainsForSite as $domain) {
             $this->domainRepository->remove($domain);


### PR DESCRIPTION
Currently it's not possible to prune a site
with a primary domain or delete a primary
domain in the Neos backend.

This change will first unset the primary domain
of a site if it's the one which should be deleted
and then deletes it.

NEOS-1839 #close