### PR TITLE
TASK: Free memory after disallowed child nodes removal

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -484,6 +484,8 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
         foreach ($this->contentDimensionCombinator->getAllAllowedCombinations() as $dimensionConfiguration) {
             $context = $this->createContext($workspace->getName(), $dimensionConfiguration);
             $removeDisallowedChildNodes($context->getRootNode());
+            $context->getFirstLevelNodeCache()->flush();
+            $this->nodeFactory->reset();
         }
 
         $disallowedChildNodesCount = count($nodes);


### PR DESCRIPTION
Free memory after removing disallowed child nodes after each dimension combination

NEOS-1852 #comment This does not the resolve the issue of much memory being used per node but prevents multiplying memory usage by the number of dimension combinations available