### PR TITLE
BUGFIX: Trim date value to prevent problems in node import

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -307,7 +307,9 @@ class NodeImportService
             case 'creationDateTime':
             case 'lastModificationDateTime':
             case 'lastPublicationDateTime':
-                $this->nodeDataStack[count($this->nodeDataStack) - 1][$elementName] = $this->propertyMapper->convert($xmlReader->readString(), 'DateTime', $this->propertyMappingConfiguration);
+                $stringValue = trim($xmlReader->readString());
+                $dateValue = $this->propertyMapper->convert($stringValue, 'DateTime', $this->propertyMappingConfiguration);
+                $this->nodeDataStack[count($this->nodeDataStack) - 1][$elementName] = $dateValue;
                 break;
             default:
                 throw new ImportException(sprintf('Unexpected element <%s> ', $elementName), 1423578065);
@@ -467,7 +469,8 @@ class NodeImportService
         switch ($currentType) {
             case 'object':
                 if ($currentClassName === 'DateTime') {
-                    $value = $this->propertyMapper->convert($reader->value, $currentClassName, $this->propertyMappingConfiguration);
+                    $stringValue = trim($reader->value);
+                    $value = $this->propertyMapper->convert($stringValue, $currentClassName, $this->propertyMappingConfiguration);
                 } elseif ($currentEncoding === 'json') {
                     $value = $this->propertyMapper->convert(json_decode($reader->value, true), $currentClassName, $this->propertyMappingConfiguration);
                 } else {

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNodeWithLinebreaks.xml
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNodeWithLinebreaks.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nodes formatVersion="2.0">
+	<node identifier="995c9174-ddd6-4d5c-cfc0-1ffc82184677" nodeName="neosdemotypo3org">
+		<variant sortingIndex="100" workspace="live" nodeType="TYPO3.Neos.NodeTypes:Page" version="14" removed="" hidden="" hiddenInIndex="">
+			<dimensions>
+				<language>en_US</language>
+				<language>en_UK</language>
+			</dimensions>
+			<accessRoles __type="array" />
+			<creationDateTime __type="object" __classname="DateTime">2015-12-21T21:56:53+00:00
+			</creationDateTime>
+			<hiddenBeforeDateTime __type="object" __classname="DateTime">2015-10-01T03:45:04+02:00</hiddenBeforeDateTime>
+			<hiddenAfterDateTime __type="object" __classname="DateTime">2015-10-22T07:50:04+02:00</hiddenAfterDateTime>
+			<properties>
+				<title __type="string">Home</title>
+				<layout __type="string">landingPage</layout>
+				<uriPathSegment __type="string">home</uriPathSegment>
+				<imageTitleText __type="string">Photo by www.daniel-bischoff.photo</imageTitleText>
+				<subpageLayout __type="string"></subpageLayout>
+			</properties>
+		</variant>
+	</node>
+</nodes>


### PR DESCRIPTION
Adds a trim around all `DateTime` string values to prevent problems with DateTimeConverter.

Fixes: #710