### PR TITLE
BUGFIX: node:repair also removes valid nodes

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -779,7 +779,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
     }
 
     /**
-     * Removes all nodes with a specific path and its children in the given workspace.
+     * Removes all nodes with a specific path and their children in the given workspace.
      *
      * @param string $nodePath
      * @param string $workspaceName


### PR DESCRIPTION
This fixes an issue with node:repair which also removes valid and
healthy nodes while deleting nodes which are abstract or assigned to
an unknown node type.

removeAbstractAndUndefinedNodes() correctly found invalid nodes, but
only used the node path and workspace name as an identifier for removing
them. If there are further nodes matching this criteria, for example
with different dimension values, these would be deleted as well,
even though they may be completely valid.

This patch introduces a new method which allows for removal of a node
specified by node identifier and dimension hash.