### PR TITLE
BUGFIX: Aloha format options

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Editors/Aloha/UiPlugin/multiSplit.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/Editors/Aloha/UiPlugin/multiSplit.js
@@ -52,13 +52,9 @@ define([
 			});
 			select.append(options);
 
-			var selectedValue;
 			select.off('change').on('change', function() {
 				var value = $(this).val();
-				if (value !== selectedValue) {
-					selectedValue = value;
-					buttons[value].click();
-				}
+				buttons[value].click();
 			});
 
 			$('body').click(function (event) {


### PR DESCRIPTION
There internal selectedValue of the tag name selection for aloha get's out of sync when changing via cursor/mouse. Since aloha already handles "changes" to same state well, no need to have this logic again.

NEOS-1883 #close