### PR TITLE
BUGFIX: Fix crossdomain-linking error

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -20,6 +20,7 @@ use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\Domain\Service\ContentContextFactory;
 use TYPO3\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
+use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\Routing\Exception\InvalidDimensionPresetCombinationException;
 use TYPO3\Neos\Routing\Exception\InvalidRequestPathException;
 use TYPO3\Neos\Routing\Exception\NoSuchDimensionValueException;
@@ -238,7 +239,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return false;
         }
 
-        $routePath = $this->resolveRoutePathForNode($siteNode, $node);
+        $routePath = $this->resolveRoutePathForNode($node);
         $this->value = $routePath;
 
         return true;
@@ -360,20 +361,19 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * If content dimensions are configured, the first path segment will the identifiers of the dimension
      * values according to the current context.
      *
-     * @param NodeInterface $siteNode The site node, used as a starting point while traversing the tree
      * @param NodeInterface $node The node where the generated path should lead to
      * @return string The relative route path, possibly prefixed with a segment for identifying the current content dimension values
      */
-    protected function resolveRoutePathForNode(NodeInterface $siteNode, NodeInterface $node)
+    protected function resolveRoutePathForNode(NodeInterface $node)
     {
         $workspaceName = $node->getContext()->getWorkspaceName();
 
         $nodeContextPath = $node->getContextPath();
         $nodeContextPathSuffix = ($workspaceName !== 'live') ? substr($nodeContextPath, strpos($nodeContextPath, '@')) : '';
 
-        $currentNodeIsSiteNode = ($siteNode === $node);
+        $currentNodeIsSiteNode = ($node->getParentPath() === SiteService::SITES_ROOT_PATH);
         $dimensionsUriSegment = $this->getUriSegmentForDimensions($node->getContext()->getDimensions(), $currentNodeIsSiteNode);
-        $requestPath = $this->getRequestPathByNode($siteNode, $node);
+        $requestPath = $this->getRequestPathByNode($node);
 
         return trim($dimensionsUriSegment . $requestPath, '/') . $nodeContextPathSuffix;
     }
@@ -416,19 +416,18 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     /**
      * Renders a request path based on the "uriPathSegment" properties of the nodes leading to the given node.
      *
-     * @param NodeInterface $siteNode Top level node, corresponds to the top level of the request path
      * @param NodeInterface $node The node where the generated path should lead to
      * @return string A relative request path
      * @throws Exception\MissingNodePropertyException if the given node doesn't have a "uriPathSegment" property set
      */
-    protected function getRequestPathByNode(NodeInterface $siteNode, NodeInterface $node)
+    protected function getRequestPathByNode(NodeInterface $node)
     {
-        if ($siteNode === $node) {
+        if ($node->getParentPath() === SiteService::SITES_ROOT_PATH) {
             return '';
         }
 
         $requestPathSegments = [];
-        while ($siteNode !== $node && $node instanceof NodeInterface) {
+        while ($node->getParentPath() !== SiteService::SITES_ROOT_PATH && $node instanceof NodeInterface) {
             if (!$node->hasProperty('uriPathSegment')) {
                 throw new Exception\MissingNodePropertyException(sprintf('Missing "uriPathSegment" property for node "%s". Nodes can be migrated with the "flow node:repair" command.', $node->getPath()), 1415020326);
             }

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -455,6 +455,28 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     /**
      * @test
      */
+    public function resolveSetsValueToContextPathIfPassedNodeCouldBeResolvedButIsInAnotherSite()
+    {
+        $mockContext = $this->buildMockContext(array('workspaceName' => 'user-robert'));
+        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/currentdotcom');
+
+        $mockSubNode = $this->buildSubNode($this->buildSiteNode($mockContext, '/sites/otherdotcom'), 'home');
+        $mockSubNode->mockProperties['uriPathSegment'] = 'home';
+        $mockSubNode->expects($this->any())->method('getContextPath')->will($this->returnValue('/sites/otherdotcom/home@user-robert'));
+
+        $mockSubSubNode = $this->buildSubNode($mockSubNode, 'ae178bc9184');
+        $mockSubSubNode->mockProperties['uriPathSegment'] = 'coffee-brands';
+        $mockSubSubNode->expects($this->any())->method('getContextPath')->will($this->returnValue('/sites/otherdotcom/home/ae178bc9184@user-robert'));
+
+        $routeValues = array('node' => $mockSubSubNode);
+        $this->assertTrue($this->routePartHandler->resolve($routeValues));
+        $this->assertSame('home/coffee-brands@user-robert', $this->routePartHandler->getValue());
+    }
+
+    /**
+     * @test
+     */
     public function resolveReturnsFalseIfGivenRouteValueIsNeitherStringNorNode()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -921,8 +921,10 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     protected function buildSiteNode(ContentContext $mockContext, $nodePath)
     {
         $nodeName = substr($nodePath, strrpos($nodePath, '/') + 1);
+        $parentNodePath = substr($nodePath, 0, strrpos($nodePath, '/'));
         $mockSiteNode = $this->buildNode($mockContext, $nodeName);
         $mockSiteNode->expects($this->any())->method('getPath')->will($this->returnValue($nodePath));
+        $mockSiteNode->expects($this->any())->method('getParentPath')->will($this->returnValue($parentNodePath));
         $mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($mockSiteNode));
         return $mockSiteNode;
     }


### PR DESCRIPTION
The ``FrontendNodeRoutePartHandler`` caused an php error when it was called with a node that originated from another site than the site in the content context. Since a comparison between the current-node and the siteNode was used as an exit-condition for the url-path generation the method did not detect the siteNode of the external node properly and traversed up to the /sites node where an error occurred because no uri-path-segment could be found.

This fix avoids this by detecting the siteNodes by checking wether the parentPath of of the node equals ``SiteService::SITES_ROOT_PATH``