### PR TITLE
BUGFIX: Escape preg_replace placeholders to prevent accidentally replacements

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/HtmlAugmenter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/HtmlAugmenter.php
@@ -51,7 +51,7 @@ class HtmlAugmenter
             return sprintf('<%s%s>%s</%s>', $fallbackTagName, $this->renderAttributes($attributes), $html, $fallbackTagName);
         }
         $this->mergeAttributes($rootElement, $attributes);
-        return preg_replace('/<(' . $rootElement->nodeName . ')\b[^>]*>/xi', '<$1' . addcslashes($this->renderAttributes($attributes), '\\') . '>', $html, 1);
+        return preg_replace('/<(' . $rootElement->nodeName . ')\b[^>]*>/xi', '<$1' . addcslashes($this->renderAttributes($attributes), '\\\$') . '>', $html, 1);
     }
 
     /**

--- a/TYPO3.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -189,6 +189,14 @@ class HtmlAugmenterTest extends UnitTestCase
                 'exclusiveAttributes' => array('some-attribute'),
                 'expectedResult' => '<div some-attribute="value"><div some-attribute>no attribute value is required to make an attribute exclusive</div></div>',
             ),
+            // Escaping possible preg_replace placeholders in attributes
+            array(
+                'html' => '<p>Simple HTML with unique root element</p>',
+                'attributes' => array('data-label' => 'Cost $0.00'),
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<p data-label="Cost $0.00">Simple HTML with unique root element</p>',
+            )
         );
     }
 


### PR DESCRIPTION
Escapes all `$` dollar signs to prevent accidentally replacement of placeholders like `$0` within the preg_replace of HtmlAugmenter.

NEOS-1865 #close