### PR TITLE
FEATURE: Allow usage of arbitrary form factories in Form node type

### DIFF
--- a/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
@@ -1,8 +1,15 @@
 {namespace form=TYPO3\Form\ViewHelpers}
 <div{attributes -> f:format.raw()}>
-	<f:if condition="{formIdentifier}">
+	<f:if condition="{formSelected}">
 		<f:then>
-			<form:render persistenceIdentifier="{formIdentifier}" presetName="{presetName}" overrideConfiguration="{overrideConfiguration}" />
+			<f:if condition="{formIdentifier}">
+				<f:then>
+					<form:render factoryClass="{factoryClass}" persistenceIdentifier="{formIdentifier}" presetName="{presetName}" overrideConfiguration="{overrideConfiguration}" />
+				</f:then>
+				<f:else>
+					<form:render factoryClass="{factoryClass}" presetName="{presetName}" overrideConfiguration="{overrideConfiguration}" />
+				</f:else>
+			</f:if>
 		</f:then>
 		<f:else>
 			<p>{f:translate(id: 'content.noValidFormIdentifier', package: 'TYPO3.Neos.NodeTypes', source: 'NodeTypes/Form')}</p>

--- a/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.Neos.NodeTypes/Resources/Private/TypoScript/Root.ts2
@@ -91,7 +91,14 @@ prototype(TYPO3.Neos.NodeTypes:FourColumn) < prototype(TYPO3.Neos.NodeTypes:Mult
 
 # Form TS Object
 prototype(TYPO3.Neos.NodeTypes:Form) {
+	@context.formIdentifier = ${q(node).property('formIdentifier')}
+
 	presetName = 'default'
+	formSelected = ${!String.isBlank(formIdentifier)}
+	formIdentifier = ${String.endsWith(formIdentifier, 'FormFactory') ? NULL : formIdentifier}
+	factoryClass = ${String.endsWith(formIdentifier, 'FormFactory') ? formIdentifier : 'TYPO3\\Form\\Factory\\ArrayFormFactory'}
+	overrideConfiguration = TS:RawArray
+
 	@cache {
 		mode = 'uncached'
 		context {


### PR DESCRIPTION
This makes use of already present features of the form:render view helper to distinguish
between forms based on a persistence identifier and forms based on custom form factories.

The corresponding additional configuration in e.g. a site package would look like this:

```
'TYPO3.Neos.NodeTypes:Form':
  properties:
    formIdentifier:
      ui:
        inspector:
          editorOptions:
            values:
              'Site\Package\Factory\DynamicContactFormFactory':
                label: 'Contact'
```

NEOS-1842 #close
