### PR TITLE
BUGFIX: Workspace publishing fails after node:repair

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -170,6 +170,12 @@ removeNodesWithInvalidWorkspace
 Will check for and optionally remove nodes which belong to a workspace which no longer
 exists.. 
 
+<u>Repair inconsistent node identifiers</u>
+fixNodesWithInconsistentIdentifier
+
+Will check for and optionally repair node identifiers which are out of sync with their
+corresponding nodes in a live workspace.
+
 <u>Missing child nodes</u>
 createMissingChildNodes
 
@@ -228,6 +234,7 @@ HELPTEXT;
             'removeBrokenEntityReferences' => [ 'cleanup' => true ],
             'removeNodesWithInvalidDimensions' => [ 'cleanup' => true ],
             'removeNodesWithInvalidWorkspace' => [ 'cleanup' => true ],
+            'fixNodesWithInconsistentIdentifier' => [ 'cleanup' => false ],
             'createMissingChildNodes' => [ 'cleanup' => false ],
             'reorderChildNodes' => [ 'cleanup' => false ],
             'addMissingDefaultValues' => [ 'cleanup' => false ],
@@ -318,6 +325,8 @@ HELPTEXT;
         $updatedNodesCount = 0;
         $nodeCreationExceptions = 0;
 
+        $nodeIdentifiersWhichNeedUpdate = [];
+
         $nodeTypes = $this->nodeTypeManager->getSubNodeTypes($nodeType->getName(), false);
         $nodeTypes[$nodeType->getName()] = $nodeType;
 
@@ -351,20 +360,32 @@ HELPTEXT;
                             }
                             $createdNodesCount++;
                         } elseif ($childNode->getIdentifier() !== $childNodeIdentifier) {
-                            if ($dryRun === false) {
-                                $nodeData = $childNode->getNodeData();
-                                $nodeData->setIdentifier($childNodeIdentifier);
-                                $this->nodeDataRepository->update($nodeData);
-                                $this->output->outputLine('Updated identifier to %s for child node "%s" in "%s"', array($childNodeIdentifier, $childNodeName, $node->getPath()));
-                            } else {
-                                $this->output->outputLine('Child node "%s" in "%s" does not have a stable identifier', array($childNodeName, $node->getPath()));
-                            }
-                            $updatedNodesCount++;
+                            $nodeIdentifiersWhichNeedUpdate[$childNode->getIdentifier()] = $childNodeIdentifier;
                         }
                     } catch (\Exception $exception) {
                         $this->output->outputLine('Could not create node named "%s" in "%s" (%s)', array($childNodeName, $node->getPath(), $exception->getMessage()));
                         $nodeCreationExceptions++;
                     }
+                }
+            }
+        }
+
+        if (count($nodeIdentifiersWhichNeedUpdate) > 0) {
+            if ($dryRun === false) {
+                foreach ($nodeIdentifiersWhichNeedUpdate as $oldNodeIdentifier => $newNodeIdentifier) {
+                    $queryBuilder = $this->entityManager->createQueryBuilder();
+                    $queryBuilder->update('TYPO3\TYPO3CR\Domain\Model\NodeData', 'n')
+                        ->set('n.identifier', $queryBuilder->expr()->literal($newNodeIdentifier))
+                        ->where('n.identifier = ?1')
+                        ->setParameter(1, $oldNodeIdentifier);
+                    $result = $queryBuilder->getQuery()->getResult();
+                    $updatedNodesCount++;
+                    $this->output->outputLine('Updated node identifier from %s to %s because it was not a "stable" identifier', [ $oldNodeIdentifier, $newNodeIdentifier ]);
+                }
+            } else {
+                foreach ($nodeIdentifiersWhichNeedUpdate as $oldNodeIdentifier => $newNodeIdentifier) {
+                    $this->output->outputLine('Child nodes with identifier "%s" need to change their identifier to "%s"', [ $oldNodeIdentifier, $newNodeIdentifier ]);
+                    $updatedNodesCount++;
                 }
             }
         }
@@ -1067,6 +1088,80 @@ HELPTEXT;
             $nodes[] = $nodeDataArray;
         }
         return $nodes;
