### PR TITLE
BUGFIX: Protect content cache against segment tokens in content

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/CacheSegmentParser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/CacheSegmentParser.php
@@ -35,10 +35,11 @@ class CacheSegmentParser
      * This method also prepares a cleaned up output which can be retrieved later. See getOutput() for more information.
      *
      * @param string $content The content to process, ie. the rendered content with some segment markers already in place
+     * @param string $randomCacheMarker A random cache marker that should be used to "protect" against content containing special characters used to mark cache segments
      * @return string The outer content with placeholders instead of the actual content segments
-     * @throws \TYPO3\TypoScript\Exception
+     * @throws Exception
      */
-    public function extractRenderedSegments($content)
+    public function extractRenderedSegments($content, $randomCacheMarker = '')
     {
         $this->output = '';
         $this->cacheEntries = array();
@@ -46,8 +47,8 @@ class CacheSegmentParser
 
         $currentPosition = 0;
         $level = 0;
-        $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN, $currentPosition);
-        $nextEndPosition = strpos($content, ContentCache::CACHE_SEGMENT_END_TOKEN, $currentPosition);
+        $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN . $randomCacheMarker, $currentPosition);
+        $nextEndPosition = strpos($content, ContentCache::CACHE_SEGMENT_END_TOKEN . $randomCacheMarker, $currentPosition);
 
         while (true) {
 
@@ -87,14 +88,14 @@ class CacheSegmentParser
                 $level--;
 
                 if ($currentLevelPart['type'] === ContentCache::SEGMENT_TYPE_UNCACHED) {
-                    $parts[$level]['content'] .= ContentCache::CACHE_SEGMENT_START_TOKEN . $identifier . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . $currentLevelPart['context'] . ContentCache::CACHE_SEGMENT_END_TOKEN;
+                    $parts[$level]['content'] .= ContentCache::CACHE_SEGMENT_START_TOKEN . ContentCache::CACHE_SEGMENT_MARKER . $identifier . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . ContentCache::CACHE_SEGMENT_MARKER . $currentLevelPart['context'] . ContentCache::CACHE_SEGMENT_END_TOKEN . ContentCache::CACHE_SEGMENT_MARKER;
                 } else {
-                    $parts[$level]['content'] .= ContentCache::CACHE_SEGMENT_START_TOKEN . $identifier . ContentCache::CACHE_SEGMENT_END_TOKEN;
+                    $parts[$level]['content'] .= ContentCache::CACHE_SEGMENT_START_TOKEN . ContentCache::CACHE_SEGMENT_MARKER . $identifier . ContentCache::CACHE_SEGMENT_END_TOKEN . ContentCache::CACHE_SEGMENT_MARKER;
                 }
 
-                $currentPosition = $nextEndPosition + 1;
+                $currentPosition = $nextEndPosition + 1 + strlen($randomCacheMarker);
 
-                $nextEndPosition = strpos($content, ContentCache::CACHE_SEGMENT_END_TOKEN, $currentPosition);
+                $nextEndPosition = strpos($content, ContentCache::CACHE_SEGMENT_END_TOKEN . $randomCacheMarker, $currentPosition);
             } else {
 
                 // Push everything until now to the current stack value
@@ -106,12 +107,12 @@ class CacheSegmentParser
                 $level++;
                 $parts[$level] = array('content' => '');
 
-                $currentPosition = $nextStartPosition + 1;
+                $currentPosition = $nextStartPosition + 1 + strlen($randomCacheMarker);
 
-                $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN, $currentPosition);
+                $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN . $randomCacheMarker, $currentPosition);
 
-                $nextIdentifierSeparatorPosition = strpos($content, ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN, $currentPosition);
-                $nextSecondIdentifierSeparatorPosition = strpos($content, ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN, $nextIdentifierSeparatorPosition + 1);
+                $nextIdentifierSeparatorPosition = strpos($content, ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . $randomCacheMarker, $currentPosition);
+                $nextSecondIdentifierSeparatorPosition = strpos($content, ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . $randomCacheMarker, $nextIdentifierSeparatorPosition + 1);
 
                 if ($nextIdentifierSeparatorPosition === false || $nextSecondIdentifierSeparatorPosition === false
                     || $nextStartPosition !== false && $nextStartPosition < $nextIdentifierSeparatorPosition
@@ -122,7 +123,7 @@ class CacheSegmentParser
                 }
 
                 $identifier = substr($content, $currentPosition, $nextIdentifierSeparatorPosition - $currentPosition);
