### PR TITLE
BUGFIX: Fix like queries using paths in NodeDataRepository

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -999,10 +999,12 @@ class NodeDataRepository extends Repository
             $pathStartingPoint = strtolower($pathStartingPoint);
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->orx()
-                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath'))
-                    ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash')))
-                ->setParameter('parentPath', $pathStartingPoint . '/%')
-                ->setParameter('pathHash', md5($pathStartingPoint));
+                    ->add($queryBuilder->expr()->eq('n.parentPathHash', ':parentPathHash'))
+                    ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'))
+                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath')))
+                ->setParameter('parentPathHash', md5($pathStartingPoint))
+                ->setParameter('pathHash', md5($pathStartingPoint))
+                ->setParameter('parentPath', rtrim($pathStartingPoint, '/') . '/%');
         }
 
         $query = $queryBuilder->getQuery();
@@ -1487,7 +1489,7 @@ class NodeDataRepository extends Repository
                     ->add($queryBuilder->expr()->eq('n.parentPathHash', ':parentPathHash'))
                     ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath')))
                 ->setParameter('parentPathHash', md5($parentPath))
-                ->setParameter('parentPath', $parentPath . '/%');
+                ->setParameter('parentPath', rtrim($parentPath, '/') . '/%');
         }
     }
 
@@ -1508,7 +1510,7 @@ class NodeDataRepository extends Repository
                     ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'))
                     ->add($queryBuilder->expr()->like('n.path', ':path')))
                 ->setParameter('pathHash', md5($path))
-                ->setParameter('path', $path . '/%');
+                ->setParameter('path', rtrim($path, '/') . '/%');
         }
     }
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -533,7 +533,7 @@ class NodeDataRepository extends Repository
      * @param boolean $recursive
      * @return array
      */
-    protected function getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $removedNodes, $recursive)
+    protected function getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $removedNodes = false, $recursive = false)
     {
         $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
 
@@ -986,7 +986,6 @@ class NodeDataRepository extends Repository
         if (strlen($term) === 0) {
             throw new \InvalidArgumentException('"term" cannot be empty: provide a term to search for.', 1421329285);
         }
-        $pathStartingPoint = strtolower($pathStartingPoint);
         $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
 
         $queryBuilder = $this->createQueryBuilder($workspaces);
@@ -997,13 +996,13 @@ class NodeDataRepository extends Repository
         $queryBuilder->andWhere("LOWER(CONCAT('', n.properties)) LIKE :term")->setParameter('term', $likeParameter);
 
         if (strlen($pathStartingPoint) > 0) {
-            $pathConstraint = $queryBuilder->expr()->orx()
-                ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath'))
-                ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'));
-            $queryBuilder
-                ->setParameter('parentPath', $pathStartingPoint . '%')
+            $pathStartingPoint = strtolower($pathStartingPoint);
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orx()
+                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath'))
+                    ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash')))
+                ->setParameter('parentPath', $pathStartingPoint . '/%')
                 ->setParameter('pathHash', md5($pathStartingPoint));
-            $queryBuilder->getDQLPart('where')->add($pathConstraint);
         }
 
         $query = $queryBuilder->getQuery();
@@ -1483,8 +1482,12 @@ class NodeDataRepository extends Repository
             $queryBuilder->andWhere('n.parentPathHash = :parentPathHash')
                 ->setParameter('parentPathHash', md5($parentPath));
         } else {
-            $queryBuilder->andWhere('n.parentPath LIKE :parentPath')
-                ->setParameter('parentPath', $parentPath . '%');
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX()
+                    ->add($queryBuilder->expr()->eq('n.parentPathHash', ':parentPathHash'))
+                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath')))
+                ->setParameter('parentPathHash', md5($parentPath))
+                ->setParameter('parentPath', $parentPath . '/%');
         }
     }
 
@@ -1500,8 +1503,12 @@ class NodeDataRepository extends Repository
             $queryBuilder->andWhere('n.pathHash = :pathHash')
                 ->setParameter('pathHash', md5($path));
         } else {
-            $queryBuilder->andWhere('n.path LIKE :path')
-                ->setParameter('path', $path . '%');
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX()
+                    ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'))
+                    ->add($queryBuilder->expr()->like('n.path', ':path')))
+                ->setParameter('pathHash', md5($path))
+                ->setParameter('path', $path . '/%');
         }
     }
 

