### PR TITLE
TASK: Fix code sample in content cache configuration

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -227,7 +227,7 @@ You can override default cache configuration in your TypoScript::
 
 You can also override cache configuration for a specific TypoScript Path::
 
-    page.content.main {
+    page.body.content.main {
     	prototype(TYPO3.Neos:Plugin).@cache.mode = 'cached'
     }
 


### PR DESCRIPTION
The path ```page.content.main``` is "invalid", the missing ```body``` segment can be annoying when reading the documentation.