### PR TITLE
TASK: Persist intermediate node:repair results

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Command;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\ConsoleOutput;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\Utility\NodeUriPathSegmentGenerator;
 use TYPO3\TYPO3CR\Command\NodeCommandControllerPluginInterface;
@@ -67,6 +68,12 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
      * @var ConsoleOutput
      */
     protected $output;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
     /**
      * Returns a short description
@@ -154,6 +161,8 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
                 }
             }
         }
+
+        $this->persistenceManager->persistAll();
     }
 
     /**


### PR DESCRIPTION
This change adds a couple of persistAll() calls to the different steps
in node:repair in order to save changes before the next steps begin.

That way, if one step fails, at least the previous steps have been
already persisted.

Additionally this may potentially prevent inconsistencies in cases where
the same node is created from NodeData multiple times without
acknowledging the Unit of Work.

Also contains a few smaller cosmetic changes to the console output.