### PR TITLE
BUGFIX: createShadow cannot be called from outside as it's protected

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -1237,7 +1237,9 @@ HELPTEXT;
                 }
 
                 if (!$dryRun) {
-                    $nodeData->createShadow($nodeDataSeenFromParentWorkspace->getPath());
+                    $shadowNode = new NodeData($nodeDataSeenFromParentWorkspace->getPath(), $nodeData->getWorkspace(), $nodeData->getIdentifier(), $nodeData->getDimensionValues());
+                    $shadowNode->similarize($nodeData);
+                    $shadowNode->setAsShadowOf($this);
                 }
                 $fixedShadowNodes++;
             }


### PR DESCRIPTION
As this is not possible the call is replaced by code duplicated from
``NodeData`` for now.