### PR TITLE
TASK: improve performance of `getRelativeNodePathByUriPathSegmentProperties`

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -406,7 +406,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             $nodes = $this->nodeSearchService->findByProperties(['uriPathSegment' => $pathSegment], [$documentNodeType], $context, $node);
             $filteredNodes = array_filter($nodes, function ($currentNode) use ($node) {
                 // Only consider direct children
-                return $currentNode->getParent()->getIdentifier() === $node->getIdentifier());
+                return $currentNode->getParent()->getIdentifier() === $node->getIdentifier();
             });
             if ($filteredNodes) {
                 $node = reset($filteredNodes);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/FrontendNodeRoutePartHandler.php
@@ -404,8 +404,12 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
 
         foreach (explode('/', $relativeRequestPath) as $pathSegment) {
             $nodes = $this->nodeSearchService->findByProperties(['uriPathSegment' => $pathSegment], [$documentNodeType], $context, $node);
-            if ($nodes) {
-                $node = reset($nodes);
+            $filteredNodes = array_filter($nodes, function ($currentNode) use ($node) {
+                // Only consider direct children
+                return $currentNode->getParent()->getIdentifier() === $node->getIdentifier());
+            });
+            if ($filteredNodes) {
+                $node = reset($filteredNodes);
                 $relativeNodePathSegments[] = $node->getName();
             } else {
                 return false;

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -124,7 +124,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
             $result = [];
             // Recursively get all the matching childNodes. We need it to return deeply nested childNodes because that's how `findByProperties` works
             $getChildNodes = function ($node) use (&$getChildNodes, &$result, $uriPathSegment) {
-                foreach($node->getChildNodes() as $childNode) {
+                foreach ($node->getChildNodes() as $childNode) {
                     $getChildNodes($childNode);
                     if ($childNode->getProperty('uriPathSegment') === $uriPathSegment) {
                         $result[] = $childNode;


### PR DESCRIPTION
Use `NodeSearchService` to query for nodes with given uriPathSegment.

On pages with a lot of nodes on the same level (>1000) this drastically
improves performance.
