### PR TITLE
TASK: De-Duplicate site and domain logic

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
@@ -61,14 +61,6 @@ trait CreateContentContextTrait
             }, $dimensions);
         }
 
-        $currentDomain = $this->_domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->_siteRepository->findFirstOnline();
-        }
-
         return $this->_contextFactory->create($contextProperties);
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
@@ -94,12 +94,8 @@ class ContentContextFactory extends ContextFactory
             'currentDomain' => null
         );
 
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $defaultContextProperties['currentSite'] = $currentDomain->getSite();
-            $defaultContextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $defaultContextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+        if (!isset($contextProperties['currentSite'])) {
+            $defaultContextProperties = $this->setDefaultSiteAndDomainFromCurrentRequest($defaultContextProperties);
         }
 
         $mergedProperties = Arrays::arrayMergeRecursiveOverrule($defaultContextProperties, $contextProperties, true);
@@ -109,6 +105,27 @@ class ContentContextFactory extends ContextFactory
 
         return $mergedProperties;
     }
+
+    /**
+     * Determines the current domain and site from the request and sets the resulting values as
+     * as defaults.
+     *
+     * @param array $defaultContextProperties
+     * @return array
+     */
+    protected function setDefaultSiteAndDomainFromCurrentRequest(array $defaultContextProperties)
+    {
+        $currentDomain = $this->domainRepository->findOneByActiveRequest();
+        if ($currentDomain !== null) {
+            $defaultContextProperties['currentSite'] = $currentDomain->getSite();
+            $defaultContextProperties['currentDomain'] = $currentDomain;
+        } else {
+            $defaultContextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+        }
+
+        return $defaultContextProperties;
+    }
+
 
     /**
      * This creates the actual identifier and needs to be overridden by builders extending this.

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
@@ -30,6 +30,18 @@ use TYPO3\TYPO3CR\Exception\InvalidNodeContextException;
 class ContentContextFactory extends ContextFactory
 {
     /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     */
