### PR TITLE
TASK: Rework CacheSegmentParser to a recursive pattern

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -66,12 +66,6 @@ class ContentCache
     const SEGMENT_TYPE_DYNAMICCACHED = 'dynamiccached';
 
     /**
-     * @Flow\Inject
-     * @var CacheSegmentParser
-     */
-    protected $parser;
-
-    /**
      * @var StringFrontend
      * @Flow\Inject
      */
@@ -219,10 +213,10 @@ class ContentCache
      */
     public function processCacheSegments($content, $storeCacheEntries = true)
     {
-        $this->parser->extractRenderedSegments($content, $this->randomCacheMarker);
+        $parser = new CacheSegmentParser($content, $this->randomCacheMarker);
 
         if ($storeCacheEntries) {
-            $segments = $this->parser->getCacheSegments();
+            $segments = $parser->getCacheSegments();
 
             foreach ($segments as $segment) {
                 $metadata = explode(';', $segment['metadata']);
@@ -235,7 +229,7 @@ class ContentCache
             }
         }
 
-        return $this->parser->getOutput();
+        return $parser->getOutput();
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
@@ -178,8 +178,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function getOutputAfterExtractReturnsOriginalTextWithoutAnnotations()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->content);
+        $parser = new CacheSegmentParser($this->content);
 
         $output = $parser->getOutput();
 
@@ -191,8 +190,8 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function extractReturnsOuterContentWithPlaceholders()
     {
-        $parser = new CacheSegmentParser();
-        $outerContent = $parser->extractRenderedSegments($this->content);
+        $parser = new CacheSegmentParser($this->content);
+        $outerContent = $parser->getOuterSegmentContent();
 
         $this->assertEquals($this->expectedOuterContent, $outerContent);
     }
@@ -202,9 +201,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function getCacheEntriesAfterExtractReturnsInnerContentWithPlaceholders()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->content);
-
+        $parser = new CacheSegmentParser($this->content);
         $entries = $parser->getCacheSegments();
 
         $this->assertEquals($this->expectedEntries, $entries);
@@ -213,12 +210,11 @@ class CacheSegmentParserTest extends UnitTestCase
     /**
      * @test
      * @expectedException \Neos\Fusion\Exception
-     * @expectedExceptionCode 1391853500
+     * @expectedExceptionCode 1391855139
      */
     public function invalidContentWithMissingEndThrowsException()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->invalidContentWithMissingEnd);
+        new CacheSegmentParser($this->invalidContentWithMissingEnd);
     }
 
     /**
@@ -228,8 +224,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function invalidContentWithExceedingEndThrowsException()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->invalidContentWithExceedingEnd);
+        new CacheSegmentParser($this->invalidContentWithExceedingEnd);
     }
 
     /**
@@ -239,8 +234,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function invalidContentWithMissingSeparatorThrowsException()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->invalidContentWithMissingSeparator);
+        new CacheSegmentParser($this->invalidContentWithMissingSeparator);
     }
 
     /**
@@ -248,8 +242,8 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function extractWithUncachedSegmentsReturnsOuterContentWithPlaceholders()
     {
-        $parser = new CacheSegmentParser();
-        $outerContent = $parser->extractRenderedSegments($this->contentWithUncachedSegments);
+        $parser = new CacheSegmentParser($this->contentWithUncachedSegments);
+        $outerContent = $parser->getOuterSegmentContent();
 
         $this->assertEquals($this->expectedOuterContentWithUncachedSegments, $outerContent);
     }
@@ -259,9 +253,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function getOutputAfterExtractWithUncachedSegmentsReturnsOriginalTextWithoutAnnotations()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->contentWithUncachedSegments);
-
+        $parser = new CacheSegmentParser($this->contentWithUncachedSegments);
         $output = $parser->getOutput();
 
         $this->assertEquals($this->expectedOutputWithUncachedSegments, $output);
@@ -272,9 +264,7 @@ class CacheSegmentParserTest extends UnitTestCase
      */
     public function getCacheSegmentsAfterExtractWithUncachedSegmentsReturnsContentWithPlaceholder()
     {
-        $parser = new CacheSegmentParser();
-        $parser->extractRenderedSegments($this->contentWithUncachedSegments);
-
+        $parser = new CacheSegmentParser($this->contentWithUncachedSegments);
         $entries = $parser->getCacheSegments();
 
         $this->assertEquals($this->expectedEntriesWithUncachedSegments, $entries);

--- a/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
@@ -11,8 +11,9 @@ namespace Neos\Fusion\Tests\Unit\Core\Cache;
  * source code.
  */
 
-use Neos\Flow\Cache\Backend\TransientMemoryBackend;
+use Neos\Cache\Backend\TransientMemoryBackend;
 use Neos\Cache\CacheAwareInterface;
+use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Core\ApplicationContext;
@@ -129,7 +130,6 @@ class ContentCacheTest extends UnitTestCase
         $contentCache = new ContentCache();
         $mockSecurityContext = $this->createMock(Context::class);
         $this->inject($contentCache, 'securityContext', $mockSecurityContext);
-        $this->inject($contentCache, 'parser', new CacheSegmentParser());
 
         $mockCache = $this->createMock(FrontendInterface::class);
         $this->inject($contentCache, 'cache', $mockCache);
@@ -150,7 +150,6 @@ class ContentCacheTest extends UnitTestCase
         $contentCache = new ContentCache();
         $mockSecurityContext = $this->createMock(Context::class);
         $this->inject($contentCache, 'securityContext', $mockSecurityContext);
-        $this->inject($contentCache, 'parser', new CacheSegmentParser());
 
         $mockCache = $this->createMock(FrontendInterface::class);
         $this->inject($contentCache, 'cache', $mockCache);
@@ -185,7 +184,6 @@ class ContentCacheTest extends UnitTestCase
         $mockPropertyMapper = $this->createMock(PropertyMapper::class);
         $mockPropertyMapper->expects($this->any())->method('convert')->will($this->returnArgument(0));
         $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
-        $this->inject($contentCache, 'parser', new CacheSegmentParser());
 
         $mockCache = $this->createMock(FrontendInterface::class);
         $this->inject($contentCache, 'cache', $mockCache);
@@ -214,9 +212,7 @@ class ContentCacheTest extends UnitTestCase
         $mockPropertyMapper->expects($this->any())->method('convert')->will($this->returnArgument(0));
         $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
 
-        $this->inject($contentCache, 'parser', new CacheSegmentParser());
-
-        $mockContext = $this->getMockBuilder(ApplicationContext::class)->disableOriginalConstructor()->getMock();
+        $mockContext = $this->getMockBuilder(EnvironmentConfiguration::class)->disableOriginalConstructor()->getMock();
         $cacheBackend = new TransientMemoryBackend($mockContext);
         $cacheFrontend = new StringFrontend('foo', $cacheBackend);
         $cacheBackend->setCache($cacheFrontend);


### PR DESCRIPTION
Rewrite the internals of the CacheSegmentParser to use a recursive
approach which should safe some memory and makes the code more readable.
Also refactors common logic for fetching tokens and content to methods
to avoid code duplication.

Additionally adds calculation of uncached segments in the currently parsed
content to make solid cache entries (full page cache) possible.
