### PR TITLE
TASK: Fix typo in custom view helpers documentation example

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/CustomViewHelpers.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CustomViewHelpers.rst
@@ -106,7 +106,7 @@ used for further processing:
 .. code-block:: php
 
 	public function render($title = NULL) {
-		if ($title = NULL) {
+		if ($title === NULL) {
 			$title = $this->renderChildren();
 		}
 		return '<h1>' . $title . '</h1>';


### PR DESCRIPTION
There was a typo in the section about "Context and Children". In the `if` block the variable `$title` got assigned and not checked.