### PR TITLE
BUGFIX: Layered workspaces should retain removed nodes

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -461,17 +461,17 @@ class Workspace
             }
         }
 
-        if ($node->isRemoved() === true) {
-            $this->nodeDataRepository->remove($targetNodeData);
-        } else {
-            $targetNodeData->similarize($node->getNodeData());
-            if ($nodeWasMoved) {
-                $targetNodeData->setPath($node->getPath(), false);
-            }
-            $targetNodeData->setLastPublicationDateTime($this->now);
-            $node->setNodeData($targetNodeData);
-            $this->nodeService->cleanUpProperties($node);
+        $targetNodeData->setRemoved($node->isRemoved());
+        $targetNodeData->similarize($sourceNodeData);
+        // TODO: This seemswrong and introduces a publish order between nodes. We should always set the path.
+        if ($nodeWasMoved) {
+            $targetNodeData->setPath($node->getPath(), false);
         }
+        $targetNodeData->setLastPublicationDateTime($this->now);
+        $node->setNodeData($targetNodeData);
+        $node->setNodeDataIsMatchingContext(null);
+        $this->nodeService->cleanUpProperties($node);
+
         $this->nodeDataRepository->remove($sourceNodeData);
     }
 
@@ -494,13 +494,9 @@ class Workspace
             $this->nodeDataRepository->remove($movedShadowNodeData);
         }
 
-        if ($targetWorkspace->getBaseWorkspace() === null && $node->isRemoved()) {
-            $this->nodeDataRepository->remove($nodeData);
-        } else {
-            $nodeData->setWorkspace($targetWorkspace);
-            $nodeData->setLastPublicationDateTime($this->now);
-            $this->nodeService->cleanUpProperties($node);
-        }
+        $nodeData->setWorkspace($targetWorkspace);
+        $nodeData->setLastPublicationDateTime($this->now);
+        $this->nodeService->cleanUpProperties($node);
         $node->setNodeDataIsMatchingContext(null);
     }
 


### PR DESCRIPTION
In a multi-layered workspace scenario a removed node should only ever
really be removed when publishing into the root workspace (live).
When publishing in a workspace that has a base workspace we should
instead publish a removed node into that workspace to overlay any
existing nodes in the base workspace.

Additionally cleans the code as some of the checks are done deeper
down again and also rely on too much internal knowledge when done
in the Workspace publish methods.

NEOS-1872 #resolve