### PR TITLE
FEATURE: Add Commands ``site:create``, ``site:activate`` and  ``site:decativate``

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -201,7 +201,7 @@ class SiteCommandController extends CommandController
                 $site = $this->siteImportService->importFromFile($filename);
             } catch (\Exception $exception) {
                 $this->systemLogger->logException($exception);
-                $this->outputLine('Error: During the import of the file "%s" an exception occurred: %s, see log for further information.', array($filename, $exception->getMessage()));
+                $this->outputLine('<error>During the import of the file "%s" an exception occurred: %s, see log for further information.</error>', array($filename, $exception->getMessage()));
                 $this->quit(1);
             }
         } else {
@@ -209,7 +209,7 @@ class SiteCommandController extends CommandController
                 $site = $this->siteImportService->importFromPackage($packageKey);
             } catch (\Exception $exception) {
                 $this->systemLogger->logException($exception);
-                $this->outputLine('Error: During the import of the "Sites.xml" from the package "%s" an exception occurred: %s, see log for further information.', array($packageKey, $exception->getMessage()));
+                $this->outputLine('<error>: During the import of the "Sites.xml" from the package "%s" an exception occurred: %s, see log for further information.</error>', array($packageKey, $exception->getMessage()));
                 $this->quit(1);
             }
         }
@@ -246,7 +246,7 @@ class SiteCommandController extends CommandController
         }
 
         if (count($sites) === 0) {
-            $this->outputLine('Error: No site for exporting found');
+            $this->outputLine('<error>No site for exporting found</error>');
             $this->quit(1);
         }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -94,7 +94,7 @@ class SiteCommandController extends CommandController
     protected $persistenceManager;
 
     /**
-     * Create a new (blank) site in the default dimension
+     * Create a new site
      *
      * This command allows to create a blank site with just a single empty document in the default dimension.
      * The name of the site, the packageKey must be specified.
@@ -272,11 +272,15 @@ class SiteCommandController extends CommandController
     /**
      * Remove all content and related data - for now. In the future we need some more sophisticated cleanup.
      *
-     * @param string $siteNodeName Name of a site root node to clear only content of this site.
+     * @param string $siteNode Name of a site root node to clear only content of this site.
+     * @param string $siteNodeName This option is deprecated, use --site-node instead
      * @return void
      */
-    public function pruneCommand($siteNodeName = null)
+    public function pruneCommand($siteNode = null, $siteNodeName = null)
     {
+        if ($siteNode !== null) {
+            $siteNodeName = $siteNode;
+        }
         if ($siteNodeName !== null) {
             $possibleSite = $this->siteRepository->findOneByNodeName($siteNodeName);
             if ($possibleSite === null) {
@@ -292,7 +296,7 @@ class SiteCommandController extends CommandController
     }
 
     /**
-     * Display a list of available sites
+     * List available sites
      *
      * @return void
      */
@@ -341,12 +345,14 @@ class SiteCommandController extends CommandController
     /**
      * Activate a site
      *
-     * @param string $siteNodeName The node name of the site to activate
+     * This command activates the specified site.
+     *
+     * @param string $siteNode The node name of the site to activate
      * @return void
      */
-    public function activateCommand($siteNodeName)
+    public function activateCommand($siteNode)
     {
-        $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+        $site = $this->siteRepository->findOneByNodeName($siteNode);
         if (!$site instanceof Site) {
             $this->outputLine('<error>Site not found.</error>');
             $this->quit(1);
@@ -360,12 +366,14 @@ class SiteCommandController extends CommandController
     /**
      * Deactivate a site
      *
-     * @param string $siteNodeName The node name of the site to deactivate
+     * This command deactivates the specified site.
+     *
+     * @param string $siteNode The node name of the site to deactivate
      * @return void
      */
-    public function deactivateCommand($siteNodeName)
+    public function deactivateCommand($siteNode)
     {
-        $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+        $site = $this->siteRepository->findOneByNodeName($siteNode);
         if (!$site instanceof Site) {
             $this->outputLine('<error>Site not found.</error>');
             $this->quit(1);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -105,16 +105,16 @@ class SiteCommandController extends CommandController
      * If no ``nodeName` option is specified the command will create a unique node-name from the name of the site.
      * If a node name is given it has to be unique for the setup.
      *
-     * If the flag ``active` is set the created site will be activated immediately.
+     * If the flag ``activate` is set to false new site will not be activated.
      *
      * @param string $name The name of the site
      * @param string $packageKey The site package
-     * @param string $nodeType The node type to use for the site node. (Default =
+     * @param string $nodeType The node type to use for the site node. (Default = TYPO3.Neos.NodeTypes:Page)
      * @param string $nodeName The name of the site node. If no nodeName is given it will be determined from the siteName.
-     * @param boolean $active Activate the new site immediately.
+     * @param boolean $inactive The new site is not activated immediately (default = false).
      * @return void
      */
-    public function createCommand($name, $packageKey, $nodeType = 'TYPO3.Neos.NodeTypes:Page', $nodeName = null, $active = false)
+    public function createCommand($name, $packageKey, $nodeType = 'TYPO3.Neos.NodeTypes:Page', $nodeName = null, $inactive = false)
     {
         if ($nodeName === null) {
             $nodeName = $this->nodeService->generateUniqueNodeName(SiteService::SITES_ROOT_PATH, $name);
@@ -156,12 +156,12 @@ class SiteCommandController extends CommandController
 
         $site = new Site($nodeName);
         $site->setSiteResourcesPackageKey($packageKey);
-        $site->setState($active ? Site::STATE_ONLINE : Site::STATE_OFFLINE);
+        $site->setState($inactive ? Site::STATE_OFFLINE : Site::STATE_ONLINE);
         $site->setName($name);
 
         $this->siteRepository->add($site);
 
-        $this->outputLine('Successfully created site "%s" with siteNode "%s", type "%s" and packageKey "%s"', [$name, $nodeName, $nodeType, $packageKey]);
+        $this->outputLine('Successfully created site "%s" with siteNode "%s", type "%s", packageKey "%s" and state "%s"', [$name, $nodeName, $nodeType, $packageKey, $inactive ? 'offline' : 'online']);
     }
 
     /**


### PR DESCRIPTION
This command adds the `site:create`command that allows to create a blank site with just a single empty document in the default dimension. The name of the site, the packageKey must be specified.

If no nodeType option is specified the command will use `TYPO3.Neos.NodeTypes:Page` as fallback. The node type must already exists and have the superType `TYPO3.Neos:Document`.

If no `nodeName` option is specified the command will create a unique node-name from the name of the site. If a node name is given it has to be unique.

If the flag ``inactivate` is set the new site will not be activated.

The commands `site:activate` and `site:deactivate` are added to bring the according feature of the neos-ui to the cli.

The command `site:list` is extended to display the online state of the sites now.

Additional the  error format of the `site:import` and `site:export` command is altered to use the error format instead of an "Error:" prefix.
