### PR TITLE
BUGFIX: `references` property type not properly converted

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodePropertyConverterService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/NodePropertyConverterService.php
@@ -133,7 +133,7 @@ class NodePropertyConverterService
         $rawType = TypeHandling::truncateElementType($dataType);
 
         // This hardcoded handling is to circumvent rewriting PropertyMappers that convert objects. Usually they expect the source to be an object already and break if not.
-        if (!TypeHandling::isSimpleType($rawType) && !is_object($propertyValue)) {
+        if (!TypeHandling::isSimpleType($rawType) && !is_object($propertyValue) && !is_array($propertyValue)) {
             return null;
         }
 


### PR DESCRIPTION
This results in `references` properties to not get wrapped with ContentElementWrappingService correctly.

Steps to reproduce: edit some property of a node of type `references`, hit apply, the property will become empty again.