### PR TITLE
TASK: set a default value of `itemName` in the `TYPO3.TypoScript:Collection` object

### DIFF
--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -100,7 +100,7 @@ TYPO3.TypoScript:Collection
 Render each item in ``collection`` using ``itemRenderer``.
 
 :collection: (array/Iterable, **required**) The array or iterable to iterate over
-:itemName: (string, **required**) Context variable name for each item
+:itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string) Context variable name for each item key, when working with array
 :iterationName: (string) If set, a context variable with iteration information will be availble under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
 :itemRenderer: (string) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated

--- a/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
@@ -1,11 +1,14 @@
 prototype(TYPO3.TypoScript:Array).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\ArrayImplementation'
 prototype(TYPO3.TypoScript:RawArray).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\RawArrayImplementation'
 prototype(TYPO3.TypoScript:Template).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\TemplateImplementation'
-prototype(TYPO3.TypoScript:Collection).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\CollectionImplementation'
 prototype(TYPO3.TypoScript:Case).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\CaseImplementation'
 prototype(TYPO3.TypoScript:Matcher).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\MatcherImplementation'
 prototype(TYPO3.TypoScript:Value).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\ValueImplementation'
 prototype(TYPO3.TypoScript:Debug).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\DebugImplementation'
+prototype(TYPO3.TypoScript:Collection) {
+	@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\CollectionImplementation'
+	itemName = 'item'
+}
 
 # Render an HTTP response header
 #


### PR DESCRIPTION
This change sets a default value of `itemName` to `item`, so you can use `TYPO3.TypoScript:Collection` object without specifying it each time:

```
helloLoop = TYPO3.TypoScript:Collection {
  collection = ${[1, 2, 3]}
  itemRenderer = ${item + '<br>'}
}
```

This change is backwards compatible, as your value for `itemName` would always override the default value.