### PR TITLE
TASK: Remove duplicate privilege check from NodeController

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
@@ -85,9 +85,6 @@ class NodeController extends ActionController
         if ($node === null) {
             throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1430218623);
         }
-        if (!$node->getContext()->isLive() && !$this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess')) {
-            $this->redirect('index', 'Login', null, array('unauthorized' => true));
-        }
 
         $inBackend = $node->getContext()->isInBackend();
 


### PR DESCRIPTION
This check is already handled by policies:
- TYPO3.Neos:PublicFrontendAccess
- TYPO3.Neos:Backend.GeneralAccess

If that redundancy is removed it makes it possible to use the
`TYPO3.Neos:Backend.OtherUsersPersonalWorkspaceAccess` policy
to grant access to any workspace to e.g. other authenticated users.
This is necessary to build a preview mechanism without an authenticated
backend user to share the state of your content with external previewers.
