### PR TITLE
BUGFIX: Add message fallback for `addFlashmessage` in AssetController

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -600,7 +600,10 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
     public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
     {
         if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media');
+            $translatedMessageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media');
+            if ($translatedMessageBody !== null) {
+                $messageBody = $translatedMessageBody;
+            }
         }
         $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'TYPO3.Media');
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -249,24 +249,4 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
         }
         return new Error($errorMessage, null, [get_class($this), $this->actionMethodName]);
     }
-
-    /**
-     * Add a translated flashMessage.
-     *
-     * @param string $messageBody The translation id for the message body.
-     * @param string $messageTitle The translation id for the message title.
-     * @param string $severity
-     * @param array $messageArguments
-     * @param integer $messageCode
-     * @return void
-     */
-    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
-    {
-        if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Modules', 'TYPO3.Neos');
-        }
-        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Modules', 'TYPO3.Neos');
-
-        parent::addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
-    }
 }


### PR DESCRIPTION
Adding a flash message in `AssetController` results in an exception if the tranlsator service returns null for a label. If the service returns null the label will be returned as a fallback.

This change also removes an unecessary method `addFlashMessage` as it implements just the same logic as `parent::addFlashMessage`. This method also calls right now the parent method with an already translated id wich can not be translated again.