### PR TITLE
BUGFIX: Align displaced expand icons in node tree

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/_Tree.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/_Tree.scss
@@ -128,6 +128,7 @@ ul.neos-dynatree-container {
 		&.neos-dynatree-exp-edl {
 			.neos-dynatree-expander {
 				@include fa-icon();
+				line-height: 24px;
 				@extend .#{$fa-css-prefix}-caret-right;
 				@include rotate(45deg);
 
@@ -154,6 +155,7 @@ ul.neos-dynatree-container {
 
 		.neos-dynatree-expander {
 			@include fa-icon();
+			line-height: 24px;
 			@extend .#{$fa-css-prefix}-caret-right;
 			cursor: pointer;
 			font-size: 16px;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -7176,6 +7176,7 @@
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  line-height: 24px;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
@@ -7208,6 +7209,7 @@
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  line-height: 24px;
   cursor: pointer;
   font-size: 16px;
 }


### PR DESCRIPTION
The expand icons in the node tree where off a few pixels along the y-axis (open and folded).

NEOS-1844 #close