### PR TITLE
TASK: `TYPO3.Neos:Menu` entryLevel should respect a starting point

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Menu.ts2
@@ -6,7 +6,7 @@ prototype(TYPO3.Neos:Menu) < prototype(TYPO3.TypoScript:Template) {
 	node = ${node}
 	items = ${this.items}
 
-	entryLevel = 1
+	entryLevel = ${this.startingPoint ? 0 : 1}
 	maximumLevels = 2
 
 	filter = 'TYPO3.Neos:Document'


### PR DESCRIPTION
If a starting point for a `TYPO3.Neos:Menu` is set the entryLevel won't work out of the box in all cases because it defaults to the first level of the site. If the starting point is below that you won't see any menu items.

This changes the default behaviour of the entryLevel. It will be set to 0 if there is a startingPoint configured otherwise stick to 1.

NEOS-1838 #resolve