### PR TITLE
BUGFIX: Fix `asset-with-metadata` endpoint for images

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -272,6 +272,8 @@ class ContentController extends ActionController
     {
         $propertyMappingConfiguration = $this->arguments->getArgument('assets')->getPropertyMappingConfiguration();
         $propertyMappingConfiguration->allowAllProperties();
+        $propertyMappingConfiguration->setTypeConverterOption(AssetInterfaceConverter::class, AssetInterfaceConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
+        $propertyMappingConfiguration->forProperty('*')->setTypeConverterOption(AssetInterfaceConverter::class, AssetInterfaceConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
     }
 
     /**


### PR DESCRIPTION
This adjusts the `Backend\ContentController` to set the
`CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED` property mapping flag
for incoming assets.

Background:
When selecting a single `Asset` in the Neos backend, its metadata
is retrieved via the `/neos/content/asset-with-metadata` endpoint.
This expects a list of asset identifiers.
However, in the case of `ImageInterface`-assets we instead send an
object `{__identity: <uuid>, __type: <type>}`.

Note: The fix is backported from #102