### PR TITLE
BUGFIX: FileTypeIconService should have only static methods

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/FileTypeIconService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/FileTypeIconService.php
@@ -52,7 +52,7 @@ class FileTypeIconService
      * @param integer $maximumHeight
      * @return integer
      */
-    protected function getDocumentIconSize($maximumWidth, $maximumHeight)
+    protected static function getDocumentIconSize($maximumWidth, $maximumHeight)
     {
         $size = max($maximumWidth, $maximumHeight);
         if ($size <= 16) {


### PR DESCRIPTION
The ``getDocumentIconSize`` method is called in ``getIcon`` which is static, therefore
it should be static as well.

NEOS-1879 #resolve