### PR TITLE
BUGFIX: Return default for loadMinifiedJavaScript

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/BackendAssetsUtility.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/BackendAssetsUtility.php
@@ -39,7 +39,12 @@ class BackendAssetsUtility
      */
     public function shouldLoadMinifiedJavascript()
     {
-        return isset($this->settings['userInterface']['loadMinifiedJavaScript']) ? $this->settings['userInterface']['loadMinifiedJavaScript'] : true;
+        if (isset($this->settings['userInterface']['loadMinifiedJavaScript'])) {
+            return $this->settings['userInterface']['loadMinifiedJavaScript'];
+        } elseif (isset($this->settings['userInterface']['loadMinifiedJavascript'])) {
+            return $this->settings['userInterface']['loadMinifiedJavascript'];
+        }
+        return true;
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Utility/BackendAssetsUtility.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Utility/BackendAssetsUtility.php
@@ -39,7 +39,7 @@ class BackendAssetsUtility
      */
     public function shouldLoadMinifiedJavascript()
     {
-        return isset($this->settings['userInterface']['loadMinifiedJavaScript']) ? $this->settings['userInterface']['loadMinifiedJavaScript'] : $this->settings['userInterface']['loadMinifiedJavascript'];
+        return isset($this->settings['userInterface']['loadMinifiedJavaScript']) ? $this->settings['userInterface']['loadMinifiedJavaScript'] : true;
     }
 
     /**


### PR DESCRIPTION
If config for `TYPO3.Neos.userInterface.loadMinifiedJavaScript` is not set, we return TRUE as default.