+    protected $domainRepository;
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     */
+    protected $siteRepository;
+
+    /**
      * The context implementation this factory will create
      *
      * @var string
@@ -81,6 +93,14 @@ class ContentContextFactory extends ContextFactory
             'currentSite' => null,
             'currentDomain' => null
         );
+
+        $currentDomain = $this->domainRepository->findOneByActiveRequest();
+        if ($currentDomain !== null) {
+            $defaultContextProperties['currentSite'] = $currentDomain->getSite();
+            $defaultContextProperties['currentDomain'] = $currentDomain;
+        } else {
+            $defaultContextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+        }
 
         $mergedProperties = Arrays::arrayMergeRecursiveOverrule($defaultContextProperties, $contextProperties, true);
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -311,15 +311,6 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             $contextProperties['dimensions'] = $dimensions;
         }
 
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
-
         return $this->contextFactory->create($contextProperties);
     }
 
@@ -585,15 +576,6 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             'inaccessibleContentShown' => ($workspaceName !== 'live'),
             'dimensions' => $dimensionsAndDimensionValues
         ];
-
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
 
         return $this->contextFactory->create($contextProperties);
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/BackendRedirectionService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/BackendRedirectionService.php
@@ -171,13 +171,6 @@ class BackendRedirectionService
             'inaccessibleContentShown' => true
         );
 
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
         return $this->contextFactory->create($contextProperties);
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/PublishingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/PublishingService.php
@@ -12,13 +12,8 @@ namespace TYPO3\Neos\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Neos\Domain\Model\Domain;
-use TYPO3\Neos\Domain\Model\Site;
-use TYPO3\Neos\Domain\Repository\DomainRepository;
-use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
-use TYPO3\TYPO3CR\Domain\Service\Context;
 
 /**
  * The workspaces service adds some basic helper methods for getting workspaces,
@@ -29,28 +24,6 @@ use TYPO3\TYPO3CR\Domain\Service\Context;
  */
 class PublishingService extends \TYPO3\TYPO3CR\Domain\Service\PublishingService
 {
-    /**
-     * @Flow\Inject
-     * @var DomainRepository
-     */
-    protected $domainRepository;
-
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
-
-    /**
-     * @var Domain
-     */
-    protected $currentDomain = false;
-
-    /**
-     * @var Site
-     */
-    protected $currentSite = false;
-
     /**
      * Publishes the given node to the specified target workspace. If no workspace is specified, the base workspace
      * is assumed.
@@ -81,33 +54,5 @@ class PublishingService extends \TYPO3\TYPO3CR\Domain\Service\PublishingService
         $sourceWorkspace->publishNodes($nodes, $targetWorkspace);
 
         $this->emitNodePublished($node, $targetWorkspace);
-    }
-
-    /**
-     * Creates a new content context based on the given workspace and the NodeData object and additionally takes
-     * the current site and current domain into account.
-     *
-     * @param Workspace $workspace Workspace for the new context
-     * @param array $dimensionValues The dimension values for the new context
-     * @param array $contextProperties Additional pre-defined context properties
-     * @return Context
-     */
-    protected function createContext(Workspace $workspace, array $dimensionValues, array $contextProperties = array())
-    {
-        if ($this->currentDomain === false) {
-            $this->currentDomain = $this->domainRepository->findOneByActiveRequest();
-        }
-
-        if ($this->currentDomain !== null) {
-            $contextProperties['currentSite'] = $this->currentDomain->getSite();
-            $contextProperties['currentDomain'] = $this->currentDomain;
-        } else {
-            if ($this->currentSite === false) {
-                $this->currentSite = $this->siteRepository->findFirstOnline();
-            }
-            $contextProperties['currentSite'] = $this->currentSite;
-        }
-
-        return parent::createContext($workspace, $dimensionValues, $contextProperties);
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
@@ -37,24 +37,4 @@ class NodeConverter extends \TYPO3\TYPO3CR\TypeConverter\NodeConverter
      * @var integer
      */
     protected $priority = 3;
-
-    /**
-     * Additionally add the current site and domain to the Context properties.
-     *
-     * {@inheritdoc}
-     */
-    protected function prepareContextProperties($workspaceName, \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
-    {
-        $contextProperties = parent::prepareContextProperties($workspaceName, $configuration, $dimensions);
-
-        $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        if ($currentDomain !== null) {
-            $contextProperties['currentSite'] = $currentDomain->getSite();
-            $contextProperties['currentDomain'] = $currentDomain;
-        } else {
-            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
-        }
-
-        return $contextProperties;
-    }
 }

--- a/TYPO3.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace TYPO3\Neos\Tests\Unit\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\ContentContextFactory;
+
+/**
+ * Testcase for the ContentContextFactory
+ *
+ */
+class ContentContextFactoryTest extends \TYPO3\Flow\Tests\UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function createWillSetDomainAndSiteFromCurrentRequestIfNotGiven()
+    {
+        $mockDomainRepository = $this->getMockBuilder(DomainRepository::class)->disableOriginalConstructor()->getMock();
+
+        $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
+
+        $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
+        $mockDomain->expects($this->atLeastOnce())->method('getSite')->will($this->returnValue($mockSite));
+        $mockDomainRepository->expects($this->atLeastOnce())->method('findOneByActiveRequest')->will($this->returnValue($mockDomain));
+
+        $mockSiteRepository = $this->getMockBuilder(SiteRepository::class)->disableOriginalConstructor()->getMock();
+        $mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue(null));
+
+        $contentContextFactory = $this->getMockBuilder(ContentContextFactory::class)->setMethods([
+            'validateContextProperties',
+            'mergeDimensionValues',
+            'mergeTargetDimensionContextProperties',
+            'getIdentifier'
+        ])->disableOriginalConstructor()->getMock();
+        $contentContextFactory->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('abc'));
+
+        $this->inject($contentContextFactory, 'domainRepository', $mockDomainRepository);
+        $this->inject($contentContextFactory, 'siteRepository', $mockSiteRepository);
+        $this->inject($contentContextFactory, 'now', new \DateTime());
+
+        /** @var ContentContext $context */
+        $context = $contentContextFactory->create(['workspaceName' => 'user-test']);
+        $this->assertEquals($mockSite, $context->getCurrentSite());
+        $this->assertEquals($mockDomain, $context->getCurrentDomain());
+    }
+}

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -315,30 +315,6 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
     /**
      * @test
-     */
-    public function matchCreatesContextForCurrentDomainIfOneIsFound()
-    {
-        $mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
-
-        $mockDomain = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
-        $mockDomain->expects($this->any())->method('getSite')->will($this->returnValue($mockSite));
-
-        $this->mockDomainRepository->expects($this->atLeastOnce())->method('findOneByActiveRequest')->will($this->returnValue($mockDomain));
-
-        $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $mockSite;
-        $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
-
-        $this->assertNull($mockContext->getCurrentDomain());
-
-        $routePath = '';
-        $this->routePartHandler->match($routePath);
-
-        $this->assertSame($mockDomain, $mockContext->getCurrentDomain());
-    }
-
-    /**
-     * @test
      * @dataProvider contextPathsAndRequestPathsDataProvider
      */
     public function matchConsidersDimensionValuePresetsSpecifiedInTheRequestUriWhileBuildingTheContext($expectedContextPath, $requestPath)
