### PR TITLE
FEATURE: Introduce --skip and --only to node:repair command

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandController.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandController.php
@@ -54,6 +54,10 @@ class NodeCommandController extends CommandController implements DescriptionAwar
      * This command analyzes and repairs the node tree structure and individual nodes
      * based on the current node type configuration.
      *
+     * It is possible to execute only one or more specific checks by providing the <b>--skip</b>
+     * or <b>--only</b> option. See the full description of checks further below for possible check
+     * identifiers.
+     *
      * The following checks will be performed:
      *
      * {pluginDescriptions}
@@ -63,13 +67,19 @@ class NodeCommandController extends CommandController implements DescriptionAwar
      *
      * ./flow node:repair --node-type TYPO3.Neos.NodeTypes:Page
      *
+     * ./flow node:repair --workspace user-robert --only removeOrphanNodes,removeNodesWithInvalidDimensions
+     *
+     * ./flow node:repair --skip removeUndefinedProperties
+     *
      * @param string $nodeType Node type name, if empty update all declared node types
      * @param string $workspace Workspace name, default is 'live'
      * @param boolean $dryRun Don't do anything, but report actions
      * @param boolean $cleanup If FALSE, cleanup tasks are skipped
+     * @param string $skip Skip the given check or checks (comma separated)
+     * @param string $only Only execute the given check or checks (comma separated)
      * @return void
      */
-    public function repairCommand($nodeType = null, $workspace = 'live', $dryRun = false, $cleanup = true)
+    public function repairCommand($nodeType = null, $workspace = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
     {
         $this->pluginConfigurations = self::detectPlugins($this->objectManager);
 
@@ -100,7 +110,7 @@ class NodeCommandController extends CommandController implements DescriptionAwar
             $plugin = $pluginConfiguration['object'];
             $this->outputLine('<b>' . $plugin->getSubCommandShortDescription('repair') . '</b>');
             $this->outputLine();
-            $plugin->invokeSubCommand('repair', $this->output, $nodeType, $workspace, $dryRun, $cleanup);
+            $plugin->invokeSubCommand('repair', $this->output, $nodeType, $workspace, $dryRun, $cleanup, $skip, $only);
             $this->outputLine();
         }
 


### PR DESCRIPTION
This change introduces two new options for the ``node:repair`` command
which allows for selective execution of ``node:repair`` checks.

The ``--skip`` option accepts one or more check names (identifiers) which
should be skipped.

If the ``--only`` option is used, only the the checks which are specified
in ``--only`` will be executed.

The identifier for each check can be looked up in the ``node:repair`` help
screen. If multiple check identifiers are specified, they need to be
separated by commas.