### PR TITLE
BUGFIX: Skip private node properties in ContentElementWrappingService

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
@@ -108,6 +108,10 @@ class ContentElementWrappingService
     protected function addNodePropertyAttributes(array $attributes, NodeInterface $node)
     {
         foreach (array_keys($node->getNodeType()->getProperties()) as $propertyName) {
+            if ($propertyName[0] === '_' && $propertyName[1] === '_') {
+                // skip fully-private properties
+                continue;
+            }
             $attributes = array_merge($attributes, $this->renderNodePropertyAttribute($node, $propertyName));
         }
 


### PR DESCRIPTION
If a nodetype has "virtual" properties configured (like when Elasticsearch
is used with Neos), trying to access those properties resulted in

    The property "…" on the subject was not accessible.

This change introduces a check for property names starting with `__` and
skips those, like already done in the `NodePropertyConverterService`

NEOS-1860 #close