### PR TITLE
TASK: Add a hint for cache clearing to the Node Type Constraints docs

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeConstraints.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeConstraints.rst
@@ -78,3 +78,6 @@ To sum it up, the following rules apply:
 - Inheritance is taking into account, so if allowing/disallowing "Foo", the subtypes of "Foo" are automatically
   allowed/disallowed. To constraint subtypes you must be more specific for those types.
 - The default is to *always deny* (in case "*" is not specified).
+
+.. note:: Node type constraints are cached in the browser's session storage. After making changes, it's a good idea to run
+          `sessionStorage.clear();` in the browser console to remove the old configuration.

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeConstraints.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeConstraints.rst
@@ -79,5 +79,5 @@ To sum it up, the following rules apply:
   allowed/disallowed. To constraint subtypes you must be more specific for those types.
 - The default is to *always deny* (in case "*" is not specified).
 
-.. note:: Node type constraints are cached in the browser's session storage. After making changes, it's a good idea to run
-          `sessionStorage.clear();` in the browser console to remove the old configuration.
+.. note:: Node type constraints are cached in the browser's session storage. After making changes, it's a good idea
+          to run `sessionStorage.clear();` in the browser console to remove the old configuration.


### PR DESCRIPTION
There are sometimes browser caching issues when working with node type constraints. This hint should help prevent some of them.