### PR TITLE
BUGFIX: Render item label section correctly

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/DimensionsMenu.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/DimensionsMenu.html
@@ -6,11 +6,11 @@
 	<f:if condition="{item.node}">
 		<f:then>
 			<neos:link.node node="{item.node}">
-				<f:render section="itemLabel" item="{item}"/>
+				<f:render section="itemLabel" arguments="{item:item}"/>
 			</neos:link.node>
 		</f:then>
 		<f:else>
-			<f:render section="itemLabel" item="{item}"/>
+			<f:render section="itemLabel" arguments="{item:item}"/>
 		</f:else>
 	</f:if>
 	</li>


### PR DESCRIPTION
This change fixes a wrong usage if the render- viewhelper for the dimensions menu `itemLabel` section