### PR TITLE
BUGFIX: Check for expected context in ParentsOperation

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Eel/FlowQueryOperations/ParentsOperation.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Eel\FlowQueryOperations;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Eel\FlowQuery\Operations\AbstractOperation;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
@@ -45,7 +46,7 @@ class ParentsOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof NodeInterface) && ($context[0]->getContext() instanceof ContentContext));
     }
 
     /**

--- a/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -43,4 +43,25 @@ class ParentsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
         $output = $q->getContext();
         $this->assertEquals(array($siteNode, $firstLevelNode), $output);
     }
+
+    /**
+     * @test
+     */
+    public function canEvaluateChecksForContentContext()
+    {
+        $operation = new \TYPO3\Neos\Eel\FlowQueryOperations\ParentsOperation();
+
+        $mockNode = $this->createMock(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::class);
+        $mockContext = $this->getMockBuilder(\TYPO3\Neos\Domain\Service\ContentContext::class)->disableOriginalConstructor()->getMock();
+        $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
+        $context = array($mockNode);
+
+        $this->assertTrue($operation->canEvaluate($context), 'Must accept ContentContext');
+
+        $mockNode = $this->createMock(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::class);
+        $mockContext = $this->getMockBuilder(\TYPO3\TYPO3CR\Domain\Service\Context::class)->disableOriginalConstructor()->getMock();
+        $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
+        $context = array($mockNode);
+        $this->assertFalse($operation->canEvaluate($context), 'Must not accept Context');
+    }
 }


### PR DESCRIPTION
The ParentsOperation in Neos expects a Neos `ContentContext` to work with,
so `canEvaluate()` should check for it to allow for proper function and
fallback handling if a "normal" CR `Context` is given.