### PR TITLE
BUGFIX: reset lastVisitedNode on site switch

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -134,6 +134,7 @@ class LoginController extends AbstractAuthenticationController
             $this->redirect('index');
         } else {
             $this->systemLogger->log(sprintf('Token-based login succeeded, token %s', $token), LOG_DEBUG);
+            $this->session->putData('lastVisitedNode', NULL);
             $this->replaceSessionCookie($sessionId);
             $this->redirect('index', 'Backend\Backend');
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -134,7 +134,7 @@ class LoginController extends AbstractAuthenticationController
             $this->redirect('index');
         } else {
             $this->systemLogger->log(sprintf('Token-based login succeeded, token %s', $token), LOG_DEBUG);
-            $this->session->putData('lastVisitedNode', NULL);
+            $this->session->putData('lastVisitedNode', null);
             $this->replaceSessionCookie($sessionId);
             $this->redirect('index', 'Backend\Backend');
         }


### PR DESCRIPTION
This fixes an error when trying to switch from a subnode of one site to another site.

The lastVisitedNode session variable is always pointing to the node that was last open in frontend to redirect to that page. 
If you visit a subpage from one site and switch to another, Neos opens the last node in the new site. In most cases this will fail.