### PR TITLE
BUGFIX: Node property search with PostgreSQL 9.5

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -993,7 +993,7 @@ class NodeDataRepository extends Repository
         $this->addNodeTypeFilterConstraintsToQueryBuilder($queryBuilder, $nodeTypeFilter);
         // Convert to lowercase, then to json, and then trim quotes from json to have valid JSON escaping.
         $likeParameter = '%' . trim(json_encode(UnicodeFunctions::strtolower($term), JSON_UNESCAPED_UNICODE), '"') . '%';
-        $queryBuilder->andWhere("LOWER(CONCAT('', n.properties)) LIKE :term")->setParameter('term', $likeParameter);
+        $queryBuilder->andWhere("LOWER(TYPO3CR_TOSTRING(n.properties)) LIKE :term")->setParameter('term', $likeParameter);
 
         if (strlen($pathStartingPoint) > 0) {
             $pathStartingPoint = strtolower($pathStartingPoint);
@@ -1419,7 +1419,7 @@ class NodeDataRepository extends Repository
         $parameters = [];
         foreach ($relationMap as $relatedObjectType => $relatedIdentifiers) {
             foreach ($relatedIdentifiers as $relatedIdentifier) {
-                $constraints[] = '(LOWER(CONCAT(\'\', n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
+                $constraints[] = '(LOWER(TYPO3CR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
                 $parameters['entity' . md5($relatedIdentifier)] = '%"__identifier": "' . strtolower($relatedIdentifier) . '"%';
             }
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -993,7 +993,7 @@ class NodeDataRepository extends Repository
         $this->addNodeTypeFilterConstraintsToQueryBuilder($queryBuilder, $nodeTypeFilter);
         // Convert to lowercase, then to json, and then trim quotes from json to have valid JSON escaping.
         $likeParameter = '%' . trim(json_encode(UnicodeFunctions::strtolower($term), JSON_UNESCAPED_UNICODE), '"') . '%';
-        $queryBuilder->andWhere("LOWER(TYPO3CR_TOSTRING(n.properties)) LIKE :term")->setParameter('term', $likeParameter);
+        $queryBuilder->andWhere("LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :term")->setParameter('term', $likeParameter);
 
         if (strlen($pathStartingPoint) > 0) {
             $pathStartingPoint = strtolower($pathStartingPoint);
@@ -1419,7 +1419,7 @@ class NodeDataRepository extends Repository
         $parameters = [];
         foreach ($relationMap as $relatedObjectType => $relatedIdentifiers) {
             foreach ($relatedIdentifiers as $relatedIdentifier) {
-                $constraints[] = '(LOWER(TYPO3CR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
+                $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
                 $parameters['entity' . md5($relatedIdentifier)] = '%"__identifier": "' . strtolower($relatedIdentifier) . '"%';
             }
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Persistence/Ast/ToStringFunction.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Persistence/Ast/ToStringFunction.php
@@ -1,0 +1,56 @@
+<?php
+namespace TYPO3\TYPO3CR\Persistence\Ast;
+
+/*
+ * This file is part of the TYPO3.TYPO3CR package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Custom DQL function to explicitly cast a value to a string
+ */
+class ToStringFunction extends FunctionNode
+{
+
+    /**
+     * @var mixed
+     */
+    protected $stringPrimary;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        // This type is defined by ANSI SQL
+        $targetType = 'VARCHAR';
+        // MySQL needs a CHAR type for string conversion (http://dev.mysql.com/doc/refman/5.7/en/type-conversion.html)
+        if ($sqlWalker->getConnection()->getDatabasePlatform()->getName() === 'mysql') {
+            $targetType = 'CHAR';
+        }
+        return 'CAST(' . $sqlWalker->walkSimpleArithmeticExpression($this->stringPrimary) . ' AS ' . $targetType . ')';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->stringPrimary = $parser->StringPrimary();
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/TYPO3.TYPO3CR/Configuration/Settings.yaml
+++ b/TYPO3.TYPO3CR/Configuration/Settings.yaml
@@ -51,7 +51,7 @@ TYPO3:
             listener: 'Gedmo\Timestampable\TimestampableListener'
         dql:
           customStringFunctions:
-            'TYPO3CR_TOSTRING': 'TYPO3\TYPO3CR\Persistence\Ast\ToStringFunction'
+            'NEOSCR_TOSTRING': 'TYPO3\TYPO3CR\Persistence\Ast\ToStringFunction'
 
     # Improve debug output for node objects by ignoring large classes
     error:

--- a/TYPO3.TYPO3CR/Configuration/Settings.yaml
+++ b/TYPO3.TYPO3CR/Configuration/Settings.yaml
@@ -43,13 +43,15 @@ TYPO3:
     fallbackNodeType: ~
 
   Flow:
-     # Register soft deletable filter & event listeners
     persistence:
       doctrine:
         eventListeners:
           'Gedmo\Timestampable\TimestampableListener':
             events: ['prePersist', 'onFlush', 'loadClassMetadata']
             listener: 'Gedmo\Timestampable\TimestampableListener'
+        dql:
+          customStringFunctions:
+            'TYPO3CR_TOSTRING': 'TYPO3\TYPO3CR\Persistence\Ast\ToStringFunction'
 
     # Improve debug output for node objects by ignoring large classes
     error:


### PR DESCRIPTION
Adds an explicit string conversion which is needed for PostgreSQL > 9.4
to convert a JSON type to string. This is needed when matching a string
pattern in the NodeSearchService against the node properties.

NEOS-1873 #resolve