--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
@@ -10,12 +10,13 @@ namespace TYPO3\TYPO3CR\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use TYPO3\Flow\Tests\Functional\Persistence\Fixtures;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\Image;
 use TYPO3\Flow\Tests\FunctionalTestCase;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
-use TYPO3\TYPO3CR\Tests\Functional\Domain\Fixtures\TestObjectForSerialization;
 
 /**
  * Functional test case.
@@ -53,10 +54,10 @@ class NodeDataRepositoryTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->nodeTypeManager = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\NodeTypeManager');
-        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
-        $this->context = $this->contextFactory->create(array('workspaceName' => 'live'));
-        $this->nodeDataRepository = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository');
+        $this->nodeDataRepository = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository::class);
+        $this->nodeTypeManager = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\NodeTypeManager::class);
+        $this->contextFactory = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface::class);
+        $this->context = $this->contextFactory->create(['workspaceName' => 'live']);
     }
 
     /**
@@ -65,7 +66,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
     public function tearDown()
     {
         parent::tearDown();
-        $this->inject($this->contextFactory, 'contextInstances', array());
+        $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
     /**
@@ -83,12 +84,112 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $relationMap = array(
-            'TYPO3\Flow\Tests\Functional\Persistence\Fixtures\Image' => array($this->persistenceManager->getIdentifierByObject($testImage))
-        );
+        $relationMap = [
+            Fixtures\Image::class => [$this->persistenceManager->getIdentifierByObject($testImage)]
+        ];
 
         $result = $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);
 
         $this->assertCount(1, $result);
+    }
+
+    protected function setUpNodes()
+    {
+        $rootNode = $this->context->getRootNode();
+        $rootNode->createNode('test-123')->createNode('below-123')->setProperty('testProperty', 'Vibiemme');
+        $rootNode->getNode('test-123')->createNode('also-below-123')->setProperty('testProperty', 'Vibiemme');
+        $rootNode->createNode('test-123456')->createNode('below-123456')->setProperty('testProperty', 'Vibiemme');
+        $rootNode->getNode('test-123456')->createNode('also-below-123456')->setProperty('testProperty', 'Vibiemme');
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * Tests findByProperties, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByPropertiesLimitsToStartingPointCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByProperties('Vibiemme', 'unstructured', $workspace, [], '/test-123');
+
+        $this->assertCount(2, $foundNodes);
+    }
+
+    /**
+     * Tests findByProperties, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByPropertiesLimitsToRootNodeCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByProperties('Vibiemme', 'unstructured', $workspace, [], '/');
+
+        $this->assertCount(4, $foundNodes);
+    }
+
+    /**
+     * Tests addParentPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByParentAndNodeTypeLimitsToStartingPointCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByParentAndNodeType('/test-123', 'unstructured', $workspace, [], false, true);
+
+        $this->assertCount(2, $foundNodes);
+    }
+
+    /**
+     * Tests addParentPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByParentAndNodeTypeLimitsToRootNodeCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByParentAndNodeType('/', 'unstructured', $workspace, [], false, true);
+
+        $this->assertCount(6, $foundNodes);
+    }
+
+    /**
+     * Tests addPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByPathWithoutReduceLimitsToStartingPointCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByPathWithoutReduce('/test-123', $workspace, false, true);
+
+        $this->assertCount(3, $foundNodes);
+    }
+
+    /**
+     * Tests addPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
+     *
+     * @test
+     */
+    public function findByPathWithoutReduceLimitsToRootNodeCorrectly()
+    {
+        $this->setUpNodes();
+
+        $workspace = $this->context->getWorkspace();
+        $foundNodes = $this->nodeDataRepository->findByPathWithoutReduce('/', $workspace, false, true);
+
+        $this->assertCount(7, $foundNodes);
     }
 }


### PR DESCRIPTION
When querying for nodes based on (parent) paths, a LIKE query was used in
certain cases. This query would include unrelated nodes, if the paths involved
would share a common prefix:

    /some/node-12
    /some/node-123

Nodes below both paths would be included because of:

    LIKE "/some/nodes-12%"

Now those queries append a slash, to read:

    LIKE "/some/nodes-12/%"

NEOS-1849 #close