### PR TITLE
FEATURE: node:repair: remove nodes with invalid dimension values

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandController.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandController.php
@@ -91,6 +91,10 @@ class NodeCommandController extends CommandController implements DescriptionAwar
             $this->outputLine('Dry run, not committing any changes.');
         }
 
+        if (!$cleanup) {
+            $this->outputLine('Omitting cleanup tasks.');
+        }
+
         foreach ($this->pluginConfigurations as $pluginConfiguration) {
             /** @var NodeCommandControllerPluginInterface $plugin */
             $plugin = $pluginConfiguration['object'];

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -398,9 +398,9 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
                 }
                 if ($node instanceof Node && !$node->dimensionsAreMatchingTargetDimensionValues()) {
                     if ($node->getNodeData()->getDimensionValues() === []) {
-                        $this->output->outputLine('Skipping node %s  because it has no dimension values set', [$node->getPath()]);
+                        $this->output->outputLine('Skipping node %s because it has no dimension values set', [$node->getPath()]);
                     } else {
-                        $this->output->outputLine('Skipping node %s  because it has invalid dimension values: %s', [$node->getPath(), json_encode($node->getNodeData()->getDimensionValues())]);
+                        $this->output->outputLine('Skipping node %s because it has invalid dimension values: %s', [$node->getPath(), json_encode($node->getNodeData()->getDimensionValues())]);
                     }
                     continue;
                 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -870,7 +870,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
      * @param boolean $dryRun Simulate?
      * @return void
      */
-    public function removeNodesWithInvalidDimensions(NodeType $nodeType = null, $workspaceName, $dryRun)
+    public function removeNodesWithInvalidDimensions(NodeType $nodeType, $workspaceName, $dryRun)
     {
         $allowedDimensionCombinations = $this->contentDimensionCombinator->getAllAllowedCombinations();
 
@@ -889,7 +889,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
             }
         }
 
-        if (count($nodesArray) === 0) {
+        if ($nodesArray === []) {
             return;
         }
 
@@ -935,11 +935,11 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
             ->setParameter('removed', false, \PDO::PARAM_BOOL);
 
         foreach ($queryBuilder->getQuery()->getArrayResult() as $nodeDataArray) {
-            if ($nodeDataArray['path'] === '/') {
+            if ($nodeDataArray['dimensionValues'] === [] || $nodeDataArray['dimensionValues'] === '') {
                 continue;
             }
             foreach ($allowedDimensionCombinations as $dimensionConfiguration) {
-                if ($dimensionConfiguration == $nodeDataArray['dimensionValues']) {
+                if ($dimensionConfiguration === $nodeDataArray['dimensionValues']) {
                     break 2;
                 }
             }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -397,7 +397,11 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
                     continue;
                 }
                 if ($node instanceof Node && !$node->dimensionsAreMatchingTargetDimensionValues()) {
-                    $this->output->outputLine('Skipping node %s  because it has invalid dimension values: %s', [$node->getPath(), json_encode($node->getNodeData()->getDimensionValues())]);
+                    if ($node->getNodeData()->getDimensionValues() === []) {
+                        $this->output->outputLine('Skipping node %s  because it has no dimension values set', [$node->getPath()]);
+                    } else {
+                        $this->output->outputLine('Skipping node %s  because it has invalid dimension values: %s', [$node->getPath(), json_encode($node->getNodeData()->getDimensionValues())]);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
This change contains an improvement for node:repair which runs an
additional check for nodes which have dimension values which are not
allowed according to the current dimension configuration.

These nodes can be either removed or the user can decide to migrate them
by other means (for example a node migration).