### PR TITLE
BUGFIX: Bust cache for content dimensions configuration

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendEndpoints.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/NeosBackendEndpoints.html
@@ -13,8 +13,8 @@
 	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
 	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
 	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
+	<link rel="neos-service-contentdimensions-index" type="application/vnd.typo3.neos.contentdimensions" href="{f:uri.action(action: 'index', controller: 'Service\ContentDimensions', package: 'TYPO3.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
 </f:alias>
-<link rel="neos-service-contentdimensions-index" type="application/vnd.typo3.neos.contentdimensions" href="{f:uri.action(action: 'index', controller: 'Service\ContentDimensions', package: 'TYPO3.Neos', absolute: true)}" />
 <link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'TYPO3.Neos', absolute: true) -> f:format.raw()}" />
 
 <!-- Temporary URL endpoints, will be removed / grouped when a REST interface is fully implemented -->


### PR DESCRIPTION
Bust the cache for content dimensions settings so changes are visible in the backend instantly.