### PR TITLE
BUGFIX: Add translation keys to replace asset view

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -11,10 +11,10 @@
                 <fieldset>
                     <legend>{neos:backend.translate(id: 'media.replaceAsset.replaceFilename', source: 'Modules', arguments: {filename: asset.resource.filename})}</legend>
                     <p class="neos-buffer-below">
-                        You can replace this asset by uploading a new file. Once replaced, the new asset will be used on all places where the asset is used on your website.<br/>
-                        <b>Note:</b> This operation will replace the asset in all published or unpublished workspaces, including the live website.
+                        {neos:backend.translate(id: 'media.replaceAsset.description', source: 'Modules', package: 'TYPO3.Neos')}<br/>
+                        <b>{neos:backend.translate(id: 'media.replaceAsset.note', source: 'Modules', package: 'TYPO3.Neos')}: </b> {neos:backend.translate(id: 'media.replaceAsset.noteText', source: 'Modules', package: 'TYPO3.Neos')}
                     </p>
-                    <label class="neos-button neos-button-primary" for="resource" title="Max. upload size {humanReadableMaximumFileUploadSize} per file" data-neos-toggle="tooltip">Choose a new file <i class="icon-file"></i></label>
+                    <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'media.replaceAsset.chooseNewFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i></label>
                     <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}" />
                 </fieldset>
                 <fieldset>
@@ -35,13 +35,13 @@
                     <legend>Usage</legend>
                     <f:if condition="{asset.inUse}">
                         <f:then>
-                            <p class="neos-buffer-below">Currently the asset is used {asset.usageCount} times.</p>
+                            <p class="neos-buffer-below">{neos:backend.translate(id: 'media.replace.usageCount', arguments: {usageCount: asset.usageCount}, source: 'Modules', package: 'TYPO3.Neos')}</p>
                             <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
-                                Show all usages
+                                {neos:backend.translate(id: 'media.replace.allUsages', source: 'Modules', package: 'TYPO3.Neos')}
                             </f:link.action>
                         </f:then>
                         <f:else>
-                            <p>Currently the asset is not in used anywhere on the website</p>
+                            <p>{neos:backend.translate(id: 'media.replace.notUsed', source: 'Modules', package: 'TYPO3.Neos')}</p>
                         </f:else>
                     </f:if>
                 </fieldset>
@@ -52,14 +52,14 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" title="Cancel editing" class="neos-button">Cancel</f:link.action>
-            <f:form.submit id="replace" class="neos-button neos-button-primary" value="Replace" />
+            <f:link.action action="index" title="Cancel editing" class="neos-button">{neos:backend.translate(id: 'cancel', source: 'Modules', package: 'TYPO3.Neos')}</f:link.action>
+            <f:form.submit id="replace" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'media.replaceAssetResource', source: 'Modules', package: 'TYPO3.Neos')}" />
         </div>
     </f:form>
 </f:section>
 
 <f:section name="ContentImage">
-    <label>Preview current file</label>
+    <label>{neos:backend.translate(id: 'media.replace.previewFile', source: 'Modules', package: 'TYPO3.Neos')}</label>
     <div class="neos-preview-image">
         <a href="{f:uri.resource(resource: asset.resource)}" target="_blank">
             <m:thumbnail asset="{asset}" maximumWidth="1000" maximumHeight="1000" alt="{asset.label}" class="img-polaroid" />

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/ReplaceAssetResource.html
@@ -9,7 +9,7 @@
         <div class="neos-row-fluid">
             <div class="neos-span8">
                 <fieldset>
-                    <legend>Replace "{asset.resource.filename}"</legend>
+                    <legend>{neos:backend.translate(id: 'media.replaceAsset.replaceFilename', source: 'Modules', arguments: {filename: asset.resource.filename})}</legend>
                     <p class="neos-buffer-below">
                         You can replace this asset by uploading a new file. Once replaced, the new asset will be used on all places where the asset is used on your website.<br/>
                         <b>Note:</b> This operation will replace the asset in all published or unpublished workspaces, including the live website.

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -926,6 +926,30 @@
 			<trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
 				<source>Replace "{filename}"</source>
 			</trans-unit>
+			<trans-unit id="media.replaceAsset.description" xml:space="preserve">
+        <source>You can replace this asset by uploading a new file. Once replaced, the new asset will be used on all places where the asset is used on your website.</source>
+      </trans-unit>
+      <trans-unit id="media.replaceAsset.note" xml:space="preserve">
+        <source>Note</source>
+      </trans-unit>
+      <trans-unit id="media.replaceAsset.noteText" xml:space="preserve">
+        <source>This operation will replace the asset in all published or unpublished workspaces, including the live website.</source>
+      </trans-unit>
+      <trans-unit id="media.replaceAsset.chooseNewFile" xml:space="preserve">
+        <source>Choose a new file</source>
+      </trans-unit>
+      <trans-unit id="media.replace.usageCount" xml:space="preserve">
+        <source>Currently the asset is used {usageCount} times.</source>
+      </trans-unit>
+      <trans-unit id="media.replace.allUsages" xml:space="preserve">
+        <source>Show all usages</source>
+      </trans-unit>
+      <trans-unit id="media.replace.notUsed" xml:space="preserve">
+        <source>Currently the asset is not in used anywhere on the website.</source>
+      </trans-unit>
+      <trans-unit id="media.replace.previewFile" xml:space="preserve">
+        <source>Preview current file</source>
+      </trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -923,6 +923,9 @@
 			<trans-unit id="media.relatedNodes.referencesTo" xml:space="preserve">
 				<source>References to "{asset}"</source>
 			</trans-unit>
+			<trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
+				<source>Replace "{filename}"</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
Replaced remaining texts with translation keys to allow translating the replace asset view.

Neos-1878 #close