### PR TITLE
!!! TASK: Give Neos session (cookie) a distinct name

### DIFF
--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -35,6 +35,9 @@ TYPO3:
                 '@format':     'html'
         authenticationStrategy: oneToken
 
+    session:
+      name: 'Neos_Session'
+
     persistence:
       doctrine:
         eventListeners:


### PR DESCRIPTION
Changes the session name from the default (TYPO3_Flow_Session) to
"Neos_Session".

This is breaking in case you configured your hosting in relation to the cookie
name (e.g. Varnish rules).