### PR TITLE
BUGFIX: Site switch fails with "session not started"

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -19,6 +19,7 @@ use TYPO3\Flow\Mvc\View\JsonView;
 use TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
 use TYPO3\Flow\Security\Exception\AuthenticationRequiredException;
 use TYPO3\Flow\Session\SessionInterface;
+use TYPO3\Flow\Session\SessionManagerInterface;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Service\BackendRedirectionService;
@@ -34,6 +35,12 @@ class LoginController extends AbstractAuthenticationController
      * @var SessionInterface
      */
     protected $session;
+
+    /**
+     * @Flow\Inject
+     * @var SessionManagerInterface
+     */
+    protected $sessionManager;
 
     /**
      * @Flow\Inject
@@ -126,18 +133,28 @@ class LoginController extends AbstractAuthenticationController
      */
     public function tokenLoginAction($token)
     {
-        $sessionId = $this->loginTokenCache->get($token);
+        $newSessionId = $this->loginTokenCache->get($token);
         $this->loginTokenCache->remove($token);
 
-        if ($sessionId === false) {
+        if ($newSessionId === false) {
             $this->systemLogger->log(sprintf('Token-based login failed, non-existing or expired token %s', $token), LOG_WARNING);
             $this->redirect('index');
-        } else {
-            $this->systemLogger->log(sprintf('Token-based login succeeded, token %s', $token), LOG_DEBUG);
-            $this->session->putData('lastVisitedNode', null);
-            $this->replaceSessionCookie($sessionId);
-            $this->redirect('index', 'Backend\Backend');
         }
+
+        $this->systemLogger->log(sprintf('Token-based login succeeded, token %s', $token), LOG_DEBUG);
+
+        $newSession = $this->sessionManager->getSession($newSessionId);
+        if ($newSession->canBeResumed()) {
+            $newSession->resume();
+        }
+        if ($newSession->isStarted()) {
+            $newSession->putData('lastVisitedNode', null);
+        } else {
+            $this->systemLogger->log(sprintf('Failed resuming or starting session %s which was referred to in the login token %s.', $newSessionId, $token), LOG_ERR);
+        }
+
+        $this->replaceSessionCookie($newSessionId);
+        $this->redirect('index', 'Backend\Backend');
     }
 
     /**


### PR DESCRIPTION
This fixes a regression introduced in #591 (commit:
1fd3fcabf61f922f9019773341d74ac17b04887d) which results in an internal
server error if a user tries to switch from one site to another using
the Neos user interface.

The code assumed that `$this->session` is already the new session the
`tokenLoginAction` is about to switch to and that this session is
already initialized. However, `$this->session` more often than not
is the session the user is about to leave and is not currently running.

The fix now unsets the `lastVisitedNode` in the new session the user
is about to switch to and makes sure that it is fully initialized.