### PR TITLE
FEATURE: Add setting ``TYPO3.Neos.defaultSiteNodeName``

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -117,7 +117,7 @@ class LoginController extends AbstractAuthenticationController
             $this->redirect('index', 'Backend\Backend');
         }
         $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        $currentSite = $currentDomain !== null ? $currentDomain->getSite() : $this->siteRepository->findFirstOnline();
+        $currentSite = $currentDomain !== null ? $currentDomain->getSite() : $this->siteRepository->findDefault();
         $this->view->assignMultiple([
             'styles' => array_filter($this->settings['userInterface']['backendLoginForm']['stylesheets']),
             'username' => $username,

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -21,6 +21,13 @@ use TYPO3\Flow\Annotations as Flow;
  */
 class SiteRepository extends \TYPO3\Flow\Persistence\Repository
 {
+
+    /**
+     * @Flow\InjectConfiguration(package="TYPO3.Neos", path="defaultSiteNodeName")
+     * @var string
+     */
+    protected $defaultSiteNodeName;
+
     /**
      * Finds the first site
      *
@@ -50,5 +57,23 @@ class SiteRepository extends \TYPO3\Flow\Persistence\Repository
     public function findFirstOnline()
     {
         return $this->findOnline()->getFirst();
+    }
+
+    /**
+     * Find the default site and fallback to first online
+     * if no default is found or the default is not online
+     */
+    public function findDefault()
+    {
+        if ($this->defaultSiteNodeName !== null) {
+            /**
+             * @var Site $defaultSite
+             */
+            $defaultSite = $this->findOneByNodeName($this->defaultSiteNodeName);
+            if ($defaultSite && $defaultSite->getState() === \TYPO3\Neos\Domain\Model\Site::STATE_ONLINE) {
+                return $defaultSite;
+            }
+        }
+        return $this->findFirstOnline();
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
@@ -120,7 +120,7 @@ class ContentContextFactory extends ContextFactory
             $defaultContextProperties['currentSite'] = $currentDomain->getSite();
             $defaultContextProperties['currentDomain'] = $currentDomain;
         } else {
-            $defaultContextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+            $defaultContextProperties['currentSite'] = $this->siteRepository->findDefault();
         }
 
         return $defaultContextProperties;

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -115,6 +115,10 @@ TYPO3:
         'TYPO3.TypoScript': TRUE
         'TYPO3.Neos': TRUE
 
+    # If a node name is specified here it will be used as default siteNode
+    # wich is displayed if no domain pattern matches the current request
+    defaultSiteNodeName: null
+
     routing:
       # Setting this to TRUE allows to use an empty uriSegment for default dimensions.
       # The only limitation is that all segments must be unique across all dimenions.


### PR DESCRIPTION
If a request is not mapped to a site via domain pattern Neos currently uses the first active site. 
This is difficult in multisite environments especially since there is no manual order of the sites and currently there is no way to control which site is shown in this case.

This change adds a setting ``defaultSiteNodeName`` wich allows to configure the behavior in this
case to become deterministic.