### PR TITLE
TASK: Do not ignore errors when converting values in node import service

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -481,7 +481,6 @@ class NodeImportService
                 } elseif ($currentEncoding === 'json') {
                     $decodedJson = json_decode($reader->value, true);
                     if (json_last_error() !== JSON_ERROR_NONE) {
-                        var_dump($reader->value);
                         throw new ImportException(sprintf('Could not parse encoded JSON in element <%s> for node %s: %s', $currentProperty, $currentNodeIdentifier, json_last_error_msg()), 1472992033);
                     }
                     $value = $this->propertyMapper->convert($decodedJson, $currentClassName, $this->propertyMappingConfiguration);

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeImportService.php
@@ -307,7 +307,9 @@ class NodeImportService
             case 'creationDateTime':
             case 'lastModificationDateTime':
             case 'lastPublicationDateTime':
-                $this->nodeDataStack[count($this->nodeDataStack) - 1][$elementName] = $this->propertyMapper->convert($xmlReader->readString(), 'DateTime', $this->propertyMappingConfiguration);
+                $stringValue = trim($xmlReader->readString());
+                $dateValue = $this->propertyMapper->convert($stringValue, 'DateTime', $this->propertyMappingConfiguration);
+                $this->nodeDataStack[count($this->nodeDataStack) - 1][$elementName] = $dateValue;
                 break;
             default:
                 throw new ImportException(sprintf('Unexpected element <%s> ', $elementName), 1423578065);
@@ -467,7 +469,8 @@ class NodeImportService
         switch ($currentType) {
             case 'object':
                 if ($currentClassName === 'DateTime') {
-                    $value = $this->propertyMapper->convert($reader->value, $currentClassName, $this->propertyMappingConfiguration);
+                    $stringValue = trim($reader->value);
+                    $value = $this->propertyMapper->convert($stringValue, $currentClassName, $this->propertyMappingConfiguration);
                 } elseif ($currentEncoding === 'json') {
                     $value = $this->propertyMapper->convert(json_decode($reader->value, true), $currentClassName, $this->propertyMappingConfiguration);
                 } else {

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNodeWithLinebreaks.xml
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/Fixtures/SingleNodeWithLinebreaks.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nodes formatVersion="2.0">
+	<node identifier="995c9174-ddd6-4d5c-cfc0-1ffc82184677" nodeName="neosdemotypo3org">
+		<variant sortingIndex="100" workspace="live" nodeType="TYPO3.Neos.NodeTypes:Page" version="14" removed="" hidden="" hiddenInIndex="">
+			<dimensions>
+				<language>en_US</language>
+				<language>en_UK</language>
+			</dimensions>
+			<accessRoles __type="array" />
+			<creationDateTime __type="object" __classname="DateTime">2015-12-21T21:56:53+00:00
+			</creationDateTime>
+			<hiddenBeforeDateTime __type="object" __classname="DateTime">2015-10-01T03:45:04+02:00</hiddenBeforeDateTime>
+			<hiddenAfterDateTime __type="object" __classname="DateTime">2015-10-22T07:50:04+02:00</hiddenAfterDateTime>
+			<properties>
+				<title __type="string">Home</title>
+				<layout __type="string">landingPage</layout>
+				<uriPathSegment __type="string">home</uriPathSegment>
+				<imageTitleText __type="string">Photo by www.daniel-bischoff.photo</imageTitleText>
+				<subpageLayout __type="string"></subpageLayout>
+			</properties>
+		</variant>
+	</node>
+</nodes>

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -92,6 +92,7 @@ class NodeImportServiceTest extends UnitTestCase
             }
             throw new \Exception('Target type ' . $targetType . ' not supported in property mapper mock');
         }));
+        $this->mockPropertyMapper->expects($this->any())->method('getMessages')->willReturn(new \TYPO3\Flow\Error\Result());
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -308,6 +309,7 @@ class NodeImportServiceTest extends UnitTestCase
                 'source' => $source
             );
         }));
+        $this->mockPropertyMapper->expects($this->any())->method('getMessages')->willReturn(new \TYPO3\Flow\Error\Result());
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -422,6 +424,7 @@ class NodeImportServiceTest extends UnitTestCase
                 'source' => $source
             );
         }));
+        $this->mockPropertyMapper->expects($this->any())->method('getMessages')->willReturn(new \TYPO3\Flow\Error\Result());
 
         $nodeImportService->import($xmlReader, '/');
 


### PR DESCRIPTION
With this change errors during element conversion are no longer silently ignored but
throw an exception during import. Before the value was simply converted to null.

Resolves: #711 
