### PR TITLE
TASK: Make the site export tidy by default

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -129,13 +129,13 @@ class SiteCommandController extends CommandController
      * assets will be embedded into the XML in base64 encoded form.
      *
      * @param string $siteNode the node name of the site to be exported; if none given will export all sites
-     * @param boolean $tidy Whether to export formatted XML
+     * @param boolean $tidy Whether to export formatted XML. This is defaults to true
      * @param string $filename relative path and filename to the XML file to create. Any resource will be stored in a sub folder "Resources".
      * @param string $packageKey Package to store the XML file in. Any resource will be stored in a sub folder "Resources".
      * @param string $nodeTypeFilter Filter the node type of the nodes, allows complex expressions (e.g. "TYPO3.Neos:Page", "!TYPO3.Neos:Page,TYPO3.Neos:Text")
      * @return void
      */
-    public function exportCommand($siteNode = null, $tidy = false, $filename = null, $packageKey = null, $nodeTypeFilter = null)
+    public function exportCommand($siteNode = null, $tidy = true, $filename = null, $packageKey = null, $nodeTypeFilter = null)
     {
         if ($siteNode === null) {
             $sites = $this->siteRepository->findAll()->toArray();


### PR DESCRIPTION
This change will make site exports via `./flow site:export` tidy by default.

NEOS-1430 #resolve