### PR TITLE
TASK: Cleanup some code across packages

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Command/MediaCommandController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Command/MediaCommandController.php
@@ -11,11 +11,14 @@ namespace TYPO3\Media\Command;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Repository\AssetRepository;
-use TYPO3\Media\Domain\Repository\ImageRepository;
 use TYPO3\Media\Domain\Repository\ThumbnailRepository;
 use TYPO3\Media\Domain\Service\ThumbnailService;
 
@@ -26,18 +29,18 @@ class MediaCommandController extends CommandController
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @Flow\Inject
-     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @var ObjectManager
      */
     protected $entityManager;
 
     /**
-     * @var \Doctrine\DBAL\Connection
+     * @var Connection
      */
     protected $dbalConnection;
 
@@ -217,7 +220,7 @@ class MediaCommandController extends CommandController
      */
     protected function initializeConnection()
     {
-        if (!$this->entityManager instanceof \Doctrine\ORM\EntityManager) {
+        if (!$this->entityManager instanceof EntityManager) {
             $this->outputLine('This command only supports database connections provided by the Doctrine ORM Entity Manager.
 				However, the current entity manager is an instance of %s.', array(get_class($this->entityManager)));
             $this->quit(1);

--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -16,16 +16,23 @@ use Doctrine\ORM\EntityNotFoundException;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Error\Message;
 use TYPO3\Flow\I18n\Translator;
+use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Mvc\View\JsonView;
+use TYPO3\Flow\Mvc\View\ViewInterface;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Flow\Utility\Files;
+use TYPO3\Fluid\View\TemplateView;
+use TYPO3\Media\Domain\Repository\AssetRepository;
 use TYPO3\Media\Domain\Repository\AudioRepository;
 use TYPO3\Media\Domain\Repository\DocumentRepository;
 use TYPO3\Media\Domain\Repository\ImageRepository;
+use TYPO3\Media\Domain\Repository\TagRepository;
 use TYPO3\Media\Domain\Repository\VideoRepository;
 use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Media\Domain\Model\AssetCollection;
 use TYPO3\Media\Domain\Model\Tag;
 use TYPO3\Media\Domain\Repository\AssetCollectionRepository;
+use TYPO3\Media\Domain\Session\BrowserState;
 use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
 
 /**
@@ -33,7 +40,7 @@ use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
  *
  * @Flow\Scope("singleton")
  */
-class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class AssetController extends ActionController
 {
     const TAG_GIVEN = 0;
     const TAG_ALL = 1;
@@ -44,13 +51,13 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\AssetRepository
+     * @var AssetRepository
      */
     protected $assetRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\TagRepository
+     * @var TagRepository
      */
     protected $tagRepository;
 
@@ -62,7 +69,7 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
 
     /**
      * @Flow\Inject(lazy = false)
-     * @var \TYPO3\Media\Domain\Session\BrowserState
+     * @var BrowserState
      */
     protected $browserState;
 
@@ -76,17 +83,17 @@ class AssetController extends \TYPO3\Flow\Mvc\Controller\ActionController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Flow\Mvc\View\JsonView'
+        'html' => TemplateView::class,
+        'json' => JsonView::class
     );
 
     /**
      * Set common variables on the view
      *
-     * @param \TYPO3\Flow\Mvc\View\ViewInterface $view
+     * @param ViewInterface $view
      * @return void
      */
-    protected function initializeView(\TYPO3\Flow\Mvc\View\ViewInterface $view)
+    protected function initializeView(ViewInterface $view)
     {
         $view->assignMultiple(array(
             'view' => $this->browserState->get('view'),

--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/ThumbnailController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/ThumbnailController.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Media\Domain\Model\Thumbnail;
 use TYPO3\Media\Domain\Service\ThumbnailService;
 
@@ -20,7 +21,7 @@ use TYPO3\Media\Domain\Service\ThumbnailService;
  *
  * @Flow\Scope("singleton")
  */
-class ThumbnailController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class ThumbnailController extends ActionController
 {
     /**
      * @Flow\Inject

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/EventListener/ImageEventListener.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/EventListener/ImageEventListener.php
@@ -13,6 +13,8 @@ namespace TYPO3\Media\Domain\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\CacheManager;
+use TYPO3\Flow\Resource\Resource;
 use TYPO3\Media\Domain\Model\ImageInterface;
 
 /**
@@ -23,7 +25,7 @@ use TYPO3\Media\Domain\Model\ImageInterface;
 class ImageEventListener
 {
     /**
-     * @var \TYPO3\Flow\Cache\CacheManager
+     * @var CacheManager
      * @Flow\Inject
      */
     protected $cacheManager;
@@ -36,7 +38,7 @@ class ImageEventListener
     {
         $entity = $eventArgs->getEntity();
         if ($entity instanceof ImageInterface) {
-            /** @var \TYPO3\Flow\Resource\Resource $resource */
+            /** @var Resource $resource */
             $resource = $eventArgs->getEntity()->getResource();
             if ($resource !== null) {
                 $this->cacheManager->getCache('TYPO3_Media_ImageSize')->remove($resource->getCacheEntryIdentifier());

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
@@ -12,9 +12,11 @@ namespace TYPO3\Media\Domain\Model;
  */
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Log\SystemLoggerInterface;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Resource\Resource as FlowResource;
 use TYPO3\Flow\Resource\ResourceManager;
@@ -86,13 +88,13 @@ class Asset implements AssetInterface
     protected $resource;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\Thumbnail>
+     * @var Collection<\TYPO3\Media\Domain\Model\Thumbnail>
      * @ORM\OneToMany(orphanRemoval=true, cascade={"all"}, mappedBy="originalAsset")
      */
     protected $thumbnails;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\Tag>
+     * @var Collection<\TYPO3\Media\Domain\Model\Tag>
      * @ORM\ManyToMany
      * @ORM\OrderBy({"label"="ASC"})
      * @Flow\Lazy
@@ -100,7 +102,7 @@ class Asset implements AssetInterface
     protected $tags;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\AssetCollection>
+     * @var Collection<\TYPO3\Media\Domain\Model\AssetCollection>
      * @ORM\ManyToMany(mappedBy="assets", cascade={"persist"})
      * @ORM\OrderBy({"title"="ASC"})
      * @Flow\Lazy
@@ -132,7 +134,7 @@ class Asset implements AssetInterface
         if ($this->thumbnails === null) {
             $this->thumbnails = new ArrayCollection();
         }
-        if ($initializationCause === \TYPO3\Flow\Object\ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
+        if ($initializationCause === ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
             $this->emitAssetCreated($this);
         }
     }
@@ -266,7 +268,7 @@ class Asset implements AssetInterface
     /**
      * Return the tags assigned to this asset
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getTags()
     {
@@ -343,10 +345,10 @@ class Asset implements AssetInterface
     /**
      * Set the tags assigned to this asset
      *
-     * @param \Doctrine\Common\Collections\Collection $tags
+     * @param Collection $tags
      * @return void
      */
-    public function setTags(\Doctrine\Common\Collections\Collection $tags)
+    public function setTags(Collection $tags)
     {
         $this->lastModified = new \DateTime();
         $this->tags = $tags;
@@ -373,7 +375,7 @@ class Asset implements AssetInterface
     /**
      * Return the asset collections this asset is included in
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getAssetCollections()
     {
@@ -383,10 +385,10 @@ class Asset implements AssetInterface
     /**
      * Set the asset collections that include this asset
      *
-     * @param \Doctrine\Common\Collections\Collection $assetCollections
+     * @param Collection $assetCollections
      * @return void
      */
-    public function setAssetCollections(\Doctrine\Common\Collections\Collection $assetCollections)
+    public function setAssetCollections(Collection $assetCollections)
     {
         $this->lastModified = new \DateTime();
         foreach ($this->assetCollections as $existingAssetCollection) {

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/AssetCollection.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Domain\Model;
  */
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -29,14 +30,14 @@ class AssetCollection
     protected $title;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\Asset>
+     * @var Collection<\TYPO3\Media\Domain\Model\Asset>
      * @ORM\ManyToMany(inversedBy="assetCollections", cascade={"persist"})
      * @Flow\Lazy
      */
     protected $assets;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\Tag>
+     * @var Collection<\TYPO3\Media\Domain\Model\Tag>
      * @ORM\ManyToMany(inversedBy="assetCollections")
      * @ORM\OrderBy({"label"="ASC"})
      * @Flow\Lazy
@@ -128,7 +129,7 @@ class AssetCollection
     /**
      * Return the tags assigned to this asset
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getTags()
     {
@@ -154,10 +155,10 @@ class AssetCollection
     /**
      * Set the tags assigned to this asset
      *
-     * @param \Doctrine\Common\Collections\Collection $tags
+     * @param Collection $tags
      * @return void
      */
-    public function setTags(\Doctrine\Common\Collections\Collection $tags)
+    public function setTags(Collection $tags)
     {
         $this->lastModified = new \DateTime();
         $this->tags = $tags;

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Image.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Image.php
@@ -12,8 +12,10 @@ namespace TYPO3\Media\Domain\Model;
  */
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Resource\Resource as FlowResource;
 use TYPO3\Media\Domain\Service\ImageService;
 use TYPO3\Media\Exception\ImageFileException;
@@ -28,7 +30,7 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
     use DimensionsTrait;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\ImageVariant>
+     * @var Collection<\TYPO3\Media\Domain\Model\ImageVariant>
      * @ORM\OneToMany(orphanRemoval=true, cascade={"all"}, mappedBy="originalAsset")
      */
     protected $variants;
@@ -61,7 +63,7 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
         if ($this->variants === null) {
             $this->variants = new ArrayCollection();
         }
-        if ($initializationCause === \TYPO3\Flow\Object\ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
+        if ($initializationCause === ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
             $this->calculateDimensionsFromResource($this->resource);
         }
         parent::initializeObject($initializationCause);
@@ -115,7 +117,7 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
      *
      * @param FlowResource $resource
      * @return void
-     * @throws \TYPO3\Media\Exception\ImageFileException
+     * @throws ImageFileException
      */
     protected function calculateDimensionsFromResource(FlowResource $resource)
     {

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ImageVariant.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ImageVariant.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Domain\Model;
  */
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
@@ -20,6 +21,8 @@ use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Resource\Resource;
 use TYPO3\Flow\Utility\TypeHandling;
 use TYPO3\Media\Domain\Model\Adjustment\ImageAdjustmentInterface;
+use TYPO3\Media\Domain\Model\Image;
+use TYPO3\Media\Domain\Service\ImageService;
 
 /**
  * A user defined variant (working copy) of an original Image asset
@@ -31,13 +34,13 @@ class ImageVariant extends Asset implements AssetVariantInterface, ImageInterfac
     use DimensionsTrait;
 
     /**
-     * @var \TYPO3\Media\Domain\Service\ImageService
+     * @var ImageService
      * @Flow\Inject
      */
     protected $imageService;
 
     /**
-     * @var \TYPO3\Media\Domain\Model\Image
+     * @var Image
      * @ORM\ManyToOne(inversedBy="variants")
      * @ORM\JoinColumn(nullable=false)
      * @Flow\Validate(type="NotEmpty")
@@ -45,7 +48,7 @@ class ImageVariant extends Asset implements AssetVariantInterface, ImageInterfac
     protected $originalAsset;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection<\TYPO3\Media\Domain\Model\Adjustment\AbstractImageAdjustment>
+     * @var ArrayCollection<\TYPO3\Media\Domain\Model\Adjustment\AbstractImageAdjustment>
      * @ORM\OneToMany(mappedBy="imageVariant", cascade={"all"}, orphanRemoval=TRUE)
      * @ORM\OrderBy({"position" = "ASC"})
      */
@@ -310,7 +313,7 @@ class ImageVariant extends Asset implements AssetVariantInterface, ImageInterfac
         if (!$existingAdjustmentFound) {
             $this->adjustments->add($adjustment);
             $adjustment->setImageVariant($this);
-            $this->adjustments = $this->adjustments->matching(new \Doctrine\Common\Collections\Criteria(null, array('position' => 'ASC')));
+            $this->adjustments = $this->adjustments->matching(new Criteria(null, array('position' => 'ASC')));
         }
 
         $this->lastModified = new \DateTime();

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Tag.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Tag.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Domain\Model;
  */
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 
@@ -30,7 +31,7 @@ class Tag
     protected $label;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\TYPO3\Media\Domain\Model\AssetCollection>
+     * @var Collection<\TYPO3\Media\Domain\Model\AssetCollection>
      * @ORM\ManyToMany(mappedBy="tags", cascade={"persist"})
      * @ORM\OrderBy({"title"="ASC"})
      * @Flow\Lazy
@@ -70,7 +71,7 @@ class Tag
     /**
      * Return the asset collections this tag is included in
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getAssetCollections()
     {
@@ -80,10 +81,10 @@ class Tag
     /**
      * Set the asset collections that include this tag
      *
-     * @param \Doctrine\Common\Collections\Collection $assetCollections
+     * @param Collection $assetCollections
      * @return void
      */
-    public function setAssetCollections(\Doctrine\Common\Collections\Collection $assetCollections)
+    public function setAssetCollections(Collection $assetCollections)
     {
         foreach ($this->assetCollections as $existingAssetCollection) {
             $existingAssetCollection->removeTag($this);

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Thumbnail.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Thumbnail.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Resource\Resource;
 use TYPO3\Flow\Utility\Arrays;
+use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Strategy\ThumbnailGeneratorStrategy;
 use TYPO3\Media\Exception;
 
@@ -105,7 +106,7 @@ class Thumbnail implements ImageInterface
     /**
      * Returns the Asset this thumbnail is derived from
      *
-     * @return \TYPO3\Media\Domain\Model\ImageInterface
+     * @return ImageInterface
      */
     public function getOriginalAsset()
     {

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/AbstractThumbnailGenerator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/AbstractThumbnailGenerator.php
@@ -15,6 +15,7 @@ use Imagine\Image\ImagineInterface;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Utility\Environment;
 use TYPO3\Media\Domain\Model\Thumbnail;
 use TYPO3\Media\Exception;
 
@@ -29,7 +30,7 @@ abstract class AbstractThumbnailGenerator implements ThumbnailGeneratorInterface
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Utility\Environment
+     * @var Environment
      */
     protected $environment;
 

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ThumbnailGeneratorInterface.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/ThumbnailGenerator/ThumbnailGeneratorInterface.php
@@ -14,7 +14,6 @@ namespace TYPO3\Media\Domain\Model\ThumbnailGenerator;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Media\Domain\Model\Thumbnail;
-use TYPO3\Media\Exception;
 
 /**
  * Thumbnail Generate Interface

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetCollectionRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetCollectionRepository.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Domain\Repository;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\QueryInterface;
 use TYPO3\Flow\Persistence\Repository;
 
 /**
@@ -24,5 +25,5 @@ class AssetCollectionRepository extends Repository
     /**
      * @var array
      */
-    protected $defaultOrderings = array('title' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING);
+    protected $defaultOrderings = array('title' => QueryInterface::ORDER_ASCENDING);
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/AssetRepository.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Domain\Repository;
  */
 
 use Doctrine\ORM\Internal\Hydration\IterableResult;
+use Doctrine\ORM\Query\ResultSetMapping;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\QueryInterface;
 use TYPO3\Flow\Persistence\QueryResultInterface;
@@ -20,6 +21,7 @@ use TYPO3\Flow\Persistence\Doctrine\Query;
 use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Media\Domain\Model\AssetCollection;
 use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\Tag;
 
 /**
  * A repository for Assets
@@ -48,7 +50,7 @@ class AssetRepository extends Repository
      * @param string $searchTerm
      * @param array $tags
      * @param AssetCollection $assetCollection*
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     * @return QueryResultInterface
      */
     public function findBySearchTermOrTags($searchTerm, array $tags = array(), AssetCollection $assetCollection = null)
     {
@@ -71,11 +73,11 @@ class AssetRepository extends Repository
     /**
      * Find Assets with the given Tag assigned
      *
-     * @param \TYPO3\Media\Domain\Model\Tag $tag
+     * @param Tag $tag
      * @param AssetCollection $assetCollection
      * @return QueryResultInterface
      */
-    public function findByTag(\TYPO3\Media\Domain\Model\Tag $tag, AssetCollection $assetCollection = null)
+    public function findByTag(Tag $tag, AssetCollection $assetCollection = null)
     {
         $query = $this->createQuery();
         $query->matching($query->contains('tags', $tag));
@@ -87,13 +89,13 @@ class AssetRepository extends Repository
     /**
      * Counts Assets with the given Tag assigned
      *
-     * @param \TYPO3\Media\Domain\Model\Tag $tag
+     * @param Tag $tag
      * @param AssetCollection $assetCollection
      * @return integer
      */
-    public function countByTag(\TYPO3\Media\Domain\Model\Tag $tag, AssetCollection $assetCollection = null)
+    public function countByTag(Tag $tag, AssetCollection $assetCollection = null)
     {
-        $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
+        $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
         if ($assetCollection === null) {
@@ -126,7 +128,7 @@ class AssetRepository extends Repository
      */
     public function countAll()
     {
-        $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
+        $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
         $queryString = "SELECT count(persistence_object_identifier) c FROM typo3_media_domain_model_asset WHERE dtype != 'typo3_media_imagevariant'";
@@ -139,7 +141,7 @@ class AssetRepository extends Repository
      * Find Assets without any tag
      *
      * @param AssetCollection $assetCollection
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     * @return QueryResultInterface
      */
     public function findUntagged(AssetCollection $assetCollection = null)
     {
@@ -158,7 +160,7 @@ class AssetRepository extends Repository
      */
     public function countUntagged(AssetCollection $assetCollection = null)
     {
-        $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
+        $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
         if ($assetCollection === null) {
@@ -176,7 +178,7 @@ class AssetRepository extends Repository
 
     /**
      * @param AssetCollection $assetCollection
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     * @return QueryResultInterface
      */
     public function findByAssetCollection(AssetCollection $assetCollection)
     {
@@ -194,7 +196,7 @@ class AssetRepository extends Repository
      */
     public function countByAssetCollection(AssetCollection $assetCollection)
     {
-        $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
+        $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
 
         $queryString = "SELECT count(a.persistence_object_identifier) c FROM typo3_media_domain_model_asset a LEFT JOIN typo3_media_domain_model_assetcollection_assets_join collectionmm ON a.persistence_object_identifier = collectionmm.media_asset WHERE collectionmm.media_assetcollection = ? AND a.dtype != 'typo3_media_imagevariant'";

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/TagRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/TagRepository.php
@@ -12,19 +12,21 @@ namespace TYPO3\Media\Domain\Repository;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\QueryInterface;
 use TYPO3\Flow\Persistence\QueryResultInterface;
+use TYPO3\Flow\Persistence\Repository;
 
 /**
  * A repository for Tags
  *
  * @Flow\Scope("singleton")
  */
-class TagRepository extends \TYPO3\Flow\Persistence\Repository
+class TagRepository extends Repository
 {
     /**
      * @var array
      */
-    protected $defaultOrderings = array('label' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING);
+    protected $defaultOrderings = array('label' => QueryInterface::ORDER_ASCENDING);
 
     /**
      * @param string $searchTerm

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/ThumbnailRepository.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Repository/ThumbnailRepository.php
@@ -11,6 +11,7 @@ namespace TYPO3\Media\Domain\Repository;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\QueryBuilder;
 use TYPO3\Flow\Annotations as Flow;
@@ -29,7 +30,7 @@ class ThumbnailRepository extends Repository
 {
     /**
      * @Flow\Inject
-     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @var ObjectManager
      */
     protected $entityManager;
 

--- a/TYPO3.Media/Classes/TYPO3/Media/Exception/ImageFileException.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Exception/ImageFileException.php
@@ -10,12 +10,13 @@ namespace TYPO3\Media\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Media\Exception;
 
 /**
  * A TYPO3.Media exception for image file errors
  *
  * @api
  */
-class ImageFileException extends \TYPO3\Media\Exception
+class ImageFileException extends Exception
 {
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Imagine/Box.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Imagine/Box.php
@@ -16,7 +16,7 @@ use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 use TYPO3\Flow\Annotations as Flow;
 
-class Box implements \Imagine\Image\BoxInterface
+class Box implements BoxInterface
 {
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/Package.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Package.php
@@ -13,6 +13,8 @@ namespace TYPO3\Media;
 
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\Package as BasePackage;
+use TYPO3\Media\Domain\Model\Asset;
+use TYPO3\Media\Domain\Service\ThumbnailGenerator;
 
 /**
  * The Media Package
@@ -26,6 +28,6 @@ class Package extends BasePackage
     public function boot(Bootstrap $bootstrap)
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
-        $dispatcher->connect('TYPO3\Media\Domain\Model\Asset', 'assetCreated', 'TYPO3\Media\Domain\Service\ThumbnailGenerator', 'createThumbnails');
+        $dispatcher->connect(Asset::class, 'assetCreated', ThumbnailGenerator::class, 'createThumbnails');
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ArrayConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ArrayConverter.php
@@ -12,7 +12,15 @@ namespace TYPO3\Media\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Media\Domain\Model\Asset;
+use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\AssetVariantInterface;
+use TYPO3\Media\Domain\Model\Image;
+use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ImageVariant;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
 
 /**
  * This converter transforms TYPO3.Media AssetInterface instances to arrays.
@@ -20,18 +28,18 @@ use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
  * @api
  * @Flow\Scope("singleton")
  */
-class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter
+class ArrayConverter extends AbstractTypeConverter
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @var array
      */
-    protected $sourceTypes = array('TYPO3\Media\Domain\Model\AssetInterface', 'TYPO3\Media\Domain\Model\ImageInterface', 'TYPO3\Media\Domain\Model\Image', 'TYPO3\Media\Domain\Model\Asset');
+    protected $sourceTypes = array(AssetInterface::class, ImageInterface::class, Image::class, Asset::class);
 
     /**
      * @var string
@@ -50,7 +58,7 @@ class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConv
      */
     public function canConvertFrom($source, $targetType)
     {
-        return ($source instanceof \TYPO3\Media\Domain\Model\AssetInterface);
+        return ($source instanceof AssetInterface);
     }
 
 
@@ -67,10 +75,10 @@ class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConv
             'resource' => $source->getResource()
         );
 
-        if ($source instanceof \TYPO3\Media\Domain\Model\AssetVariantInterface) {
+        if ($source instanceof AssetVariantInterface) {
             $sourceChildPropertiesToBeConverted['originalAsset'] = $source->getOriginalAsset();
         }
-        if ($source instanceof \TYPO3\Media\Domain\Model\ImageVariant) {
+        if ($source instanceof ImageVariant) {
             $sourceChildPropertiesToBeConverted['adjustments'] = $source->getAdjustments();
         }
 
@@ -82,10 +90,10 @@ class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConv
      *
      * @param string $targetType is ignored
      * @param string $propertyName is ignored
-     * @param \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration is ignored
+     * @param PropertyMappingConfigurationInterface $configuration is ignored
      * @return string always "array"
      */
-    public function getTypeOfChildProperty($targetType, $propertyName, \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration)
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
     {
         return 'array';
     }
@@ -103,7 +111,7 @@ class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConv
     {
         $identity = $this->persistenceManager->getIdentifierByObject($source);
         switch (true) {
-            case $source instanceof \TYPO3\Media\Domain\Model\ImageVariant:
+            case $source instanceof ImageVariant:
                 if (!isset($convertedChildProperties['originalAsset']) || !is_array($convertedChildProperties['originalAsset'])) {
                     return null;
                 }
@@ -115,7 +123,7 @@ class ArrayConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConv
                     'originalAsset' => $convertedChildProperties['originalAsset'],
                     'adjustments' => $convertedChildProperties['adjustments']
                 );
-            case $source instanceof \TYPO3\Media\Domain\Model\AssetInterface:
+            case $source instanceof AssetInterface:
                 if (!isset($convertedChildProperties['resource']) || !is_array($convertedChildProperties['resource'])) {
                     return null;
                 }

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/AssetInterfaceConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/AssetInterfaceConverter.php
@@ -12,11 +12,25 @@ namespace TYPO3\Media\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Property\Exception\InvalidDataTypeException;
+use TYPO3\Flow\Property\Exception\InvalidPropertyMappingConfigurationException;
+use TYPO3\Flow\Property\Exception\InvalidSourceException;
+use TYPO3\Flow\Property\Exception\InvalidTargetException;
+use TYPO3\Flow\Property\Exception\TargetNotFoundException;
 use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\ObjectConverter;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Flow\Resource\Resource;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Validation\Error;
 use TYPO3\Flow\Validation\Validator\UuidValidator;
 use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\Document;
+use TYPO3\Media\Domain\Model\Image;
+use TYPO3\Media\Domain\Model\Thumbnail;
+use TYPO3\Media\Domain\Repository\AssetRepository;
+use TYPO3\Media\Domain\Strategy\AssetModelMappingStrategyInterface;
 
 /**
  * This converter transforms to \TYPO3\Media\Domain\Model\ImageInterface (Image or ImageVariant) objects.
@@ -39,7 +53,7 @@ class AssetInterfaceConverter extends PersistentObjectConverter
     /**
      * @var string
      */
-    protected $targetType = 'TYPO3\Media\Domain\Model\AssetInterface';
+    protected $targetType = AssetInterface::class;
 
     /**
      * @var integer
@@ -48,25 +62,25 @@ class AssetInterfaceConverter extends PersistentObjectConverter
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\AssetRepository
+     * @var AssetRepository
      */
     protected $assetRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Strategy\AssetModelMappingStrategyInterface
+     * @var AssetModelMappingStrategyInterface
      */
     protected $assetModelMappingStrategy;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      */
     protected $resourceManager;
 
@@ -75,7 +89,7 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      *
      * @var string
      */
-    protected static $defaultNewAssetType = 'TYPO3\Media\Domain\Model\Document';
+    protected static $defaultNewAssetType = Document::class;
 
     /**
      * Maps resource identifiers to assets that already got created during the current request.
@@ -131,9 +145,9 @@ class AssetInterfaceConverter extends PersistentObjectConverter
     {
         switch ($propertyName) {
             case 'resource':
-                return 'TYPO3\Flow\Resource\Resource';
+                return Resource::class;
             case 'originalAsset':
-                return 'TYPO3\Media\Domain\Model\Image';
+                return Image::class;
             case 'title':
                 return 'string';
         }
@@ -148,8 +162,8 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @param string $originalTargetType
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string
-     * @throws \TYPO3\Flow\Property\Exception\InvalidDataTypeException
-     * @throws \TYPO3\Flow\Property\Exception\InvalidPropertyMappingConfigurationException
+     * @throws InvalidDataTypeException
+     * @throws InvalidPropertyMappingConfigurationException
      * @throws \InvalidArgumentException
      */
     public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
@@ -162,12 +176,12 @@ class AssetInterfaceConverter extends PersistentObjectConverter
             if ($configuration === null) {
                 throw new \InvalidArgumentException('A property mapping configuration must be given, not NULL.', 1421443628);
             }
-            if ($configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\ObjectConverter', self::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED) !== true) {
-                throw new \TYPO3\Flow\Property\Exception\InvalidPropertyMappingConfigurationException('Override of target type not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED" to TRUE.', 1421443641);
+            if ($configuration->getConfigurationValue(ObjectConverter::class, self::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED) !== true) {
+                throw new InvalidPropertyMappingConfigurationException('Override of target type not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED" to TRUE.', 1421443641);
             }
 
             if ($targetType !== $originalTargetType && is_a($targetType, $originalTargetType, true) === false) {
-                throw new \TYPO3\Flow\Property\Exception\InvalidDataTypeException('The given type "' . $targetType . '" is not a subtype of "' . $originalTargetType . '".', 1421443648);
+                throw new InvalidDataTypeException('The given type "' . $targetType . '" is not a subtype of "' . $originalTargetType . '".', 1421443648);
             }
         }
 
@@ -181,8 +195,8 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @param string $targetType must implement 'TYPO3\Media\Domain\Model\AssetInterface'
      * @param array $convertedChildProperties
      * @param PropertyMappingConfigurationInterface $configuration
-     * @return \TYPO3\Flow\Validation\Error|\TYPO3\Media\Domain\Model\Image The converted Image, a Validation Error or NULL
-     * @throws \TYPO3\Flow\Property\Exception\InvalidTargetException
+     * @return Error|Image The converted Image, a Validation Error or NULL
+     * @throws InvalidTargetException
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
@@ -235,7 +249,7 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @param array &$possibleConstructorArgumentValues
      * @param string $objectType
      * @return object The created instance
-     * @throws \TYPO3\Flow\Property\Exception\InvalidTargetException if a required constructor argument is missing
+     * @throws InvalidTargetException if a required constructor argument is missing
      */
     protected function buildObject(array &$possibleConstructorArgumentValues, $objectType)
     {
@@ -253,17 +267,17 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @param mixed $identity
      * @param string $targetType
      * @return object
-     * @throws \TYPO3\Flow\Property\Exception\TargetNotFoundException
-     * @throws \TYPO3\Flow\Property\Exception\InvalidSourceException
+     * @throws TargetNotFoundException
+     * @throws InvalidSourceException
      */
     protected function fetchObjectFromPersistence($identity, $targetType)
     {
-        if ($targetType === 'TYPO3\Media\Domain\Model\Thumbnail') {
+        if ($targetType === Thumbnail::class) {
             $object = $this->persistenceManager->getObjectByIdentifier($identity, $targetType);
         } elseif (is_string($identity)) {
             $object = $this->assetRepository->findByIdentifier($identity);
         } else {
-            throw new \TYPO3\Flow\Property\Exception\InvalidSourceException('The identity property "' . $identity . '" is not a string.', 1415817618);
+            throw new InvalidSourceException('The identity property "' . $identity . '" is not a string.', 1415817618);
         }
 
         return $object;

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageConverter.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Media\Domain\Model\Image;
 
 /**
  * This converter transforms to \TYPO3\Media\Domain\Model\Image objects.
@@ -24,7 +25,7 @@ class ImageConverter extends ImageInterfaceConverter
     /**
      * @var string
      */
-    protected $targetType = 'TYPO3\Media\Domain\Model\Image';
+    protected $targetType = Image::class;
 
     /**
      * @var integer

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceArrayPresenter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceArrayPresenter.php
@@ -12,9 +12,14 @@ namespace TYPO3\Media\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
 use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Utility\TypeHandling;
+use TYPO3\Flow\Validation\Error;
 use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Domain\Model\ImageVariant;
 
 /**
  * This converter transforms \TYPO3\Media\Domain\Model\ImageInterface (Image or ImageVariant) objects to array representations.
@@ -27,7 +32,7 @@ class ImageInterfaceArrayPresenter extends AbstractTypeConverter
     /**
      * @var array
      */
-    protected $sourceTypes = array('TYPO3\Media\Domain\Model\ImageInterface');
+    protected $sourceTypes = array(ImageInterface::class);
 
     /**
      * @var string
@@ -41,7 +46,7 @@ class ImageInterfaceArrayPresenter extends AbstractTypeConverter
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
@@ -75,17 +80,17 @@ class ImageInterfaceArrayPresenter extends AbstractTypeConverter
      * @param ImageInterface $source
      * @param string $targetType must be 'string'
      * @param array $convertedChildProperties
-     * @param \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration
-     * @return string|\TYPO3\Flow\Validation\Error The converted Image, a Validation Error or NULL
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string|Error The converted Image, a Validation Error or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
         $data = array(
             '__identity' => $this->persistenceManager->getIdentifierByObject($source),
             '__type' => TypeHandling::getTypeForValue($source)
         );
 
-        if ($source instanceof \TYPO3\Media\Domain\Model\ImageVariant) {
+        if ($source instanceof ImageVariant) {
             $data['originalAsset'] = [
                 '__identity' => $this->persistenceManager->getIdentifierByObject($source->getOriginalAsset()),
             ];
@@ -94,7 +99,7 @@ class ImageInterfaceArrayPresenter extends AbstractTypeConverter
             foreach ($source->getAdjustments() as $adjustment) {
                 $index = TypeHandling::getTypeForValue($adjustment);
                 $adjustments[$index] = array();
-                foreach (\TYPO3\Flow\Reflection\ObjectAccess::getGettableProperties($adjustment) as $propertyName => $propertyValue) {
+                foreach (ObjectAccess::getGettableProperties($adjustment) as $propertyName => $propertyValue) {
                     $adjustments[$index][$propertyName] = $propertyValue;
                 }
             }

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceConverter.php
@@ -14,6 +14,8 @@ namespace TYPO3\Media\TypeConverter;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ImageVariant;
 
@@ -40,7 +42,7 @@ class ImageInterfaceConverter extends AssetInterfaceConverter
     /**
      * @var string
      */
-    protected $targetType = 'TYPO3\Media\Domain\Model\ImageInterface';
+    protected $targetType = ImageInterface::class;
 
     /**
      * @var integer
@@ -52,7 +54,7 @@ class ImageInterfaceConverter extends AssetInterfaceConverter
      *
      * @var string
      */
-    protected static $defaultNewAssetType = 'TYPO3\Media\Domain\Model\Image';
+    protected static $defaultNewAssetType = Image::class;
 
     /**
      * All properties in the source array except __identity are sub-properties.
@@ -101,7 +103,7 @@ class ImageInterfaceConverter extends AssetInterfaceConverter
 
                     $adjustment = $this->propertyMapper->convert($adjustmentOptions, $adjustmentType, $configuration);
                     if ($identity !== null) {
-                        \TYPO3\Flow\Reflection\ObjectAccess::setProperty($adjustment, 'persistence_object_identifier', $identity, true);
+                        ObjectAccess::setProperty($adjustment, 'persistence_object_identifier', $identity, true);
                     }
 
                     $adjustments[] = $adjustment;

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceJsonSerializer.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageInterfaceJsonSerializer.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
 
 /**
@@ -38,10 +39,10 @@ class ImageInterfaceJsonSerializer extends ImageInterfaceArrayPresenter
      * @param ImageInterface $source
      * @param string $targetType must be 'string'
      * @param array $convertedChildProperties
-     * @param \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration
+     * @param PropertyMappingConfigurationInterface $configuration
      * @return string The converted ImageInterface
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
         $data = parent::convertFrom($source, 'array', $convertedChildProperties, $configuration);
         return json_encode($data);

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageVariantConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ImageVariantConverter.php
@@ -25,7 +25,7 @@ class ImageVariantConverter extends ImageInterfaceConverter
     /**
      * @var string
      */
-    protected $targetType = 'TYPO3\Media\Domain\Model\ImageVariant';
+    protected $targetType = ImageVariant::class;
 
     /**
      * @var integer
@@ -43,5 +43,5 @@ class ImageVariantConverter extends ImageInterfaceConverter
      *
      * @var string
      */
-    protected static $defaultNewAssetType = 'TYPO3\Media\Domain\Model\ImageVariant';
+    protected static $defaultNewAssetType = ImageVariant::class;
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ProcessingInstructionsConverter.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/TypeConverter/ProcessingInstructionsConverter.php
@@ -10,11 +10,17 @@ namespace TYPO3\Media\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Property\Exception\TypeConverterException;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Media\Domain\Model\Adjustment\CropImageAdjustment;
+use TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
 
 /**
  * Converts an array of processing instructions to matching adjustments
  */
-class ProcessingInstructionsConverter extends \TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter
+class ProcessingInstructionsConverter extends AbstractTypeConverter
 {
     /**
      * @var array
@@ -45,12 +51,12 @@ class ProcessingInstructionsConverter extends \TYPO3\Flow\Property\TypeConverter
      * @param array $source
      * @param string $targetType
      * @param array $convertedChildProperties
-     * @param \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration
+     * @param PropertyMappingConfigurationInterface $configuration
      * @return array the target type, or an error object if a user-error occurred
-     * @throws \TYPO3\Flow\Property\Exception\TypeConverterException thrown in case a developer error occurred
+     * @throws TypeConverterException thrown in case a developer error occurred
      * @api
      */
-    public function convertFrom($source, $targetType = 'array', array $convertedChildProperties = array(), \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType = 'array', array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
         $result = array();
         foreach ($source as $processingInstruction) {
@@ -63,13 +69,13 @@ class ProcessingInstructionsConverter extends \TYPO3\Flow\Property\TypeConverter
                         $this->transferOptionFromCommandToAdjustment($processingInstruction['options'], $options, 'start.y', 'y');
                         $this->transferOptionFromCommandToAdjustment($processingInstruction['options'], $options, 'size.width', 'width');
                         $this->transferOptionFromCommandToAdjustment($processingInstruction['options'], $options, 'size.height', 'height');
-                        $adjustment = new \TYPO3\Media\Domain\Model\Adjustment\CropImageAdjustment($options);
+                        $adjustment = new CropImageAdjustment($options);
                         break;
                     case 'resize':
                         $options = array();
                         $this->transferOptionFromCommandToAdjustment($processingInstruction['options'], $options, 'size.width', 'width');
                         $this->transferOptionFromCommandToAdjustment($processingInstruction['options'], $options, 'size.height', 'height');
-                        $adjustment = new \TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment($options);
+                        $adjustment = new ResizeImageAdjustment($options);
                         break;
                 }
 
@@ -91,9 +97,9 @@ class ProcessingInstructionsConverter extends \TYPO3\Flow\Property\TypeConverter
      */
     protected function transferOptionFromCommandToAdjustment(array $commandOptions, array &$adjustmentOptions, $commandOptionPath, $adjustmentOptionName)
     {
-        $commandOptionValue = \TYPO3\Flow\Reflection\ObjectAccess::getPropertyPath($commandOptions, $commandOptionPath);
+        $commandOptionValue = ObjectAccess::getPropertyPath($commandOptions, $commandOptionPath);
         if ($commandOptionValue !== null) {
-            \TYPO3\Flow\Reflection\ObjectAccess::setProperty($adjustmentOptions, $adjustmentOptionName, $commandOptionValue);
+            ObjectAccess::setProperty($adjustmentOptions, $adjustmentOptionName, $commandOptionValue);
         }
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Validator/ImageOrientationValidator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Validator/ImageOrientationValidator.php
@@ -12,6 +12,8 @@ namespace TYPO3\Media\Validator;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException;
+use TYPO3\Media\Domain\Model\ImageInterface;
 
 /**
  * Validator that checks the orientation (square, portrait, landscape) of a given image.
@@ -39,14 +41,14 @@ class ImageOrientationValidator extends \TYPO3\Flow\Validation\Validator\Abstrac
      * configured orientation (square, portrait and/or landscape)
      * Note: a value of NULL or empty string ('') is considered valid
      *
-     * @param \TYPO3\Media\Domain\Model\ImageInterface $image The image that should be validated
+     * @param ImageInterface $image The image that should be validated
      * @return void
      * @api
      */
     protected function isValid($image)
     {
         $this->validateOptions();
-        if (!$image instanceof \TYPO3\Media\Domain\Model\ImageInterface) {
+        if (!$image instanceof ImageInterface) {
             $this->addError('The given value was not an Image instance.', 1328028604);
             return;
         }
@@ -63,24 +65,24 @@ class ImageOrientationValidator extends \TYPO3\Flow\Validation\Validator\Abstrac
 
     /**
      * @return void
-     * @throws \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException if the configured validation options are incorrect
+     * @throws InvalidValidationOptionsException if the configured validation options are incorrect
      */
     protected function validateOptions()
     {
         if (!isset($this->options['allowedOrientations'])) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "allowedOrientations" was not specified.', 1328028795);
+            throw new InvalidValidationOptionsException('The option "allowedOrientations" was not specified.', 1328028795);
         } elseif (!is_array($this->options['allowedOrientations']) || $this->options['allowedOrientations'] === array()) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "allowedOrientations" must be an array with at least one element of "square", "portrait" or "landscape".', 1328028798);
+            throw new InvalidValidationOptionsException('The option "allowedOrientations" must be an array with at least one element of "square", "portrait" or "landscape".', 1328028798);
         }
         foreach ($this->options['allowedOrientations'] as $orientation) {
-            if ($orientation !== \TYPO3\Media\Domain\Model\ImageInterface::ORIENTATION_LANDSCAPE
-                && $orientation !== \TYPO3\Media\Domain\Model\ImageInterface::ORIENTATION_PORTRAIT
-                && $orientation !== \TYPO3\Media\Domain\Model\ImageInterface::ORIENTATION_SQUARE) {
-                throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException(sprintf('The option "allowedOrientations" contains an invalid orientation "%s".', $orientation), 1328029114);
+            if ($orientation !== ImageInterface::ORIENTATION_LANDSCAPE
+                && $orientation !== ImageInterface::ORIENTATION_PORTRAIT
+                && $orientation !== ImageInterface::ORIENTATION_SQUARE) {
+                throw new InvalidValidationOptionsException(sprintf('The option "allowedOrientations" contains an invalid orientation "%s".', $orientation), 1328029114);
             }
         }
         if (count($this->options['allowedOrientations']) === 3) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "allowedOrientations" must contain at most two elements of "square", "portrait" or "landscape".', 1328029781);
+            throw new InvalidValidationOptionsException('The option "allowedOrientations" must contain at most two elements of "square", "portrait" or "landscape".', 1328029781);
         }
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/Validator/ImageSizeValidator.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Validator/ImageSizeValidator.php
@@ -12,6 +12,9 @@ namespace TYPO3\Media\Validator;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException;
+use TYPO3\Flow\Validation\Validator\AbstractValidator;
+use TYPO3\Media\Domain\Model\ImageInterface;
 
 /**
  * Validator that checks size (resolution) of a given image
@@ -19,7 +22,7 @@ use TYPO3\Flow\Annotations as Flow;
  * Example:
  * [at]Flow\Validate("$image", type="\TYPO3\Media\Validator\ImageSizeValidator", options={ "minimumWidth"=150, "maximumResolution"=60000 })
  */
-class ImageSizeValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidator
+class ImageSizeValidator extends AbstractValidator
 {
     /**
      * @var array
@@ -37,7 +40,7 @@ class ImageSizeValidator extends \TYPO3\Flow\Validation\Validator\AbstractValida
      * The given $value is valid if it is an \TYPO3\Media\Domain\Model\ImageInterface of the configured resolution
      * Note: a value of NULL or empty string ('') is considered valid
      *
-     * @param \TYPO3\Media\Domain\Model\ImageInterface $image The image that should be validated
+     * @param ImageInterface $image The image that should be validated
      * @return void
      * @api
      */
@@ -45,7 +48,7 @@ class ImageSizeValidator extends \TYPO3\Flow\Validation\Validator\AbstractValida
     {
         $this->validateOptions();
 
-        if (!$image instanceof \TYPO3\Media\Domain\Model\ImageInterface) {
+        if (!$image instanceof ImageInterface) {
             $this->addError('The given value was not an Image instance.', 1327943859);
             return;
         }
@@ -72,7 +75,7 @@ class ImageSizeValidator extends \TYPO3\Flow\Validation\Validator\AbstractValida
 
     /**
      * @return void
-     * @throws \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException if the configured validation options are incorrect
+     * @throws InvalidValidationOptionsException if the configured validation options are incorrect
      */
     protected function validateOptions()
     {
@@ -82,17 +85,17 @@ class ImageSizeValidator extends \TYPO3\Flow\Validation\Validator\AbstractValida
             && !isset($this->options['maximumHeight'])
             && !isset($this->options['minimumResolution'])
             && !isset($this->options['maximumResolution'])) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('At least one of the options "minimumWidth", "maximumWidth", "minimumHeight", "maximumHeight", "minimumResolution" or "maximumResolution" must be specified.', 1328026094);
+            throw new InvalidValidationOptionsException('At least one of the options "minimumWidth", "maximumWidth", "minimumHeight", "maximumHeight", "minimumResolution" or "maximumResolution" must be specified.', 1328026094);
         }
         if (isset($this->options['minimumWidth']) && isset($this->options['maximumWidth'])
             && $this->options['minimumWidth'] > $this->options['maximumWidth']) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "minimumWidth" must not be greater than "maximumWidth".', 1327946137);
+            throw new InvalidValidationOptionsException('The option "minimumWidth" must not be greater than "maximumWidth".', 1327946137);
         } elseif (isset($this->options['minimumHeight']) && isset($this->options['maximumHeight'])
             && $this->options['minimumHeight'] > $this->options['maximumHeight']) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "minimumHeight" must not be greater than "maximumHeight".', 1327946156);
+            throw new InvalidValidationOptionsException('The option "minimumHeight" must not be greater than "maximumHeight".', 1327946156);
         } elseif (isset($this->options['minimumResolution']) && isset($this->options['maximumResolution'])
             && $this->options['minimumResolution'] > $this->options['maximumResolution']) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException('The option "minimumResolution" must not be greater than "maximumResolution".', 1327946274);
+            throw new InvalidValidationOptionsException('The option "minimumResolution" must not be greater than "maximumResolution".', 1327946274);
         }
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
@@ -10,6 +10,7 @@ namespace TYPO3\Media\ViewHelpers\Form;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 /**
  * View Helper which creates a simple checkbox (<input type="checkbox">).
@@ -41,7 +42,7 @@ namespace TYPO3\Media\ViewHelpers\Form;
  *
  * @api
  */
-class CheckboxViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper
+class CheckboxViewHelper extends AbstractFormFieldViewHelper
 {
     /**
      * @var string

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Format/RelativeDateViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Format/RelativeDateViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\ViewHelpers\Format;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Utility\Now;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -38,12 +39,12 @@ class RelativeDateViewHelper extends AbstractViewHelper
             throw new \InvalidArgumentException('No valid date given,', 1424647058);
         }
         // More than 11 months ago
-        $now = new \TYPO3\Flow\Utility\Now();
+        $now = new Now();
         if ($date < $now->modify('-11 months')) {
             return $date->format('Y M j');
         }
         // Same day of same year
-        $now = new \TYPO3\Flow\Utility\Now();
+        $now = new Now();
         if ($date->format('Y z') === $now->format('Y z')) {
             return $date->format('H:i');
         }

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Media\ViewHelpers;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
@@ -97,7 +98,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         $this->registerTagAttribute('ismap', 'string', 'Specifies an image as a server-side image-map. Rarely used. Look at usemap instead', false);
         $this->registerTagAttribute('usemap', 'string', 'Specifies an image as a client-side image-map', false);
         // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', 'TYPO3\Media\Domain\Model\AssetInterface', 'The asset to be rendered - DEPRECATED, use the "image" argument instead', false);
+        $this->registerArgument('asset', AssetInterface::class, 'The asset to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
@@ -12,9 +12,12 @@ namespace TYPO3\Media\ViewHelpers;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Media\Domain\Service\ThumbnailService;
 
 /**
  * Renders an <img> HTML tag from a given TYPO3.Media's asset instance
@@ -68,20 +71,20 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 class ThumbnailViewHelper extends AbstractTagBasedViewHelper
 {
     /**
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      * @Flow\Inject
      */
     protected $resourceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\ThumbnailService
+     * @var ThumbnailService
      */
     protected $thumbnailService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\AssetService
+     * @var AssetService
      */
     protected $assetService;
 

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
@@ -12,6 +12,8 @@ namespace TYPO3\Media\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
@@ -39,7 +41,7 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
  *
  * @see \TYPO3\Media\ViewHelpers\ImageViewHelper
  */
-class ImageViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
+class ImageViewHelper extends AbstractViewHelper
 {
     /**
      * @Flow\Inject
@@ -60,7 +62,7 @@ class ImageViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
     {
         parent::initializeArguments();
         // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', 'TYPO3\Media\Domain\Model\AssetInterface', 'The image to be rendered - DEPRECATED, use the "image" argument instead', false);
+        $this->registerArgument('asset', AssetInterface::class, 'The image to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ThumbnailViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ThumbnailViewHelper.php
@@ -12,8 +12,12 @@ namespace TYPO3\Media\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Media\Domain\Service\ThumbnailService;
 
 /**
  * Renders the src path of a thumbnail image of a given TYPO3.Media asset instance
@@ -39,23 +43,23 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
  *
  * @see \TYPO3\Media\ViewHelpers\ThumbnailViewHelper
  */
-class ThumbnailViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
+class ThumbnailViewHelper extends AbstractViewHelper
 {
     /**
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      * @Flow\Inject
      */
     protected $resourceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\ThumbnailService
+     * @var ThumbnailService
      */
     protected $thumbnailService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\AssetService
+     * @var AssetService
      */
     protected $assetService;
 

--- a/TYPO3.Media/Tests/Functional/AbstractTest.php
+++ b/TYPO3.Media/Tests/Functional/AbstractTest.php
@@ -10,11 +10,16 @@ namespace TYPO3\Media\Tests\Functional;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Resource\Resource;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+use TYPO3\Flow\Utility\Files;
 
 /**
  * Abstract Functional Test template
  */
-abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
+abstract class AbstractTest extends FunctionalTestCase
 {
     /**
      * @var string
@@ -28,28 +33,28 @@ abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     protected $oldPersistentResourcesStorageBaseUri;
 
     /**
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      */
     protected $resourceManager;
 
     public function tearDown()
     {
-        $persistenceManager = self::$bootstrap->getObjectManager()->get('TYPO3\Flow\Persistence\PersistenceManagerInterface');
+        $persistenceManager = self::$bootstrap->getObjectManager()->get(PersistenceManagerInterface::class);
         if (is_callable(array($persistenceManager, 'tearDown'))) {
             $persistenceManager->tearDown();
         }
-        self::$bootstrap->getObjectManager()->forgetInstance('TYPO3\Flow\Persistence\PersistenceManagerInterface');
+        self::$bootstrap->getObjectManager()->forgetInstance(PersistenceManagerInterface::class);
         parent::tearDown();
     }
 
     /**
      * Creates an Image object from a file using a mock resource (in order to avoid a database resource pointer entry)
      * @param string $imagePathAndFilename
-     * @return \TYPO3\Flow\Resource\Resource
+     * @return Resource
      */
     protected function getMockResourceByImagePath($imagePathAndFilename)
     {
-        $imagePathAndFilename = \TYPO3\Flow\Utility\Files::getUnixStylePath($imagePathAndFilename);
+        $imagePathAndFilename = Files::getUnixStylePath($imagePathAndFilename);
         $hash = sha1_file($imagePathAndFilename);
         copy($imagePathAndFilename, 'resource://' . $hash);
         return $mockResource = $this->createMockResourceAndPointerFromHash($hash);
@@ -61,11 +66,11 @@ abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      * file_put_content('resource://' . $hash) before
      *
      * @param string $hash
-     * @return \TYPO3\Flow\Resource\Resource
+     * @return Resource
      */
     protected function createMockResourceAndPointerFromHash($hash)
     {
-        $mockResource = $this->getMockBuilder('TYPO3\Flow\Resource\Resource')->setMethods(array('getHash', 'getUri'))->getMock();
+        $mockResource = $this->getMockBuilder(Resource::class)->setMethods(array('getHash', 'getUri'))->getMock();
         $mockResource->expects($this->any())
                 ->method('getHash')
                 ->will($this->returnValue($hash));
@@ -81,9 +86,9 @@ abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     protected function prepareTemporaryDirectory()
     {
-        $this->temporaryDirectory = \TYPO3\Flow\Utility\Files::concatenatePaths(array(FLOW_PATH_DATA, 'Temporary', 'Testing', str_replace('\\', '_', __CLASS__)));
+        $this->temporaryDirectory = Files::concatenatePaths(array(FLOW_PATH_DATA, 'Temporary', 'Testing', str_replace('\\', '_', __CLASS__)));
         if (!file_exists($this->temporaryDirectory)) {
-            \TYPO3\Flow\Utility\Files::createDirectoryRecursively($this->temporaryDirectory);
+            Files::createDirectoryRecursively($this->temporaryDirectory);
         }
     }
 
@@ -93,6 +98,6 @@ abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     protected function prepareResourceManager()
     {
-        $this->resourceManager = $this->objectManager->get('TYPO3\Flow\Resource\ResourceManager');
+        $this->resourceManager = $this->objectManager->get(ResourceManager::class);
     }
 }

--- a/TYPO3.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
+++ b/TYPO3.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
@@ -10,13 +10,19 @@ namespace TYPO3\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
+use TYPO3\Flow\Utility\Files;
+use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Media\Domain\Model\Tag;
+use TYPO3\Media\Domain\Repository\AssetRepository;
+use TYPO3\Media\Domain\Repository\TagRepository;
+use TYPO3\Media\Tests\Functional\AbstractTest;
 
 /**
  * Testcase for an asset repository
  *
  */
-class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
+class AssetRepositoryTest extends AbstractTest
 {
     /**
      * @var boolean
@@ -24,12 +30,12 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     protected static $testablePersistenceEnabled = true;
 
     /**
-     * @var \TYPO3\Media\Domain\Repository\AssetRepository
+     * @var AssetRepository
      */
     protected $assetRepository;
 
     /**
-     * @var \TYPO3\Media\Domain\Repository\TagRepository
+     * @var TagRepository
      */
     protected $tagRepository;
 
@@ -39,14 +45,14 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     public function setUp()
     {
         parent::setUp();
-        if (!$this->persistenceManager instanceof \TYPO3\Flow\Persistence\Doctrine\PersistenceManager) {
+        if (!$this->persistenceManager instanceof PersistenceManager) {
             $this->markTestSkipped('Doctrine persistence is not enabled');
         }
         $this->prepareTemporaryDirectory();
         $this->prepareResourceManager();
 
-        $this->assetRepository = $this->objectManager->get('TYPO3\Media\Domain\Repository\AssetRepository');
-        $this->tagRepository = $this->objectManager->get('TYPO3\Media\Domain\Repository\TagRepository');
+        $this->assetRepository = $this->objectManager->get(AssetRepository::class);
+        $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
     /**
@@ -56,7 +62,7 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     {
         parent::tearDown();
 
-        \TYPO3\Flow\Utility\Files::removeDirectoryRecursively($this->temporaryDirectory);
+        Files::removeDirectoryRecursively($this->temporaryDirectory);
     }
 
     /**
@@ -65,14 +71,14 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     public function assetsCanBePersisted()
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/license.txt');
-        $asset = new \TYPO3\Media\Domain\Model\Asset($resource);
+        $asset = new Asset($resource);
 
         $this->assetRepository->add($asset);
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
         $this->assertCount(1, $this->assetRepository->findAll());
-        $this->assertInstanceOf('TYPO3\Media\Domain\Model\Asset', $this->assetRepository->findAll()->getFirst());
+        $this->assertInstanceOf(Asset::class, $this->assetRepository->findAll()->getFirst());
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {
@@ -88,9 +94,9 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
         $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/license.txt');
         $resource2 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
 
-        $asset1 = new \TYPO3\Media\Domain\Model\Asset($resource1);
+        $asset1 = new Asset($resource1);
         $asset1->setTitle('foo bar');
-        $asset2 = new \TYPO3\Media\Domain\Model\Asset($resource2);
+        $asset2 = new Asset($resource2);
         $asset2->setTitle('foobar');
 
         $this->assetRepository->add($asset1);
@@ -120,9 +126,9 @@ class AssetRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
 
         $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/license.txt');
         $resource2 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
-        $asset1 = new \TYPO3\Media\Domain\Model\Asset($resource1);
+        $asset1 = new Asset($resource1);
         $asset1->setTitle('asset for homepage');
-        $asset2 = new \TYPO3\Media\Domain\Model\Asset($resource2);
+        $asset2 = new Asset($resource2);
         $asset2->setTitle('just another asset');
         $asset2->addTag($tag);
 

--- a/TYPO3.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
+++ b/TYPO3.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
@@ -10,13 +10,16 @@ namespace TYPO3\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
 use TYPO3\Media\Domain\Model\Tag;
+use TYPO3\Media\Domain\Repository\TagRepository;
+use TYPO3\Media\Tests\Functional\AbstractTest;
 
 /**
  * Testcase for an tag repository
  *
  */
-class TagRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
+class TagRepositoryTest extends AbstractTest
 {
     /**
      * @var boolean
@@ -24,7 +27,7 @@ class TagRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     protected static $testablePersistenceEnabled = true;
 
     /**
-     * @var \TYPO3\Media\Domain\Repository\TagRepository
+     * @var TagRepository
      */
     protected $tagRepository;
 
@@ -34,11 +37,11 @@ class TagRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
     public function setUp()
     {
         parent::setUp();
-        if (!$this->persistenceManager instanceof \TYPO3\Flow\Persistence\Doctrine\PersistenceManager) {
+        if (!$this->persistenceManager instanceof PersistenceManager) {
             $this->markTestSkipped('Doctrine persistence is not enabled');
         }
 
-        $this->tagRepository = $this->objectManager->get('TYPO3\Media\Domain\Repository\TagRepository');
+        $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
     /**
@@ -52,7 +55,7 @@ class TagRepositoryTest extends \TYPO3\Media\Tests\Functional\AbstractTest
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
         $this->assertCount(1, $this->tagRepository->findAll());
-        $this->assertInstanceOf('TYPO3\Media\Domain\Model\Tag', $this->tagRepository->findAll()->getFirst());
+        $this->assertInstanceOf(Tag::class, $this->tagRepository->findAll()->getFirst());
     }
 
     /**

--- a/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
+++ b/TYPO3.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
@@ -27,7 +27,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithInsetMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'));
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'));
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 83);
@@ -46,7 +46,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithOutboundMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'));
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'));
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 110);
@@ -64,7 +64,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function ifWidthIsSetHeightIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'));
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'));
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 83);
@@ -80,7 +80,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function ifHeightIsSetWidthIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'));
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'));
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(127, 95);
@@ -96,7 +96,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function minimumHeightIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'), array(
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'), array(
             array(
                 'maximumWidth' => 250,
                 'maximumHeight' => 250,
@@ -116,7 +116,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function minimumWidthIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'), array(
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'), array(
             array(
                 'maximumWidth' => 250,
                 'maximumHeight' => 250,
@@ -168,7 +168,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         );
 
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock('TYPO3\Media\Domain\Model\Adjustment\ResizeImageAdjustment', array('dummy'), array($options));
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, array('dummy'), array($options));
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box($expectedWidth, $expectedHeight);

--- a/TYPO3.Media/Tests/Unit/Domain/Model/VideoTest.php
+++ b/TYPO3.Media/Tests/Unit/Domain/Model/VideoTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Media\Tests\Unit\Domain\Model;
  * source code.
  */
 
+use TYPO3\Flow\Resource\Resource;
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Media\Domain\Model\Video;
 
@@ -24,7 +25,7 @@ class VideoTest extends UnitTestCase
      */
     public function dimensionsDefaultToMinusOneOnConstruct()
     {
-        $mockResource = $this->createMock('TYPO3\Flow\Resource\Resource');
+        $mockResource = $this->createMock(Resource::class);
 
         $video = new Video($mockResource);
 

--- a/TYPO3.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
+++ b/TYPO3.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
@@ -10,14 +10,24 @@ namespace TYPO3\Media\Tests\Unit\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Property\PropertyMappingConfiguration;
+use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\Image;
+use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\TypeConverter\ImageInterfaceConverter;
+use TYPO3\Flow\Resource\Resource;
 
 /**
  * Testcase for the ImageConverter
  */
-class ImageInterfaceConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ImageInterfaceConverterTest extends UnitTestCase
 {
     /**
-     * @var \TYPO3\Media\TypeConverter\ImageInterfaceConverter
+     * @var ImageInterfaceConverter
      */
     protected $converter;
 
@@ -26,14 +36,14 @@ class ImageInterfaceConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setUp()
     {
-        $this->converter = new \TYPO3\Media\TypeConverter\ImageInterfaceConverter();
-        $this->mockReflectionService = $this->createMock('TYPO3\Flow\Reflection\ReflectionService');
+        $this->converter = new ImageInterfaceConverter();
+        $this->mockReflectionService = $this->createMock(ReflectionService::class);
         $this->inject($this->converter, 'reflectionService', $this->mockReflectionService);
 
-        $this->mockPersistenceManager = $this->createMock('TYPO3\Flow\Persistence\PersistenceManagerInterface');
+        $this->mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
         $this->inject($this->converter, 'persistenceManager', $this->mockPersistenceManager);
 
-        $this->mockObjectManager = $this->createMock('TYPO3\Flow\Object\ObjectManagerInterface');
+        $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->inject($this->converter, 'objectManager', $this->mockObjectManager);
     }
 
@@ -43,7 +53,7 @@ class ImageInterfaceConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function checkMetadata()
     {
         $this->assertEquals(array('string', 'array'), $this->converter->getSupportedSourceTypes());
-        $this->assertEquals('TYPO3\Media\Domain\Model\ImageInterface', $this->converter->getSupportedTargetType());
+        $this->assertEquals(ImageInterface::class, $this->converter->getSupportedTargetType());
         $this->assertEquals(2, $this->converter->getPriority());
     }
 
@@ -52,11 +62,11 @@ class ImageInterfaceConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function canConvertFromDataProvider()
     {
-        $dummyResource = $this->createMock('TYPO3\Flow\Resource\Resource');
+        $dummyResource = $this->createMock(Resource::class);
         return array(
-            array(array('resource' => $dummyResource), 'TYPO3\Media\Domain\Model\Image', true),
-            array(array('__identity' => 'foo'), 'TYPO3\Media\Domain\Model\Image', false),
-            array(array('resource' => $dummyResource), 'TYPO3\Media\Domain\Model\ImageInterface', true),
+            array(array('resource' => $dummyResource), Image::class, true),
+            array(array('__identity' => 'foo'), Image::class, false),
+            array(array('resource' => $dummyResource), ImageInterface::class, true),
         );
     }
 
@@ -81,9 +91,9 @@ class ImageInterfaceConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->mockObjectManager->expects($this->any())->method('getClassNameByObjectName')->will($this->returnCallback(function ($objectType) {
             return $objectType;
         }));
-        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
-        $configuration->setTypeConverterOption('TYPO3\Media\TypeConverter\ImageInterfaceConverter', \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
+        $configuration = new PropertyMappingConfiguration();
+        $configuration->setTypeConverterOption(ImageInterfaceConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
 
-        $this->assertNull($this->converter->convertFrom(array(), 'TYPO3\Media\Domain\Model\Image', array(), $configuration));
+        $this->assertNull($this->converter->convertFrom(array(), Image::class, array(), $configuration));
     }
 }

--- a/TYPO3.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
+++ b/TYPO3.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
@@ -11,20 +11,22 @@ namespace TYPO3\Media\Tests\Unit\Validator;
  * source code.
  */
 
+use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Validator\ImageOrientationValidator;
 
 /**
  * Testcase for the ImageOrientationValidator
  *
  */
-class ImageOrientationValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ImageOrientationValidatorTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function validatorReturnsErrorsIfGivenValueIsNoImage()
     {
-        $validator = new \TYPO3\Media\Validator\ImageOrientationValidator(array('allowedOrientations' => array(ImageInterface::ORIENTATION_LANDSCAPE)));
+        $validator = new ImageOrientationValidator(array('allowedOrientations' => array(ImageInterface::ORIENTATION_LANDSCAPE)));
 
         $value = new \stdClass();
         $this->assertTrue($validator->validate($value)->hasErrors());
@@ -52,8 +54,8 @@ class ImageOrientationValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function invalidOptionsTests(array $options)
     {
-        $validator = new \TYPO3\Media\Validator\ImageOrientationValidator($options);
-        $image = $this->createMock('TYPO3\Media\Domain\Model\ImageInterface');
+        $validator = new ImageOrientationValidator($options);
+        $image = $this->createMock(ImageInterface::class);
         $validator->validate($image);
     }
 
@@ -80,8 +82,8 @@ class ImageOrientationValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function validatorTests(array $options, $imageOrientation, $isValid)
     {
-        $validator = new \TYPO3\Media\Validator\ImageOrientationValidator($options);
-        $image = $this->createMock('TYPO3\Media\Domain\Model\ImageInterface');
+        $validator = new ImageOrientationValidator($options);
+        $image = $this->createMock(ImageInterface::class);
         $image->expects($this->any())->method('getOrientation')->will($this->returnValue($imageOrientation));
 
         $validationResult = $validator->validate($image);

--- a/TYPO3.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
+++ b/TYPO3.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
@@ -10,19 +10,22 @@ namespace TYPO3\Media\Tests\Unit\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\ImageInterface;
+use TYPO3\Media\Validator\ImageSizeValidator;
 
 /**
  * Testcase for the ImageSizeValidator
  *
  */
-class ImageSizeValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ImageSizeValidatorTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function validatorReturnsErrorsIfGivenValueIsNoImage()
     {
-        $validator = new \TYPO3\Media\Validator\ImageSizeValidator(array('minimumWidth' => 123));
+        $validator = new ImageSizeValidator(array('minimumWidth' => 123));
 
         $value = new \stdClass();
         $this->assertTrue($validator->validate($value)->hasErrors());
@@ -50,8 +53,8 @@ class ImageSizeValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function invalidOptionsTests(array $options)
     {
-        $validator = new \TYPO3\Media\Validator\ImageSizeValidator($options);
-        $image = $this->createMock('TYPO3\Media\Domain\Model\ImageInterface');
+        $validator = new ImageSizeValidator($options);
+        $image = $this->createMock(ImageInterface::class);
         $validator->validate($image);
     }
 
@@ -98,8 +101,8 @@ class ImageSizeValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function validatorTests(array $options, $imageWidth, $imageHeight, $isValid)
     {
-        $validator = new \TYPO3\Media\Validator\ImageSizeValidator($options);
-        $image = $this->createMock('TYPO3\Media\Domain\Model\ImageInterface');
+        $validator = new ImageSizeValidator($options);
+        $image = $this->createMock(ImageInterface::class);
         $image->expects($this->any())->method('getWidth')->will($this->returnValue($imageWidth));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue($imageHeight));
 

--- a/TYPO3.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
+++ b/TYPO3.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\Tests\Unit\Validator;
  */
 
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Validator\ImageTypeValidator;
 
 /**
@@ -52,7 +53,7 @@ class ImageTypeValidatorTest extends UnitTestCase
      */
     public function validatorTests(array $options, $actualMediaType, $supposedToBeValid)
     {
-        $image = $this->getMockBuilder('TYPO3\Media\Domain\Model\Image')->disableOriginalConstructor()->getMock();
+        $image = $this->getMockBuilder(Image::class)->disableOriginalConstructor()->getMock();
         $image->expects($this->any())->method('getMediaType')->will($this->returnValue($actualMediaType));
 
         $validator = new ImageTypeValidator($options);

--- a/TYPO3.Neos.Kickstarter/Classes/TYPO3/Neos/Kickstarter/Service/GeneratorService.php
+++ b/TYPO3.Neos.Kickstarter/Classes/TYPO3/Neos/Kickstarter/Service/GeneratorService.php
@@ -16,6 +16,7 @@ use TYPO3\Flow\Package\MetaData;
 use TYPO3\Flow\Package\MetaData\PackageConstraint;
 use TYPO3\Flow\Package\MetaDataInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Utility\Exception;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\TYPO3CR\Domain\Repository\ContentDimensionRepository;
 
@@ -150,7 +151,7 @@ class GeneratorService extends \TYPO3\Kickstart\Service\GeneratorService
      * Generate additional folders for site packages.
      *
      * @param string $packageKey
-     * @throws \TYPO3\Flow\Utility\Exception
+     * @throws Exception
      */
     protected function generateAdditionalFolders($packageKey)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -16,6 +16,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Aop\JoinPointInterface;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Flow\Utility\Arrays;
+use TYPO3\Neos\Exception;
 
 /**
  * @Flow\Scope("singleton")
@@ -93,7 +94,7 @@ class NodeTypeConfigurationEnrichmentAspect
     /**
      * @param string $nodeTypeName
      * @param array $configuration
-     * @throws \TYPO3\Neos\Exception
+     * @throws Exception
      * @return void
      */
     protected function addEditorDefaultsToNodeTypeConfiguration($nodeTypeName, array &$configuration)
@@ -123,7 +124,7 @@ class NodeTypeConfigurationEnrichmentAspect
                 } elseif (isset($defaultConfigurationFromDataType['editor'])) {
                     $editor = $defaultConfigurationFromDataType['editor'];
                 } else {
-                    throw new \TYPO3\Neos\Exception('Could not find editor for ' . $propertyName . ' in node type ' . $nodeTypeName, 1436809123);
+                    throw new Exception('Could not find editor for ' . $propertyName . ' in node type ' . $nodeTypeName, 1436809123);
                 }
 
                 // SECOND STEP: Build up the full inspector configuration by merging:

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/PluginUriAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/PluginUriAspect.php
@@ -14,6 +14,8 @@ namespace TYPO3\Neos\Aspects;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Aop\JoinPointInterface;
 use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Neos\Service\PluginService;
 use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\Eel\FlowQuery\FlowQuery;
@@ -26,14 +28,14 @@ class PluginUriAspect
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Object\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
      * The pluginService
      *
-     * @var \TYPO3\Neos\Service\PluginService
+     * @var PluginService
      * @Flow\Inject
      */
     protected $pluginService;
@@ -45,7 +47,7 @@ class PluginUriAspect
      */
     public function rewritePluginViewUris(JoinPointInterface $joinPoint)
     {
-        /** @var \TYPO3\Flow\Mvc\ActionRequest $request */
+        /** @var ActionRequest $request */
         $request = $joinPoint->getProxy()->getRequest();
         $arguments = $joinPoint->getMethodArguments();
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/SiteRepositoryCachingAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/SiteRepositoryCachingAspect.php
@@ -13,6 +13,9 @@ namespace TYPO3\Neos\Aspects;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Aop\JoinPointInterface;
+use TYPO3\Flow\Utility\Environment;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Model\Site;
 
 /**
  * Aspect to memoize values from SiteRepository without the overhead of a query cache
@@ -24,23 +27,23 @@ class SiteRepositoryCachingAspect
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Utility\Environment
+     * @var Environment
      */
     protected $environment;
 
     /**
-     * @var \TYPO3\Neos\Domain\Model\Site|boolean
+     * @var Site|boolean
      */
     protected $firstOnlineSite = false;
 
     /**
-     * @var \TYPO3\Neos\Domain\Model\Domain|boolean
+     * @var Domain|boolean
      */
     protected $domainForActiveRequest = false;
 
     /**
      * @Flow\Around("method(TYPO3\Neos\Domain\Repository\SiteRepository->findFirstOnline())")
-     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     * @param JoinPointInterface $joinPoint The current join point
      * @return mixed
      */
     public function cacheFirstOnlineSite(JoinPointInterface $joinPoint)
@@ -54,7 +57,7 @@ class SiteRepositoryCachingAspect
 
     /**
      * @Flow\Around("method(TYPO3\Neos\Domain\Repository\DomainRepository->findOneByActiveRequest())")
-     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     * @param JoinPointInterface $joinPoint The current join point
      * @return mixed
      */
     public function cacheDomainForActiveRequest(JoinPointInterface $joinPoint)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/TypoScriptCachingAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Aspects/TypoScriptCachingAspect.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Aspects;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Aop\JoinPointInterface;
+use TYPO3\Flow\Cache\Frontend\VariableFrontend;
 
 /**
  * @Flow\Scope("singleton")
@@ -22,13 +23,13 @@ class TypoScriptCachingAspect
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Cache\Frontend\VariableFrontend
+     * @var VariableFrontend
      */
     protected $typoScriptCache;
 
     /**
      * @Flow\Around("setting(TYPO3.Neos.typoScript.enableObjectTreeCache) && method(TYPO3\Neos\Domain\Service\TypoScriptService->getMergedTypoScriptObjectTree())")
-     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     * @param JoinPointInterface $joinPoint The current join point
      * @return mixed
      */
     public function cacheGetMergedTypoScriptObjectTree(JoinPointInterface $joinPoint)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/DomainCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/DomainCommandController.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Command;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cli\CommandController;
 use TYPO3\Flow\Validation\ValidatorResolver;
 use TYPO3\Neos\Domain\Model\Domain;
 use TYPO3\Neos\Domain\Model\Site;
@@ -23,7 +24,7 @@ use TYPO3\Neos\Domain\Repository\SiteRepository;
  *
  * @Flow\Scope("singleton")
  */
-class DomainCommandController extends \TYPO3\Flow\Cli\CommandController
+class DomainCommandController extends CommandController
 {
     /**
      * @var DomainRepository
@@ -115,7 +116,7 @@ class DomainCommandController extends \TYPO3\Flow\Cli\CommandController
         $availableDomains = array();
 
         foreach ($domains as $domain) {
-            /** @var \TYPO3\Neos\Domain\Model\Domain $domain */
+            /** @var Domain $domain */
             array_push($availableDomains, array(
                 'nodeName' => $domain->getSite()->getNodeName(),
                 'hostPattern' => $domain->getHostPattern(),

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/SiteCommandController.php
@@ -13,7 +13,9 @@ namespace TYPO3\Neos\Command;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\SiteExportService;
 use TYPO3\Neos\Domain\Service\SiteImportService;
@@ -58,7 +60,7 @@ class SiteCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Log\SystemLoggerInterface
+     * @var SystemLoggerInterface
      */
     protected $systemLogger;
 
@@ -209,7 +211,7 @@ class SiteCommandController extends CommandController
         $availableSites = array();
 
         foreach ($sites as $site) {
-            /** @var \TYPO3\Neos\Domain\Model\Site $site */
+            /** @var Site $site */
             array_push($availableSites, array(
                 'name' => $site->getName(),
                 'nodeName' => $site->getNodeName(),

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/WorkspaceCommandController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/WorkspaceCommandController.php
@@ -14,7 +14,9 @@ namespace TYPO3\Neos\Command;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
 use TYPO3\Neos\Domain\Model\User;
+use TYPO3\Neos\Domain\Service\UserService;
 use TYPO3\Neos\Service\PublishingService;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 
@@ -40,7 +42,7 @@ class WorkspaceCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\UserService
+     * @var UserService
      */
     protected $userService;
 
@@ -103,7 +105,7 @@ class WorkspaceCommandController extends CommandController
         $this->outputLine('The workspace %s contains %u unpublished nodes.', [$workspaceName, count($nodes)]);
 
         foreach ($nodes as $node) {
-            /** @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface $node */
+            /** @var NodeInterface $node */
             if ($verbose) {
                 $this->outputLine('    ' . $node->getPath());
             }
@@ -146,7 +148,7 @@ class WorkspaceCommandController extends CommandController
         $this->outputLine('The workspace %s contains %u unpublished nodes.', [$workspaceName, count($nodes)]);
 
         foreach ($nodes as $node) {
-            /** @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface $node */
+            /** @var NodeInterface $node */
             if ($node->getPath() !== '/') {
                 if ($verbose) {
                     $this->outputLine('    ' . $node->getPath());

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/BackendController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/BackendController.php
@@ -12,45 +12,51 @@ namespace TYPO3\Neos\Controller\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\Frontend\StringFrontend;
 use TYPO3\Flow\I18n\Locale;
+use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Session\SessionInterface;
 use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\Neos\Service\BackendRedirectionService;
+use TYPO3\Neos\Service\LinkingService;
+use TYPO3\Neos\Service\XliffService;
 
 /**
  * The Neos Backend controller
  *
  * @Flow\Scope("singleton")
  */
-class BackendController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class BackendController extends ActionController
 {
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\BackendRedirectionService
+     * @var BackendRedirectionService
      */
     protected $backendRedirectionService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\XliffService
+     * @var XliffService
      */
     protected $xliffService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\LinkingService
+     * @var LinkingService
      */
     protected $linkingService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Cache\Frontend\StringFrontend
+     * @var StringFrontend
      */
     protected $loginTokenCache;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Session\SessionInterface
+     * @var SessionInterface
      */
     protected $currentSession;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ContentController.php
@@ -13,20 +13,27 @@ namespace TYPO3\Neos\Controller\Backend;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\EelHelper\TranslationHelper;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Property\PropertyMappingConfiguration;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ImageVariant;
+use TYPO3\Media\Domain\Repository\AssetRepository;
+use TYPO3\Media\Domain\Repository\ImageRepository;
 use TYPO3\Media\Domain\Service\ThumbnailService;
 use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
 use TYPO3\Media\Domain\Repository\AssetCollectionRepository;
+use TYPO3\Media\TypeConverter\ImageInterfaceArrayPresenter;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
+use TYPO3\Neos\Domain\Model\PluginViewDefinition;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
+use TYPO3\Neos\Service\PluginService;
 use TYPO3\Neos\TypeConverter\EntityToIdentityConverter;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\Eel\FlowQuery\FlowQuery;
@@ -43,13 +50,13 @@ class ContentController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\AssetRepository
+     * @var AssetRepository
      */
     protected $assetRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\ImageRepository
+     * @var ImageRepository
      */
     protected $imageRepository;
 
@@ -67,27 +74,27 @@ class ContentController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      */
     protected $resourceManager;
 
     /**
      * The pluginService
      *
-     * @var \TYPO3\Neos\Service\PluginService
+     * @var PluginService
      * @Flow\Inject
      */
     protected $pluginService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\TypeConverter\ImageInterfaceArrayPresenter
+     * @var ImageInterfaceArrayPresenter
      */
     protected $imageInterfaceArrayPresenter;
 
@@ -330,7 +337,7 @@ class ContentController extends ActionController
 
         $views = array();
         if ($node !== null) {
-            /** @var $pluginViewDefinition \TYPO3\Neos\Domain\Model\PluginViewDefinition */
+            /** @var $pluginViewDefinition PluginViewDefinition */
             $pluginViewDefinitions = $this->pluginService->getPluginViewDefinitionsByPluginNodeType($node->getNodeType());
             foreach ($pluginViewDefinitions as $pluginViewDefinition) {
                 $label = $pluginViewDefinition->getLabel();

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MediaBrowserController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MediaBrowserController.php
@@ -14,11 +14,12 @@ namespace TYPO3\Neos\Controller\Backend;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\Media\Domain\Repository\AssetRepository;
+use TYPO3\Neos\Controller\Module\Management\AssetController;
 
 /**
  * Controller for asset handling
  */
-class MediaBrowserController extends \TYPO3\Neos\Controller\Module\Management\AssetController
+class MediaBrowserController extends AssetController
 {
     /**
      * @var array

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MenuController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MenuController.php
@@ -12,17 +12,19 @@ namespace TYPO3\Neos\Controller\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Neos\Controller\Backend\MenuHelper;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 
 /**
  * @Flow\Scope("singleton")
  */
-class MenuController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class MenuController extends ActionController
 {
     use BackendUserTranslationTrait;
 
     /**
-     * @var \TYPO3\Neos\Controller\Backend\MenuHelper
+     * @var MenuHelper
      * @Flow\Inject
      */
     protected $menuHelper;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MenuHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/MenuHelper.php
@@ -13,7 +13,10 @@ namespace TYPO3\Neos\Controller\Backend;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
 use TYPO3\Flow\Utility\Arrays;
+use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
 
 /**
  * A helper class for menu generation in backend controllers / view helpers
@@ -23,13 +26,13 @@ use TYPO3\Flow\Utility\Arrays;
 class MenuHelper
 {
     /**
-     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     * @var SiteRepository
      * @Flow\Inject
      */
     protected $siteRepository;
 
     /**
-     * @var \TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface
+     * @var PrivilegeManagerInterface
      * @Flow\Inject
      */
     protected $privilegeManager;
@@ -50,7 +53,7 @@ class MenuHelper
     /**
      * Build a list of sites
      *
-     * @param \TYPO3\Flow\Mvc\Controller\ControllerContext $controllerContext
+     * @param ControllerContext $controllerContext
      * @return array
      */
     public function buildSiteList(ControllerContext $controllerContext)
@@ -62,7 +65,7 @@ class MenuHelper
         foreach ($this->siteRepository->findOnline() as $site) {
             $uri = null;
             $active = false;
-            /** @var $site \TYPO3\Neos\Domain\Model\Site */
+            /** @var $site Site */
             if ($site->hasActiveDomains()) {
                 $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {
                     return $domain->getHostPattern();
@@ -101,7 +104,7 @@ class MenuHelper
     }
 
     /**
-     * @param \TYPO3\Flow\Mvc\Controller\ControllerContext $controllerContext
+     * @param ControllerContext $controllerContext
      * @return array
      */
     public function buildModuleList(ControllerContext $controllerContext)
@@ -155,7 +158,7 @@ class MenuHelper
     }
 
     /**
-     * @param \TYPO3\Flow\Mvc\Controller\ControllerContext $controllerContext
+     * @param ControllerContext $controllerContext
      * @param string $module
      * @param array $moduleConfiguration
      * @param string $modulePath

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
@@ -14,8 +14,12 @@ namespace TYPO3\Neos\Controller\Backend;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Http\Response;
+use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Mvc\Dispatcher;
+use TYPO3\Flow\Security\Context;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Flow\Utility\MediaTypes;
+use TYPO3\Neos\Controller\Backend\MenuHelper;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\Controller\Exception\DisabledModuleException;
 
@@ -24,24 +28,24 @@ use TYPO3\Neos\Controller\Exception\DisabledModuleException;
  *
  * @Flow\Scope("singleton")
  */
-class ModuleController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class ModuleController extends ActionController
 {
     use BackendUserTranslationTrait;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Mvc\Dispatcher
+     * @var Dispatcher
      */
     protected $dispatcher;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Security\Context
+     * @var Context
      */
     protected $securityContext;
 
     /**
-     * @var \TYPO3\Neos\Controller\Backend\MenuHelper
+     * @var MenuHelper
      * @Flow\Inject
      */
     protected $menuHelper;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/SettingsController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/SettingsController.php
@@ -12,13 +12,14 @@ namespace TYPO3\Neos\Controller\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Flow\Utility\PositionalArraySorter;
 
 /**
  * @Flow\Scope("singleton")
  */
-class SettingsController extends \TYPO3\Flow\Mvc\Controller\ActionController
+class SettingsController extends ActionController
 {
     /**
      * @return string

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/BackendUserTranslationTrait.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/BackendUserTranslationTrait.php
@@ -12,6 +12,9 @@ namespace TYPO3\Neos\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\I18n\Locale;
+use TYPO3\Flow\I18n\Service;
+use TYPO3\Neos\Service\UserService;
 
 /**
  * A trait to add backend translation based on the backend users settings
@@ -20,13 +23,13 @@ trait BackendUserTranslationTrait
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\I18n\Service
+     * @var Service
      */
     protected $_localizationService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\UserService
+     * @var UserService
      */
     protected $_userService;
 
@@ -37,6 +40,6 @@ trait BackendUserTranslationTrait
      */
     protected function initializeObject()
     {
-        $this->_localizationService->getConfiguration()->setCurrentLocale(new \TYPO3\Flow\I18n\Locale($this->_userService->getInterfaceLanguage()));
+        $this->_localizationService->getConfiguration()->setCurrentLocale(new Locale($this->_userService->getInterfaceLanguage()));
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
@@ -12,6 +12,10 @@ namespace TYPO3\Neos\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\ContentContextFactory;
 use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Utility\NodePaths;
@@ -23,19 +27,19 @@ trait CreateContentContextTrait
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\ContentContextFactory
+     * @var ContentContextFactory
      */
     protected $_contextFactory;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     * @var DomainRepository
      */
     protected $_domainRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     * @var SiteRepository
      */
     protected $_siteRepository;
 
@@ -44,7 +48,7 @@ trait CreateContentContextTrait
      *
      * @param string $workspaceName Name of the workspace to set for the context
      * @param array $dimensions Optional list of dimensions and their values which should be set
-     * @return \TYPO3\Neos\Domain\Service\ContentContext
+     * @return ContentContext
      */
     protected function createContentContext($workspaceName, array $dimensions = array())
     {
@@ -76,7 +80,7 @@ trait CreateContentContextTrait
      * Generates a Context that exactly fits the given NodeData Workspace, Dimensions & Site.
      *
      * @param NodeData $nodeData
-     * @return \TYPO3\Neos\Domain\Service\ContentContext
+     * @return ContentContext
      */
     protected function createContextMatchingNodeData(NodeData $nodeData)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Exception/NoTypoScriptConfigurationException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Exception/NoTypoScriptConfigurationException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Controller\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Controller\Exception;
 
 /**
  * A "No TypoScript" exception
  *
  */
-class NoTypoScriptConfigurationException extends \TYPO3\Neos\Controller\Exception
+class NoTypoScriptConfigurationException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Exception/NodeCreationException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Exception/NodeCreationException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Controller\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Controller\Exception;
 
 /**
  * A "Node Creation" exception
  *
  */
-class NodeCreationException extends \TYPO3\Neos\Controller\Exception
+class NodeCreationException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
@@ -20,6 +20,7 @@ use TYPO3\Neos\Controller\Exception\NodeNotFoundException;
 use TYPO3\Neos\Controller\Exception\UnresolvableShortcutException;
 use TYPO3\Neos\Domain\Model\UserInterfaceMode;
 use TYPO3\Neos\Domain\Service\NodeShortcutResolver;
+use TYPO3\Neos\View\TypoScriptView;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
@@ -51,10 +52,10 @@ class NodeController extends ActionController
     /**
      * @var string
      */
-    protected $defaultViewObjectName = 'TYPO3\Neos\View\TypoScriptView';
+    protected $defaultViewObjectName = TypoScriptView::class;
 
     /**
-     * @var \TYPO3\Neos\View\TypoScriptView
+     * @var TypoScriptView
      */
     protected $view;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\Frontend\StringFrontend;
 use TYPO3\Flow\Error\Message;
 use TYPO3\Flow\Http\Cookie;
 use TYPO3\Flow\Mvc\ActionRequest;
@@ -20,6 +21,7 @@ use TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationControll
 use TYPO3\Flow\Security\Exception\AuthenticationRequiredException;
 use TYPO3\Flow\Session\SessionInterface;
 use TYPO3\Flow\Session\SessionManagerInterface;
+use TYPO3\Flow\Tests\Functional\Mvc\ViewsConfiguration\Fixtures\TemplateView;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Service\BackendRedirectionService;
@@ -62,7 +64,7 @@ class LoginController extends AbstractAuthenticationController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Cache\Frontend\StringFrontend
+     * @var StringFrontend
      */
     protected $loginTokenCache;
 
@@ -76,8 +78,8 @@ class LoginController extends AbstractAuthenticationController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Flow\Mvc\View\JsonView'
+        'html' => TemplateView::class,
+        'json' => JsonView::class
     );
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/AbstractModuleController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/AbstractModuleController.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Controller\Module;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Mvc\View\ViewInterface;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 
 /**
@@ -38,10 +39,10 @@ abstract class AbstractModuleController extends ActionController
     }
 
     /**
-     * @param \TYPO3\Flow\Mvc\View\ViewInterface $view
+     * @param ViewInterface $view
      * @return void
      */
-    protected function initializeView(\TYPO3\Flow\Mvc\View\ViewInterface $view)
+    protected function initializeView(ViewInterface $view)
     {
         $view->assign('moduleConfiguration', $this->moduleConfiguration);
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/ConfigurationController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/ConfigurationController.php
@@ -12,6 +12,10 @@ namespace TYPO3\Neos\Controller\Module\Administration;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Configuration\ConfigurationSchemaValidator;
+use TYPO3\Flow\Configuration\Exception\SchemaValidationException;
+use TYPO3\Flow\Utility\SchemaGenerator;
 use TYPO3\Neos\Controller\Module\AbstractModuleController;
 use TYPO3\Flow\Error\Message;
 
@@ -22,19 +26,19 @@ class ConfigurationController extends AbstractModuleController
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Configuration\ConfigurationManager
+     * @var ConfigurationManager
      */
     protected $configurationManager;
 
     /**
      * @Flow\Inject(lazy = FALSE)
-     * @var \TYPO3\Flow\Configuration\ConfigurationSchemaValidator
+     * @var ConfigurationSchemaValidator
      */
     protected $configurationSchemaValidator;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Utility\SchemaGenerator
+     * @var SchemaGenerator
      */
     protected $schemaGenerator;
 
@@ -55,7 +59,7 @@ class ConfigurationController extends AbstractModuleController
 
             try {
                 $this->view->assign('validationResult', $this->configurationSchemaValidator->validate($type));
-            } catch (\TYPO3\Flow\Configuration\Exception\SchemaValidationException $exception) {
+            } catch (SchemaValidationException $exception) {
                 $this->addFlashMessage(htmlspecialchars($exception->getMessage()), 'An error occurred during validation of the configuration.', Message::SEVERITY_ERROR, array(), 1412373972);
             }
         } else {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/PackagesController.php
@@ -15,16 +15,18 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Error\Error;
 use TYPO3\Flow\Error\Message;
 use TYPO3\Flow\Error\Warning;
+use TYPO3\Flow\Package;
 use TYPO3\Flow\Package\Exception\ProtectedPackageKeyException;
 use TYPO3\Flow\Package\Exception\UnknownPackageException;
 use TYPO3\Flow\Package\Exception;
+use TYPO3\Neos\Controller\Module\AbstractModuleController;
 
 /**
  * The TYPO3 Package Management module controller
  *
  * @Flow\Scope("singleton")
  */
-class PackagesController extends \TYPO3\Neos\Controller\Module\AbstractModuleController
+class PackagesController extends AbstractModuleController
 {
     /**
      * @Flow\Inject
@@ -39,7 +41,7 @@ class PackagesController extends \TYPO3\Neos\Controller\Module\AbstractModuleCon
     {
         $packageGroups = array();
         foreach ($this->packageManager->getAvailablePackages() as $package) {
-            /** @var \TYPO3\Flow\Package $package */
+            /** @var Package $package */
             $packagePath = substr($package->getPackagepath(), strlen(FLOW_PATH_PACKAGES));
             $packageGroup = substr($packagePath, 0, strpos($packagePath, '/'));
             $packageGroups[$packageGroup][$package->getPackageKey()] = array(

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
@@ -14,7 +14,9 @@ namespace TYPO3\Neos\Controller\Module\Administration;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Error\Message;
 use TYPO3\Flow\Log\SystemLoggerInterface;
+use TYPO3\Flow\Package\PackageInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Session\SessionInterface;
 use TYPO3\Media\Domain\Repository\AssetCollectionRepository;
 use TYPO3\Neos\Controller\Module\AbstractModuleController;
 use TYPO3\Neos\Domain\Model\Domain;
@@ -23,6 +25,7 @@ use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\SiteImportService;
 use TYPO3\Neos\Domain\Service\SiteService;
+use TYPO3\Neos\Kickstarter\Service\GeneratorService;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
@@ -89,7 +92,7 @@ class SitesController extends AbstractModuleController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Session\SessionInterface
+     * @var SessionInterface
      */
     protected $session;
 
@@ -100,7 +103,7 @@ class SitesController extends AbstractModuleController
     {
         $sitePackagesAndSites = array();
         foreach ($this->packageManager->getFilteredPackages('available', null, 'typo3-flow-site') as $sitePackageKey => $sitePackage) {
-            /** \TYPO3\Flow\Package\PackageInterface $sitePackage */
+            /** @var PackageInterface $sitePackage */
             $sitePackagesAndSites[strtolower(str_replace('.', '_', $sitePackageKey))] = array('package' => $sitePackage, 'packageKey' => $sitePackage->getPackageKey(), 'packageIsActive' => $this->packageManager->isPackageActive($sitePackage->getPackageKey()));
         }
         $sites = $this->siteRepository->findAll();
@@ -208,7 +211,7 @@ class SitesController extends AbstractModuleController
                 $this->redirect('index');
             }
 
-            $generatorService = $this->objectManager->get('TYPO3\Neos\Kickstarter\Service\GeneratorService');
+            $generatorService = $this->objectManager->get(GeneratorService::class);
             $generatorService->generateSitePackage($packageKey, $siteName);
         } else {
             $packageKey = $site;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/UsersController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/UsersController.php
@@ -64,11 +64,11 @@ class UsersController extends AbstractModuleController
             $propertyMappingConfigurationForUser = $this->arguments->getArgument('user')->getPropertyMappingConfiguration();
             $propertyMappingConfigurationForUserName = $propertyMappingConfigurationForUser->forProperty('user.name');
             $propertyMappingConfigurationForPrimaryAccount = $propertyMappingConfigurationForUser->forProperty('user.primaryAccount');
-            $propertyMappingConfigurationForPrimaryAccount->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, '\TYPO3\Flow\Security\Account');
+            $propertyMappingConfigurationForPrimaryAccount->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, Account::class);
             /** @var PropertyMappingConfiguration $propertyMappingConfiguration */
             foreach (array($propertyMappingConfigurationForUser, $propertyMappingConfigurationForUserName, $propertyMappingConfigurationForPrimaryAccount) as $propertyMappingConfiguration) {
-                $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
-                $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+                $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
+                $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
             }
         }
         $this->currentUser = $this->userService->getCurrentUser();

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/AdministrationController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/AdministrationController.php
@@ -18,6 +18,6 @@ use TYPO3\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class AdministrationController extends \TYPO3\Neos\Controller\Module\AbstractModuleController
+class AdministrationController extends AbstractModuleController
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -21,6 +21,7 @@ use TYPO3\Flow\Security\Context;
 use TYPO3\Flow\Utility\TypeHandling;
 use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Media\Domain\Model\AssetCollection;
+use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
@@ -133,10 +134,10 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
     /**
      * Delete an asset
      *
-     * @param \TYPO3\Media\Domain\Model\Asset $asset
+     * @param Asset $asset
      * @return void
      */
-    public function deleteAction(\TYPO3\Media\Domain\Model\Asset $asset)
+    public function deleteAction(Asset $asset)
     {
         $relatedNodes = $this->getRelatedNodes($asset);
         if (count($relatedNodes) > 0) {
@@ -192,15 +193,15 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
     }
 
     /**
-     * @param \TYPO3\Media\Domain\Model\Asset $asset
+     * @param Asset $asset
      * @return array
      */
-    protected function getRelatedNodes(\TYPO3\Media\Domain\Model\Asset $asset)
+    protected function getRelatedNodes(Asset $asset)
     {
         $relationMap = [];
         $relationMap[TypeHandling::getTypeForValue($asset)] = [$this->persistenceManager->getIdentifierByObject($asset)];
 
-        if ($asset instanceof \TYPO3\Media\Domain\Model\Image) {
+        if ($asset instanceof Image) {
             foreach ($asset->getVariants() as $variant) {
                 $type = TypeHandling::getTypeForValue($variant);
                 if (!isset($relationMap[$type])) {
@@ -245,7 +246,7 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
     /**
      * Individual error FlashMessage that hides which action fails in production.
      *
-     * @return \TYPO3\Flow\Error\Message The flash message or FALSE if no flash message should be set
+     * @return Message The flash message or FALSE if no flash message should be set
      */
     protected function getErrorFlashMessage()
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/HistoryController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/HistoryController.php
@@ -13,12 +13,11 @@ namespace TYPO3\Neos\Controller\Module\Management;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\View\ViewInterface;
-use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Neos\Controller\Module\AbstractModuleController;
 use TYPO3\Neos\EventLog\Domain\Model\Event;
 use TYPO3\Neos\EventLog\Domain\Model\EventsOnDate;
-use TYPO3\Neos\EventLog\Domain\Model\NodeEvent;
 use TYPO3\Neos\EventLog\Domain\Repository\EventRepository;
+use TYPO3\Neos\View\TypoScriptView;
 
 /**
  * Controller for the history module of Neos, displaying the timeline of changes.
@@ -34,7 +33,7 @@ class HistoryController extends AbstractModuleController
     /**
      * @var string
      */
-    protected $defaultViewObjectName = 'TYPO3\TypoScript\View\TypoScriptView';
+    protected $defaultViewObjectName = TypoScriptView::class;
 
     /**
      * Show event overview.

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -20,6 +20,7 @@ use TYPO3\Flow\I18n\Translator;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Property\PropertyMappingConfigurationBuilder;
+use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Flow\Security\Context;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Neos\Controller\Module\AbstractModuleController;
@@ -33,6 +34,7 @@ use TYPO3\Neos\Service\PublishingService;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\TYPO3CR\Exception\WorkspaceException;
 use TYPO3\TYPO3CR\TypeConverter\NodeConverter;
 use TYPO3\TYPO3CR\Utility;
 use TYPO3\Neos\Utility\User as UserUtility;
@@ -111,10 +113,10 @@ class WorkspacesController extends AbstractModuleController
     protected function initializeAction()
     {
         if ($this->arguments->hasArgument('node')) {
-            $this->arguments->getArgument('node')->getPropertyMappingConfiguration()->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+            $this->arguments->getArgument('node')->getPropertyMappingConfiguration()->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         }
         if ($this->arguments->hasArgument('nodes')) {
-            $this->arguments->getArgument('nodes')->getPropertyMappingConfiguration()->forProperty('*')->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+            $this->arguments->getArgument('nodes')->getPropertyMappingConfiguration()->forProperty('*')->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         }
         parent::initializeAction();
     }
@@ -238,11 +240,11 @@ class WorkspacesController extends AbstractModuleController
      */
     protected function initializeUpdateAction()
     {
-        $converter = new \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter();
+        $converter = new PersistentObjectConverter();
         $this->arguments->getArgument('workspace')->getPropertyMappingConfiguration()
             ->forProperty('owner')
             ->setTypeConverter($converter)
-            ->setTypeConverterOption(\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::class, \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, User::class);
+            ->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, User::class);
         parent::initializeAction();
     }
 
@@ -360,7 +362,7 @@ class WorkspacesController extends AbstractModuleController
      *
      * @param NodeInterface $node
      * @param Workspace $selectedWorkspace
-     * @throws \TYPO3\TYPO3CR\Exception\WorkspaceException
+     * @throws WorkspaceException
      */
     public function discardNodeAction(NodeInterface $node, Workspace $selectedWorkspace)
     {
@@ -383,9 +385,9 @@ class WorkspacesController extends AbstractModuleController
     public function publishOrDiscardNodesAction(array $nodes, $action, Workspace $selectedWorkspace = null)
     {
         $propertyMappingConfiguration = $this->propertyMappingConfigurationBuilder->build();
-        $propertyMappingConfiguration->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+        $propertyMappingConfiguration->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         foreach ($nodes as $key => $node) {
-            $nodes[$key] = $this->propertyMapper->convert($node, 'TYPO3\TYPO3CR\Domain\Model\NodeInterface', $propertyMappingConfiguration);
+            $nodes[$key] = $this->propertyMapper->convert($node, NodeInterface::class, $propertyMappingConfiguration);
         }
         switch ($action) {
             case 'publish':

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/ManagementController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/ManagementController.php
@@ -18,6 +18,6 @@ use TYPO3\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class ManagementController extends \TYPO3\Neos\Controller\Module\AbstractModuleController
+class ManagementController extends AbstractModuleController
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/User/UserSettingsController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/User/UserSettingsController.php
@@ -59,10 +59,10 @@ class UserSettingsController extends AbstractModuleController
             $propertyMappingConfigurationForUser = $this->arguments->getArgument('user')->getPropertyMappingConfiguration();
             $propertyMappingConfigurationForUserName = $propertyMappingConfigurationForUser->forProperty('user.name');
             $propertyMappingConfigurationForPrimaryAccount = $propertyMappingConfigurationForUser->forProperty('user.primaryAccount');
-            $propertyMappingConfigurationForPrimaryAccount->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, '\TYPO3\Flow\Security\Account');
+            $propertyMappingConfigurationForPrimaryAccount->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, Account::class);
             /** @var PropertyMappingConfiguration $propertyMappingConfiguration */
             foreach (array($propertyMappingConfigurationForUser, $propertyMappingConfigurationForUserName, $propertyMappingConfigurationForPrimaryAccount) as $propertyMappingConfiguration) {
-                $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+                $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
             }
         }
         $this->currentUser = $this->userService->getCurrentUser();

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/UserController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/UserController.php
@@ -18,6 +18,6 @@ use TYPO3\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class UserController extends \TYPO3\Neos\Controller\Module\AbstractModuleController
+class UserController extends AbstractModuleController
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/AssetsController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/AssetsController.php
@@ -13,7 +13,12 @@ namespace TYPO3\Neos\Controller\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Mvc\View\ViewInterface;
+use TYPO3\Fluid\View\TemplateView;
+use TYPO3\Media\Domain\Repository\AssetRepository;
+use TYPO3\Media\Domain\Repository\TagRepository;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
+use TYPO3\Neos\View\Service\AssetJsonView;
 
 /**
  * Rudimentary REST service for assets
@@ -26,13 +31,13 @@ class AssetsController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\AssetRepository
+     * @var AssetRepository
      */
     protected $assetRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Repository\TagRepository
+     * @var TagRepository
      */
     protected $tagRepository;
 
@@ -46,8 +51,8 @@ class AssetsController extends ActionController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Neos\View\Service\AssetJsonView'
+        'html' => TemplateView::class,
+        'json' => AssetJsonView::class
     );
 
     /**
@@ -62,10 +67,10 @@ class AssetsController extends ActionController
     );
 
     /**
-     * @param \TYPO3\Flow\Mvc\View\ViewInterface $view
+     * @param ViewInterface $view
      * @return void
      */
-    public function initializeView(\TYPO3\Flow\Mvc\View\ViewInterface $view)
+    public function initializeView(ViewInterface $view)
     {
         $view->assign('asyncThumbnails', $this->asyncThumbnails);
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/AssetsController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/AssetsController.php
@@ -19,6 +19,9 @@ use TYPO3\Media\Domain\Repository\AssetRepository;
 use TYPO3\Media\Domain\Repository\TagRepository;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\View\Service\AssetJsonView;
+use TYPO3\Flow\I18n\Service;
+use TYPO3\Flow\I18n\Locale;
+use TYPO3\Neos\Service\UserService;
 
 /**
  * Rudimentary REST service for assets

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/ContentDimensionsController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/ContentDimensionsController.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Controller\Service;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Flow\Mvc\View\JsonView;
+use TYPO3\Flow\Tests\Functional\Mvc\ViewsConfiguration\Fixtures\TemplateView;
 use TYPO3\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 
@@ -28,8 +29,8 @@ class ContentDimensionsController extends ActionController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Flow\Mvc\View\JsonView'
+        'html' => TemplateView::class,
+        'json' => JsonView::class
     );
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/NodesController.php
@@ -13,12 +13,15 @@ namespace TYPO3\Neos\Controller\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Property\Exception;
 use TYPO3\Flow\Property\PropertyMapper;
+use TYPO3\Fluid\View\TemplateView;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\Domain\Service\NodeSearchServiceInterface;
 use TYPO3\Neos\Domain\Service\SiteService;
+use TYPO3\Neos\View\Service\NodeJsonView;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TYPO3CR\Domain\Service\Context;
@@ -57,8 +60,8 @@ class NodesController extends ActionController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Neos\View\Service\NodeJsonView'
+        'html' => TemplateView::class,
+        'json' => NodeJsonView::class
     );
 
     /**
@@ -133,7 +136,7 @@ class NodesController extends ActionController
         foreach ($node->getProperties() as $propertyName => $propertyValue) {
             try {
                 $convertedProperties[$propertyName] = $this->propertyMapper->convert($propertyValue, 'string');
-            } catch (\TYPO3\Flow\Property\Exception $exception) {
+            } catch (Exception $exception) {
                 $convertedProperties[$propertyName] = '';
             }
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Service/WorkspacesController.php
@@ -14,6 +14,8 @@ namespace TYPO3\Neos\Controller\Service;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Fluid\View\TemplateView;
+use TYPO3\Neos\View\Service\WorkspaceJsonView;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 
@@ -41,8 +43,8 @@ class WorkspacesController extends ActionController
      * @var array
      */
     protected $viewFormatToObjectNameMap = [
-        'html' => 'TYPO3\Fluid\View\TemplateView',
-        'json' => 'TYPO3\Neos\View\Service\WorkspaceJsonView'
+        'html' => TemplateView::class,
+        'json' => WorkspaceJsonView::class
     ];
 
     /**
@@ -137,7 +139,7 @@ class WorkspacesController extends ActionController
     {
         $propertyMappingConfiguration = $this->arguments->getArgument('workspace')->getPropertyMappingConfiguration();
         $propertyMappingConfiguration->allowProperties('name', 'baseWorkspace');
-        $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+        $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/EventListener/AccountPostEventListener.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/EventListener/AccountPostEventListener.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Domain\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\CacheManager;
 use TYPO3\Flow\Security\Account;
 
 /**
@@ -23,7 +24,7 @@ use TYPO3\Flow\Security\Account;
 class AccountPostEventListener
 {
     /**
-     * @var \TYPO3\Flow\Cache\CacheManager
+     * @var CacheManager
      * @Flow\Inject
      */
     protected $cacheManager;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Domain.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Domain.php
@@ -13,6 +13,8 @@ namespace TYPO3\Neos\Domain\Model;
 
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\CacheAwareInterface;
+use TYPO3\Neos\Domain\Model\Site;
 
 /**
  * Domain Model of a Domain
@@ -20,7 +22,7 @@ use TYPO3\Flow\Annotations as Flow;
  * @Flow\Entity
  * @Flow\Scope("prototype")
  */
-class Domain implements \TYPO3\Flow\Cache\CacheAwareInterface
+class Domain implements CacheAwareInterface
 {
     /**
      * @var string
@@ -46,7 +48,7 @@ class Domain implements \TYPO3\Flow\Cache\CacheAwareInterface
     protected $port;
 
     /**
-     * @var \TYPO3\Neos\Domain\Model\Site
+     * @var Site
      * @ORM\ManyToOne(inversedBy="domains")
      * @Flow\Validate(type="NotEmpty")
      */
@@ -143,7 +145,7 @@ class Domain implements \TYPO3\Flow\Cache\CacheAwareInterface
     /**
      * Returns the site this domain is pointing to
      *
-     * @return \TYPO3\Neos\Domain\Model\Site
+     * @return Site
      * @api
      */
     public function getSite()

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/DomainRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/DomainRepository.php
@@ -12,7 +12,12 @@ namespace TYPO3\Neos\Domain\Repository;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Http\HttpRequestHandlerInterface;
 use TYPO3\Flow\Persistence\QueryInterface;
+use TYPO3\Flow\Persistence\Repository;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Service\DomainMatchingStrategy;
 
 /**
  * The Site Repository
@@ -20,17 +25,17 @@ use TYPO3\Flow\Persistence\QueryInterface;
  * @Flow\Scope("singleton")
  * @api
  */
-class DomainRepository extends \TYPO3\Flow\Persistence\Repository
+class DomainRepository extends Repository
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\DomainMatchingStrategy
+     * @var DomainMatchingStrategy
      */
     protected $domainMatchingStrategy;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Core\Bootstrap
+     * @var Bootstrap
      */
     protected $bootstrap;
 
@@ -63,7 +68,7 @@ class DomainRepository extends \TYPO3\Flow\Persistence\Repository
      *
      * @param string $host Host the domain should match with (eg. "localhost" or "www.neos.io")
      * @param boolean $onlyActive Only include active domains
-     * @return \TYPO3\Neos\Domain\Model\Domain
+     * @return Domain
      * @api
      */
     public function findOneByHost($host, $onlyActive = false)
@@ -73,13 +78,13 @@ class DomainRepository extends \TYPO3\Flow\Persistence\Repository
     }
 
     /**
-     * @return \TYPO3\Neos\Domain\Model\Domain
+     * @return Domain
      */
     public function findOneByActiveRequest()
     {
         $matchingDomain = null;
         $activeRequestHandler = $this->bootstrap->getActiveRequestHandler();
-        if ($activeRequestHandler instanceof \TYPO3\Flow\Http\HttpRequestHandlerInterface) {
+        if ($activeRequestHandler instanceof HttpRequestHandlerInterface) {
             $matchingDomain = $this->findOneByHost($activeRequestHandler->getHttpRequest()->getUri()->getHost(), true);
         }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -12,6 +12,9 @@ namespace TYPO3\Neos\Domain\Repository;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\QueryResultInterface;
+use TYPO3\Flow\Persistence\Repository;
+use TYPO3\Neos\Domain\Model\Site;
 
 /**
  * The Site Repository
@@ -19,12 +22,12 @@ use TYPO3\Flow\Annotations as Flow;
  * @Flow\Scope("singleton")
  * @api
  */
-class SiteRepository extends \TYPO3\Flow\Persistence\Repository
+class SiteRepository extends Repository
 {
     /**
      * Finds the first site
      *
-     * @return \TYPO3\Neos\Domain\Model\Site The first site or NULL if none exists
+     * @return Site The first site or NULL if none exists
      * @api
      */
     public function findFirst()
@@ -35,17 +38,17 @@ class SiteRepository extends \TYPO3\Flow\Persistence\Repository
     /**
      * Find all sites with status "online"
      *
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     * @return QueryResultInterface
      */
     public function findOnline()
     {
-        return $this->findByState(\TYPO3\Neos\Domain\Model\Site::STATE_ONLINE);
+        return $this->findByState(Site::STATE_ONLINE);
     }
 
     /**
      * Find first site with status "online"
      *
-     * @return \TYPO3\Neos\Domain\Model\Site
+     * @return Site
      */
     public function findFirstOnline()
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContext.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContext.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Domain\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Flow\Security\Exception;
 use TYPO3\Neos\Domain\Model\Domain;
 use TYPO3\Neos\Domain\Model\UserInterfaceMode;
 use TYPO3\Neos\Domain\Model\Site;
@@ -174,7 +175,7 @@ class ContentContext extends Context
     {
         try {
             return $this->privilegeManager->isPrivilegeTargetGranted('TYPO3.Neos:Backend.GeneralAccess');
-        } catch (\TYPO3\Flow\Security\Exception $exception) {
+        } catch (Exception $exception) {
             return false;
         }
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
@@ -34,7 +34,7 @@ class ContentContextFactory extends ContextFactory
      *
      * @var string
      */
-    protected $contextImplementation = 'TYPO3\Neos\Domain\Service\ContentContext';
+    protected $contextImplementation = ContentContext::class;
 
     /**
      * Creates the actual Context instance.

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/LegacySiteImportService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/LegacySiteImportService.php
@@ -16,16 +16,20 @@ use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Package\Exception\InvalidPackageStateException;
 use TYPO3\Flow\Package\Exception\UnknownPackageException;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Resource\Resource;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Flow\Utility\Files;
+use TYPO3\Media\Domain\Model\Asset;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Model\ImageVariant;
 use TYPO3\Media\Domain\Repository\ImageRepository;
 use TYPO3\Media\Domain\Repository\AssetRepository;
 use TYPO3\Neos\Domain\Exception as DomainException;
+use TYPO3\Neos\Domain\Exception;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Exception as NeosException;
@@ -33,6 +37,8 @@ use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TYPO3CR\Domain\Service\Context;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Domain\Utility\NodePaths;
 
@@ -127,13 +133,13 @@ class LegacySiteImportService
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
+     * @var ContextFactoryInterface
      */
     protected $contextFactory;
 
@@ -142,10 +148,10 @@ class LegacySiteImportService
      */
     public function initializeObject()
     {
-        $this->imageVariantClassNames = $this->reflectionService->getAllSubClassNamesForClass('TYPO3\Media\Domain\Model\ImageVariant');
-        array_unshift($this->imageVariantClassNames, 'TYPO3\Media\Domain\Model\ImageVariant');
+        $this->imageVariantClassNames = $this->reflectionService->getAllSubClassNamesForClass(ImageVariant::class);
+        array_unshift($this->imageVariantClassNames, ImageVariant::class);
 
-        $this->assetClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Media\Domain\Model\AssetInterface');
+        $this->assetClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetInterface::class);
 
         $this->dateTimeClassNames = $this->reflectionService->getAllSubClassNamesForClass('DateTime');
         array_unshift($this->dateTimeClassNames, 'DateTime');
@@ -208,7 +214,7 @@ class LegacySiteImportService
     }
 
     /**
-     * @return \TYPO3\TYPO3CR\Domain\Service\Context
+     * @return Context
      */
     protected function createContext()
     {
@@ -309,7 +315,7 @@ class LegacySiteImportService
      *
      * @param \SimpleXMLElement $nodeXml
      * @return NodeType
-     * @throws \TYPO3\Neos\Domain\Exception
+     * @throws Exception
      */
     protected function parseNodeType(\SimpleXMLElement $nodeXml)
     {
@@ -397,14 +403,14 @@ class LegacySiteImportService
                 foreach ($nodePropertyXml->children() as $childNodeXml) {
                     $entry = null;
 
-                    if (!isset($childNodeXml['__classname']) || !in_array($childNodeXml['__classname'], array('TYPO3\Media\Domain\Model\Image', 'TYPO3\Media\Domain\Model\Asset'))) {
+                    if (!isset($childNodeXml['__classname']) || !in_array($childNodeXml['__classname'], array(Image::class, Asset::class))) {
                         // Only arrays of asset objects are supported now
                         continue;
                     }
 
                     $entryClassName = (string)$childNodeXml['__classname'];
                     if (isset($childNodeXml['__identifier'])) {
-                        if ($entryClassName === 'TYPO3\Media\Domain\Model\Image') {
+                        if ($entryClassName === Image::class) {
                             $entry = $this->imageRepository->findByIdentifier((string)$childNodeXml['__identifier']);
                         } else {
                             $entry = $this->assetRepository->findByIdentifier((string)$childNodeXml['__identifier']);
@@ -481,7 +487,7 @@ class LegacySiteImportService
      * @param string|null $hash
      * @param string|null $content
      * @param string $forcedIdentifier
-     * @return \TYPO3\Flow\Resource\Resource
+     * @return Resource
      * @throws NeosException
      */
     protected function importResource($fileName, $hash = null, $content = null, $forcedIdentifier = null)
@@ -649,7 +655,7 @@ class LegacySiteImportService
      * get a `title` property being the site's name, and being set to hidden in index.
      *
      * @param \SimpleXMLElement $siteXml
-     * @param \TYPO3\Neos\Domain\Model\Site $site
+     * @param Site $site
      * @return void
      */
     protected function upgradeLegacySiteXml(\SimpleXMLElement $siteXml, Site $site)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeShortcutResolver.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/NodeShortcutResolver.php
@@ -41,7 +41,7 @@ class NodeShortcutResolver
      * * a string (in case the target is a plain text URI or an asset:// URI)
      * * NULL in case the shortcut cannot be resolved
      *
-     * @param \TYPO3\TYPO3CR\Domain\Model\NodeInterface $node
+     * @param NodeInterface $node
      * @return NodeInterface|string|NULL
      */
     public function resolveShortcutTarget(NodeInterface $node)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteImportService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteImportService.php
@@ -18,6 +18,8 @@ use TYPO3\Flow\Package\Exception\UnknownPackageException;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\ImageVariant;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\EventLog\Domain\Service\EventEmittingService;
@@ -127,10 +129,10 @@ class SiteImportService
      */
     public function initializeObject()
     {
-        $this->imageVariantClassNames = $this->reflectionService->getAllSubClassNamesForClass('TYPO3\Media\Domain\Model\ImageVariant');
-        array_unshift($this->imageVariantClassNames, 'TYPO3\Media\Domain\Model\ImageVariant');
+        $this->imageVariantClassNames = $this->reflectionService->getAllSubClassNamesForClass(ImageVariant::class);
+        array_unshift($this->imageVariantClassNames, ImageVariant::class);
 
-        $this->assetClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Media\Domain\Model\AssetInterface');
+        $this->assetClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetInterface::class);
 
         $this->dateTimeClassNames = $this->reflectionService->getAllSubClassNamesForClass('DateTime');
         array_unshift($this->dateTimeClassNames, 'DateTime');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/SiteService.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Domain\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
@@ -57,7 +58,7 @@ class SiteService
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
@@ -12,9 +12,12 @@ namespace TYPO3\Neos\Domain\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Controller\ControllerContext;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TypoScript\Core\Parser;
+use TYPO3\TypoScript\Core\Runtime;
 
 /**
  * The TypoScript Service
@@ -26,7 +29,7 @@ class TypoScriptService
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\TypoScript\Core\Parser
+     * @var Parser
      */
     protected $typoScriptParser;
 
@@ -118,13 +121,13 @@ class TypoScriptService
      * Create a runtime for the given site node
      *
      * @param \TYPO3\TYPO3CR\Domain\Model\NodeInterface $currentSiteNode
-     * @param \TYPO3\Flow\Mvc\Controller\ControllerContext $controllerContext
-     * @return \TYPO3\TypoScript\Core\Runtime
+     * @param ControllerContext $controllerContext
+     * @return Runtime
      */
-    public function createRuntime(NodeInterface $currentSiteNode, \TYPO3\Flow\Mvc\Controller\ControllerContext $controllerContext)
+    public function createRuntime(NodeInterface $currentSiteNode, ControllerContext $controllerContext)
     {
         $typoScriptObjectTree = $this->getMergedTypoScriptObjectTree($currentSiteNode);
-        $typoScriptRuntime = new \TYPO3\TypoScript\Core\Runtime($typoScriptObjectTree, $controllerContext);
+        $typoScriptRuntime = new Runtime($typoScriptObjectTree, $controllerContext);
         return $typoScriptRuntime;
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Domain\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\Flow\Security\Account;
 use TYPO3\Flow\Security\AccountFactory;
 use TYPO3\Flow\Security\AccountRepository;
@@ -768,7 +769,7 @@ class UserService
      *
      * @param User $user The new user to create a workspace for
      * @param Account $account The user's backend account
-     * @throws \TYPO3\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws IllegalObjectTypeException
      */
     protected function createPersonalWorkspace(User $user, Account $account)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Repository/EventRepository.php
@@ -14,6 +14,8 @@ namespace TYPO3\Neos\EventLog\Domain\Repository;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\Doctrine\Repository;
 use TYPO3\Flow\Persistence\QueryInterface;
+use TYPO3\Flow\Persistence\QueryResultInterface;
+use TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException;
 use TYPO3\Neos\EventLog\Domain\Model\NodeEvent;
 
 /**
@@ -36,8 +38,8 @@ class EventRepository extends Repository
      * @param integer $offset
      * @param integer $limit
      * @param string $workspaceName
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
-     * @throws \TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException
+     * @return QueryResultInterface
+     * @throws PropertyNotAccessibleException
      */
     public function findRelevantEventsByWorkspace($offset, $limit, $workspaceName)
     {
@@ -57,8 +59,8 @@ class EventRepository extends Repository
      *
      * @param integer $offset
      * @param integer $limit
-     * @return \TYPO3\Flow\Persistence\QueryResultInterface
-     * @throws \TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException
+     * @return QueryResultInterface
+     * @throws PropertyNotAccessibleException
      */
     public function findRelevantEvents($offset, $limit)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Service/EventEmittingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Domain/Service/EventEmittingService.php
@@ -75,7 +75,7 @@ class EventEmittingService
      * @throws Exception
      * @return Event
      */
-    public function emit($eventType, array $data, $eventClassName = 'TYPO3\Neos\EventLog\Domain\Model\Event')
+    public function emit($eventType, array $data, $eventClassName = Event::class)
     {
         if (!$this->isEnabled()) {
             throw new Exception('Event log not enabled', 1418464933);
@@ -98,7 +98,7 @@ class EventEmittingService
      * @return Event
      * @see emit()
      */
-    public function generate($eventType, array $data, $eventClassName = 'TYPO3\Neos\EventLog\Domain\Model\Event')
+    public function generate($eventType, array $data, $eventClassName = Event::class)
     {
         $event = new $eventClassName($eventType, $data, $this->currentAccountIdentifier, $this->getCurrentContext());
         $this->lastGeneratedEvent = $event;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/AbstractIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/AbstractIntegrationService.php
@@ -12,13 +12,14 @@ namespace TYPO3\Neos\EventLog\Integrations;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\Context;
 use TYPO3\Neos\EventLog\Domain\Service\EventEmittingService;
 
 abstract class AbstractIntegrationService
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Security\Context
+     * @var Context
      */
     protected $securityContext;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/EntityIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/EntityIntegrationService.php
@@ -11,8 +11,10 @@ namespace TYPO3\Neos\EventLog\Integrations;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use TYPO3\Eel\CompilingEvaluator;
+use TYPO3\Eel\Exception;
 use TYPO3\Eel\Utility;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Log\SystemLoggerInterface;
@@ -30,7 +32,7 @@ class EntityIntegrationService extends AbstractIntegrationService
      * interface ...
      *
      * @Flow\Inject
-     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @var ObjectManager
      */
     protected $entityManager;
 
@@ -78,7 +80,7 @@ class EntityIntegrationService extends AbstractIntegrationService
      *
      * @param OnFlushEventArgs $eventArgs
      * @return void
-     * @throws \TYPO3\Eel\Exception
+     * @throws Exception
      */
     public function onFlush(OnFlushEventArgs $eventArgs)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
@@ -11,6 +11,7 @@ namespace TYPO3\Neos\EventLog\Integrations;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\EntityManager;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
@@ -37,7 +38,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
 
     /**
      * @Flow\Inject
-     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @var ObjectManager
      */
     protected $entityManager;
 
@@ -99,7 +100,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         }
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->generate(self::NODE_ADDED, array(), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+        $nodeEvent = $this->eventEmittingService->generate(self::NODE_ADDED, array(), NodeEvent::class);
         $this->currentNodeAddEvents[] = $nodeEvent;
         $this->eventEmittingService->pushContext($nodeEvent);
     }
@@ -213,7 +214,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         }
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->emit(self::NODE_REMOVED, array(), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+        $nodeEvent = $this->eventEmittingService->emit(self::NODE_REMOVED, array(), NodeEvent::class);
         $nodeEvent->setNode($node);
     }
 
@@ -251,7 +252,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         /* @var $nodeEvent NodeEvent */
         $nodeEvent = $this->eventEmittingService->emit(self::NODE_COPY, array(
             'copiedInto' => $targetParentNode->getContextPath()
-        ), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+        ), NodeEvent::class);
         $nodeEvent->setNode($sourceNode);
         $this->eventEmittingService->pushContext();
     }
@@ -296,7 +297,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         $nodeEvent = $this->eventEmittingService->emit(self::NODE_MOVE, array(
             'referenceNode' => $referenceNode->getContextPath(),
             'moveOperation' => $moveOperation
-        ), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+        ), NodeEvent::class);
         $nodeEvent->setNode($movedNode);
         $this->eventEmittingService->pushContext();
     }
@@ -346,7 +347,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
                 'targetWorkspace' => $context->getWorkspaceName(),
                 'targetDimensions' => $context->getTargetDimensions(),
                 'recursive' => $recursive
-            ), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+            ), NodeEvent::class);
             $nodeEvent->setNode($node);
             $this->eventEmittingService->pushContext();
         }
@@ -396,7 +397,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
 
             if (isset($data['oldLabel']) && isset($data['newLabel'])) {
                 if ($data['oldLabel'] !== $data['newLabel']) {
-                    $nodeEvent = $this->eventEmittingService->emit(self::NODE_LABEL_CHANGED, array('oldLabel' => $data['oldLabel'], 'newLabel' => $data['newLabel']), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+                    $nodeEvent = $this->eventEmittingService->emit(self::NODE_LABEL_CHANGED, array('oldLabel' => $data['oldLabel'], 'newLabel' => $data['newLabel']), NodeEvent::class);
                     $nodeEvent->setNode($node);
                 }
                 unset($data['oldLabel']);
@@ -404,7 +405,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             }
 
             if (!empty($data)) {
-                $nodeEvent = $this->eventEmittingService->emit(self::NODE_UPDATED, $data, 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+                $nodeEvent = $this->eventEmittingService->emit(self::NODE_UPDATED, $data, NodeEvent::class);
                 $nodeEvent->setNode($node);
             }
         }
@@ -459,7 +460,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         foreach ($this->scheduledNodeEventUpdates as $documentPublish) {
 
             /* @var $nodeEvent NodeEvent */
-            $nodeEvent = $this->eventEmittingService->emit(self::DOCUMENT_PUBLISHED, array(), 'TYPO3\Neos\EventLog\Domain\Model\NodeEvent');
+            $nodeEvent = $this->eventEmittingService->emit(self::DOCUMENT_PUBLISHED, array(), NodeEvent::class);
             $nodeEvent->setNode($documentPublish['documentNode']);
             $nodeEvent->setWorkspaceName($documentPublish['targetWorkspace']);
             $this->persistenceManager->whitelistObject($nodeEvent);
@@ -468,7 +469,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             $parentEventIdentifier = $this->persistenceManager->getIdentifierByObject($nodeEvent);
 
             $qb = $entityManager->createQueryBuilder();
-            $qb->update('TYPO3\Neos\EventLog\Domain\Model\NodeEvent', 'e')
+            $qb->update(NodeEvent::class, 'e')
                 ->set('e.parentEvent', ':parentEventIdentifier')
                 ->setParameter('parentEventIdentifier', $parentEventIdentifier)
                 ->where('e.parentEvent IS NULL')

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -13,9 +13,23 @@ namespace TYPO3\Neos;
 
 use TYPO3\Flow\Cache\CacheManager;
 use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Monitor\FileMonitor;
+use TYPO3\Flow\Mvc\Routing\RouterCachingService;
 use TYPO3\Flow\Package\Package as BasePackage;
+use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
+use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\Neos\Domain\Service\SiteImportService;
+use TYPO3\Neos\Domain\Service\SiteService;
+use TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService;
+use TYPO3\Neos\Routing\Cache\RouteCacheFlusher;
+use TYPO3\Neos\Service\PublishingService;
 use TYPO3\Neos\Utility\NodeUriPathSegmentGenerator;
+use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+use TYPO3\TYPO3CR\Domain\Service\Context;
+use TYPO3\TypoScript\Core\Cache\ContentCache;
 
 /**
  * The Neos Package
@@ -31,16 +45,16 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
         $flushConfigurationCache = function () use ($bootstrap) {
-            $cacheManager = $bootstrap->getEarlyInstance('TYPO3\Flow\Cache\CacheManager');
+            $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
             $cacheManager->getCache('TYPO3_Neos_Configuration_Version')->flush();
         };
 
         $flushXliffServiceCache = function () use ($bootstrap) {
-            $cacheManager = $bootstrap->getEarlyInstance('TYPO3\Flow\Cache\CacheManager');
+            $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
             $cacheManager->getCache('TYPO3_Neos_XliffToJsonTranslations')->flush();
         };
 
-        $dispatcher->connect('TYPO3\Flow\Monitor\FileMonitor', 'filesHaveChanged', function ($fileMonitorIdentifier, array $changedFiles) use ($flushConfigurationCache, $flushXliffServiceCache) {
+        $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', function ($fileMonitorIdentifier, array $changedFiles) use ($flushConfigurationCache, $flushXliffServiceCache) {
             switch ($fileMonitorIdentifier) {
                 case 'TYPO3CR_NodeTypesConfiguration':
                 case 'Flow_ConfigurationFiles':
@@ -52,71 +66,71 @@ class Package extends BasePackage
             }
         });
 
-        $dispatcher->connect('TYPO3\Neos\Domain\Model\Site', 'siteChanged', $flushConfigurationCache);
-        $dispatcher->connect('TYPO3\Neos\Domain\Model\Site', 'siteChanged', 'TYPO3\Flow\Mvc\Routing\RouterCachingService', 'flushCaches');
+        $dispatcher->connect(Site::class, 'siteChanged', $flushConfigurationCache);
+        $dispatcher->connect(Site::class, 'siteChanged', 'TYPO3\Flow\Mvc\Routing\RouterCachingService', 'flushCaches');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeUpdated', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeAdded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodeMove', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(Node::class, 'nodeUpdated', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(Node::class, 'nodeAdded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(Node::class, 'nodeRemoved', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(Node::class, 'beforeNodeMove', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePropertyChanged', function (NodeInterface $node, $propertyName) use ($bootstrap) {
+        $dispatcher->connect(Node::class, 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
+        $dispatcher->connect(Node::class, 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');
+        $dispatcher->connect(Node::class, 'nodePropertyChanged', function (NodeInterface $node, $propertyName) use ($bootstrap) {
             if ($propertyName === 'uriPathSegment') {
                 NodeUriPathSegmentGenerator::setUniqueUriPathSegment($node);
-                $bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
+                $bootstrap->getObjectManager()->get(RouteCacheFlusher::class)->registerNodeChange($node);
             }
         });
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', function (NodeInterface $node, $oldPath, $newPath, $recursion) {
+        $dispatcher->connect(Node::class, 'nodePathChanged', function (NodeInterface $node, $oldPath, $newPath, $recursion) {
             if (!$recursion) {
                 NodeUriPathSegmentGenerator::setUniqueUriPathSegment($node);
             }
         });
 
-        $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodeDiscarded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(PublishingService::class, 'nodePublished', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(PublishingService::class, 'nodeDiscarded', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
-        $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', function ($node, $targetWorkspace) use ($bootstrap) {
+        $dispatcher->connect(Node::class, 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(Node::class, 'nodeRemoved', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(PublishingService::class, 'nodePublished', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect(PublishingService::class, 'nodePublished', function ($node, $targetWorkspace) use ($bootstrap) {
             $cacheManager = $bootstrap->getObjectManager()->get(CacheManager::class);
             if ($cacheManager->hasCache('Flow_Persistence_Doctrine')) {
                 $cacheManager->getCache('Flow_Persistence_Doctrine')->flush();
             }
         });
-        $dispatcher->connect('TYPO3\Flow\Persistence\Doctrine\PersistenceManager', 'allObjectsPersisted', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'commit');
+        $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', RouteCacheFlusher::class, 'commit');
 
-        $dispatcher->connect('TYPO3\Neos\Domain\Service\SiteService', 'sitePruned', 'TYPO3\TypoScript\Core\Cache\ContentCache', 'flush');
-        $dispatcher->connect('TYPO3\Neos\Domain\Service\SiteService', 'sitePruned', 'TYPO3\Flow\Mvc\Routing\RouterCachingService', 'flushCaches');
+        $dispatcher->connect(SiteService::class, 'sitePruned', ContentCache::class, 'flush');
+        $dispatcher->connect(SiteService::class, 'sitePruned', RouterCachingService::class, 'flushCaches');
 
-        $dispatcher->connect('TYPO3\Neos\Domain\Service\SiteImportService', 'siteImported', 'TYPO3\TypoScript\Core\Cache\ContentCache', 'flush');
-        $dispatcher->connect('TYPO3\Neos\Domain\Service\SiteImportService', 'siteImported', 'TYPO3\Flow\Mvc\Routing\RouterCachingService', 'flushCaches');
+        $dispatcher->connect(SiteImportService::class, 'siteImported', ContentCache::class, 'flush');
+        $dispatcher->connect(SiteImportService::class, 'siteImported', RouterCachingService::class, 'flushCaches');
 
         // Eventlog
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodeCreate', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeNodeCreate');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'afterNodeCreate', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'afterNodeCreate');
+        $dispatcher->connect(Node::class, 'beforeNodeCreate', TYPO3CRIntegrationService::class, 'beforeNodeCreate');
+        $dispatcher->connect(Node::class, 'afterNodeCreate', TYPO3CRIntegrationService::class, 'afterNodeCreate');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeUpdated', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'nodeUpdated');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'nodeRemoved');
+        $dispatcher->connect(Node::class, 'nodeUpdated', TYPO3CRIntegrationService::class, 'nodeUpdated');
+        $dispatcher->connect(Node::class, 'nodeRemoved', TYPO3CRIntegrationService::class, 'nodeRemoved');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodePropertyChange', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeNodePropertyChange');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePropertyChanged', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'nodePropertyChanged');
+        $dispatcher->connect(Node::class, 'beforeNodePropertyChange', TYPO3CRIntegrationService::class, 'beforeNodePropertyChange');
+        $dispatcher->connect(Node::class, 'nodePropertyChanged', TYPO3CRIntegrationService::class, 'nodePropertyChanged');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodeCopy', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeNodeCopy');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'afterNodeCopy', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'afterNodeCopy');
+        $dispatcher->connect(Node::class, 'beforeNodeCopy', TYPO3CRIntegrationService::class, 'beforeNodeCopy');
+        $dispatcher->connect(Node::class, 'afterNodeCopy', TYPO3CRIntegrationService::class, 'afterNodeCopy');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'beforeNodeMove', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeNodeMove');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'afterNodeMove', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'afterNodeMove');
+        $dispatcher->connect(Node::class, 'beforeNodeMove', TYPO3CRIntegrationService::class, 'beforeNodeMove');
+        $dispatcher->connect(Node::class, 'afterNodeMove', TYPO3CRIntegrationService::class, 'afterNodeMove');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Service\Context', 'beforeAdoptNode', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeAdoptNode');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Service\Context', 'afterAdoptNode', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'afterAdoptNode');
+        $dispatcher->connect(Context::class, 'beforeAdoptNode', TYPO3CRIntegrationService::class, 'beforeAdoptNode');
+        $dispatcher->connect(Context::class, 'afterAdoptNode', TYPO3CRIntegrationService::class, 'afterAdoptNode');
 
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Workspace', 'beforeNodePublishing', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'beforeNodePublishing');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Workspace', 'afterNodePublishing', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'afterNodePublishing');
+        $dispatcher->connect(Workspace::class, 'beforeNodePublishing', TYPO3CRIntegrationService::class, 'beforeNodePublishing');
+        $dispatcher->connect(Workspace::class, 'afterNodePublishing', TYPO3CRIntegrationService::class, 'afterNodePublishing');
 
-        $dispatcher->connect('TYPO3\Flow\Persistence\Doctrine\PersistenceManager', 'allObjectsPersisted', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'updateEventsAfterPublish');
-        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'repositoryObjectsPersisted', 'TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService', 'updateEventsAfterPublish');
+        $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', TYPO3CRIntegrationService::class, 'updateEventsAfterPublish');
+        $dispatcher->connect(NodeDataRepository::class, 'repositoryObjectsPersisted', TYPO3CRIntegrationService::class, 'updateEventsAfterPublish');
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Aspects/RouteCacheAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Aspects/RouteCacheAspect.php
@@ -41,7 +41,7 @@ class RouteCacheAspect
      * Add the current node and all parent identifiers to be used for cache entry tagging
      *
      * @Flow\Before("method(TYPO3\Flow\Mvc\Routing\RouterCachingService->extractUuids())")
-     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     * @param JoinPointInterface $joinPoint The current join point
      * @return void
      */
     public function addCurrentNodeIdentifier(JoinPointInterface $joinPoint)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/BackendModuleArgumentsRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/BackendModuleArgumentsRoutePartHandler.php
@@ -12,17 +12,20 @@ namespace TYPO3\Neos\Routing;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Routing\DynamicRoutePart;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Utility\Arrays;
 
 /**
  * A route part handler for finding nodes specifically in the website's frontend.
  *
  * @Flow\Scope("singleton")
  */
-class BackendModuleArgumentsRoutePartHandler extends \TYPO3\Flow\Mvc\Routing\DynamicRoutePart
+class BackendModuleArgumentsRoutePartHandler extends DynamicRoutePart
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
@@ -47,7 +50,7 @@ class BackendModuleArgumentsRoutePartHandler extends \TYPO3\Flow\Mvc\Routing\Dyn
                 }
             }
             if ($exceedingArguments !== array()) {
-                $exceedingArguments = \TYPO3\Flow\Utility\Arrays::removeEmptyElementsRecursively($exceedingArguments);
+                $exceedingArguments = Arrays::removeEmptyElementsRecursively($exceedingArguments);
                 $exceedingArguments = $this->persistenceManager->convertObjectsToIdentityArrays($exceedingArguments);
                 $queryString = http_build_query(array($this->name => $exceedingArguments), null, '&');
                 if ($queryString !== '') {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/BackendModuleRoutePartHandler.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/BackendModuleRoutePartHandler.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Routing;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Routing\DynamicRoutePart;
 use TYPO3\Flow\Utility\Arrays;
 
 /**
@@ -19,7 +20,7 @@ use TYPO3\Flow\Utility\Arrays;
  *
  * @Flow\Scope("singleton")
  */
-class BackendModuleRoutePartHandler extends \TYPO3\Flow\Mvc\Routing\DynamicRoutePart
+class BackendModuleRoutePartHandler extends DynamicRoutePart
 {
     const MATCHRESULT_FOUND = true;
     const MATCHRESULT_NOSUCHMODULE = -1;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/InvalidDimensionPresetCombinationException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/InvalidDimensionPresetCombinationException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * An "invalid dimension preset combination" exception
  */
-class InvalidDimensionPresetCombinationException extends \TYPO3\Neos\Routing\Exception
+class InvalidDimensionPresetCombinationException extends Exception
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/InvalidRequestPathException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/InvalidRequestPathException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * An "invalid request path" exception
  */
-class InvalidRequestPathException extends \TYPO3\Neos\Routing\Exception
+class InvalidRequestPathException extends Exception
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/MissingNodePropertyException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/MissingNodePropertyException.php
@@ -10,10 +10,11 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * An exception for nodes missing a required property
  */
-class MissingNodePropertyException extends \TYPO3\Neos\Routing\Exception
+class MissingNodePropertyException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoHomepageException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoHomepageException.php
@@ -10,10 +10,11 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no homepage" exception
  */
-class NoHomepageException extends \TYPO3\Neos\Routing\Exception
+class NoHomepageException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSiteException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSiteException.php
@@ -10,10 +10,11 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no site" exception
  */
-class NoSiteException extends \TYPO3\Neos\Routing\Exception
+class NoSiteException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSiteNodeException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSiteNodeException.php
@@ -10,10 +10,11 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no site node" exception
  */
-class NoSiteNodeException extends \TYPO3\Neos\Routing\Exception
+class NoSiteNodeException extends Exception
 {
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSuchDimensionValueException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSuchDimensionValueException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no such dimension value" exception
  */
-class NoSuchDimensionValueException extends \TYPO3\Neos\Routing\Exception
+class NoSuchDimensionValueException extends Exception
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSuchNodeException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoSuchNodeException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no such node" exception
  */
-class NoSuchNodeException extends \TYPO3\Neos\Routing\Exception
+class NoSuchNodeException extends Exception
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoWorkspaceException.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Exception/NoWorkspaceException.php
@@ -10,11 +10,12 @@ namespace TYPO3\Neos\Routing\Exception;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Neos\Routing\Exception;
 
 /**
  * A "no workspace" exception
  */
-class NoWorkspaceException extends \TYPO3\Neos\Routing\Exception
+class NoWorkspaceException extends Exception
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/NodeIdentityConverterAspect.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/NodeIdentityConverterAspect.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Routing;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Aop\JoinPointInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
@@ -30,10 +31,10 @@ class NodeIdentityConverterAspect
      * Convert the object to its context path, if we deal with TYPO3CR nodes.
      *
      * @Flow\Around("method(TYPO3\Flow\Persistence\AbstractPersistenceManager->convertObjectToIdentityArray())")
-     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint the joinpoint
+     * @param JoinPointInterface $joinPoint the joinpoint
      * @return string|array the context path to be used for routing
      */
-    public function convertNodeToContextPathForRouting(\TYPO3\Flow\Aop\JoinPointInterface $joinPoint)
+    public function convertNodeToContextPathForRouting(JoinPointInterface $joinPoint)
     {
         $objectArgument = $joinPoint->getMethodArgument('object');
         if ($objectArgument instanceof NodeInterface) {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
@@ -14,8 +14,12 @@ namespace TYPO3\Neos\Service;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Property\PropertyMappingConfiguration;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Flow\Utility\TypeHandling;
+use TYPO3\Media\Domain\Model\Asset;
+use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\TypeConverter\EntityToIdentityConverter;
 use TYPO3\TYPO3CR\Domain\Model\Node;
@@ -104,7 +108,6 @@ class ContentElementWrappingService
             if (!$this->nodeAuthorizationService->isGrantedToEditNode($node)) {
                 return $content;
             }
-
 
             if ($node->isRemoved()) {
                 $classNames[] = 'neos-contentelement-removed';
@@ -261,25 +264,25 @@ class ContentElementWrappingService
             }
         }
 
-        if ($propertyValue instanceof \TYPO3\Media\Domain\Model\ImageInterface) {
-            $propertyMappingConfiguration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
+        if ($propertyValue instanceof ImageInterface) {
+            $propertyMappingConfiguration = new PropertyMappingConfiguration();
             return json_encode($this->entityToIdentityConverter->convertFrom($propertyValue, 'array', array(), $propertyMappingConfiguration));
         }
 
         // Serialize an Asset to JSON (the NodeConverter expects JSON for object type properties)
-        if ($dataType === ltrim('TYPO3\Media\Domain\Model\Asset', '\\') && $propertyValue !== null) {
-            if ($propertyValue instanceof \TYPO3\Media\Domain\Model\Asset) {
+        if ($dataType === ltrim(Asset::class, '\\') && $propertyValue !== null) {
+            if ($propertyValue instanceof Asset::class) {
                 return json_encode($this->persistenceManager->getIdentifierByObject($propertyValue));
             }
         }
 
         // Serialize an array of Assets to JSON
         if (is_array($propertyValue)) {
-            $parsedType = \TYPO3\Flow\Utility\TypeHandling::parseType($dataType);
-            if ($parsedType['elementType'] === ltrim('TYPO3\Media\Domain\Model\Asset', '\\')) {
+            $parsedType = TypeHandling::parseType($dataType);
+            if ($parsedType['elementType'] === ltrim(Asset::class, '\\')) {
                 $convertedValues = array();
                 foreach ($propertyValue as $singlePropertyValue) {
-                    if ($singlePropertyValue instanceof \TYPO3\Media\Domain\Model\Asset) {
+                    if ($singlePropertyValue instanceof Asset::class) {
                         $convertedValues[] = $this->persistenceManager->getIdentifierByObject($singlePropertyValue);
                     }
                 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
@@ -271,7 +271,7 @@ class ContentElementWrappingService
 
         // Serialize an Asset to JSON (the NodeConverter expects JSON for object type properties)
         if ($dataType === ltrim(Asset::class, '\\') && $propertyValue !== null) {
-            if ($propertyValue instanceof Asset::class) {
+            if ($propertyValue instanceof Asset) {
                 return json_encode($this->persistenceManager->getIdentifierByObject($propertyValue));
             }
         }
@@ -282,7 +282,7 @@ class ContentElementWrappingService
             if ($parsedType['elementType'] === ltrim(Asset::class, '\\')) {
                 $convertedValues = array();
                 foreach ($propertyValue as $singlePropertyValue) {
-                    if ($singlePropertyValue instanceof Asset::class) {
+                    if ($singlePropertyValue instanceof Asset) {
                         $convertedValues[] = $this->persistenceManager->getIdentifierByObject($singlePropertyValue);
                     }
                 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/DataSourceController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/DataSourceController.php
@@ -12,8 +12,10 @@ namespace TYPO3\Neos\Service\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\View\JsonView;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Flow\Reflection\ReflectionService;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\Neos\Service\DataSource\DataSourceInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -30,7 +32,7 @@ class DataSourceController extends AbstractServiceController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'json' => 'TYPO3\Flow\Mvc\View\JsonView'
+        'json' => JsonView::class
     );
 
     /**
@@ -72,10 +74,10 @@ class DataSourceController extends AbstractServiceController
      */
     public static function getDataSources($objectManager)
     {
-        $reflectionService = $objectManager->get('TYPO3\Flow\Reflection\ReflectionService');
+        $reflectionService = $objectManager->get(ReflectionService::class);
 
         $dataSources = array();
-        $dataSourceClassNames = $reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Neos\Service\DataSource\DataSourceInterface');
+        $dataSourceClassNames = $reflectionService->getAllImplementationClassNamesForInterface(DataSourceInterface::class);
         /** @var $dataSourceClassName DataSourceInterface */
         foreach ($dataSourceClassNames as $dataSourceClassName) {
             $identifier = $dataSourceClassName::getIdentifier();

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/NodeController.php
@@ -13,7 +13,10 @@ namespace TYPO3\Neos\Service\Controller;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Eel\FlowQuery\FlowQuery;
+use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Service\NodeSearchService;
+use TYPO3\Neos\Service\NodeOperations;
 use TYPO3\Neos\Service\View\NodeView;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -42,8 +45,8 @@ class NodeController extends AbstractServiceController
      * @var array
      */
     protected $viewFormatToObjectNameMap = array(
-        'html' => 'TYPO3\Neos\Service\View\NodeView',
-        'json' => 'TYPO3\Neos\Service\View\NodeView'
+        'html' => NodeView::class,
+        'json' => NodeView::class
     );
 
     /**
@@ -86,13 +89,13 @@ class NodeController extends AbstractServiceController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\NodeOperations
+     * @var NodeOperations
      */
     protected $nodeOperations;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     * @var DomainRepository
      */
     protected $domainRepository;
 
@@ -104,7 +107,7 @@ class NodeController extends AbstractServiceController
     protected function initializeAction()
     {
         if ($this->arguments->hasArgument('referenceNode')) {
-            $this->arguments->getArgument('referenceNode')->getPropertyMappingConfiguration()->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+            $this->arguments->getArgument('referenceNode')->getPropertyMappingConfiguration()->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         }
         $this->uriBuilder->setRequest($this->request->getMainRequest());
         if (in_array($this->request->getControllerActionName(), array('update', 'updateAndRender'), true)) {
@@ -113,8 +116,8 @@ class NodeController extends AbstractServiceController
             $propertyMappingConfiguration->allowOverrideTargetType();
             $propertyMappingConfiguration->allowAllProperties();
             $propertyMappingConfiguration->skipUnknownProperties();
-            $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
-            $propertyMappingConfiguration->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
+            $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+            $propertyMappingConfiguration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
         }
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/WorkspaceController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Controller/WorkspaceController.php
@@ -12,7 +12,14 @@ namespace TYPO3\Neos\Service\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMapper;
+use TYPO3\Flow\Property\PropertyMappingConfigurationBuilder;
+use TYPO3\Neos\Service\PublishingService;
+use TYPO3\Neos\Service\View\NodeView;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 use TYPO3\TYPO3CR\TypeConverter\NodeConverter;
 
 /**
@@ -23,40 +30,40 @@ class WorkspaceController extends AbstractServiceController
     /**
      * @var string
      */
-    protected $defaultViewObjectName = 'TYPO3\Neos\Service\View\NodeView';
+    protected $defaultViewObjectName = NodeView::class;
 
     /**
-     * @var \TYPO3\Neos\Service\View\NodeView
+     * @var NodeView
      */
     protected $view;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository
+     * @var NodeDataRepository
      */
     protected $nodeDataRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\PublishingService
+     * @var PublishingService
      */
     protected $publishingService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository
+     * @var WorkspaceRepository
      */
     protected $workspaceRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Property\PropertyMapper
+     * @var PropertyMapper
      */
     protected $propertyMapper;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Property\PropertyMappingConfigurationBuilder
+     * @var PropertyMappingConfigurationBuilder
      */
     protected $propertyMappingConfigurationBuilder;
 
@@ -70,7 +77,7 @@ class WorkspaceController extends AbstractServiceController
                 ->arguments
                 ->getArgument('node')
                 ->getPropertyMappingConfiguration()
-                ->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+                ->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         }
 
         if ($this->arguments->hasArgument('nodes')) {
@@ -79,7 +86,7 @@ class WorkspaceController extends AbstractServiceController
                 ->getArgument('nodes')
                 ->getPropertyMappingConfiguration()
                 ->forProperty('*')
-                ->setTypeConverterOption('TYPO3\TYPO3CR\TypeConverter\NodeConverter', NodeConverter::REMOVED_CONTENT_SHOWN, true);
+                ->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         }
     }
 
@@ -164,7 +171,7 @@ class WorkspaceController extends AbstractServiceController
     /**
      * Get every unpublished node in the workspace with the given workspace name
      *
-     * @param \TYPO3\TYPO3CR\Domain\Model\Workspace $workspace
+     * @param Workspace $workspace
      * @return void
      */
     public function getWorkspaceWideUnpublishedNodesAction($workspace)
@@ -175,7 +182,7 @@ class WorkspaceController extends AbstractServiceController
     /**
      * Discard everything in the workspace with the given workspace name
      *
-     * @param \TYPO3\TYPO3CR\Domain\Model\Workspace $workspace
+     * @param Workspace $workspace
      * @return void
      */
     public function discardAllAction($workspace)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/DataSource/AbstractDataSource.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/DataSource/AbstractDataSource.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Service\DataSource;
  */
 
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Neos\Exception;
 
 /**
  * Data source interface for getting data.
@@ -37,12 +38,12 @@ abstract class AbstractDataSource implements DataSourceInterface
     /**
      * @return string the short name of the operation
      * @api
-     * @throws \TYPO3\Neos\Exception
+     * @throws Exception
      */
     public static function getIdentifier()
     {
         if (!is_string(static::$identifier)) {
-            throw new \TYPO3\Neos\Exception('Identifier in class ' . __CLASS__ . ' is empty.', 1414090236);
+            throw new Exception('Identifier in class ' . __CLASS__ . ' is empty.', 1414090236);
         }
 
         return static::$identifier;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
@@ -237,7 +237,7 @@ class LinkingService
             }
             preg_match(NodeInterface::MATCH_PATTERN_CONTEXTPATH, $nodeString, $matches);
             if (isset($matches['WorkspaceName']) && $matches['WorkspaceName'] !== '') {
-                $node = $this->propertyMapper->convert($nodeString, 'TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+                $node = $this->propertyMapper->convert($nodeString, NodeInterface::class);
             } else {
                 if ($baseNode === null) {
                     throw new NeosException('The baseNode argument is required for linking to nodes with a relative path.', 1407879905);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/PluginService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/PluginService.php
@@ -210,7 +210,7 @@ class PluginService
         /** @var $context ContentContext */
         $context = $node->getContext();
         foreach ($this->getNodes(['TYPO3.Neos:PluginView'], $context) as $pluginViewNode) {
-            /** @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface $pluginViewNode */
+            /** @var NodeInterface $pluginViewNode */
             if ($pluginViewNode->isRemoved()) {
                 continue;
             }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/TransliterationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/TransliterationService.php
@@ -11,6 +11,7 @@ namespace TYPO3\Neos\Service;
  * source code.
  */
 
+use Behat\Transliterator\Transliterator;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\Service as LocalizationService;
 
@@ -50,8 +51,8 @@ class TransliterationService
         }
 
         // Transliterate (transform 北京 to 'Bei Jing')
-        if (preg_match('/[\x80-\xff]/', $text) && \Behat\Transliterator\Transliterator::validUtf8($text)) {
-            $text = \Behat\Transliterator\Transliterator::utf8ToAscii($text);
+        if (preg_match('/[\x80-\xff]/', $text) && Transliterator::validUtf8($text)) {
+            $text = Transliterator::utf8ToAscii($text);
         }
 
         return $text;

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/VieSchemaBuilder.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 
 /**
  * Generate a schema in JSON format for the VIE dataTypes validation, necessary
@@ -25,7 +26,7 @@ use TYPO3\TYPO3CR\Domain\Model\NodeType;
 class VieSchemaBuilder
 {
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
+     * @var NodeTypeManager
      * @Flow\Inject
      */
     protected $nodeTypeManager;
@@ -106,7 +107,7 @@ class VieSchemaBuilder
 
     /**
      * @param string $nodeTypeName
-     * @param \TYPO3\TYPO3CR\Domain\Model\NodeType $nodeType
+     * @param NodeType $nodeType
      * @return void
      */
     protected function readNodeTypeConfiguration($nodeTypeName, NodeType $nodeType)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Service\View;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Flow\Log\SystemLoggerInterface;
+use TYPO3\Flow\Mvc\View\JsonView;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
 use TYPO3\Neos\Security\Authorization\Privilege\NodeTreePrivilege;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -28,7 +29,7 @@ use TYPO3\TYPO3CR\Security\Authorization\Privilege\Node\NodePrivilegeSubject;
  *
  * @Flow\Scope("prototype")
  */
-class NodeView extends \TYPO3\Flow\Mvc\View\JsonView
+class NodeView extends JsonView
 {
     /**
      * @var integer

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/XliffService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/XliffService.php
@@ -13,6 +13,8 @@ namespace TYPO3\Neos\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cache\Frontend\VariableFrontend;
+use TYPO3\Flow\Error\Result;
+use TYPO3\Flow\I18n\Exception;
 use TYPO3\Flow\I18n\Xliff\XliffParser;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Utility\Arrays;
@@ -76,8 +78,8 @@ class XliffService
      * The json will be cached.
      *
      * @param Locale $locale The locale
-     * @return \TYPO3\Flow\Error\Result
-     * @throws \TYPO3\Flow\I18n\Exception
+     * @return Result
+     * @throws Exception
      */
     public function getCachedJson(Locale $locale)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/AdministratorStep.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/AdministratorStep.php
@@ -12,15 +12,19 @@ namespace TYPO3\Neos\Setup\Step;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\AccountRepository;
 use TYPO3\Flow\Validation\Validator\NotEmptyValidator;
 use TYPO3\Flow\Validation\Validator\StringLengthValidator;
+use TYPO3\Form\Core\Model\FormDefinition;
 use TYPO3\Neos\Domain\Service\UserService;
 use TYPO3\Neos\Validation\Validator\UserDoesNotExistValidator;
+use TYPO3\Party\Domain\Repository\PartyRepository;
+use TYPO3\Setup\Step\AbstractStep;
 
 /**
  * @Flow\Scope("singleton")
  */
-class AdministratorStep extends \TYPO3\Setup\Step\AbstractStep
+class AdministratorStep extends AbstractStep
 {
     /**
      * @var boolean
@@ -29,13 +33,13 @@ class AdministratorStep extends \TYPO3\Setup\Step\AbstractStep
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Security\AccountRepository
+     * @var AccountRepository
      */
     protected $accountRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Party\Domain\Repository\PartyRepository
+     * @var PartyRepository
      */
     protected $partyRepository;
 
@@ -48,10 +52,10 @@ class AdministratorStep extends \TYPO3\Setup\Step\AbstractStep
     /**
      * Returns the form definitions for the step
      *
-     * @param \TYPO3\Form\Core\Model\FormDefinition $formDefinition
+     * @param FormDefinition $formDefinition
      * @return void
      */
-    protected function buildForm(\TYPO3\Form\Core\Model\FormDefinition $formDefinition)
+    protected function buildForm(FormDefinition $formDefinition)
     {
         $page1 = $formDefinition->createPage('page1');
         $page1->setRenderingOption('header', 'Create administrator account');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/FinalStep.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/FinalStep.php
@@ -13,19 +13,22 @@ namespace TYPO3\Neos\Setup\Step;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Core\ApplicationContext;
+use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Form\Core\Model\FormDefinition;
+use TYPO3\Setup\Step\AbstractStep;
 
 /**
  * @Flow\Scope("singleton")
  */
-class FinalStep extends \TYPO3\Setup\Step\AbstractStep
+class FinalStep extends AbstractStep
 {
     /**
      * Returns the form definitions for the step
      *
-     * @param \TYPO3\Form\Core\Model\FormDefinition $formDefinition
+     * @param FormDefinition $formDefinition
      * @return void
      */
-    protected function buildForm(\TYPO3\Form\Core\Model\FormDefinition $formDefinition)
+    protected function buildForm(FormDefinition $formDefinition)
     {
         $page1 = $formDefinition->createPage('page1');
         $page1->setRenderingOption('header', 'Setup complete');
@@ -42,7 +45,7 @@ class FinalStep extends \TYPO3\Setup\Step\AbstractStep
         $docs->setProperty('href', 'https://neos.readthedocs.org/');
         $docs->setProperty('target', '_blank');
 
-        $contextEnv = \TYPO3\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
+        $contextEnv = Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
         $applicationContext = new ApplicationContext($contextEnv);
         if (!$applicationContext->isProduction()) {
             $context = $page1->createElement('contextSection', 'TYPO3.Form:Section');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/NeosSpecificRequirementsStep.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/NeosSpecificRequirementsStep.php
@@ -13,20 +13,24 @@ namespace TYPO3\Neos\Setup\Step;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Configuration\Source\YamlSource;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Flow\Utility\Files;
+use TYPO3\Form\Core\Model\FormDefinition;
+use TYPO3\Imagine\ImagineFactory;
+use TYPO3\Setup\Step\AbstractStep;
 
 /**
  * @Flow\Scope("singleton")
  */
-class NeosSpecificRequirementsStep extends \TYPO3\Setup\Step\AbstractStep
+class NeosSpecificRequirementsStep extends AbstractStep
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Configuration\Source\YamlSource
+     * @var YamlSource
      */
     protected $configurationSource;
 
@@ -38,7 +42,7 @@ class NeosSpecificRequirementsStep extends \TYPO3\Setup\Step\AbstractStep
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Imagine\ImagineFactory
+     * @var ImagineFactory
      */
     protected $imagineFactory;
 
@@ -57,7 +61,7 @@ class NeosSpecificRequirementsStep extends \TYPO3\Setup\Step\AbstractStep
     /**
      * {@inheritdoc}
      */
-    protected function buildForm(\TYPO3\Form\Core\Model\FormDefinition $formDefinition)
+    protected function buildForm(FormDefinition $formDefinition)
     {
         $page1 = $formDefinition->createPage('page1');
         $page1->setRenderingOption('header', 'Neos requirements check');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/SiteImportStep.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Setup/Step/SiteImportStep.php
@@ -12,13 +12,31 @@ namespace TYPO3\Neos\Setup\Step;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Log\SystemLoggerInterface;
+use TYPO3\Flow\Mvc\FlashMessageContainer;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
+use TYPO3\Flow\Validation\Validator\NotEmptyValidator;
+use TYPO3\Form\Core\Model\FinisherContext;
+use TYPO3\Form\Core\Model\FormDefinition;
+use TYPO3\Form\Finishers\ClosureFinisher;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\SiteImportService;
+use TYPO3\Neos\Validation\Validator\PackageKeyValidator;
 use TYPO3\Setup\Exception as SetupException;
 use TYPO3\Flow\Error\Message;
+use TYPO3\Setup\Exception;
+use TYPO3\Setup\Step\AbstractStep;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
  * @Flow\Scope("singleton")
  */
-class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
+class SiteImportStep extends AbstractStep
 {
     /**
      * @var boolean
@@ -27,82 +45,82 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Package\PackageManagerInterface
+     * @var PackageManagerInterface
      */
     protected $packageManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     * @var SiteRepository
      */
     protected $siteRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\SiteImportService
+     * @var SiteImportService
      */
     protected $siteImportService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     * @var DomainRepository
      */
     protected $domainRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Mvc\FlashMessageContainer
+     * @var FlashMessageContainer
      */
     protected $flashMessageContainer;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository
+     * @var NodeDataRepository
      */
     protected $nodeDataRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository
+     * @var WorkspaceRepository
      */
     protected $workspaceRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Object\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * @var \TYPO3\Form\Finishers\ClosureFinisher
+     * @var ClosureFinisher
      */
     protected $closureFinisher;
 
     /**
-     * @var \TYPO3\Flow\Log\SystemLoggerInterface
+     * @var SystemLoggerInterface
      * @Flow\Inject
      */
     protected $systemLogger;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
+     * @var ContextFactoryInterface
      */
     protected $contextFactory;
 
     /**
      * Returns the form definitions for the step
      *
-     * @param \TYPO3\Form\Core\Model\FormDefinition $formDefinition
+     * @param FormDefinition $formDefinition
      * @return void
      */
-    protected function buildForm(\TYPO3\Form\Core\Model\FormDefinition $formDefinition)
+    protected function buildForm(FormDefinition $formDefinition)
     {
         $page1 = $formDefinition->createPage('page1');
         $page1->setRenderingOption('header', 'Create a new site');
@@ -122,7 +140,7 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
             $site = $importSection->createElement('site', 'TYPO3.Form:SingleSelectDropdown');
             $site->setLabel('Select a site package');
             $site->setProperty('options', $sitePackages);
-            $site->addValidator(new \TYPO3\Flow\Validation\Validator\NotEmptyValidator());
+            $site->addValidator(new NotEmptyValidator());
 
             $sites = $this->siteRepository->findAll();
             if ($sites->count() > 0) {
@@ -143,7 +161,7 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
             $newPackageSection->setLabel('Create a new site package with a dummy site');
             $packageName = $newPackageSection->createElement('packageKey', 'TYPO3.Form:SingleLineText');
             $packageName->setLabel('Package Name (in form "Vendor.DomainCom")');
-            $packageName->addValidator(new \TYPO3\Neos\Validation\Validator\PackageKeyValidator());
+            $packageName->addValidator(new PackageKeyValidator());
 
             $siteName = $newPackageSection->createElement('siteName', 'TYPO3.Form:SingleLineText');
             $siteName->setLabel('Site Name (e.g. "domain.com")');
@@ -158,10 +176,10 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
         $explanation->setProperty('elementClassAttribute', 'alert alert-info');
 
         $step = $this;
-        $callback = function (\TYPO3\Form\Core\Model\FinisherContext $finisherContext) use ($step) {
+        $callback = function (FinisherContext $finisherContext) use ($step) {
             $step->importSite($finisherContext);
         };
-        $this->closureFinisher = new \TYPO3\Form\Finishers\ClosureFinisher();
+        $this->closureFinisher = new ClosureFinisher();
         $this->closureFinisher->setOption('closure', $callback);
         $formDefinition->addFinisher($this->closureFinisher);
 
@@ -169,11 +187,11 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
     }
 
     /**
-     * @param \TYPO3\Form\Core\Model\FinisherContext $finisherContext
+     * @param FinisherContext $finisherContext
      * @return void
-     * @throws \TYPO3\Setup\Exception
+     * @throws Exception
      */
-    public function importSite(\TYPO3\Form\Core\Model\FinisherContext $finisherContext)
+    public function importSite(FinisherContext $finisherContext)
     {
         $formValues = $finisherContext->getFormRuntime()->getFormState()->getFormValues();
 
@@ -187,7 +205,7 @@ class SiteImportStep extends \TYPO3\Setup\Step\AbstractStep
 
         if (!empty($formValues['packageKey'])) {
             if ($this->packageManager->isPackageAvailable($formValues['packageKey'])) {
-                throw new \TYPO3\Setup\Exception(sprintf('The package key "%s" already exists.', $formValues['packageKey']), 1346759486);
+                throw new Exception(sprintf('The package key "%s" already exists.', $formValues['packageKey']), 1346759486);
             }
             $packageKey = $formValues['packageKey'];
             $siteName = $formValues['siteName'];

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TYPO3CR/Transformations/AssetTransformation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TYPO3CR/Transformations/AssetTransformation.php
@@ -17,6 +17,9 @@ use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Utility\TypeHandling;
 use TYPO3\Media\Domain\Model\Asset;
+use TYPO3\Media\Domain\Model\Audio;
+use TYPO3\Media\Domain\Model\Document;
+use TYPO3\Media\Domain\Model\Video;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Migration\Transformations\AbstractTransformation;
 
@@ -102,10 +105,10 @@ class AssetTransformation extends AbstractTransformation
     protected function getHandledObjectTypes()
     {
         return array(
-            'TYPO3\Media\Domain\Model\Asset',
-            'TYPO3\Media\Domain\Model\Audio',
-            'TYPO3\Media\Domain\Model\Document',
-            'TYPO3\Media\Domain\Model\Video'
+            Asset::class,
+            Audio::class,
+            Document::class,
+            Video::class
         );
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypeConverter/NodeConverter.php
@@ -12,6 +12,9 @@ namespace TYPO3\Neos\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Property\PropertyMappingConfigurationInterface;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
 
 /**
  * An Object Converter for nodes which can be used for routing (but also for other
@@ -23,13 +26,13 @@ class NodeConverter extends \TYPO3\TYPO3CR\TypeConverter\NodeConverter
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\DomainRepository
+     * @var DomainRepository
      */
     protected $domainRepository;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Repository\SiteRepository
+     * @var SiteRepository
      */
     protected $siteRepository;
 
@@ -43,7 +46,7 @@ class NodeConverter extends \TYPO3\TYPO3CR\TypeConverter\NodeConverter
      *
      * {@inheritdoc}
      */
-    protected function prepareContextProperties($workspaceName, \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
+    protected function prepareContextProperties($workspaceName, PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
     {
         $contextProperties = parent::prepareContextProperties($workspaceName, $configuration, $dimensions);
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\TypoScript\Cache;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TypoScript\Core\Cache\ContentCache;
@@ -35,7 +36,7 @@ class ContentCacheFlusher
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Log\SystemLoggerInterface
+     * @var SystemLoggerInterface
      */
     protected $systemLogger;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/ContentElementWrappingImplementation.php
@@ -50,7 +50,7 @@ class ContentElementWrappingImplementation extends AbstractTypoScriptObject
      * Evaluate this TypoScript object and return the result
      *
      * @return mixed
-     * @throws \TYPO3\Neos\Domain\Exception
+     * @throws Exception
      */
     public function evaluate()
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Helper/RenderingHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Helper/RenderingHelper.php
@@ -15,6 +15,7 @@ use TYPO3\Eel\ProtectedContextAwareInterface;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
+use TYPO3\TYPO3CR\Exception\NodeTypeNotFoundException;
 
 /**
  * Render Content Dimension Names, Node Labels
@@ -86,7 +87,7 @@ class RenderingHelper implements ProtectedContextAwareInterface
      * Render the label for the given $nodeTypeName
      *
      * @param string $nodeTypeName
-     * @throws \TYPO3\TYPO3CR\Exception\NodeTypeNotFoundException
+     * @throws NodeTypeNotFoundException
      * @return string
      */
     public function labelForNodeType($nodeTypeName)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/MenuImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/MenuImplementation.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\TypoScript;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TypoScript\Exception as TypoScriptException;
+use TYPO3\TypoScript\Exception;
 
 /**
  * A TypoScript Menu object
@@ -214,7 +215,7 @@ class MenuImplementation extends AbstractMenuImplementation
      * If entryLevel is configured this will be taken into account as well.
      *
      * @return NodeInterface
-     * @throws \TYPO3\TypoScript\Exception
+     * @throws Exception
      */
     protected function findMenuStartingPoint()
     {
@@ -233,7 +234,7 @@ class MenuImplementation extends AbstractMenuImplementation
     /**
      * Checks if the given menuItem is on the last level for this menu, either defined by maximumLevels or lastLevels.
      *
-     * @param \TYPO3\TYPO3CR\Domain\Model\NodeInterface $menuItemNode
+     * @param NodeInterface $menuItemNode
      * @return boolean
      */
     protected function isOnLastLevelOfMenu(NodeInterface $menuItemNode)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/NodeUriPathSegmentGenerator.php
@@ -11,9 +11,11 @@ namespace TYPO3\Neos\Utility;
  * source code.
  */
 
+use Behat\Transliterator\Transliterator;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\Locale;
+use TYPO3\Neos\Exception;
 use TYPO3\Neos\Service\TransliterationService;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
@@ -70,9 +72,9 @@ class NodeUriPathSegmentGenerator
                 $language = $locale->getLanguage();
             }
         } elseif (strlen($text) === 0) {
-            throw new \TYPO3\Neos\Exception('Given text was empty.', 1457591815);
+            throw new Exception('Given text was empty.', 1457591815);
         }
         $text = $this->transliterationService->transliterate($text, isset($language) ? $language : null);
-        return \Behat\Transliterator\Transliterator::urlize($text);
+        return Transliterator::urlize($text);
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/HostnameValidator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/HostnameValidator.php
@@ -12,11 +12,12 @@ namespace TYPO3\Neos\Validation\Validator;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Validator\AbstractValidator;
 
 /**
  * Validator for http://tools.ietf.org/html/rfc1123 compatible host names
  */
-class HostnameValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidator
+class HostnameValidator extends AbstractValidator
 {
     /**
      * @var array

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/NodeNameValidator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/NodeNameValidator.php
@@ -12,16 +12,18 @@ namespace TYPO3\Neos\Validation\Validator;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Validator\RegularExpressionValidator;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
  * Validator for node names
  */
-class NodeNameValidator extends \TYPO3\Flow\Validation\Validator\RegularExpressionValidator
+class NodeNameValidator extends RegularExpressionValidator
 {
     /**
      * @var array
      */
     protected $supportedOptions = array(
-        'regularExpression' => array(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::MATCH_PATTERN_NAME, 'The regular expression to use for validation, used as given', 'string')
+        'regularExpression' => array(NodeInterface::MATCH_PATTERN_NAME, 'The regular expression to use for validation, used as given', 'string')
     );
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/PackageKeyValidator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/PackageKeyValidator.php
@@ -12,16 +12,18 @@ namespace TYPO3\Neos\Validation\Validator;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Package\PackageInterface;
+use TYPO3\Flow\Validation\Validator\RegularExpressionValidator;
 
 /**
  * Validator for package keys
  */
-class PackageKeyValidator extends \TYPO3\Flow\Validation\Validator\RegularExpressionValidator
+class PackageKeyValidator extends RegularExpressionValidator
 {
     /**
      * @var array
      */
     protected $supportedOptions = array(
-        'regularExpression' => array(\TYPO3\Flow\Package\PackageInterface::PATTERN_MATCH_PACKAGEKEY, 'The regular expression to use for validation, used as given', 'string')
+        'regularExpression' => array(PackageInterface::PATTERN_MATCH_PACKAGEKEY, 'The regular expression to use for validation, used as given', 'string')
     );
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/PasswordValidator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Validation/Validator/PasswordValidator.php
@@ -10,11 +10,15 @@ namespace TYPO3\Neos\Validation\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Validation\Exception\InvalidSubjectException;
+use TYPO3\Flow\Validation\Validator\AbstractValidator;
+use TYPO3\Flow\Validation\Validator\NotEmptyValidator;
+use TYPO3\Flow\Validation\Validator\StringLengthValidator;
 
 /**
  * Validator for passwords
  */
-class PasswordValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidator
+class PasswordValidator extends AbstractValidator
 {
     /**
      * @var array
@@ -34,20 +38,20 @@ class PasswordValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidat
      *
      * @param mixed $value The value that should be validated
      * @return void
-     * @throws \TYPO3\Flow\Validation\Exception\InvalidSubjectException
+     * @throws InvalidSubjectException
      */
     protected function isValid($value)
     {
         if (!is_array($value)) {
-            throw new \TYPO3\Flow\Validation\Exception\InvalidSubjectException('The given value was not an array.', 1324641197);
+            throw new InvalidSubjectException('The given value was not an array.', 1324641197);
         }
 
         $password = trim(strval(array_shift($value)));
         $repeatPassword = trim(strval(array_shift($value)));
 
-        $passwordNotEmptyValidator = new \TYPO3\Flow\Validation\Validator\NotEmptyValidator;
+        $passwordNotEmptyValidator = new NotEmptyValidator;
         $passwordNotEmptyValidatorResult = $passwordNotEmptyValidator->validate($password);
-        $repeatPasswordNotEmptyValidator = new \TYPO3\Flow\Validation\Validator\NotEmptyValidator;
+        $repeatPasswordNotEmptyValidator = new NotEmptyValidator;
         $repeatPasswordNotEmptyValidatorResult = $repeatPasswordNotEmptyValidator->validate($repeatPassword);
 
         if (($passwordNotEmptyValidatorResult->hasErrors() === true) && ($repeatPasswordNotEmptyValidatorResult->hasErrors() === true)) {
@@ -62,7 +66,7 @@ class PasswordValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidat
             return;
         }
 
-        $stringLengthValidator = new \TYPO3\Flow\Validation\Validator\StringLengthValidator(array(
+        $stringLengthValidator = new StringLengthValidator(array(
             'minimum' => $this->options['minimum'],
             'maximum' => $this->options['maximum'],
         ));

--- a/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
@@ -14,7 +14,10 @@ namespace TYPO3\Neos\View;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Http\Response;
 use TYPO3\Flow\I18n\Locale;
+use TYPO3\Flow\I18n\Service;
 use TYPO3\Flow\Mvc\View\AbstractView;
+use TYPO3\Neos\Domain\Service\TypoScriptService;
+use TYPO3\Neos\Exception;
 use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TypoScript\Core\Runtime;
@@ -28,7 +31,7 @@ class TypoScriptView extends AbstractView
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\I18n\Service
+     * @var Service
      */
     protected $i18nService;
 
@@ -43,7 +46,7 @@ class TypoScriptView extends AbstractView
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\TypoScriptService
+     * @var TypoScriptService
      */
     protected $typoScriptService;
 
@@ -55,7 +58,7 @@ class TypoScriptView extends AbstractView
     protected $typoScriptPath = 'root';
 
     /**
-     * @var \TYPO3\TypoScript\Core\Runtime
+     * @var Runtime
      */
     protected $typoScriptRuntime;
 
@@ -137,7 +140,7 @@ class TypoScriptView extends AbstractView
      *
      * @return boolean TRUE if $node can be rendered at $typoScriptPath
      *
-     * @throws \TYPO3\Neos\Exception
+     * @throws Exception
      */
     public function canRenderWithNodeAndPath()
     {
@@ -181,13 +184,13 @@ class TypoScriptView extends AbstractView
 
     /**
      * @return NodeInterface
-     * @throws \TYPO3\Neos\Exception
+     * @throws Exception
      */
     protected function getCurrentNode()
     {
         $currentNode = isset($this->variables['value']) ? $this->variables['value'] : null;
         if (!$currentNode instanceof Node) {
-            throw new \TYPO3\Neos\Exception('TypoScriptView needs a variable \'value\' set with a Node object.', 1329736456);
+            throw new Exception('TypoScriptView needs a variable \'value\' set with a Node object.', 1329736456);
         }
         return $currentNode;
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ContainerViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ContainerViewHelper.php
@@ -13,8 +13,12 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Flow\Security\Context;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Fluid\View\StandaloneView;
+use TYPO3\Neos\Controller\Backend\MenuHelper;
+use TYPO3\Neos\Domain\Model\User;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
@@ -36,18 +40,18 @@ class ContainerViewHelper extends AbstractViewHelper
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Flow\Security\Context
+     * @var Context
      */
     protected $securityContext;
 
     /**
-     * @var \TYPO3\Neos\Controller\Backend\MenuHelper
+     * @var MenuHelper
      * @Flow\Inject
      */
     protected $menuHelper;
 
     /**
-     * @var \TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface
+     * @var PrivilegeManagerInterface
      * @Flow\Inject
      */
     protected $privilegeManager;
@@ -79,7 +83,7 @@ class ContainerViewHelper extends AbstractViewHelper
         $innerView->setFormat('html');
         $innerView->setPartialRootPath('resource://TYPO3.Neos/Private/Partials');
 
-        $user = $this->securityContext->getPartyByType('TYPO3\Neos\Domain\Model\User');
+        $user = $this->securityContext->getPartyByType(User::class);
 
         $innerView->assignMultiple(array(
             'node' => $node,

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/CssBuiltVersionViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/CssBuiltVersionViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Utility\BackendAssetsUtility;
 
 /**
  * Returns a shortened md5 of the built CSS file
@@ -20,7 +21,7 @@ class CssBuiltVersionViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractVie
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Utility\BackendAssetsUtility
+     * @var BackendAssetsUtility
      */
     protected $backendAssetsUtility;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptBuiltVersionViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptBuiltVersionViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Utility\BackendAssetsUtility;
 
 /**
  * Returns a shortened md5 of the built JavaScript file
@@ -20,7 +21,7 @@ class JavascriptBuiltVersionViewHelper extends \TYPO3\Fluid\Core\ViewHelper\Abst
 {
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Utility\BackendAssetsUtility
+     * @var BackendAssetsUtility
      */
     protected $backendAssetsUtility;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -22,6 +22,7 @@ use TYPO3\Flow\Utility\PositionalArraySorter;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Utility\BackendAssetsUtility;
 
 /**
  * ViewHelper for the backend JavaScript configuration. Renders the required JS snippet to configure
@@ -71,7 +72,7 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Utility\BackendAssetsUtility
+     * @var BackendAssetsUtility
      */
     protected $backendAssetsUtility;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ShouldLoadMinifiedJavascriptViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ShouldLoadMinifiedJavascriptViewHelper.php
@@ -12,11 +12,13 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\Neos\Utility\BackendAssetsUtility;
 
 /**
  * Returns TRUE if the minified Neos JavaScript sources should be loaded, FALSE otherwise.
  */
-class ShouldLoadMinifiedJavascriptViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
+class ShouldLoadMinifiedJavascriptViewHelper extends AbstractViewHelper
 {
     /**
      * @see AbstractViewHelper::isOutputEscapingEnabled()
@@ -26,7 +28,7 @@ class ShouldLoadMinifiedJavascriptViewHelper extends \TYPO3\Fluid\Core\ViewHelpe
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Utility\BackendAssetsUtility
+     * @var BackendAssetsUtility
      */
     protected $backendAssetsUtility;
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/TranslateViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/TranslateViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
 
 use TYPO3\Flow\I18n\EelHelper\TranslationHelper;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\I18n\Exception;
 use TYPO3\Fluid\ViewHelpers\TranslateViewHelper as FluidTranslateViewHelper;
 use TYPO3\Fluid\Core\ViewHelper;
 use TYPO3\Neos\Domain\Model\User;
@@ -111,7 +112,7 @@ class TranslateViewHelper extends FluidTranslateViewHelper
                 $translation = parent::render($id, $value, $arguments, $source, $package, $quantity, 'en');
             }
             return $translation;
-        } catch (\TYPO3\Flow\I18n\Exception $exception) {
+        } catch (Exception $exception) {
             return $value ?: $id;
         }
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/XliffCacheVersionViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/XliffCacheVersionViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\ViewHelpers\Backend;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\Neos\Service\XliffService;
 
 /**
  * ViewHelper for rendering the current version identifier for the
@@ -23,7 +24,7 @@ class XliffCacheVersionViewHelper extends AbstractViewHelper
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Service\XliffService
+     * @var XliffService
      */
     protected $xliffService;
 

--- a/TYPO3.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
+++ b/TYPO3.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
@@ -5,7 +5,12 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit_Framework_Assert as Assert;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\Flow\Utility\Arrays;
+use TYPO3\Neos\Domain\Service\UserService;
 use TYPO3\Neos\EventLog\Domain\Model\Event;
+use TYPO3\Neos\EventLog\Domain\Model\NodeEvent;
+use TYPO3\Neos\EventLog\Domain\Repository\EventRepository;
+use TYPO3\Neos\EventLog\Integrations\EntityIntegrationService;
+use TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService;
 
 /**
  * A trait with shared step definitions for common use by other contexts
@@ -80,7 +85,7 @@ trait HistoryDefinitionsTrait
 
     protected function checkSingleEvent($expected, Event $event, &$eventsByInternalId, &$unmatchedParentEvents)
     {
-        /* @var $event \TYPO3\Neos\EventLog\Domain\Model\NodeEvent */
+        /* @var $event NodeEvent */
         $rowId = null;
         foreach ($expected as $rowName => $rowValue) {
             switch ($rowName) {
@@ -134,19 +139,19 @@ trait HistoryDefinitionsTrait
     }
 
     /**
-     * @return \TYPO3\Neos\EventLog\Domain\Repository\EventRepository
+     * @return EventRepository
      */
     protected function getEventRepository()
     {
-        return $this->getObjectManager()->get(\TYPO3\Neos\EventLog\Domain\Repository\EventRepository::class);
+        return $this->getObjectManager()->get(EventRepository::class);
     }
 
     /**
-     * @return \TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService
+     * @return TYPO3CRIntegrationService
      */
     protected function getTYPO3CRIntegrationService()
     {
-        return $this->getObjectManager()->get(\TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService::class);
+        return $this->getObjectManager()->get(TYPO3CRIntegrationService::class);
     }
 
     /**
@@ -155,8 +160,8 @@ trait HistoryDefinitionsTrait
     public function iHaveTheFollowingMonitorEntitiesConfiguration(PyStringNode $string)
     {
         $configuration = Yaml::parse($string->getRaw());
-        /* @var $entityIntegrationService \TYPO3\Neos\EventLog\Integrations\EntityIntegrationService */
-        $entityIntegrationService = $this->getObjectManager()->get(\TYPO3\Neos\EventLog\Integrations\EntityIntegrationService::class);
+        /* @var $entityIntegrationService EntityIntegrationService */
+        $entityIntegrationService = $this->getObjectManager()->get(EntityIntegrationService::class);
         $entityIntegrationService->setMonitorEntitiesSetting($configuration);
     }
 
@@ -166,7 +171,7 @@ trait HistoryDefinitionsTrait
     public function iCreateTheFollowingAccounts(TableNode $table)
     {
         foreach ($table->getHash() as $row) {
-            $user = $this->getObjectManager()->get(\TYPO3\Neos\Domain\Service\UserService::class)->createUser(
+            $user = $this->getObjectManager()->get(UserService::class)->createUser(
                 $row['User'],
                 $row['Password'],
                 $row['First Name'],

--- a/TYPO3.Neos/Tests/Functional/AbstractNodeTest.php
+++ b/TYPO3.Neos/Tests/Functional/AbstractNodeTest.php
@@ -10,11 +10,19 @@ namespace TYPO3\Neos\Tests\Functional;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Property\PropertyMapper;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
+use TYPO3\Neos\Domain\Service\SiteImportService;
+use TYPO3\TYPO3CR\Domain\Model\Node;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
  * Base test case for nodes
  */
-abstract class AbstractNodeTest extends \TYPO3\Flow\Tests\FunctionalTestCase
+abstract class AbstractNodeTest extends FunctionalTestCase
 {
     /**
      * @var boolean
@@ -37,12 +45,12 @@ abstract class AbstractNodeTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     protected $nodeContextPath = '/sites/example/home';
 
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface
+     * @var NodeInterface
      */
     protected $node;
 
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
+     * @var ContextFactoryInterface
      */
     protected $contextFactory;
 
@@ -50,9 +58,9 @@ abstract class AbstractNodeTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         parent::setUp();
         $this->markSkippedIfNodeTypesPackageIsNotInstalled();
-        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contentContext = $this->contextFactory->create(array('workspaceName' => 'live'));
-        $siteImportService = $this->objectManager->get('TYPO3\Neos\Domain\Service\SiteImportService');
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
         $siteImportService->importFromFile(__DIR__ . '/' . $this->fixtureFileName, $contentContext);
         $this->persistenceManager->persistAll();
 
@@ -65,13 +73,13 @@ abstract class AbstractNodeTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      * Retrieve a node through the property mapper
      *
      * @param $contextPath
-     * @return \TYPO3\TYPO3CR\Domain\Model\NodeInterface
+     * @return NodeInterface
      */
     protected function getNodeWithContextPath($contextPath)
     {
         /* @var $propertyMapper \TYPO3\Flow\Property\PropertyMapper */
-        $propertyMapper = $this->objectManager->get('TYPO3\Flow\Property\PropertyMapper');
-        $node = $propertyMapper->convert($contextPath, 'TYPO3\TYPO3CR\Domain\Model\Node');
+        $propertyMapper = $this->objectManager->get(PropertyMapper::class);
+        $node = $propertyMapper->convert($contextPath, Node::class);
         $this->assertFalse($propertyMapper->getMessages()->hasErrors(), 'There were errors converting ' . $contextPath);
         return $node;
     }
@@ -81,12 +89,12 @@ abstract class AbstractNodeTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         parent::tearDown();
 
         $this->inject($this->contextFactory, 'contextInstances', array());
-        $this->inject($this->objectManager->get('TYPO3\Media\TypeConverter\AssetInterfaceConverter'), 'resourcesAlreadyConvertedToAssets', array());
+        $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', array());
     }
 
     protected function markSkippedIfNodeTypesPackageIsNotInstalled()
     {
-        $packageManager = $this->objectManager->get('TYPO3\Flow\Package\PackageManagerInterface');
+        $packageManager = $this->objectManager->get(PackageManagerInterface::class);
         if (!$packageManager->isPackageActive('TYPO3.Neos.NodeTypes')) {
             $this->markTestSkipped('This test needs the TYPO3.Neos.NodeTypes package.');
         }

--- a/TYPO3.Neos/Tests/Functional/Command/BehatTestHelper.php
+++ b/TYPO3.Neos/Tests/Functional/Command/BehatTestHelper.php
@@ -62,7 +62,7 @@ class BehatTestHelper
      */
     public function initializeObject()
     {
-        self::$bootstrap = Bootstrap::$staticObjectManager->get('TYPO3\Flow\Core\Bootstrap');
+        self::$bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
         $this->isolated = false;
     }
 

--- a/TYPO3.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
+++ b/TYPO3.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Neos\Tests\Functional\Controller\Backend;
  * source code.
  */
 
+use TYPO3\Flow\Tests\FunctionalTestCase;
 use TYPO3\Neos\Domain\Model\User;
 
 /**
@@ -18,7 +19,7 @@ use TYPO3\Neos\Domain\Model\User;
  *
  * @group large
  */
-class BackendControllerSecurityTest extends \TYPO3\Flow\Tests\FunctionalTestCase
+class BackendControllerSecurityTest extends FunctionalTestCase
 {
     /**
      * @var boolean

--- a/TYPO3.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
+++ b/TYPO3.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Neos\Tests\Functional\Domain\Service;
  * source code.
  */
 
+use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Tests\FunctionalTestCase;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Service\SiteExportService;
@@ -61,12 +62,12 @@ class SiteImportExportServiceTest extends FunctionalTestCase
     {
         parent::setUp();
         $this->markSkippedIfNodeTypesPackageIsNotInstalled();
-        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contentContext = $this->contextFactory->create(array('workspaceName' => 'live'));
 
-        $this->siteImportService = $this->objectManager->get('TYPO3\Neos\Domain\Service\SiteImportService');
+        $this->siteImportService = $this->objectManager->get(SiteImportService::class);
 
-        $this->siteExportService = $this->objectManager->get('TYPO3\Neos\Domain\Service\SiteExportService');
+        $this->siteExportService = $this->objectManager->get(SiteExportService::class);
 
         $this->importedSite = $this->siteImportService->importFromFile(__DIR__ . '/' . $this->fixtureFileName, $contentContext);
         $this->persistenceManager->persistAll();
@@ -94,7 +95,7 @@ class SiteImportExportServiceTest extends FunctionalTestCase
      */
     protected function markSkippedIfNodeTypesPackageIsNotInstalled()
     {
-        $packageManager = $this->objectManager->get('TYPO3\Flow\Package\PackageManagerInterface');
+        $packageManager = $this->objectManager->get(PackageManagerInterface::class);
         if (!$packageManager->isPackageActive('TYPO3.Neos.NodeTypes')) {
             $this->markTestSkipped('This test needs the TYPO3.Neos.NodeTypes package.');
         }

--- a/TYPO3.Neos/Tests/Functional/NodeRenamingTest.php
+++ b/TYPO3.Neos/Tests/Functional/NodeRenamingTest.php
@@ -10,6 +10,9 @@ namespace TYPO3\Neos\Tests\Functional;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Security\Authorization\TestingPrivilegeManager;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 
 /**
  * Functional test case which tests the renaming of nodes from within a workspace.
@@ -32,12 +35,12 @@ class NodeRenamingTest extends AbstractNodeTest
     public function setUp()
     {
         parent::setUp();
-        $privilegeManager = $this->objectManager->get('TYPO3\Flow\Security\Authorization\TestingPrivilegeManager');
+        $privilegeManager = $this->objectManager->get(TestingPrivilegeManager::class);
         $privilegeManager->setOverrideDecision(true);
 
         $liveWorkspace = $this->node->getWorkspace();
-        $personalWorkspace = new \TYPO3\TYPO3CR\Domain\Model\Workspace('user-test', $liveWorkspace);
-        $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository')->add($personalWorkspace);
+        $personalWorkspace = new Workspace('user-test', $liveWorkspace);
+        $this->objectManager->get(WorkspaceRepository::class)->add($personalWorkspace);
         $this->persistenceManager->persistAll();
 
         $this->nodeInTestWorkspace = $this->getNodeWithContextPath('/sites/example/home@user-test');

--- a/TYPO3.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
+++ b/TYPO3.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Tests\Functional\Service;
  */
 
 use TYPO3\Flow\Tests\FunctionalTestCase;
+use TYPO3\Neos\Service\NodeTypeSchemaBuilder;
 
 /**
  * Testcase for the NodeTypeSchemaBuilder
@@ -19,7 +20,7 @@ use TYPO3\Flow\Tests\FunctionalTestCase;
 class NodeTypeSchemaBuilderTest extends FunctionalTestCase
 {
     /**
-     * @var \TYPO3\Neos\Service\NodeTypeSchemaBuilder
+     * @var NodeTypeSchemaBuilder
      */
     protected $nodeTypeSchemaBuilder;
 
@@ -33,7 +34,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->nodeTypeSchemaBuilder = $this->objectManager->get('TYPO3\Neos\Service\NodeTypeSchemaBuilder');
+        $this->nodeTypeSchemaBuilder = $this->objectManager->get(NodeTypeSchemaBuilder::class);
         $this->schema = $this->nodeTypeSchemaBuilder->generateNodeTypeSchema();
     }
 

--- a/TYPO3.Neos/Tests/Functional/TypoScript/RenderingTest.php
+++ b/TYPO3.Neos/Tests/Functional/TypoScript/RenderingTest.php
@@ -11,6 +11,16 @@ namespace TYPO3\Neos\Tests\Functional\TypoScript;
  * source code.
  */
 
+use TYPO3\Flow\Http\Request;
+use TYPO3\Flow\Http\Response;
+use TYPO3\Flow\Http\Uri;
+use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Mvc\Controller\Arguments;
+use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Flow\Mvc\FlashMessageContainer;
+use TYPO3\Flow\Mvc\Routing\UriBuilder;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\TypoScriptService;
 use TYPO3\Neos\Tests\Functional\AbstractNodeTest;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -317,7 +327,7 @@ class RenderingTest extends AbstractNodeTest
             $typoScriptRuntime->injectSettings(array('debugMode' => true, 'rendering' => array('exceptionHandler' => 'TYPO3\TypoScript\Core\ExceptionHandlers\ThrowingHandler')));
         }
         $contentContext = $this->node->getContext();
-        if (!$contentContext instanceof \TYPO3\Neos\Domain\Service\ContentContext) {
+        if (!$contentContext instanceof ContentContext) {
             $this->fail('Node context must be of type ContentContext');
         }
         $typoScriptRuntime->pushContextArray(array(
@@ -340,7 +350,7 @@ class RenderingTest extends AbstractNodeTest
      */
     protected function createRuntimeWithFixtures($additionalTypoScriptFile = null)
     {
-        $typoScriptService = new \TYPO3\Neos\Domain\Service\TypoScriptService();
+        $typoScriptService = new TypoScriptService();
         $typoScriptService->setSiteRootTypoScriptPattern(__DIR__ . '/Fixtures/BaseTypoScript.ts2');
 
         if ($additionalTypoScriptFile !== null) {
@@ -355,23 +365,23 @@ class RenderingTest extends AbstractNodeTest
     }
 
     /**
-     * @return \TYPO3\Flow\Mvc\Controller\ControllerContext
+     * @return ControllerContext
      */
     protected function buildMockControllerContext()
     {
-        $httpRequest = \TYPO3\Flow\Http\Request::create(new \TYPO3\Flow\Http\Uri('http://foo.bar/bazfoo'));
-        $request = new \TYPO3\Flow\Mvc\ActionRequest($httpRequest);
-        $response = new \TYPO3\Flow\Http\Response();
-        /** @var \TYPO3\Flow\Mvc\Controller\Arguments $mockArguments */
-        $mockArguments = $this->getMockBuilder(\TYPO3\Flow\Mvc\Controller\Arguments::class)->disableOriginalConstructor()->getMock();
-        $uriBuilder = new \TYPO3\Flow\Mvc\Routing\UriBuilder();
+        $httpRequest = Request::create(new Uri('http://foo.bar/bazfoo'));
+        $request = new ActionRequest($httpRequest);
+        $response = new Response();
+        /** @var Arguments $mockArguments */
+        $mockArguments = $this->getMockBuilder(Arguments::class)->disableOriginalConstructor()->getMock();
+        $uriBuilder = new UriBuilder();
 
-        $controllerContext = new \TYPO3\Flow\Mvc\Controller\ControllerContext(
+        $controllerContext = new ControllerContext(
             $request,
             $response,
             $mockArguments,
             $uriBuilder,
-            $this->createMock('TYPO3\Flow\Mvc\FlashMessageContainer')
+            $this->createMock(FlashMessageContainer::class)
         );
         return $controllerContext;
     }

--- a/TYPO3.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -19,15 +19,24 @@ use TYPO3\Flow\Mvc\FlashMessageContainer;
 use TYPO3\Flow\Mvc\Routing\UriBuilder;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Tests\FunctionalTestCase;
+use TYPO3\Flow\Tests\FunctionalTestRequestHandler;
 use TYPO3\Fluid\Core\ViewHelper\TemplateVariableContainer;
 use TYPO3\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3\Fluid\View\AbstractTemplateView;
+use TYPO3\Fluid\View\TemplateView;
+use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
 use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\SiteImportService;
 use TYPO3\Neos\ViewHelpers\Uri\NodeViewHelper;
+use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TypoScript\Core\Runtime;
+use TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView;
+use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
 
 /**
  * Functional test for the NodeViewHelper
@@ -71,15 +80,15 @@ class NodeViewHelperTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->nodeDataRepository = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository');
-        $domainRepository = $this->objectManager->get('TYPO3\Neos\Domain\Repository\DomainRepository');
-        $siteRepository = $this->objectManager->get('TYPO3\Neos\Domain\Repository\SiteRepository');
-        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+        $domainRepository = $this->objectManager->get(DomainRepository::class);
+        $siteRepository = $this->objectManager->get(SiteRepository::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contextProperties = array(
             'workspaceName' => 'live'
         );
         $contentContext = $this->contextFactory->create($contextProperties);
-        $siteImportService = $this->objectManager->get('TYPO3\Neos\Domain\Service\SiteImportService');
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
         $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml', $contentContext);
         $this->persistenceManager->persistAll();
 
@@ -95,17 +104,17 @@ class NodeViewHelperTest extends FunctionalTestCase
 
         $this->contentContext = $contentContext;
 
-        $this->propertyMapper = $this->objectManager->get('TYPO3\Flow\Property\PropertyMapper');
+        $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);
 
-        $this->viewHelper = new \TYPO3\Neos\ViewHelpers\Link\NodeViewHelper();
-        /** @var $requestHandler \TYPO3\Flow\Tests\FunctionalTestRequestHandler */
+        $this->viewHelper = new NodeViewHelper();
+        /** @var $requestHandler FunctionalTestRequestHandler */
         $requestHandler = self::$bootstrap->getActiveRequestHandler();
         $httpRequest = $requestHandler->getHttpRequest();
         $httpRequest->setBaseUri(new Uri('http://neos.test/'));
         $controllerContext = new ControllerContext(new ActionRequest($httpRequest), $requestHandler->getHttpResponse(), new Arguments(array()), new UriBuilder());
         $this->inject($this->viewHelper, 'controllerContext', $controllerContext);
 
-        $typoScriptObject = $this->getAccessibleMock('\TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation', array('dummy'), array(), '', false);
+        $typoScriptObject = $this->getAccessibleMock(TemplateImplementation::class, array('dummy'), array(), '', false);
         $this->tsRuntime = new Runtime(array(), $controllerContext);
         $this->tsRuntime->pushContextArray(array(
             'documentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home'),
@@ -113,7 +122,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         ));
         $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
         /** @var AbstractTemplateView|\PHPUnit_Framework_MockObject_MockObject $mockView */
-        $mockView = $this->getAccessibleMock('TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView', array(), array(), '', false);
+        $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($typoScriptObject));
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
@@ -132,7 +141,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         parent::tearDown();
 
         $this->inject($this->contextFactory, 'contextInstances', array());
-        $this->inject($this->objectManager->get('TYPO3\Media\TypeConverter\AssetInterfaceConverter'), 'resourcesAlreadyConvertedToAssets', array());
+        $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', array());
     }
 
     /**
@@ -140,7 +149,7 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     public function viewHelperRendersUriViaGivenNodeObject()
     {
-        $targetNode = $this->propertyMapper->convert('/sites/example/home', 'TYPO3\TYPO3CR\Domain\Model\Node');
+        $targetNode = $this->propertyMapper->convert('/sites/example/home', Node::class);
 
         $this->assertSame('<a href="/en/home.html">' . $targetNode->getLabel() . '</a>', $this->viewHelper->render($targetNode));
     }
@@ -191,8 +200,8 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
 
         // The tests should also work in a regular fluid view, so we set that and repeat the tests
-        $mockView = $this->getAccessibleMock('TYPO3\Fluid\View\TemplateView', array(), array(), '', false);
-        $viewHelperVariableContainer = new \TYPO3\Fluid\Core\ViewHelper\ViewHelperVariableContainer();
+        $mockView = $this->getAccessibleMock(TemplateView::class, array(), array(), '', false);
+        $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
         $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home@live'));

--- a/TYPO3.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -16,8 +16,22 @@ use TYPO3\Flow\Mvc\Controller\Arguments;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
 use TYPO3\Flow\Mvc\FlashMessageContainer;
 use TYPO3\Flow\Mvc\Routing\UriBuilder;
+use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Tests\FunctionalTestCase;
+use TYPO3\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use TYPO3\Fluid\View\TemplateView;
+use TYPO3\Media\TypeConverter\AssetInterfaceConverter;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\SiteImportService;
+use TYPO3\Neos\ViewHelpers\Uri\NodeViewHelper;
+use TYPO3\TYPO3CR\Domain\Model\Node;
+use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\TypoScript\Core\Runtime;
+use TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView;
+use TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation;
 
 /**
  * Functional test for the NodeViewHelper
@@ -29,47 +43,47 @@ class NodeViewHelperTest extends FunctionalTestCase
     protected static $testablePersistenceEnabled = true;
 
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository
+     * @var NodeDataRepository
      */
     protected $nodeDataRepository;
 
     /**
-     * @var \TYPO3\Flow\Property\PropertyMapper
+     * @var PropertyMapper
      */
     protected $propertyMapper;
 
     /**
-     * @var \TYPO3\Neos\ViewHelpers\Uri\NodeViewHelper
+     * @var NodeViewHelper
      */
     protected $viewHelper;
 
     /**
-     * @var \TYPO3\TypoScript\Core\Runtime
+     * @var Runtime
      */
     protected $tsRuntime;
 
     /**
-     * @var \TYPO3\Neos\Domain\Service\ContentContext
+     * @var ContentContext
      */
     protected $contentContext;
 
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
+     * @var ContextFactoryInterface
      */
     protected $contextFactory;
 
     public function setUp()
     {
         parent::setUp();
-        $this->nodeDataRepository = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository');
-        $domainRepository = $this->objectManager->get('TYPO3\Neos\Domain\Repository\DomainRepository');
-        $siteRepository = $this->objectManager->get('TYPO3\Neos\Domain\Repository\SiteRepository');
-        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+        $domainRepository = $this->objectManager->get(DomainRepository::class);
+        $siteRepository = $this->objectManager->get(SiteRepository::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contextProperties = array(
             'workspaceName' => 'live'
         );
         $contentContext = $this->contextFactory->create($contextProperties);
-        $siteImportService = $this->objectManager->get('TYPO3\Neos\Domain\Service\SiteImportService');
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
         $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml', $contentContext);
         $this->persistenceManager->persistAll();
 
@@ -84,9 +98,9 @@ class NodeViewHelperTest extends FunctionalTestCase
 
         $this->contentContext = $contentContext;
 
-        $this->propertyMapper = $this->objectManager->get('TYPO3\Flow\Property\PropertyMapper');
+        $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);
 
-        $this->viewHelper = new \TYPO3\Neos\ViewHelpers\Uri\NodeViewHelper();
+        $this->viewHelper = new NodeViewHelper();
         /** @var $requestHandler \TYPO3\Flow\Tests\FunctionalTestRequestHandler */
         $requestHandler = self::$bootstrap->getActiveRequestHandler();
         $httpRequest = $requestHandler->getHttpRequest();
@@ -94,16 +108,16 @@ class NodeViewHelperTest extends FunctionalTestCase
         $controllerContext = new ControllerContext(new ActionRequest($httpRequest), $requestHandler->getHttpResponse(), new Arguments(array()), new UriBuilder());
         $this->inject($this->viewHelper, 'controllerContext', $controllerContext);
 
-        $typoScriptObject = $this->getAccessibleMock('\TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation', array('dummy'), array(), '', false);
+        $typoScriptObject = $this->getAccessibleMock(TemplateImplementation::class, array('dummy'), array(), '', false);
         $this->tsRuntime = new Runtime(array(), $controllerContext);
         $this->tsRuntime->pushContextArray(array(
             'documentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home'),
             'alternativeDocumentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')
         ));
         $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
-        $mockView = $this->getAccessibleMock('TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView', array(), array(), '', false);
+        $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($typoScriptObject));
-        $viewHelperVariableContainer = new \TYPO3\Fluid\Core\ViewHelper\ViewHelperVariableContainer();
+        $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
     }
@@ -113,7 +127,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         parent::tearDown();
 
         $this->inject($this->contextFactory, 'contextInstances', array());
-        $this->inject($this->objectManager->get('TYPO3\Media\TypeConverter\AssetInterfaceConverter'), 'resourcesAlreadyConvertedToAssets', array());
+        $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', array());
     }
 
     /**
@@ -121,7 +135,7 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     public function viewHelperRendersUriViaGivenNodeObject()
     {
-        $targetNode = $this->propertyMapper->convert('/sites/example/home', 'TYPO3\TYPO3CR\Domain\Model\Node');
+        $targetNode = $this->propertyMapper->convert('/sites/example/home', Node::class);
 
         $this->assertOutputLinkValid('home.html', $this->viewHelper->render($targetNode));
     }
@@ -172,8 +186,8 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
 
         // The tests should also work in a regular fluid view, so we set that and repeat the tests
-        $mockView = $this->getAccessibleMock('TYPO3\Fluid\View\TemplateView', array(), array(), '', false);
-        $viewHelperVariableContainer = new \TYPO3\Fluid\Core\ViewHelper\ViewHelperVariableContainer();
+        $mockView = $this->getAccessibleMock(TemplateView::class, array(), array(), '', false);
+        $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
         $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('/sites/example/home@live'));

--- a/TYPO3.Neos/Tests/Unit/Domain/Model/DomainTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Model/DomainTest.php
@@ -10,19 +10,22 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Model\Site;
 
 /**
  * Testcase for the "Domain" domain model
  *
  */
-class DomainTest extends \TYPO3\Flow\Tests\UnitTestCase
+class DomainTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function setHostPatternAllowsForSettingTheHostPatternOfTheDomain()
     {
-        $domain = new \TYPO3\Neos\Domain\Model\Domain();
+        $domain = new Domain();
         $domain->setHostPattern('typo3.com');
         $this->assertSame('typo3.com', $domain->getHostPattern());
     }
@@ -32,9 +35,9 @@ class DomainTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setSiteSetsTheSiteTheDomainIsPointingTo()
     {
-        $mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
-        $domain = new \TYPO3\Neos\Domain\Model\Domain;
+        $domain = new Domain;
         $domain->setSite($mockSite);
         $this->assertSame($mockSite, $domain->getSite());
     }

--- a/TYPO3.Neos/Tests/Unit/Domain/Model/SiteTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Model/SiteTest.php
@@ -10,19 +10,21 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Site;
 
 /**
  * Testcase for the "Site" domain model
  *
  */
-class SiteTest extends \TYPO3\Flow\Tests\UnitTestCase
+class SiteTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function aNameCanBeSetAndRetrievedFromTheSite()
     {
-        $site = new \TYPO3\Neos\Domain\Model\Site('');
+        $site = new Site('');
         $site->setName('My cool website');
         $this->assertSame('My cool website', $site->getName());
     }
@@ -32,8 +34,8 @@ class SiteTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function theDefaultStateOfASiteIsOffline()
     {
-        $site = new \TYPO3\Neos\Domain\Model\Site('');
-        $this->assertSame(\TYPO3\Neos\Domain\Model\Site::STATE_OFFLINE, $site->getState());
+        $site = new Site('');
+        $this->assertSame(Site::STATE_OFFLINE, $site->getState());
     }
 
     /**
@@ -41,9 +43,9 @@ class SiteTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function theStateCanBeSetAndRetrieved()
     {
-        $site = new \TYPO3\Neos\Domain\Model\Site('');
-        $site->setState(\TYPO3\Neos\Domain\Model\Site::STATE_ONLINE);
-        $this->assertSame(\TYPO3\Neos\Domain\Model\Site::STATE_ONLINE, $site->getState());
+        $site = new Site('');
+        $site->setState(Site::STATE_ONLINE);
+        $this->assertSame(Site::STATE_ONLINE, $site->getState());
     }
 
     /**
@@ -51,7 +53,7 @@ class SiteTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function theSiteResourcesPackageKeyCanBeSetAndRetrieved()
     {
-        $site = new \TYPO3\Neos\Domain\Model\Site('');
+        $site = new Site('');
         $site->setSiteResourcesPackageKey('Foo');
         $this->assertSame('Foo', $site->getSiteResourcesPackageKey());
     }

--- a/TYPO3.Neos/Tests/Unit/Domain/Model/UserTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Model/UserTest.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Model;
 use TYPO3\Flow\Security\Account;
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Neos\Domain\Model\User;
+use TYPO3\Neos\Domain\Model\UserPreferences;
 
 /**
  * Test case for the "User" domain model
@@ -27,6 +28,6 @@ class UserTest extends UnitTestCase
     public function constructorInitializesPreferences()
     {
         $user = new User();
-        $this->assertInstanceOf('TYPO3\Neos\Domain\Model\UserPreferences', $user->getPreferences());
+        $this->assertInstanceOf(UserPreferences::class, $user->getPreferences());
     }
 }

--- a/TYPO3.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
@@ -10,12 +10,17 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Repository\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Persistence\QueryResultInterface;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Repository\DomainRepository;
+use TYPO3\Neos\Domain\Service\DomainMatchingStrategy;
 
 /**
  * Testcase for the Domain Repository
  *
  */
-class DomainRepositoryTest extends \TYPO3\Flow\Tests\UnitTestCase
+class DomainRepositoryTest extends UnitTestCase
 {
     /**
      * @test
@@ -23,18 +28,18 @@ class DomainRepositoryTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function findByHostInvokesTheDomainMatchingStrategyToFindDomainsMatchingTheGivenHost()
     {
         $mockDomains = array();
-        $mockDomains[] = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
-        $mockDomains[] = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
-        $mockDomains[] = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
+        $mockDomains[] = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
+        $mockDomains[] = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
+        $mockDomains[] = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
 
         $expectedDomains = array($mockDomains[0], $mockDomains[2]);
 
-        $mockDomainMatchingStrategy = $this->getMockBuilder('TYPO3\Neos\Domain\Service\DomainMatchingStrategy')->disableOriginalConstructor()->getMock();
+        $mockDomainMatchingStrategy = $this->getMockBuilder(DomainMatchingStrategy::class)->disableOriginalConstructor()->getMock();
         $mockDomainMatchingStrategy->expects($this->any())->method('getSortedMatches')->with('myhost', $mockDomains)->will($this->returnValue($expectedDomains));
 
-        $mockResult = $this->createMock('TYPO3\Flow\Persistence\QueryResultInterface');
+        $mockResult = $this->createMock(QueryResultInterface::class);
         $mockResult->expects($this->once())->method('toArray')->will($this->returnValue($mockDomains));
-        $domainRepository = $this->getAccessibleMock('TYPO3\Neos\Domain\Repository\DomainRepository', array('findAll'), array(), '', false);
+        $domainRepository = $this->getAccessibleMock(DomainRepository::class, array('findAll'), array(), '', false);
         $domainRepository->expects($this->once())->method('findAll')->will($this->returnValue($mockResult));
         $domainRepository->_set('domainMatchingStrategy', $mockDomainMatchingStrategy);
 

--- a/TYPO3.Neos/Tests/Unit/Domain/Service/ContentContextTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Service/ContentContextTest.php
@@ -10,21 +10,26 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Model\Site;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\ContentContextFactory;
 
 /**
  * Testcase for the Content Context
  *
  */
-class ContentContextTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ContentContextTest extends UnitTestCase
 {
     /**
-     * @var \TYPO3\Neos\Domain\Service\ContentContextFactory
+     * @var ContentContextFactory
      */
     protected $contextFactory;
 
     public function setUp()
     {
-        $this->contextFactory = new \TYPO3\Neos\Domain\Service\ContentContextFactory();
+        $this->contextFactory = new ContentContextFactory();
     }
 
     /**
@@ -32,7 +37,7 @@ class ContentContextTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getCurrentSiteReturnsTheCurrentSite()
     {
-        $mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
         $contextProperties = array(
             'workspaceName' => null,
@@ -46,7 +51,7 @@ class ContentContextTest extends \TYPO3\Flow\Tests\UnitTestCase
             'currentDomain' => null
         );
 
-        $contentContext = $this->getAccessibleMock('TYPO3\Neos\Domain\Service\ContentContext', array('dummy'), $contextProperties);
+        $contentContext = $this->getAccessibleMock(ContentContext::class, array('dummy'), $contextProperties);
         $this->assertSame($mockSite, $contentContext->getCurrentSite());
     }
 
@@ -55,7 +60,7 @@ class ContentContextTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getCurrentDomainReturnsTheCurrentDomainIfAny()
     {
-        $mockDomain = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
+        $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
 
         $contextProperties = array(
             'workspaceName' => null,
@@ -68,7 +73,7 @@ class ContentContextTest extends \TYPO3\Flow\Tests\UnitTestCase
             'currentSite' => null,
             'currentDomain' => null
         );
-        $contentContext = $this->getAccessibleMock('TYPO3\Neos\Domain\Service\ContentContext', array('dummy'), $contextProperties);
+        $contentContext = $this->getAccessibleMock(ContentContext::class, array('dummy'), $contextProperties);
 
         $this->assertNull($contentContext->getCurrentDomain());
         $contentContext->_set('currentDomain', $mockDomain);

--- a/TYPO3.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/TYPO3.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -10,23 +10,26 @@ namespace TYPO3\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Service\DomainMatchingStrategy;
 
 /**
  * Testcase for the Content Service
  *
  */
-class DomainMatchingStrategyTest extends \TYPO3\Flow\Tests\UnitTestCase
+class DomainMatchingStrategyTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function getSortedMatchesReturnsOneGivenDomainIfItMatchesExactly()
     {
-        $mockDomains = array($this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock());
+        $mockDomains = array($this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock());
         $mockDomains[0]->expects($this->any())->method('getHostPattern')->will($this->returnValue('www.neos.io'));
         $expectedDomains = array($mockDomains[0]);
 
-        $strategy = new \TYPO3\Neos\Domain\Service\DomainMatchingStrategy();
+        $strategy = new DomainMatchingStrategy();
         $actualDomains = $strategy->getSortedMatches('www.neos.io', $mockDomains);
         $this->assertSame($expectedDomains, $actualDomains);
     }
@@ -37,16 +40,16 @@ class DomainMatchingStrategyTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function getSortedMatchesFiltersTheGivenDomainsByTheSpecifiedHostAndReturnsThemSortedWithBestMatchesFirst()
     {
         $mockDomains = array(
-            $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
-            $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
-            $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
-            $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
         );
 
-        $mockDomains[0]->setHostPattern('*.typo3.org');
-        $mockDomains[1]->setHostPattern('flow.typo3.org');
+        $mockDomains[0]->setHostPattern('*.neos.io');
+        $mockDomains[1]->setHostPattern('flow.neos.io');
         $mockDomains[2]->setHostPattern('*');
-        $mockDomains[3]->setHostPattern('yacumboolu.typo3.org');
+        $mockDomains[3]->setHostPattern('yacumboolu.neos.io');
 
         $expectedDomains = array(
             $mockDomains[1],
@@ -54,8 +57,8 @@ class DomainMatchingStrategyTest extends \TYPO3\Flow\Tests\UnitTestCase
             $mockDomains[2]
         );
 
-        $strategy = new \TYPO3\Neos\Domain\Service\DomainMatchingStrategy();
-        $actualDomains = $strategy->getSortedMatches('flow.typo3.org', $mockDomains);
+        $strategy = new DomainMatchingStrategy();
+        $actualDomains = $strategy->getSortedMatches('flow.neos.io', $mockDomains);
         $this->assertSame($expectedDomains, $actualDomains);
     }
 
@@ -65,15 +68,15 @@ class DomainMatchingStrategyTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function getSortedMatchesReturnsNoMatchIfDomainIsLongerThanHostname()
     {
         $mockDomains = array(
-            $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(array('dummy'))->getMock(),
         );
 
-        $mockDomains[0]->setHostPattern('flow.typo3.org');
+        $mockDomains[0]->setHostPattern('flow.neos.io');
 
         $expectedDomains = array();
 
-        $strategy = new \TYPO3\Neos\Domain\Service\DomainMatchingStrategy();
-        $actualDomains = $strategy->getSortedMatches('typo3.org', $mockDomains);
+        $strategy = new DomainMatchingStrategy();
+        $actualDomains = $strategy->getSortedMatches('neos.io', $mockDomains);
         $this->assertSame($expectedDomains, $actualDomains);
     }
 }

--- a/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/TYPO3.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -10,20 +10,26 @@ namespace TYPO3\Neos\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Eel\FlowQuery\FlowQuery;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Eel\FlowQueryOperations\ParentsOperation;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Service\Context;
 
 /**
  * Testcase for the FlowQuery ParentsOperation
  */
-class ParentsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ParentsOperationTest extends UnitTestCase
 {
     /**
      * @test
      */
     public function parentsWillReturnTheSiteNodeAsRootLevelParent()
     {
-        $siteNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
-        $firstLevelNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
-        $secondLevelNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+        $siteNode = $this->createMock(NodeInterface::class);
+        $firstLevelNode = $this->createMock(NodeInterface::class);
+        $secondLevelNode = $this->createMock(NodeInterface::class);
 
         $siteNode->expects($this->any())->method('getPath')->will($this->returnValue('/site'));
         $mockContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
@@ -35,9 +41,9 @@ class ParentsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
         $secondLevelNode->expects($this->any())->method('getPath')->will($this->returnValue('/site/first/second'));
 
         $context = array($secondLevelNode);
-        $q = new \TYPO3\Eel\FlowQuery\FlowQuery($context);
+        $q = new FlowQuery($context);
 
-        $operation = new \TYPO3\Neos\Eel\FlowQueryOperations\ParentsOperation();
+        $operation = new ParentsOperation();
         $operation->evaluate($q, array());
 
         $output = $q->getContext();
@@ -49,17 +55,17 @@ class ParentsOperationTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function canEvaluateChecksForContentContext()
     {
-        $operation = new \TYPO3\Neos\Eel\FlowQueryOperations\ParentsOperation();
+        $operation = new ParentsOperation();
 
-        $mockNode = $this->createMock(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::class);
-        $mockContext = $this->getMockBuilder(\TYPO3\Neos\Domain\Service\ContentContext::class)->disableOriginalConstructor()->getMock();
+        $mockNode = $this->createMock(NodeInterface::class);
+        $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
         $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
         $context = array($mockNode);
 
         $this->assertTrue($operation->canEvaluate($context), 'Must accept ContentContext');
 
-        $mockNode = $this->createMock(\TYPO3\TYPO3CR\Domain\Model\NodeInterface::class);
-        $mockContext = $this->getMockBuilder(\TYPO3\TYPO3CR\Domain\Service\Context::class)->disableOriginalConstructor()->getMock();
+        $mockNode = $this->createMock(NodeInterface::class);
+        $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
         $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
         $context = array($mockNode);
         $this->assertFalse($operation->canEvaluate($context), 'Must not accept Context');

--- a/TYPO3.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
@@ -10,13 +10,16 @@ namespace TYPO3\Neos\Tests\Unit\Routing;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Controller\Module\Administration\UsersController;
+use TYPO3\Neos\Controller\Module\AdministrationController;
 use TYPO3\Neos\Routing\BackendModuleRoutePartHandler;
 
 /**
  * Testcase for the Backend Module Route Part Handler
  *
  */
-class BackendModuleRoutePartHandlerTest extends \TYPO3\Flow\Tests\UnitTestCase
+class BackendModuleRoutePartHandlerTest extends UnitTestCase
 {
     /**
      * Data provider for ... see below
@@ -28,16 +31,16 @@ class BackendModuleRoutePartHandlerTest extends \TYPO3\Flow\Tests\UnitTestCase
             'unknown root module' => array('unknown', BackendModuleRoutePartHandler::MATCHRESULT_NOSUCHMODULE, null),
             'unknown submodule' => array('unknown/module', BackendModuleRoutePartHandler::MATCHRESULT_NOSUCHMODULE, null),
             'unknown submodule with root module' => array('administration/unknown', BackendModuleRoutePartHandler::MATCHRESULT_NOSUCHMODULE, null),
-            'root module' =>  array('administration', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration', 'controller' => 'TYPO3\Neos\Controller\Module\AdministrationController', 'action' => 'index')),
-            'submodule' => array('administration/users', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => 'TYPO3\Neos\Controller\Module\Administration\UsersController', 'action' => 'index')),
-            'submodule with action' => array('administration/users/new', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => 'TYPO3\Neos\Controller\Module\Administration\UsersController', 'action' => 'new')),
+            'root module' =>  array('administration', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration', 'controller' => AdministrationController::class, 'action' => 'index')),
+            'submodule' => array('administration/users', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => UsersController::class, 'action' => 'index')),
+            'submodule with action' => array('administration/users/new', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => UsersController::class, 'action' => 'new')),
             'module without controller' => array('nocontroller', BackendModuleRoutePartHandler::MATCHRESULT_NOCONTROLLER, null),
             'submodule without controller' => array('administration/nocontroller', BackendModuleRoutePartHandler::MATCHRESULT_NOCONTROLLER, null),
 
             // Json requests
-            'root module in json' =>  array('administration.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration', 'controller' => 'TYPO3\Neos\Controller\Module\AdministrationController', 'action' => 'index', 'format' => 'json')),
-            'submodule in json' => array('administration/users.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => 'TYPO3\Neos\Controller\Module\Administration\UsersController', 'action' => 'index', 'format' => 'json')),
-            'submodule with action in json' => array('administration/users/new.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => 'TYPO3\Neos\Controller\Module\Administration\UsersController', 'action' => 'new', 'format' => 'json')),
+            'root module in json' =>  array('administration.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration', 'controller' => AdministrationController::class, 'action' => 'index', 'format' => 'json')),
+            'submodule in json' => array('administration/users.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => UsersController::class, 'action' => 'index', 'format' => 'json')),
+            'submodule with action in json' => array('administration/users/new.json', BackendModuleRoutePartHandler::MATCHRESULT_FOUND, array('module' => 'administration/users', 'controller' => UsersController::class, 'action' => 'new', 'format' => 'json')),
         );
     }
 
@@ -53,10 +56,10 @@ class BackendModuleRoutePartHandlerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $routePartHandler->injectSettings(array(
             'modules' => array(
                 'administration' => array(
-                    'controller' => 'TYPO3\Neos\Controller\Module\AdministrationController',
+                    'controller' => AdministrationController::class,
                     'submodules' => array(
                         'users' => array(
-                            'controller' => 'TYPO3\Neos\Controller\Module\Administration\UsersController'
+                            'controller' => UsersController::class
                         ),
                         'nocontroller' => array()
                     ),

--- a/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/TYPO3.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -14,12 +14,18 @@ namespace TYPO3\Neos\Tests\Unit\Routing;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Security\Context as SecurityContext;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Domain;
+use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Domain\Service\ConfigurationContentDimensionPresetSource;
 use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Routing\Exception\NoHomepageException;
 use TYPO3\Neos\Routing\FrontendNodeRoutePartHandler;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactory;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
@@ -79,7 +85,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->routePartHandler->setName('node');
 
         // The mockContextFactory is configured to return the last mock context which has been built with buildMockContext():
-        $mockContextFactory = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\ContextFactory')->setMethods(array('create'))->getMock();
+        $mockContextFactory = $this->getMockBuilder(ContextFactory::class)->setMethods(array('create'))->getMock();
         $mockContextFactory->mockContext = null;
         $mockContextFactory->expects($this->any())->method('create')->will($this->returnCallback(function ($contextProperties) use ($mockContextFactory) {
             if (isset($contextProperties['currentSite'])) {
@@ -99,15 +105,15 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->mockContextFactory = $mockContextFactory;
         $this->inject($this->routePartHandler, 'contextFactory', $this->mockContextFactory);
 
-        $this->mockSystemLogger = $this->createMock('TYPO3\Flow\Log\SystemLoggerInterface');
+        $this->mockSystemLogger = $this->createMock(SystemLoggerInterface::class);
         $this->inject($this->routePartHandler, 'systemLogger', $this->mockSystemLogger);
 
         $this->inject($this->routePartHandler, 'securityContext', new SecurityContext());
 
-        $this->mockDomainRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\DomainRepository')->disableOriginalConstructor()->getMock();
+        $this->mockDomainRepository = $this->getMockBuilder(DomainRepository::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->routePartHandler, 'domainRepository', $this->mockDomainRepository);
 
-        $this->mockSiteRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\SiteRepository')->disableOriginalConstructor()->getMock();
+        $this->mockSiteRepository = $this->getMockBuilder(SiteRepository::class)->disableOriginalConstructor()->getMock();
         $this->mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue(null));
         $this->inject($this->routePartHandler, 'siteRepository', $this->mockSiteRepository);
 
@@ -142,7 +148,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsTrueIfTheNodeExists()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $expectedContextPath = '/sites/examplecom/home';
@@ -174,7 +180,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsFalseIfASiteExistsButNoSiteNodeExists()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
         $routePath = 'home';
         $this->assertFalse($this->routePartHandler->match($routePath));
@@ -186,7 +192,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsFalseIfTheNodeCouldNotBeFound()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -204,7 +210,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsFalseIfTheWorkspaceCouldNotBeFound()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -225,7 +231,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function valueContainsContextPathOfFoundNode()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
@@ -249,7 +255,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsFalseOnNotMatchingSiteNodes()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
@@ -275,7 +281,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchCreatesContextForLiveWorkspaceByDefault()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -297,7 +303,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchCreatesContextForCustomWorkspaceIfSpecifiedInNodeContextPath()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -318,9 +324,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      */
     public function matchCreatesContextForCurrentDomainIfOneIsFound()
     {
-        $mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
-        $mockDomain = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
+        $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
         $mockDomain->expects($this->any())->method('getSite')->will($this->returnValue($mockSite));
 
         $this->mockDomainRepository->expects($this->atLeastOnce())->method('findOneByActiveRequest')->will($this->returnValue($mockDomain));
@@ -384,7 +390,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         ));
 
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
@@ -402,7 +408,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchReturnsFalseIfContextPathIsInvalid()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -418,7 +424,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function matchStripsOffSuffixIfSplitStringIsSpecified()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -436,7 +442,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveSetsValueToContextPathIfPassedNodeCouldBeResolved()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'user-robert'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -458,7 +464,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveSetsValueToContextPathIfPassedNodeCouldBeResolvedButIsInAnotherSite()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'user-robert'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/currentdotcom');
 
         $mockSubNode = $this->buildSubNode($this->buildSiteNode($mockContext, '/sites/otherdotcom'), 'home');
@@ -480,7 +486,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveReturnsFalseIfGivenRouteValueIsNeitherStringNorNode()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -499,7 +505,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveCreatesContextForLiveWorkspaceByDefault()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -527,7 +533,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveCreatesContextForTheWorkspaceMentionedInTheContextString()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'user-johndoe'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
@@ -555,7 +561,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveCreatesContextForCurrentDomainIfGivenValueIsAStringAndADomainIsFound()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'user-johndoe'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
         $mockContext->mockSiteNode = $mockSiteNode;
 
@@ -563,7 +569,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
             return ($nodePath === '/sites/examplecom') ? $mockSiteNode : null;
         }));
 
-        $mockDomain = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Domain')->disableOriginalConstructor()->getMock();
+        $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
         $this->mockDomainRepository->expects($this->atLeastOnce())->method('findOneByActiveRequest')->will($this->returnValue($mockDomain));
 
         $that = $this;
@@ -583,7 +589,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveReturnsFalseIfWorkspaceMentionedInTheContextDoesNotExist()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'user-johndoe'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
         $mockContext->mockSiteNode = $mockSiteNode;
 
@@ -604,7 +610,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveReturnsFalseIfNodeMentionedInTheContextPathDoesNotExist()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
         $mockContext->mockSiteNode = $mockSiteNode;
 
@@ -618,7 +624,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     public function resolveReturnsFalseIfNodeIsNoDocument()
     {
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         // The important bit: sub node is not a document but TYPO3.Neos:Content
@@ -641,7 +647,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->routePartHandler->setOptions(array('onlyMatchSiteNodes' => true));
 
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
@@ -702,7 +708,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         ));
 
         $mockContext = $this->buildMockContext(array('workspaceName' => 'live'));
-        $mockContext->mockSite = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
         $mockSiteNode->expects($this->any())->method('getContextPath')->will($this->returnValue('/sites/examplecom'));
@@ -822,10 +828,10 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
             $contextProperties['currentDateTime'] = new \DateTime;
         }
 
-        $mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $mockWorkspace->expects($this->any())->method('getName')->will($this->returnValue($contextProperties['workspaceName']));
 
-        $mockContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
+        $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockWorkspace = $mockWorkspace;
         $mockContext->expects($this->any())->method('getWorkspace')->will($this->returnCallback(function () use ($mockContext) {
             return $mockContext->mockWorkspace;
@@ -885,12 +891,12 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      */
     protected function buildNode(ContentContext $mockContext, $nodeName, $nodeTypeName = 'TYPO3.Neos:Document')
     {
-        $mockNodeType = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeType')->disableOriginalConstructor()->getMock();
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNodeType->expects($this->any())->method('isOfType')->will($this->returnCallback(function ($expectedNodeTypeName) use ($nodeTypeName) {
             return $expectedNodeTypeName === $nodeTypeName;
         }));
 
-        $mockNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+        $mockNode = $this->createMock(NodeInterface::class);
         $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
         $mockNode->expects($this->any())->method('getIdentifier')->will($this->returnValue('site-node-uuid'));
         $mockNode->expects($this->any())->method('getName')->will($this->returnValue($nodeName));

--- a/TYPO3.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Tests\Unit\Service;
  */
 
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Exception;
 use TYPO3\Neos\Service\HtmlAugmenter;
 
 /**
@@ -246,7 +247,7 @@ class HtmlAugmenterTest extends UnitTestCase
      * @param array $exclusiveAttributes
      * @test
      * @dataProvider invalidAttributesDataProvider
-     * @expectedException \TYPO3\Neos\Exception
+     * @expectedException Exception
      */
     public function invalidAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes)
     {

--- a/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -11,15 +11,21 @@ namespace TYPO3\Neos\Tests\Unit\Service;
  * source code.
  */
 
+use TYPO3\Flow\Persistence\QueryResultInterface;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Repository\DomainRepository;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Service\PublishingService;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
+use TYPO3\TYPO3CR\Domain\Model\NodeData;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
+use TYPO3\TYPO3CR\Domain\Service\Context;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
@@ -73,12 +79,12 @@ class PublishingServiceTest extends UnitTestCase
     protected $mockBaseWorkspace;
 
     /**
-     * @var \TYPO3\Flow\Persistence\QueryResultInterface
+     * @var QueryResultInterface
      */
     protected $mockQueryResult;
 
     /**
-     * @var \TYPO3\Neos\Domain\Model\Site
+     * @var Site
      */
     protected $mockSite;
     /**
@@ -91,27 +97,27 @@ class PublishingServiceTest extends UnitTestCase
     {
         $this->publishingService = new PublishingService();
 
-        $this->mockWorkspaceRepository = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository')->disableOriginalConstructor()->setMethods(array('findOneByName'))->getMock();
+        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->setMethods(array('findOneByName'))->getMock();
         $this->inject($this->publishingService, 'workspaceRepository', $this->mockWorkspaceRepository);
 
-        $this->mockNodeDataRepository = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository')->disableOriginalConstructor()->setMethods(array('findByWorkspace'))->getMock();
+        $this->mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(array('findByWorkspace'))->getMock();
         $this->inject($this->publishingService, 'nodeDataRepository', $this->mockNodeDataRepository);
 
-        $this->mockNodeFactory = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Factory\NodeFactory')->disableOriginalConstructor()->getMock();
+        $this->mockNodeFactory = $this->getMockBuilder(NodeFactory::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->publishingService, 'nodeFactory', $this->mockNodeFactory);
 
-        $this->mockContextFactory = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface')->disableOriginalConstructor()->getMock();
+        $this->mockContextFactory = $this->getMockBuilder(ContextFactoryInterface::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->publishingService, 'contextFactory', $this->mockContextFactory);
 
-        $this->mockDomainRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\DomainRepository')->disableOriginalConstructor()->getMock();
+        $this->mockDomainRepository = $this->getMockBuilder(DomainRepository::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->publishingService, 'domainRepository', $this->mockDomainRepository);
 
-        $this->mockSiteRepository = $this->getMockBuilder('TYPO3\Neos\Domain\Repository\SiteRepository')->disableOriginalConstructor()->getMock();
-        $this->mockSite = $this->getMockBuilder('TYPO3\Neos\Domain\Model\Site')->disableOriginalConstructor()->getMock();
+        $this->mockSiteRepository = $this->getMockBuilder(SiteRepository::class)->disableOriginalConstructor()->getMock();
+        $this->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $this->mockSiteRepository->expects($this->any())->method('findFirstOnline')->will($this->returnValue($this->mockSite));
         $this->inject($this->publishingService, 'siteRepository', $this->mockSiteRepository);
 
-        $this->mockBaseWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $this->mockBaseWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $this->mockBaseWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
         $this->mockBaseWorkspace->expects($this->any())->method('getBaseWorkspace')->will($this->returnValue(null));
 
@@ -119,7 +125,7 @@ class PublishingServiceTest extends UnitTestCase
         $this->mockContentDimensionPresetSource->expects($this->any())->method('findPresetsByTargetValues')->will($this->returnArgument(0));
         $this->inject($this->publishingService, 'contentDimensionPresetSource', $this->mockContentDimensionPresetSource);
 
-        $this->mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $this->mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $this->mockWorkspace->expects($this->any())->method('getName')->will($this->returnValue('workspace-name'));
         $this->mockWorkspace->expects($this->any())->method('getBaseWorkspace')->will($this->returnValue($this->mockBaseWorkspace));
     }
@@ -140,7 +146,7 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function getUnpublishedNodesReturnsANodeInstanceForEveryNodeInTheGivenWorkspace()
     {
-        $mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
+        $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $expectedContextProperties = array(
             'workspaceName' => $this->mockWorkspace->getName(),
@@ -152,14 +158,14 @@ class PublishingServiceTest extends UnitTestCase
         );
         $this->mockContextFactory->expects($this->any())->method('create')->with($expectedContextProperties)->will($this->returnValue($mockContext));
 
-        $mockNodeData1 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
-        $mockNodeData2 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
+        $mockNodeData1 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
+        $mockNodeData2 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
 
         $mockNodeData1->expects($this->any())->method('getDimensionValues')->will($this->returnValue(array()));
         $mockNodeData2->expects($this->any())->method('getDimensionValues')->will($this->returnValue(array()));
 
-        $mockNode1 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
-        $mockNode2 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode1 = $this->getMockBuilder(NodeInterface::class)->getMock();
+        $mockNode2 = $this->getMockBuilder(NodeInterface::class)->getMock();
 
         $mockNode1->expects($this->any())->method('getNodeData')->will($this->returnValue($mockNodeData1));
         $mockNode1->expects($this->any())->method('getPath')->will($this->returnValue('/node1'));
@@ -180,7 +186,7 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function getUnpublishedNodesDoesNotReturnInvalidNodes()
     {
-        $mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
+        $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $expectedContextProperties = array(
             'workspaceName' => $this->mockWorkspace->getName(),
@@ -192,13 +198,13 @@ class PublishingServiceTest extends UnitTestCase
         );
         $this->mockContextFactory->expects($this->any())->method('create')->with($expectedContextProperties)->will($this->returnValue($mockContext));
 
-        $mockNodeData1 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
-        $mockNodeData2 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
+        $mockNodeData1 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
+        $mockNodeData2 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
 
         $mockNodeData1->expects($this->any())->method('getDimensionValues')->will($this->returnValue(array()));
         $mockNodeData2->expects($this->any())->method('getDimensionValues')->will($this->returnValue(array()));
 
-        $mockNode1 = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode1 = $this->getMockBuilder(NodeInterface::class)->getMock();
 
         $mockNode1->expects($this->any())->method('getNodeData')->will($this->returnValue($mockNodeData1));
         $mockNode1->expects($this->any())->method('getPath')->will($this->returnValue('/node1'));
@@ -228,14 +234,14 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function publishNodePublishesTheGivenNodeFromItsWorkspaceToTheSpecifiedTargetWorkspace()
     {
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNodeType = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeType')->disableOriginalConstructor()->getMock();
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
 
-        $mockTargetWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $this->mockWorkspace->expects($this->atLeastOnce())->method('publishNodes')->with(array($mockNode), $mockTargetWorkspace);
         $this->publishingService->publishNode($mockNode, $mockTargetWorkspace);
@@ -246,9 +252,9 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function publishNodePublishesTheGivenNodeToItsBaseWorkspaceIfNoTargetWorkspaceIsSpecified()
     {
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNodeType = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeType')->disableOriginalConstructor()->getMock();
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
@@ -262,17 +268,17 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function publishNodePublishesTheNodeAndItsChildNodeCollectionsIfTheNodeIsADocument()
     {
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
-        $mockChildNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
+        $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNodeType = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeType')->disableOriginalConstructor()->getMock();
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNodeType->expects($this->atLeastOnce())->method('isOfType')->with('TYPO3.Neos:Document')->will($this->returnValue(true));
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
         $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('TYPO3.Neos:ContentCollection')->will($this->returnValue(array($mockChildNode)));
 
-        $mockTargetWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $this->mockWorkspace->expects($this->atLeastOnce())->method('publishNodes')->with(array($mockNode, $mockChildNode), $mockTargetWorkspace);
         $this->publishingService->publishNode($mockNode, $mockTargetWorkspace);
@@ -284,17 +290,17 @@ class PublishingServiceTest extends UnitTestCase
      */
     public function publishNodePublishesTheNodeAndItsChildNodeCollectionsIfTheNodeTypeHasChildNodes()
     {
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
-        $mockChildNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
+        $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNodeType = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeType')->disableOriginalConstructor()->setMethods(array('hasConfiguration', 'isOfType'))->getMock();
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(array('hasConfiguration', 'isOfType'))->getMock();
         $mockNodeType->expects($this->atLeastOnce())->method('hasConfiguration')->with('childNodes')->will($this->returnValue(true));
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
         $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('TYPO3.Neos:ContentCollection')->will($this->returnValue(array($mockChildNode)));
 
-        $mockTargetWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $this->mockWorkspace->expects($this->atLeastOnce())->method('publishNodes')->with(array($mockNode, $mockChildNode), $mockTargetWorkspace);
         $this->publishingService->publishNode($mockNode, $mockTargetWorkspace);

--- a/TYPO3.Neos/Tests/Unit/Service/UserServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/UserServiceTest.php
@@ -13,8 +13,10 @@ namespace TYPO3\Neos\Tests\Unit\Service;
 
 use TYPO3\Flow\Security\Context;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Model\User;
 use TYPO3\Neos\Domain\Service\UserService as UserDomainService;
 use TYPO3\Neos\Service\UserService;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository;
 
 /**
@@ -41,10 +43,10 @@ class UserServiceTest extends UnitTestCase
     {
         $this->userService = new UserService();
 
-        $this->mockUserDomainService = $this->getMockBuilder(\TYPO3\Neos\Domain\Service\UserService::class)->getMock();
+        $this->mockUserDomainService = $this->getMockBuilder(UserDomainService::class)->getMock();
         $this->inject($this->userService, 'userDomainService', $this->mockUserDomainService);
 
-        $this->mockWorkspaceRepository = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository')->disableOriginalConstructor()->setMethods(array('findOneByName'))->getMock();
+        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->setMethods(array('findOneByName'))->getMock();
         $this->inject($this->userService, 'workspaceRepository', $this->mockWorkspaceRepository);
     }
 
@@ -53,7 +55,7 @@ class UserServiceTest extends UnitTestCase
      */
     public function getBackendUserReturnsTheCurrentlyLoggedInUser()
     {
-        $mockUser = $this->getMockBuilder('TYPO3\Neos\Domain\Model\User')->disableOriginalConstructor()->getMock();
+        $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
 
         $this->mockUserDomainService->expects($this->atLeastOnce())->method('getCurrentUser')->will($this->returnValue($mockUser));
         $this->assertSame($mockUser, $this->userService->getBackendUser());
@@ -73,8 +75,8 @@ class UserServiceTest extends UnitTestCase
      */
     public function getPersonalWorkspaceReturnsTheUsersWorkspaceIfAUserIsLoggedIn()
     {
-        $mockUser = $this->getMockBuilder('TYPO3\Neos\Domain\Model\User')->disableOriginalConstructor()->getMock();
-        $mockUserWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
+        $mockUserWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $this->mockUserDomainService->expects($this->atLeastOnce())->method('getCurrentUser')->will($this->returnValue($mockUser));
         $this->mockUserDomainService->expects($this->atLeastOnce())->method('getUserName')->with($mockUser)->will($this->returnValue('TheUserName'));
@@ -96,7 +98,7 @@ class UserServiceTest extends UnitTestCase
      */
     public function getPersonalWorkspaceNameReturnsTheUsersWorkspaceNameIfAUserIsLoggedIn()
     {
-        $mockUser = $this->getMockBuilder('TYPO3\Neos\Domain\Model\User')->disableOriginalConstructor()->getMock();
+        $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
 
         $this->mockUserDomainService->expects($this->atLeastOnce())->method('getCurrentUser')->will($this->returnValue($mockUser));
         $this->mockUserDomainService->expects($this->atLeastOnce())->method('getUserName')->with($mockUser)->will($this->returnValue('TheUserName'));

--- a/TYPO3.Neos/Tests/Unit/Service/VieSchemaBuilderTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/VieSchemaBuilderTest.php
@@ -11,7 +11,12 @@ namespace TYPO3\Neos\Tests\Functional\Service;
  * source code.
  */
 
+use TYPO3\Flow\Cache\Frontend\StringFrontend;
+use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Media\Domain\Model\Image;
+use TYPO3\Neos\Service\VieSchemaBuilder;
+use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 
 /**
  * Testcase for the VieSchemaBuilder
@@ -20,12 +25,12 @@ use TYPO3\Flow\Tests\UnitTestCase;
 class VieSchemaBuilderTest extends UnitTestCase
 {
     /**
-     * @var \TYPO3\Neos\Service\VieSchemaBuilder
+     * @var VieSchemaBuilder
      */
     protected $vieSchemaBuilder;
 
     /**
-     * @var \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
+     * @var NodeTypeManager
      */
     protected $nodeTypeManager;
 
@@ -90,7 +95,7 @@ class VieSchemaBuilderTest extends UnitTestCase
             ),
             'properties' => array(
                 'image' => array(
-                    'type' => 'TYPO3\Neos\Domain\Model\Media\Image',
+                    'type' => Image::class,
                     'label' => 'Image'
                 )
             )
@@ -99,15 +104,15 @@ class VieSchemaBuilderTest extends UnitTestCase
 
     public function setUp()
     {
-        $this->vieSchemaBuilder = $this->getAccessibleMock('TYPO3\Neos\Service\VieSchemaBuilder', array('dummy'));
+        $this->vieSchemaBuilder = $this->getAccessibleMock(VieSchemaBuilder::class, array('dummy'));
 
-        $mockConfigurationManager = $this->getMockBuilder('TYPO3\Flow\Configuration\ConfigurationManager')->disableOriginalConstructor()->getMock();
+        $mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
         $mockConfigurationManager->expects($this->any())->method('getConfiguration')->with('NodeTypes')->will($this->returnValue($this->nodeTypesFixture));
 
-        $this->nodeTypeManager = $this->getAccessibleMock('TYPO3\TYPO3CR\Domain\Service\NodeTypeManager', array('dummy'));
+        $this->nodeTypeManager = $this->getAccessibleMock(NodeTypeManager::class, array('dummy'));
         $this->nodeTypeManager->_set('configurationManager', $mockConfigurationManager);
 
-        $mockCache = $this->getMockBuilder(\TYPO3\Flow\Cache\Frontend\StringFrontend::class)->disableOriginalConstructor()->getMock();
+        $mockCache = $this->getMockBuilder(StringFrontend::class)->disableOriginalConstructor()->getMock();
         $mockCache->expects($this->any())->method('get')->willReturn(null);
         $this->nodeTypeManager->_set('fullConfigurationCache', $mockCache);
 

--- a/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
+++ b/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
@@ -11,9 +11,13 @@ namespace TYPO3\Neos\Tests\Unit\TypoScript;
  * source code.
  */
 
+use TYPO3\Flow\Http\Request;
+use TYPO3\Flow\Http\Uri;
+use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
 use TYPO3\Flow\Mvc\Routing\UriBuilder;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Exception;
 use TYPO3\Neos\Service\LinkingService;
 use TYPO3\Neos\TypoScript\ConvertUrisImplementation;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -74,32 +78,32 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     public function setUp()
     {
-        $this->convertUrisImplementation = $this->getAccessibleMock('TYPO3\Neos\TypoScript\ConvertUrisImplementation', array('tsValue'), array(), '', false);
+        $this->convertUrisImplementation = $this->getAccessibleMock(ConvertUrisImplementation::class, array('tsValue'), array(), '', false);
 
-        $this->mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();
+        $this->mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
+        $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
         $this->mockContext->expects($this->any())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
 
-        $this->mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $this->mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContext));
 
-        $this->mockHttpUri = $this->getMockBuilder('TYPO3\Flow\Http\Uri')->disableOriginalConstructor()->getMock();
+        $this->mockHttpUri = $this->getMockBuilder(Uri::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpUri->expects($this->any())->method('getHost')->will($this->returnValue('localhost'));
 
-        $this->mockHttpRequest = $this->getMockBuilder('TYPO3\Flow\Http\Request')->disableOriginalConstructor()->getMock();
+        $this->mockHttpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpRequest->expects($this->any())->method('getUri')->will($this->returnValue($this->mockHttpUri));
 
-        $this->mockActionRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->mockActionRequest->expects($this->any())->method('getHttpRequest')->will($this->returnValue($this->mockHttpRequest));
 
-        $this->mockControllerContext = $this->getMockBuilder('TYPO3\Flow\Mvc\Controller\ControllerContext')->disableOriginalConstructor()->getMock();
+        $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->mockControllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->mockActionRequest));
 
-        $this->mockLinkingService = $this->createMock('TYPO3\Neos\Service\LinkingService');
+        $this->mockLinkingService = $this->createMock(LinkingService::class);
         $this->convertUrisImplementation->_set('linkingService', $this->mockLinkingService);
 
-        $this->mockTsRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
         $this->convertUrisImplementation->_set('tsRuntime', $this->mockTsRuntime);
     }
@@ -121,7 +125,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3\Neos\Domain\Exception
+     * @expectedException Exception
      */
     public function evaluateThrowsExceptionIfValueIsNoString()
     {
@@ -133,7 +137,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3\Neos\Domain\Exception
+     * @expectedException Exception
      */
     public function evaluateThrowsExceptionIfTheCurrentContextArrayDoesNotContainANode()
     {

--- a/TYPO3.Neos/Tests/Unit/TypoScript/PluginImplementationTest.php
+++ b/TYPO3.Neos/Tests/Unit/TypoScript/PluginImplementationTest.php
@@ -11,8 +11,12 @@ namespace TYPO3\Neos\Tests\Unit\TypoScript;
  * source code.
  */
 
+use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Http\Response;
+use TYPO3\Flow\Http\Uri;
+use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Flow\Mvc\Dispatcher;
 use TYPO3\Flow\Mvc\Routing\UriBuilder;
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Neos\Service\LinkingService;
@@ -46,25 +50,25 @@ class PluginImplementationTest extends UnitTestCase
 
     public function setUp()
     {
-        $this->pluginImplementation = $this->getAccessibleMock('TYPO3\Neos\TypoScript\PluginImplementation', ['buildPluginRequest'], [], '', false);
+        $this->pluginImplementation = $this->getAccessibleMock(PluginImplementation::class, ['buildPluginRequest'], [], '', false);
 
-        $this->mockHttpUri = $this->getMockBuilder('TYPO3\Flow\Http\Uri')->disableOriginalConstructor()->getMock();
+        $this->mockHttpUri = $this->getMockBuilder(Uri::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpUri->expects($this->any())->method('getHost')->will($this->returnValue('localhost'));
 
-        $this->mockHttpRequest = $this->getMockBuilder('TYPO3\Flow\Http\Request')->disableOriginalConstructor()->getMock();
+        $this->mockHttpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpRequest->expects($this->any())->method('getUri')->will($this->returnValue($this->mockHttpUri));
 
-        $this->mockActionRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->mockActionRequest->expects($this->any())->method('getHttpRequest')->will($this->returnValue($this->mockHttpRequest));
 
-        $this->mockControllerContext = $this->getMockBuilder('TYPO3\Flow\Mvc\Controller\ControllerContext')->disableOriginalConstructor()->getMock();
+        $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->mockControllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->mockActionRequest));
 
-        $this->mockTsRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
         $this->pluginImplementation->_set('tsRuntime', $this->mockTsRuntime);
 
-        $this->mockDispatcher = $this->getMockBuilder('TYPO3\Flow\Mvc\Dispatcher')->disableOriginalConstructor()->getMock();
+        $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->getMock();
         $this->pluginImplementation->_set('dispatcher', $this->mockDispatcher);
     }
 

--- a/TYPO3.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
+++ b/TYPO3.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
@@ -11,13 +11,14 @@ namespace TYPO3\Neos\Tests\Unit\Validation\Validator;
  * source code.
  */
 
+use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Neos\Validation\Validator\HostnameValidator;
 
 /**
  * Testcase for the HostNameValidator
  *
  */
-class HostNameValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
+class HostNameValidatorTest extends UnitTestCase
 {
     public function hostNameDataProvider()
     {

--- a/TYPO3.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
+++ b/TYPO3.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
@@ -11,7 +11,9 @@ namespace TYPO3\Neos\Tests\Unit\Validation\Validator;
  * source code.
  */
 
+use TYPO3\Flow\Security\Account;
 use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Neos\Domain\Service\UserService;
 use TYPO3\Neos\Validation\Validator\UserDoesNotExistValidator;
 
 /**
@@ -37,7 +39,7 @@ class UserDoesNotExistValidatorTest extends UnitTestCase
     {
         $validator = new UserDoesNotExistValidator();
 
-        $mockUserService = $this->createMock('TYPO3\Neos\Domain\Service\UserService');
+        $mockUserService = $this->createMock(UserService::class);
         $this->inject($validator, 'userService', $mockUserService);
 
         $result = $validator->validate('j.doe');
@@ -52,10 +54,10 @@ class UserDoesNotExistValidatorTest extends UnitTestCase
     {
         $validator = new UserDoesNotExistValidator();
 
-        $mockUserService = $this->createMock('TYPO3\Neos\Domain\Service\UserService');
+        $mockUserService = $this->createMock(UserService::class);
         $this->inject($validator, 'userService', $mockUserService);
 
-        $mockUser = $this->createMock('TYPO3\Flow\Security\Account');
+        $mockUser = $this->createMock(Account::class);
 
         $mockUserService
             ->expects($this->atLeastOnce())

--- a/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
+++ b/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
@@ -10,17 +10,23 @@ namespace TYPO3\Neos\Tests\Unit\View;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Http\Response;
+use TYPO3\Flow\Mvc\Controller\ControllerContext;
 use TYPO3\Flow\Security\Context;
+use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Neos\Domain\Service\ContentContext;
+use TYPO3\Neos\Domain\Service\TypoScriptService;
 use TYPO3\Neos\View\TypoScriptView;
 use TYPO3\TYPO3CR\Domain\Model\Node;
+use TYPO3\TYPO3CR\Domain\Model\NodeData;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TypoScript\Core\Runtime;
 
 /**
  * Testcase for the TypoScript View
  *
  */
-class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
+class TypoScriptViewTest extends UnitTestCase
 {
     /**
      * @var ContentContext
@@ -54,27 +60,27 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setUpMockView()
     {
-        $this->mockContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
+        $this->mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
-        $this->mockContextualizedNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Node')->setMethods(array('getContext'))->setConstructorArgs(array($mockNode, $this->mockContext))->getMock();
-        $mockSiteNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+        $mockNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
+        $this->mockContextualizedNode = $this->getMockBuilder(Node::class)->setMethods(array('getContext'))->setConstructorArgs(array($mockNode, $this->mockContext))->getMock();
+        $mockSiteNode = $this->createMock(NodeInterface::class);
 
         $this->mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($mockSiteNode));
         $this->mockContext->expects($this->any())->method('getDimensions')->will($this->returnValue(array()));
 
         $this->mockContextualizedNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContext));
 
-        $this->mockRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\Flow\Mvc\Controller\ControllerContext')->disableOriginalConstructor()->getMock();
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockSecurityContext = $this->getMockBuilder('TYPO3\Flow\Security\Context')->disableOriginalConstructor()->getMock();
+        $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $mockTypoScriptService = $this->createMock('TYPO3\Neos\Domain\Service\TypoScriptService');
+        $mockTypoScriptService = $this->createMock(TypoScriptService::class);
         $mockTypoScriptService->expects($this->any())->method('createRuntime')->will($this->returnValue($this->mockRuntime));
 
-        $this->mockView = $this->getAccessibleMock('TYPO3\Neos\View\TypoScriptView', array('getClosestDocumentNode'));
+        $this->mockView = $this->getAccessibleMock(TypoScriptView::class, array('getClosestDocumentNode'));
         $this->mockView->expects($this->any())->method('getClosestDocumentNode')->will($this->returnValue($this->mockContextualizedNode));
 
         $this->inject($this->mockView, 'controllerContext', $mockControllerContext);
@@ -90,7 +96,7 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function attemptToRenderWithoutNodeInformationAtAllThrowsException()
     {
-        $view = $this->getAccessibleMock('TYPO3\Neos\View\TypoScriptView', array('dummy'));
+        $view = $this->getAccessibleMock(TypoScriptView::class, array('dummy'));
         $view->render();
     }
 
@@ -100,7 +106,7 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function attemptToRenderWithInvalidNodeInformationThrowsException()
     {
-        $view = $this->getAccessibleMock('TYPO3\Neos\View\TypoScriptView', array('dummy'));
+        $view = $this->getAccessibleMock(TypoScriptView::class, array('dummy'));
         $view->_set('variables', array('value' => 'foo'));
         $view->render();
     }
@@ -120,32 +126,32 @@ class TypoScriptViewTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function renderMergesHttpResponseIfOutputIsHttpMessage()
     {
-        $mockContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
+        $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
-        $mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeData')->disableOriginalConstructor()->getMock();
-        $mockContextualizedNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Node')->setMethods(array('getContext'))->setConstructorArgs(array($mockNode, $mockContext))->getMock();
-        $mockSiteNode = $this->createMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
+        $mockNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
+        $mockContextualizedNode = $this->getMockBuilder(Node::class)->setMethods(array('getContext'))->setConstructorArgs(array($mockNode, $mockContext))->getMock();
+        $mockSiteNode = $this->createMock(NodeInterface::class);
 
         $mockContext->expects($this->any())->method('getCurrentSiteNode')->will($this->returnValue($mockSiteNode));
         $mockContext->expects($this->any())->method('getDimensions')->will($this->returnValue(array()));
 
         $mockContextualizedNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
 
-        $mockResponse = $this->createMock('TYPO3\Flow\Http\Response');
+        $mockResponse = $this->createMock(Response::class);
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\Flow\Mvc\Controller\ControllerContext')->disableOriginalConstructor()->getMock();
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $mockControllerContext->expects($this->any())->method('getResponse')->will($this->returnValue($mockResponse));
 
-        $mockRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $mockRuntime->expects($this->any())->method('render')->will($this->returnValue("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\nMessage body"));
         $mockRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($mockControllerContext));
 
-        $mockTypoScriptService = $this->createMock('TYPO3\Neos\Domain\Service\TypoScriptService');
+        $mockTypoScriptService = $this->createMock(TypoScriptService::class);
         $mockTypoScriptService->expects($this->any())->method('createRuntime')->will($this->returnValue($mockRuntime));
 
-        $mockSecurityContext = $this->getMockBuilder('TYPO3\Flow\Security\Context')->disableOriginalConstructor()->getMock();
+        $mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $view = $this->getAccessibleMock('TYPO3\Neos\View\TypoScriptView', array('getClosestDocumentNode'));
+        $view = $this->getAccessibleMock(TypoScriptView::class, array('getClosestDocumentNode'));
         $view->expects($this->any())->method('getClosestDocumentNode')->will($this->returnValue($mockContextualizedNode));
 
         $this->inject($view, 'securityContext', $mockSecurityContext);

--- a/TYPO3.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -83,28 +83,28 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
     public function setUp()
     {
         parent::setUp();
-        $this->editableViewHelper = $this->getAccessibleMock('TYPO3\Neos\ViewHelpers\ContentElement\EditableViewHelper', array('renderChildren'));
+        $this->editableViewHelper = $this->getAccessibleMock(EditableViewHelper::class, array('renderChildren'));
 
-        $this->mockPrivilegeManager = $this->getMockBuilder('TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface')->getMock();
+        $this->mockPrivilegeManager = $this->getMockBuilder(PrivilegeManagerInterface::class)->getMock();
         $this->inject($this->editableViewHelper, 'privilegeManager', $this->mockPrivilegeManager);
 
         $this->mockNodeAuthorizationService = $this->getMockBuilder(AuthorizationService::class)->getMock();
         $this->inject($this->editableViewHelper, 'nodeAuthorizationService', $this->mockNodeAuthorizationService);
 
-        $this->mockTemplateImplementation = $this->getMockBuilder('TYPO3\TypoScript\TypoScriptObjects\TemplateImplementation')->disableOriginalConstructor()->getMock();
+        $this->mockTemplateImplementation = $this->getMockBuilder(TemplateImplementation::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockTsRuntime = $this->getMockBuilder('TYPO3\TypoScript\Core\Runtime')->disableOriginalConstructor()->getMock();
+        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockContentContext = $this->getMockBuilder('TYPO3\Neos\Domain\Service\ContentContext')->disableOriginalConstructor()->getMock();
+        $this->mockContentContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockNode = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\NodeInterface')->getMock();
+        $this->mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContentContext));
         $this->mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue(new NodeType('Acme.Test:Headline', [], [])));
 
         $this->mockTsContext = array('node' => $this->mockNode);
         $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
         $this->mockTemplateImplementation->expects($this->any())->method('getTsRuntime')->will($this->returnValue($this->mockTsRuntime));
-        $this->mockView = $this->getAccessibleMock('TYPO3\TypoScript\TypoScriptObjects\Helpers\FluidView', array(), array(), '', false);
+        $this->mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $this->mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($this->mockTemplateImplementation));
 
         $this->editableViewHelper->initializeArguments();

--- a/TYPO3.Neos/Tests/Unit/ViewHelpers/IncludeJavaScriptViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Unit/ViewHelpers/IncludeJavaScriptViewHelperTest.php
@@ -10,15 +10,21 @@ namespace TYPO3\Neos\Tests\Unit\ViewHelpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Flow\Resource\Publishing\ResourcePublisher;
+use TYPO3\Flow\Tests\UnitTestCase;
+use TYPO3\Fluid\Core\Rendering\RenderingContext;
+use TYPO3\Neos\ViewHelpers\IncludeJavaScriptViewHelper;
 
 /**
  * Testcase for the IncludeJavaScript view helper
  * @deprecated Same as the ViewHelper this test is for
  */
-class IncludeJavaScriptViewHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
+class IncludeJavaScriptViewHelperTest extends UnitTestCase
 {
     /**
-     * @var \TYPO3\Neos\ViewHelpers\IncludeJavaScriptViewHelper
+     * @var IncludeJavaScriptViewHelper
      */
     protected $viewHelper;
 
@@ -27,14 +33,14 @@ class IncludeJavaScriptViewHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setUp()
     {
-        $this->request = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->request = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->request->expects($this->any())->method('getControllerPackageKey')->will($this->returnValue('MyPackage'));
-        $this->controllerContext = $this->getMockBuilder('TYPO3\Flow\Mvc\Controller\ControllerContext')->disableOriginalConstructor()->getMock();
+        $this->controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
-        $this->resourcePublisher = $this->getMockBuilder('TYPO3\Flow\Resource\Publishing\ResourcePublisher')->disableOriginalConstructor()->getMock();
+        $this->resourcePublisher = $this->getMockBuilder(ResourcePublisher::class)->disableOriginalConstructor()->getMock();
         $this->resourcePublisher->expects($this->any())->method('getStaticResourcesWebBaseUri')->will($this->returnValue('StaticResourceUri/'));
-        $this->viewHelper = $this->getAccessibleMock('TYPO3\Neos\ViewHelpers\IncludeJavaScriptViewHelper', array('iterateDirectoryRecursively'));
-        $renderingContext = new \TYPO3\Fluid\Core\Rendering\RenderingContext();
+        $this->viewHelper = $this->getAccessibleMock(IncludeJavaScriptViewHelper::class, array('iterateDirectoryRecursively'));
+        $renderingContext = new RenderingContext();
         $renderingContext->setControllerContext($this->controllerContext);
         $this->viewHelper->setRenderingContext($renderingContext);
         $this->viewHelper->_set('resourcePublisher', $this->resourcePublisher);

--- a/TYPO3.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
@@ -46,11 +46,11 @@ class ModuleViewHelperTest extends UnitTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->viewHelper = $this->getAccessibleMock('TYPO3\Neos\ViewHelpers\Link\ModuleViewHelper', array('renderChildren'));
-        $this->tagBuilder = $this->createMock('TYPO3\Fluid\Core\ViewHelper\TagBuilder');
-        $this->uriModuleViewHelper = $this->getMockBuilder('TYPO3\Neos\ViewHelpers\Uri\ModuleViewHelper')->setMethods(array('setRenderingContext', 'render'))->getMock();
+        $this->viewHelper = $this->getAccessibleMock(ModuleViewHelper::class, array('renderChildren'));
+        $this->tagBuilder = $this->createMock(TagBuilder::class);
+        $this->uriModuleViewHelper = $this->getMockBuilder(\TYPO3\Neos\ViewHelpers\Uri\ModuleViewHelper::class)->setMethods(array('setRenderingContext', 'render'))->getMock();
 
-        $this->dummyRenderingContext = $this->createMock('TYPO3\Fluid\Core\Rendering\RenderingContextInterface');
+        $this->dummyRenderingContext = $this->createMock(RenderingContextInterface::class);
         $this->inject($this->viewHelper, 'renderingContext', $this->dummyRenderingContext);
 
         $this->inject($this->viewHelper, 'tag', $this->tagBuilder);

--- a/TYPO3.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
@@ -34,8 +34,8 @@ class ModuleViewHelperTest extends UnitTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->viewHelper = $this->getMockBuilder('TYPO3\Neos\ViewHelpers\Uri\ModuleViewHelper')->setMethods(array('setMainRequestToUriBuilder'))->getMock();
-        $this->uriBuilder = $this->createMock('TYPO3\Flow\Mvc\Routing\UriBuilder');
+        $this->viewHelper = $this->getMockBuilder(ModuleViewHelper::class)->setMethods(array('setMainRequestToUriBuilder'))->getMock();
+        $this->uriBuilder = $this->createMock(UriBuilder::class);
         $this->inject($this->viewHelper, 'uriBuilder', $this->uriBuilder);
     }
 


### PR DESCRIPTION
This changes makes use of the use statement and `::class` method to get rid of the namespaces as much as possible
