### PR TITLE
BUGFIX: Correctly remove NodeDimension association in setDimensions

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -694,11 +694,20 @@ class NodeData extends AbstractNodeData
                 if (!$dimensionExisted) {
                     $dimensionToBeSet->setNodeData($this);
                     $dimensionsToBeSet[] = $dimensionToBeSet;
+                    $this->dimensions->add($dimensionToBeSet);
                 }
             }
+
+            // remove entries not to be set
+            foreach ($this->dimensions as $dimension) {
+                if (array_search($dimension, $dimensionsToBeSet) === false) {
+                    $this->dimensions->removeElement($dimension);
+                }
+            }
+        } else {
+            $this->dimensions = new ArrayCollection($dimensionsToBeSet);
         }
 
-        $this->dimensions = new ArrayCollection($dimensionsToBeSet);
         $this->buildDimensionValues();
     }
 

--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/NodeDataTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/NodeDataTest.php
@@ -11,6 +11,10 @@ namespace TYPO3\TYPO3CR\Tests\Functional\Domain;
  * source code.
  */
 
+use TYPO3\Neos\Domain\Service\SiteImportService;
+use TYPO3\TYPO3CR\Domain\Model\NodeDimension;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+
 /**
  * Functional test case.
  */
@@ -183,6 +187,116 @@ class NodeDataTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         // The identifier comes from the Fixture.
         $resultingNodeData = $nodeDataRepository->findOneByIdentifier('78f5c720-e8df-2573-1fc1-f7ce5b338485', $context->getWorkspace(true), array());
 
+        $this->assertEmpty($resultingNodeData->getDimensions());
+    }
+
+    /**
+     * @test
+     */
+    public function setDimensionsSetsDimensions()
+    {
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
+        $siteImportService->importFromFile(__DIR__ . '/../Fixtures/NodeStructure.xml', $this->context);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        $nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
+        $this->assertCount(1, $resultingNodeData->getDimensions());
+        $values = $resultingNodeData->getDimensionValues();
+        $this->assertEquals('en_US', $values['language'][0]);
+        $nodeDimension = new NodeDimension($resultingNodeData, 'language', 'lv');
+        $resultingNodeData->setDimensions([$nodeDimension]);
+
+        $nodeDataRepository->update($resultingNodeData);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
+        $this->assertCount(1, $resultingNodeData->getDimensions());
+        $values = $resultingNodeData->getDimensionValues();
+        $this->assertEquals('lv', $values['language'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function setDimensionsKeepsExistingDimensions()
+    {
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
+        $siteImportService->importFromFile(__DIR__ . '/../Fixtures/NodeStructure.xml', $this->context);
+        $this->persistenceManager->persistAll();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        $nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
+        $resultingNodeData->setDimensions([
+            new NodeDimension($resultingNodeData, 'language', 'lv'),
+            new NodeDimension($resultingNodeData, 'language', 'en_US')
+        ]);
+        $nodeDataRepository->update($resultingNodeData);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
+        $this->assertCount(2, $resultingNodeData->getDimensions());
+        $values = $resultingNodeData->getDimensionValues();
+        $this->assertEquals('en_US', $values['language'][0]);
+        $this->assertEquals('lv', $values['language'][1]);
+    }
+
+    /**
+     * @test
+     */
+    public function setDimensionsToEMptyArrayRemovesDimensions()
+    {
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
+        $siteImportService->importFromFile(__DIR__ . '/../Fixtures/NodeStructure.xml', $this->context);
+        $this->persistenceManager->persistAll();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        $nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
+        $this->assertNotEmpty($resultingNodeData->getDimensions());
+        $resultingNodeData->setDimensions([]);
+        $nodeDataRepository->update($resultingNodeData);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+
+        // The context is not important here, just a quick way to get a (live) workspace
+        $context = $this->contextFactory->create();
+        // The identifier comes from the Fixture.
+        /** @var \TYPO3\TYPO3CR\Domain\Model\NodeData $resultingNodeData */
+        $resultingNodeData = $nodeDataRepository->findOneByIdentifier('9fa376af-a1b8-83ac-bedc-9ad83c8598bc', $context->getWorkspace(true), []);
         $this->assertEmpty($resultingNodeData->getDimensions());
     }
 }


### PR DESCRIPTION
The setDimensions method on NodeData did simply replace the ArrayCollection
with a new one. This left previously attached NodeDimension entities in the
database, leading to issues.

This change fixes that by no longer replacing the full collection but working on
the contained entries instead.

This fix was the base for a new task to node:repair that removes any content
dimensions set on those nodes. Because when the root or the sites node have
content dimensions assigned, this can lead to issues with nodes not being found
when traversing from the root node.

