### PR TITLE
!!! BUGFIX: Keep supertypes unset in supertypes unset

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeType.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeType.php
@@ -199,6 +199,14 @@ class NodeType
             $this->addInheritedSuperTypes($superTypes, $inheritedSuperType);
             $superTypes[$inheritedSuperTypeName] = $inheritedSuperType;
         }
+
+        // the method getSuperTypes() is a magic getter
+        $superTypesInSuperType = $superType->getSuperTypes() ?: [];
+        foreach ($superTypesInSuperType as $inheritedSuperTypeName => $inheritedSuperType) {
+            if (!$inheritedSuperType) {
+                unset($superTypes[$inheritedSuperTypeName]);
+            }
+        }
     }
 
     /**

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -91,6 +91,31 @@ class NodeTypeTest extends \TYPO3\Flow\Tests\UnitTestCase
                     'type' => 'string'
                 )
             )
+        ),
+        'TYPO3.TYPO3CR.Testing:SubShortcut' => array(
+            'superTypes' => array(
+                'TYPO3.TYPO3CR.Testing:Shortcut' => true
+            ),
+            'ui' => array(
+                'label' => 'Sub-Shortcut'
+            )
+        ),
+        'TYPO3.TYPO3CR.Testing:SubSubShortcut' => array(
+            'superTypes' => array(
+                'TYPO3.TYPO3CR.Testing:SubShortcut' => true,
+                'TYPO3.TYPO3CR.Testing:SomeMixin' => true
+            ),
+            'ui' => array(
+                'label' => 'Sub-Sub-Shortcut'
+            )
+        ),
+        'TYPO3.TYPO3CR.Testing:SubSubSubShortcut' => array(
+            'superTypes' => array(
+                'TYPO3.TYPO3CR.Testing:SubSubShortcut' => true
+            ),
+            'ui' => array(
+                'label' => 'Sub-Sub-Sub-Shortcut'
+            )
         )
     );
 
@@ -109,7 +134,7 @@ class NodeTypeTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setDeclaredSuperTypesExpectsAnArrayOfNodeTypesAsKeys()
     {
-        $folderType = new NodeType('TYPO3CR:Folder', array('foo' => true), array());
+        new NodeType('TYPO3CR:Folder', array('foo' => true), array());
     }
 
     /**
@@ -118,7 +143,7 @@ class NodeTypeTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setDeclaredSuperTypesAcceptsAnArrayOfNodeTypes()
     {
-        $folderType = new NodeType('TYPO3CR:Folder', array('foo'), array());
+        new NodeType('TYPO3CR:Folder', array('foo'), array());
     }
 
     /**
@@ -350,6 +375,45 @@ class NodeTypeTest extends \TYPO3\Flow\Tests\UnitTestCase
         );
         $this->assertSame($expectedProperties, $nodeType->getProperties());
     }
+
+    /**
+     * This test asserts that a supertype that has been inherited can be removed by a supertype again.
+     * @test
+     */
+    public function inheritedSuperSuperTypesCanBeRemoved()
+    {
+        $nodeType = $this->getNodeType('TYPO3.TYPO3CR.Testing:SubShortcut');
+        $this->assertSame('Sub-Shortcut', $nodeType->getLabel());
+
+        $expectedProperties = array(
+            'target' => array(
+                'type' => 'string'
+            )
+        );
+        $this->assertSame($expectedProperties, $nodeType->getProperties());
+    }
+
+    /**
+     * This test asserts that a supertype that has been inherited can be removed by a supertype again.
+     * @test
+     */
+    public function superTypesRemovedByInheritanceCanBeAddedAgain()
+    {
+        $nodeType = $this->getNodeType('TYPO3.TYPO3CR.Testing:SubSubSubShortcut');
+        $this->assertSame('Sub-Sub-Sub-Shortcut', $nodeType->getLabel());
+
+        $expectedProperties = array(
+            'target' => array(
+                'type' => 'string'
+            ),
+            'someMixinProperty' => array(
+                'type' => 'string',
+                'label' => 'Important hint'
+            )
+        );
+        $this->assertSame($expectedProperties, $nodeType->getProperties());
+    }
+
     /**
      * Return a nodetype built from the nodeTypesFixture
      *


### PR DESCRIPTION
No, the title is not an error. Here is what happens:

- You define a node type and inherit from "Document"
- In that NodeType unset a supertype declared in "Document"
- Now inherit from that nodetype again, and whatever the unset supertype
  declared, will be back

This is caused by how the inherited supertypes are read using the method
getDeclaredSuperTypes, which only returns the used supertypes, not the
ones not used - even if "actively not used".

This change fixes that and is marked breaking because there might be things
disappearing from your nodetypes, depending on the nesting of your hierarchy.