### PR TITLE
BUGFIX: Add support for ImageMagick 7

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -66,13 +66,20 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $im->setImageFormat('png');
             $im->setImageBackgroundColor('white');
             $im->setImageCompose(\Imagick::COMPOSITE_OVER);
-            $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
+            if (defined('\Imagick::ALPHACHANNEL_OFF')) {
+                $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OFF);
+            } else {
+                $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
+            }
             $im->thumbnailImage($width, $height, true);
 
-            $im->flattenImages();
-            // Replace flattenImages in imagick 3.3.0
-            // @see https://pecl.php.net/package/imagick/3.3.0RC2
-            // $im->mergeImageLayers(\Imagick::LAYERMETHOD_MERGE);
+            if (method_exists($im, 'mergeImageLayers')) {
+                // Replace flattenImages in imagick 3.3.0
+                // @see https://pecl.php.net/package/imagick/3.3.0RC2
+                $im->mergeImageLayers(\Imagick::LAYERMETHOD_MERGE);
+            } else {
+                $im->flattenImages();
+            }
 
             $resource = $this->resourceManager->importResourceFromContent($im->getImageBlob(), $filenameWithoutExtension . '.png');
             $im->destroy();


### PR DESCRIPTION
ImageMagick 7 has some breaking changes and Imagick has reacted on this. Some of there changes are also breaking changes. Using ImageMagick >= 7.0 makes it's mandatory to use Imagick >= 3.4.3RC1.

In case of running Neos with these versions the `DocumentThumbnailGenerator` throws Fatal errors, because of missing class constant `\Imagick::ALPHACHANNEL_RESET` and missing method `Imagick::flattenImages`.