+    }
+
+    /**
+     * Detect and fix nodes in non-live workspaces whose identifier does not match their corresponding node in the
+     * live workspace.
+     *
+     * @param string $workspaceName This argument will be ignored
+     * @param boolean $dryRun Simulate?
+     * @return void
+     */
+    public function fixNodesWithInconsistentIdentifier($workspaceName, $dryRun)
+    {
+        $this->output->outputLine('Checking for nodes with inconsistent identifier ...');
+
+        $nodesArray = [];
+        $liveWorkspaceNames = [];
+        $nonLiveWorkspaceNames = [];
+        foreach ($this->workspaceRepository->findAll() as $workspace) {
+            /** @var Workspace $workspace */
+            if ($workspace->getBaseWorkspace() !== null) {
+                $nonLiveWorkspaceNames[] = $workspace->getName();
+            } else {
+                $liveWorkspaceNames[] = $workspace->getName();
+            }
+        }
+
+        foreach ($nonLiveWorkspaceNames as $workspaceName) {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = $this->entityManager->createQueryBuilder();
+            $queryBuilder->select('nonlive.Persistence_Object_Identifier, nonlive.identifier, nonlive.path, live.identifier AS liveIdentifier')
+                ->from('TYPO3\TYPO3CR\Domain\Model\NodeData', 'nonlive')
+                ->join('TYPO3\TYPO3CR\Domain\Model\NodeData', 'live', 'WITH', 'live.path = nonlive.path AND live.dimensionsHash = nonlive.dimensionsHash AND live.identifier != nonlive.identifier')
+                ->where('nonlive.workspace = ?1')
+                ->andWhere($queryBuilder->expr()->in('live.workspace', $liveWorkspaceNames))
+                ->andWhere('nonlive.path != \'/\'')
+                ->setParameter(1, $workspaceName)
+            ;
+
+            foreach ($queryBuilder->getQuery()->getArrayResult() as $nodeDataArray) {
+                $this->output->outputLine('Node %s in workspace %s has identifier %s but live node has identifier %s.', [$nodeDataArray['path'], $workspaceName, $nodeDataArray['identifier'], $nodeDataArray['liveIdentifier']]);
+                $nodesArray[] = $nodeDataArray;
+            }
+        }
+
+        if ($nodesArray === []) {
+            return;
+        }
+
+        if (!$dryRun) {
+            $self = $this;
+            $this->output->outputLine();
+            $this->output->outputLine('Nodes with inconsistent identifiers found.');
+            $this->askBeforeExecutingTask(sprintf('Do you want to fix the identifiers of %s node%s now?', count($nodesArray), count($nodesArray) > 1 ? 's' : ''), function () use ($self, $nodesArray) {
+                foreach ($nodesArray as $nodeArray) {
+                    /** @var QueryBuilder $queryBuilder */
+                    $queryBuilder = $this->entityManager->createQueryBuilder();
+                    $queryBuilder->update('TYPO3\TYPO3CR\Domain\Model\NodeData', 'nonlive')
+                        ->set('nonlive.identifier', $queryBuilder->expr()->literal($nodeArray['liveIdentifier']))
+                        ->where('nonlive.Persistence_Object_Identifier = ?1')
+                        ->setParameter(1, $nodeArray['Persistence_Object_Identifier']);
+                    $result = $queryBuilder->getQuery()->getResult();
+                    if ($result !== 1) {
+                        $self->output->outputLine('<error>Error:</error> The update query returned an unexpected result!');
+                        $self->output->outputLine('<b>Query:</b> ' . $queryBuilder->getQuery()->getSQL());
+                        $self->output->outputLine('<b>Result:</b> %s', [ var_export($result, true)]);
+                        exit(1);
+                    }
+                }
+                $self->output->outputLine('Fixed inconsistent identifiers.');
+            });
+        } else {
+            $this->output->outputLine('Found %s node%s with inconsistent identifiers which need to be fixed.', array(count($nodesArray), count($nodesArray) > 1 ? 's' : ''));
+        }
+        $this->output->outputLine();
     }
 
     /**


### PR DESCRIPTION
This change addresses an issue which results in a fatal error caused
by foreign key constraints when a user tries to publish her changes
to another workspace. The root cause is that the task in node:repair
which fixes "unstable" node identifiers of auto-created child nodes
only changes identifiers of nodes in a specific workspace (by default
the "live" workspace) and by that irreversibly disconnects corresponding
nodes in other workspaces.

The fix consists of two parts: First, the "create missing child nodes"
task of node:repair is modified so that node identifiers are always
changed accross all workspaces. Second, there is a new node:repair
task which detects and fixes inconsistencies caused by this bug.

If you experience the symptom described earlier, simply run a
node:repair to fix the inconsistencies.

The steps to reproduce the bug based on the Neos Demo site (as of
August 1st, 2016) are:

1. Log in to the backend and modify the title of the page "Forms". Don't
   publish the change yet.
2. From the command line call node:repair and see that child node
   identifiers are changed.
3. Try to publish the changes to the live workspace.

The UI will report an error which is caused by a failed SQL update.
With this patch applied, the changes should be able to publish without
any errors.