### PR TITLE
BUGFIX: Remove double negative from error message

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
@@ -558,7 +558,7 @@ class Parser implements ParserInterface
         if (preg_match('#([^\*]*)\*\*/\*#', $include, $matches) === 1) {
             $basePath = $matches['1'];
             if (!is_dir($basePath)) {
-                throw new Exception(sprintf('The path %s does not point to a non-directory.', $basePath), 1415033179);
+                throw new Exception(sprintf('The path %s does not point to a directory.', $basePath), 1415033179);
             }
             $recursiveDirectoryIterator = new \RecursiveDirectoryIterator($basePath);
             $iterator = new \RecursiveIteratorIterator($recursiveDirectoryIterator);
@@ -566,7 +566,7 @@ class Parser implements ParserInterface
         } elseif (preg_match('#([^\*]*)\*#', $include, $matches) === 1) {
             $basePath = $matches['1'];
             if (!is_dir($basePath)) {
-                throw new Exception(sprintf('The path %s does not point to a non-directory.', $basePath), 1415033180);
+                throw new Exception(sprintf('The path %s does not point to a directory.', $basePath), 1415033180);
             }
             $iterator = new \DirectoryIterator($basePath);
         }


### PR DESCRIPTION
When writing `include: NodeTypes/**/*` in `Root.ts2` a misleading exception shows up, if the directory does not exist.