-                $contextOrMetadata = substr($content, $nextIdentifierSeparatorPosition + 1, $nextSecondIdentifierSeparatorPosition - $nextIdentifierSeparatorPosition - 1);
+                $contextOrMetadata = substr($content, $nextIdentifierSeparatorPosition + 1 + strlen($randomCacheMarker), $nextSecondIdentifierSeparatorPosition - $nextIdentifierSeparatorPosition - 1 - strlen($randomCacheMarker));
 
                 $parts[$level]['identifier'] = $identifier;
                 if (strpos($identifier, 'eval=') === 0) {
@@ -133,9 +134,9 @@ class CacheSegmentParser
                     $parts[$level]['metadata'] = $contextOrMetadata;
                 }
 
-                $currentPosition = $nextSecondIdentifierSeparatorPosition + 1;
+                $currentPosition = $nextSecondIdentifierSeparatorPosition + 1 + strlen($randomCacheMarker);
 
-                $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN, $currentPosition);
+                $nextStartPosition = strpos($content, ContentCache::CACHE_SEGMENT_START_TOKEN . $randomCacheMarker, $currentPosition);
             }
         };
 

--- a/TYPO3.TypoScript/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
+++ b/TYPO3.TypoScript/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
@@ -45,9 +45,9 @@ class CacheSegmentParserTest extends UnitTestCase
 
     protected $expectedOuterContent = "
 		outer content
-		\x02123456789\x03
+		\x02CONTENT_CACHE123456789\x03CONTENT_CACHE
 		with some text
