### PR TITLE
BUGFIX: Fix resizing of images with "extreme" ratios

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -13,9 +13,9 @@ namespace TYPO3\Media\Domain\Model\Adjustment;
 
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
-use Imagine\Image\Box;
 use Imagine\Image\Point;
 use Imagine\Image\ImageInterface as ImagineImageInterface;
+use TYPO3\Media\Imagine\Box;
 
 /**
  * An adjustment for cropping an image

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -12,7 +12,7 @@ namespace TYPO3\Media\Domain\Model\Adjustment;
  */
 
 use Doctrine\ORM\Mapping as ORM;
-use Imagine\Image\Box;
+use TYPO3\Media\Imagine\Box;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\ImageInterface as ImagineImageInterface;
 use Imagine\Image\Point;

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ImageService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ImageService.php
@@ -11,7 +11,7 @@ namespace TYPO3\Media\Domain\Service;
  * source code.
  */
 
-use Imagine\Image\Box;
+use TYPO3\Media\Imagine\Box;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\Exception\InvalidConfigurationException;
 use TYPO3\Flow\Resource\Resource as FlowResource;

--- a/TYPO3.Media/Classes/TYPO3/Media/Imagine/Box.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Imagine/Box.php
@@ -1,0 +1,124 @@
+<?php
+namespace TYPO3\Media\Imagine;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Imagine\Image\BoxInterface;
+use Imagine\Image\Point;
+use Imagine\Image\PointInterface;
+use TYPO3\Flow\Annotations as Flow;
+
+class Box implements \Imagine\Image\BoxInterface
+{
+
+    /**
+     * @var integer
+     */
+    private $width;
+
+    /**
+     * @var integer
+     */
+    private $height;
+
+    /**
+     * Constructs the Size with given width and height
+     *
+     * @param integer $width
+     * @param integer $height
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($width, $height)
+    {
+        if ($height < 1 || $width < 1) {
+            throw new \InvalidArgumentException(sprintf('Length of either side cannot be 0 or negative, current size is %sx%s',
+                $width, $height), 1465382619);
+        }
+
+        $this->width = (integer)$width;
+        $this->height = (integer)$height;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function scale($ratio)
+    {
+        return new static(max(round($ratio * $this->width), 1), max(round($ratio * $this->height), 1));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increase($size)
+    {
+        return new static((integer)$size + $this->width, (integer)$size + $this->height);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains(BoxInterface $box, PointInterface $start = null)
+    {
+        $start = $start ? $start : new Point(0, 0);
+
+        return $start->in($this) && $this->width >= $box->getWidth() + $start->getX() && $this->height >= $box->getHeight() + $start->getY();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function square()
+    {
+        return $this->width * $this->height;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return sprintf('%dx%d px', $this->width, $this->height);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function widen($width)
+    {
+        return $this->scale($width / $this->width);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function heighten($height)
+    {
+        return $this->scale($height / $this->height);
+    }
+}

--- a/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
+++ b/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
@@ -11,7 +11,7 @@ namespace TYPO3\Media\Tests\Unit\Domain\Model\Adjustment;
  * source code.
  */
 
-use Imagine\Image\Box;
+use TYPO3\Media\Imagine\Box;
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
 use TYPO3\Media\Domain\Model\ImageInterface;
@@ -86,6 +86,46 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         $expectedDimensions = new Box(127, 95);
 
         $adjustment->setHeight(95);
+
+        $this->assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
+    }
+
+    /**
+     * @test
+     */
+    public function minimumHeightIsGreaterZero()
+    {
+        /** @var ResizeImageAdjustment $adjustment */
+        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'), array(
+            array(
+                'maximumWidth' => 250,
+                'maximumHeight' => 250,
+                'ratioMode' => ImageInterface::RATIOMODE_INSET
+            )
+        ));
+
+        $originalDimensions = new Box(2000, 2);
+        $expectedDimensions = new Box(250, 1);
+
+        $this->assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
+    }
+
+    /**
+     * @test
+     */
+    public function minimumWidthIsGreaterZero()
+    {
+        /** @var ResizeImageAdjustment $adjustment */
+        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'), array(
+            array(
+                'maximumWidth' => 250,
+                'maximumHeight' => 250,
+                'ratioMode' => ImageInterface::RATIOMODE_INSET
+            )
+        ));
+
+        $originalDimensions = new Box(2, 2000);
+        $expectedDimensions = new Box(1, 250);
 
         $this->assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
     }


### PR DESCRIPTION
Images that have extreme dimensions (e.g. 2000x2) could cause exceptions
when scaling because of a zero width or height when calculating the
resulting thumbnail size.

This change introduces a custom Imagine Box implementation that prevents
boxes with zero width or height when scaling a box.

NEOS-576 #comment PR 564 is related to this