### PR TITLE
TASK: change caching behaviour when no `entryIdentifier` is set

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
@@ -279,13 +279,11 @@ class RuntimeContentCache
      */
     protected function buildCacheIdentifierValues($configuration, $typoScriptPath, $tsObject)
     {
-        $cacheIdentifierValues = array();
+        $objectType = '<TYPO3.TypoScript:GlobalCacheIdentifiers>';
         if (isset($configuration['entryIdentifier']['__objectType'])) {
-            $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier', $tsObject);
-        } else {
-            $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier<TYPO3.TypoScript:GlobalCacheIdentifiers>', $tsObject);
+            $objectType = '<' . $configuration['entryIdentifier']['__objectType'] . '>';
         }
-        return $cacheIdentifierValues;
+        return $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier' . $objectType, $tsObject);
     }
 
     /**

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
@@ -280,18 +280,10 @@ class RuntimeContentCache
     protected function buildCacheIdentifierValues($configuration, $typoScriptPath, $tsObject)
     {
         $cacheIdentifierValues = array();
-        if (isset($configuration['entryIdentifier'])) {
-            if (isset($configuration['entryIdentifier']['__objectType'])) {
-                $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier', $tsObject);
-            } else {
-                $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier<TYPO3.TypoScript:GlobalCacheIdentifiers>', $tsObject);
-            }
+        if (isset($configuration['entryIdentifier']['__objectType'])) {
+            $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier', $tsObject);
         } else {
-            foreach ($this->runtime->getCurrentContext() as $key => $value) {
-                if (is_string($value) || is_bool($value) || is_integer($value) || $value instanceof CacheAwareInterface) {
-                    $cacheIdentifierValues[$key] = $value;
-                }
-            }
+            $cacheIdentifierValues = $this->runtime->evaluate($typoScriptPath . '/__meta/cache/entryIdentifier<TYPO3.TypoScript:GlobalCacheIdentifiers>', $tsObject);
         }
         return $cacheIdentifierValues;
     }

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -462,6 +462,18 @@ contentCache.entryIdentifiersAreMergedWithGlobalIdentifiers < contentCache.cache
 	}
 }
 
+contentCache.globalIdentifiersAreUsedWithBlankEntryIdentifiers < contentCache.cachedSegment {
+	prototype(TYPO3.TypoScript:GlobalCacheIdentifiers) {
+		site = ${site}
+	}
+
+	@cache {
+		entryTags {
+			1 = ${site}
+		}
+	}
+}
+
 contentCache.entryIdentifierPrototypeCanBeOverwritten < contentCache.cachedSegment {
 	prototype(TYPO3.TypoScript:GlobalCacheIdentifiers) {
 		site = ${site}
@@ -477,7 +489,6 @@ contentCache.entryIdentifierPrototypeCanBeOverwritten < contentCache.cachedSegme
 		}
 	}
 }
-
 
 contentCache.uncachedSegmentInCachedSegmentCanOverrideContextVariables = TYPO3.TypoScript:Array {
 	5 = 'Outer segment|'


### PR DESCRIPTION
The old behaviour was to try to construct the entryIdentifier from all
context vars, which did not make a lot of sense.

With the new behaviour, the entryIdentifier is filled with identifiers from the
`TYPO3.TypoScript:GlobalCacheIdentifiers` prototype.

So in many cases, it would not be necessary to provide any
entryIdentifiers at all and just configure GlobalCacheIdentifiers.