### PR TITLE
BUGFIX: Make close button in Image preview work

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.js]
+indent_style = tab
+indent_size = 4
+
 # PHP should follow the PSR-2 standard
 [*.php]
 indent_size = 4


### PR DESCRIPTION
When a user navigates to the single view of an asset by clicking on the thumbnail in the inspector,
the close button of the single will work again.

NEOS-1871 #close