-		\x026789012345\x03
+		\x02CONTENT_CACHE6789012345\x03CONTENT_CACHE
 	";
 
     protected $expectedEntries = array(
@@ -74,7 +74,7 @@ class CacheSegmentParserTest extends UnitTestCase
 
         '4567890123' => array(
             'content' => "dolor
-				\x025678901234\x03
+				\x02CONTENT_CACHE5678901234\x03CONTENT_CACHE
 			sit",
             'identifier' => '4567890123',
             'type' => 'cached',
@@ -85,9 +85,9 @@ class CacheSegmentParserTest extends UnitTestCase
             'identifier' => '123456789',
             'type' => 'cached',
             'content' => "foo bar baz
-			bar bar \x022345678901\x03
-			foo foo \x023456789012\x03
-			baz baz \x024567890123\x03",
+			bar bar \x02CONTENT_CACHE2345678901\x03CONTENT_CACHE
+			foo foo \x02CONTENT_CACHE3456789012\x03CONTENT_CACHE
+			baz baz \x02CONTENT_CACHE4567890123\x03CONTENT_CACHE",
             'metadata' => 'AllDocumentNodes'
         ),
 
@@ -141,16 +141,16 @@ class CacheSegmentParserTest extends UnitTestCase
 
     protected $expectedOuterContentWithUncachedSegments = "
 		outer content
-		\x02123456789\x03
+		\x02CONTENT_CACHE123456789\x03CONTENT_CACHE
 		with some text
-		\x02eval=bar/baz\x1f{\"node\":\"/sites/demo/home\"}\x03
-		\x026789012345\x03
+		\x02CONTENT_CACHEeval=bar/baz\x1fCONTENT_CACHE{\"node\":\"/sites/demo/home\"}\x03CONTENT_CACHE
+		\x02CONTENT_CACHE6789012345\x03CONTENT_CACHE
 	";
 
     protected $expectedEntriesWithUncachedSegments = array(
         '4567890123' => array(
             'content' => "dolor
-				\x02eval=foo/bar\x1f{}\x03
+				\x02CONTENT_CACHEeval=foo/bar\x1fCONTENT_CACHE{}\x03CONTENT_CACHE
 			sit",
             'identifier' => '4567890123',
             'type' => 'cached',
@@ -161,7 +161,7 @@ class CacheSegmentParserTest extends UnitTestCase
             'identifier' => '123456789',
             'type' => 'cached',
             'content' => "foo bar baz
-			baz baz \x024567890123\x03",
+			baz baz \x02CONTENT_CACHE4567890123\x03CONTENT_CACHE",
             'metadata' => 'AllDocumentNodes'
         ),
 

--- a/TYPO3.TypoScript/Tests/Unit/Core/Cache/ContentCacheTest.php
+++ b/TYPO3.TypoScript/Tests/Unit/Core/Cache/ContentCacheTest.php
@@ -20,6 +20,7 @@ use TYPO3\TypoScript\Core\Cache\ContentCache;
  */
 class ContentCacheTest extends UnitTestCase
 {
+
     /**
      * @return array
      */
@@ -29,7 +30,10 @@ class ContentCacheTest extends UnitTestCase
             array('Everything', 'Everything'),
             array('Node_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef', 'Node_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef'),
             array('NodeType_TYPO3.Neos.NodeTypes:Page', 'NodeType_TYPO3_Neos_NodeTypes-Page'),
-            array('DescendentOf_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef', 'DescendentOf_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef')
+            array(
+                'DescendentOf_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef',
+                'DescendentOf_f6dc5e8e-03d9-306f-1572-92ab7a7bc4ef'
+            )
         );
     }
 
@@ -107,7 +111,7 @@ class ContentCacheTest extends UnitTestCase
         $mockSecurityContext = $this->createMock('TYPO3\Flow\Security\Context');
         $this->inject($contentCache, 'securityContext', $mockSecurityContext);
         $segement = $contentCache->createCacheSegment('My content', '/foo/bar', array(42), array('Foo', 'Bar'), 60);
-        $this->assertContains(ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . 'Foo,Bar;60' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN, $segement);
+        $this->assertContains('Foo,Bar;60' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN, $segement);
     }
 
     /**
@@ -125,8 +129,123 @@ class ContentCacheTest extends UnitTestCase
 
         $segement = $contentCache->createCacheSegment('My content', '/foo/bar', array(42), array('Foo', 'Bar'), 60);
 
-        $mockCache->expects($this->once())->method('set')->with($this->anything(), $this->anything(), $this->anything(), 60);
+        $mockCache->expects($this->once())->method('set')->with($this->anything(), $this->anything(), $this->anything(),
+            60);
 
         $contentCache->processCacheSegments($segement);
+    }
+
+    /**
+     * @test
+     */
+    public function createCacheSegmentAndProcessCacheSegmentsDoesWorkWithCacheSegmentTokensInContent()
+    {
+        $contentCache = new ContentCache();
+        $mockSecurityContext = $this->createMock('TYPO3\Flow\Security\Context');
+        $this->inject($contentCache, 'securityContext', $mockSecurityContext);
+        $this->inject($contentCache, 'parser', new CacheSegmentParser());
+
+        $mockCache = $this->createMock('TYPO3\Flow\Cache\Frontend\FrontendInterface');
+        $this->inject($contentCache, 'cache', $mockCache);
+
+        $invalidContent = 'You should probably not use ' . ContentCache::CACHE_SEGMENT_START_TOKEN . ', ' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . ' or ' . ContentCache::CACHE_SEGMENT_END_TOKEN . ' inside your content.';
+
+        $content = $contentCache->createCacheSegment($invalidContent, 'some.typoscripth.path', array('node' => 'foo'),
+            array('mytag1', 'mytag2'));
+
+        $validContent = 'But the cache should not fail because of it.';
+
+        $content .= $contentCache->createCacheSegment($validContent, 'another.typoscripth.path', array('node' => 'bar'),
+            array('mytag2'), 86400);
+
+        $mockCache->expects($this->at(0))->method('set')->with($this->anything(), $invalidContent,
+            array('mytag1', 'mytag2'), null);
+        $mockCache->expects($this->at(1))->method('set')->with($this->anything(), $validContent, array('mytag2'),
+            86400);
+
+        $output = $contentCache->processCacheSegments($content);
+
+        $this->assertSame($invalidContent . $validContent, $output);
+    }
+
+    /**
+     * @test
+     */
+    public function createUncachedSegmentAndProcessCacheSegmentsDoesWorkWithCacheSegmentTokensInContent()
+    {
+        $contentCache = new ContentCache();
+
+        $mockPropertyMapper = $this->createMock('TYPO3\Flow\Property\PropertyMapper');
+        $mockPropertyMapper->expects($this->any())->method('convert')->will($this->returnArgument(0));
+        $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
+        $this->inject($contentCache, 'parser', new CacheSegmentParser());
+
+        $mockCache = $this->createMock('TYPO3\Flow\Cache\Frontend\FrontendInterface');
+        $this->inject($contentCache, 'cache', $mockCache);
+
+        $invalidContent = 'You should probably not use ' . ContentCache::CACHE_SEGMENT_START_TOKEN . ', ' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . ' or ' . ContentCache::CACHE_SEGMENT_END_TOKEN . ' inside your uncached content.';
+
+        $content = $contentCache->createUncachedSegment($invalidContent, 'uncached.typoscript.path',
+            array('node' => 'A node identifier'));
+
+        $output = $contentCache->processCacheSegments($content);
+
+        $this->assertSame($invalidContent, $output);
+    }
+
+    /**
+     * @test
+     */
+    public function getCachedSegmentWithExistingCacheEntryReplacesNestedCachedSegments()
+    {
+        $contentCache = new ContentCache();
+
+        $mockSecurityContext = $this->createMock('TYPO3\Flow\Security\Context');
+        $this->inject($contentCache, 'securityContext', $mockSecurityContext);
+
+        $mockPropertyMapper = $this->createMock('TYPO3\Flow\Property\PropertyMapper');
+        $mockPropertyMapper->expects($this->any())->method('convert')->will($this->returnArgument(0));
+        $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
+
+        $this->inject($contentCache, 'parser', new CacheSegmentParser());
+
+        $mockContext = $this->getMockBuilder('TYPO3\Flow\Core\ApplicationContext')->disableOriginalConstructor()->getMock();
+        $cacheBackend = new \TYPO3\Flow\Cache\Backend\TransientMemoryBackend($mockContext);
+        $cacheFrontend = new \TYPO3\Flow\Cache\Frontend\StringFrontend('foo', $cacheBackend);
+        $cacheBackend->setCache($cacheFrontend);
+        $this->inject($contentCache, 'cache', $cacheFrontend);
+
+        $invalidContent = 'You should probably not use ' . ContentCache::CACHE_SEGMENT_START_TOKEN . ', ' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . ' or ' . ContentCache::CACHE_SEGMENT_END_TOKEN . ' inside your content.';
+
+        $innerCachedContent = $contentCache->createCacheSegment($invalidContent, 'some.typoscripth.path.innerCached',
+            array('node' => 'foo'), array('mytag1', 'mytag2'));
+
+        $uncachedCommandOutput = 'This content is highly dynamic with ' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN . ' and ' . ContentCache::CACHE_SEGMENT_END_TOKEN;
+        $innerUncachedContent = $contentCache->createUncachedSegment($uncachedCommandOutput,
+            'some.typoscripth.path.innerUncached', array('node' => 'A node identifier'));
+
+        $outerContentStart = 'You can nest cached segments like <';
+        $outerContentMiddle = '> or uncached segments like <';
+        $outerContentEnd = '> inside other segments.';
+
+        $outerContent = $outerContentStart . $innerCachedContent . $outerContentMiddle . $innerUncachedContent . $outerContentEnd;
+
+        $content = $contentCache->createCacheSegment($outerContent, 'some.typoscripth.path', array('node' => 'bar'),
+            array('mytag2'), 86400);
+        $output = $contentCache->processCacheSegments($content);
+
+        $expectedOutput = $outerContentStart . $invalidContent . $outerContentMiddle . $uncachedCommandOutput . $outerContentEnd;
+
+        $this->assertSame($expectedOutput, $output);
+
+        $cachedContent = $contentCache->getCachedSegment(function ($command) use ($uncachedCommandOutput) {
+            if ($command === 'eval=some.typoscripth.path.innerUncached') {
+                return $uncachedCommandOutput;
+            } else {
+                $this->fail('Unexpected command: ' . $command);
+            }
+        }, 'some.typoscripth.path', array('node' => 'bar'));
+
+        $this->assertSame($expectedOutput, $cachedContent);
     }
 }


### PR DESCRIPTION
This change adds a random cache marker directly to the content cache
which will be used after cache segment tokens to add a better protection
against content that contains one of these characters. The parser will
only match against the cache segment tokens with added marker, so the
chance of accidentally breaking the content cache should be very low.

NEOS-365 #close