### PR TITLE
BUGFIX: Fix error message when creating new site package

### DIFF
--- a/TYPO3.Neos.Kickstarter/Classes/TYPO3/Neos/Kickstarter/Command/KickstartCommandController.php
+++ b/TYPO3.Neos.Kickstarter/Classes/TYPO3/Neos/Kickstarter/Command/KickstartCommandController.php
@@ -46,7 +46,7 @@ class KickstartCommandController extends CommandController
     public function siteCommand($packageKey, $siteName)
     {
         if (!$this->packageManager->isPackageKeyValid($packageKey)) {
-            $this->outputLine('Package key "%s" is not valid. Only UpperCamelCase with alphanumeric characters and underscore, please!', array($packageKey));
+            $this->outputLine('Package key "%s" is not valid. Only UpperCamelCase in the format "Vendor.PackageKey", please!', array($packageKey));
             $this->quit(1);
         }
 


### PR DESCRIPTION
The previous error message did not say, that the format `Vendor.PackageKey` is mandatory.