@@ -524,34 +500,6 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         }));
 
         $routeValues = array('node' => '/sites/examplecom/home@user-johndoe');
-        $this->assertTrue($this->routePartHandler->resolve($routeValues));
-    }
-
-    /**
-     * @test
-     */
-    public function resolveCreatesContextForCurrentDomainIfGivenValueIsAStringAndADomainIsFound()
-    {
-        $mockContext = $this->buildMockContext(array('workspaceName' => 'user-johndoe'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
-        $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
-        $mockContext->mockSiteNode = $mockSiteNode;
-
-        $mockContext->expects($this->any())->method('getNode')->will($this->returnCallback(function ($nodePath) use ($mockSiteNode) {
-            return ($nodePath === '/sites/examplecom') ? $mockSiteNode : null;
-        }));
-
-        $mockDomain = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
-        $this->mockDomainRepository->expects($this->atLeastOnce())->method('findOneByActiveRequest')->will($this->returnValue($mockDomain));
-
-        $that = $this;
-        $this->mockContextFactory->expects($this->once())->method('create')->will($this->returnCallback(function ($contextProperties) use ($that, $mockContext, $mockDomain) {
-            // The important assertion:
-            $that->assertSame($mockDomain, $contextProperties['currentDomain']);
-            return $mockContext;
-        }));
-
-        $routeValues = array('node' => '/sites/examplecom');
         $this->assertTrue($this->routePartHandler->resolve($routeValues));
     }
 

--- a/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -53,16 +53,6 @@ class PublishingServiceTest extends UnitTestCase
     protected $mockContextFactory;
 
     /**
-     * @var DomainRepository
-     */
-    protected $mockDomainRepository;
-
-    /**
-     * @var SiteRepository
-     */
-    protected $mockSiteRepository;
-
-    /**
      * @var Workspace
      */
     protected $mockWorkspace;
@@ -77,10 +67,6 @@ class PublishingServiceTest extends UnitTestCase
      */
     protected $mockQueryResult;
 
-    /**
-     * @var \TYPO3\Neos\Domain\Model\Site
-     */
-    protected $mockSite;
     /**
 
      * @var ContentDimensionPresetSourceInterface
@@ -102,15 +88,7 @@ class PublishingServiceTest extends UnitTestCase
 
         $this->mockContextFactory = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface')->disableOriginalConstructor()->getMock();
         $this->inject($this->publishingService, 'contextFactory', $this->mockContextFactory);
-
-        $this->mockDomainRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\DomainRepository')->disableOriginalConstructor()->getMock();
-        $this->inject($this->publishingService, 'domainRepository', $this->mockDomainRepository);
-
-        $this->mockSiteRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\SiteRepository')->disableOriginalConstructor()->getMock();
-        $this->mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
-        $this->mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue($this->mockSite));
-        $this->inject($this->publishingService, 'siteRepository', $this->mockSiteRepository);
-
+        
         $this->mockBaseWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
         $this->mockBaseWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
         $this->mockBaseWorkspace->expects($this->any())->method('getBaseWorkspace')->will($this->returnValue(null));
@@ -147,7 +125,6 @@ class PublishingServiceTest extends UnitTestCase
             'inaccessibleContentShown' => true,
             'invisibleContentShown' => true,
             'removedContentShown' => true,
-            'currentSite' => $this->mockSite,
             'dimensions' => array()
         );
         $this->mockContextFactory->expects($this->any())->method('create')->with($expectedContextProperties)->will($this->returnValue($mockContext));
@@ -187,7 +164,6 @@ class PublishingServiceTest extends UnitTestCase
             'inaccessibleContentShown' => true,
             'invisibleContentShown' => true,
             'removedContentShown' => true,
-            'currentSite' => $this->mockSite,
             'dimensions' => array()
         );
         $this->mockContextFactory->expects($this->any())->method('create')->with($expectedContextProperties)->will($this->returnValue($mockContext));


### PR DESCRIPTION
The logic to fetch site and domain for the ``ContentContext`` was
duplicated in several parts of Neos. This duplication is rather useless
as the values derived by it can be seen as default values for the two
properties. Therefore the logic was refactored to the
``ContentContextFactory`` and removed from other places in favor of
letting the factory set it as default.