### PR TITLE
TASK: Make the InsertNode panel keyboard friendly

### DIFF
--- a/TYPO3.Neos/Resources/Private/Partials/Backend/UserMenu.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Backend/UserMenu.html
@@ -14,5 +14,10 @@
 				<i class="icon-sliders"></i> {neos:backend.translate(id: 'userSettings.label', source: 'Modules', value: 'User Settings')}
 			</neos:link.module>
 		</li>
+		<li>
+			<a href="#" class="neos-open-shortcuts" title="Open shortcut map">
+				<i class="icon-keyboard"></i> {neos:backend.translate(id: 'shortcuts', value: 'Shortcuts', value: 'Keyboard Shortcuts')}
+			</a>
+		</li>
 	</ul>
 </div>

--- a/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Content/_InsertNodePanel.scss
@@ -1,7 +1,11 @@
 .neos-insert-node-panel {
 	.neos-header {
 		i {
+			color: $blue;
 			vertical-align: baseline;
+		}
+		strong {
+			font-weight: 700;
 		}
 	}
 
@@ -61,11 +65,21 @@
 	.neos-modal-body {
 		max-height: calc(100vh - #{$unit * 2 + 52 + 72 + 80});
 		overflow-y: auto;
+
+		> ul {
+			margin-top: 12px;
+		}
 	}
 
 	.neos-modal-footer {
 		border-top: 1px solid $grayLight;
 		margin-top: -1px;
+	}
+
+	.neos-modal-footer-tips {
+		text-align: center;
+		font-style: italic;
+		color: $textSubtleLight;
 	}
 
 	.neos-content-new-selecttype-button {
@@ -93,17 +107,21 @@
 				text-align: center;
 				vertical-align: baseline;
 			}
+
+			&:focus {
+				outline: none;
+			}
 		}
 
-		&:focus, &:hover {
+		&--current {
 			background-color: $blue;
 
 			button {
 				outline: none;
-			}
 
-			i {
-				color: #fff;
+				i {
+					color: #fff;
+				}
 			}
 
 			.neos-help-message-button {

--- a/TYPO3.Neos/Resources/Private/Styles/Neos.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Neos.scss
@@ -93,6 +93,7 @@
 	@import "Widget/pagination";
 	@import "ContextBar/AlohaLinkEditor";
 	@import "ContextBar/AlohaAddTable";
+	@import "Shared/KeyboardShortcutsDialog";
 }
 
 @import "Content";

--- a/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
@@ -3,8 +3,14 @@
   left: 32.25% !important;
 
   .neos-subheader {
-    padding: 0 16px 15px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
     margin: 0;
+    position: relative;
+    border-bottom: 1px solid #3f3f3f;
+    overflow: hidden;
+    margin-bottom: 15px;
   }
 
   .neos-modal-body {
@@ -15,12 +21,11 @@
       box-sizing: border-box;
       float: left;
 
-      ul {
+      .neos-shortcut-list {
         border: none;
         margin-bottom: 1em;
 
-        li {
-          float: left;
+        .neos-shortcut {
           margin: 0;
           width: 100%;
           vertical-align: top;
@@ -28,9 +33,8 @@
 
           .neos-shortcut-body {
             width: 100%;
-            line-height: 25px;
+            float: none;
             height: 25px;
-            float: left;
             text-align: left;
             background-color: transparent;
             -webkit-box-sizing: border-box;
@@ -39,41 +43,33 @@
             white-space: nowrap;
 
             display: inline-block;
-            padding: 0 16px;
+            padding: 0 $defaultMargin;
             margin: 0;
             font-family: 'Noto Sans', sans-serif;
             -webkit-font-smoothing: antialiased;
             color: #fff;
             font-size: 14px;
-            vertical-align: middle;
 
-            .neos-span {
-              margin-right: 5px;
-              float: left;
-              display: block;
-              margin-left: 0;
-              width: 25px;
-
-              i {
-                margin: 7px 0 0 4px;
-                display: block;
-              }
-
-              strong {
-                font-weight: 700;
-              }
+            .neos-shortcut-icon,
+            .neos-shortcut-label,
+            .neos-shortcut-keys {
+              display: inline-block;
+              vertical-align: middle;
+              height: 25px;
             }
 
-            .shortcut-keys {
+            .neos-shortcut-icon {
+              margin: 0;
+              width: 25px;
+            }
+            .neos-shortcut-keys {
               float: right;
-              padding: 0 10px;
               color: #adadad;
             }
-          }
 
-          span {
-            float: right;
-            width: 100px;
+            i {
+              color: #00b5ff;
+            }
           }
         }
       }

--- a/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
@@ -1,0 +1,77 @@
+.neos-show-shortcuts {
+  .neos-subheader {
+    padding: 0 16px 15px;
+    margin: 0;
+  }
+  .neos-modal-body {
+    .neos-column-body {
+      width: 50%;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      float: left;
+      ul {
+        border: none;
+        margin-bottom: 1em;
+
+        li {
+          float: left;
+          margin: 0;
+          width: 100%;
+          vertical-align: top;
+          margin-bottom: 1em;
+
+          .neos-shortcut-body {
+            width: 100%;
+            line-height: 25px;
+            height: 25px;
+            float: left;
+            text-align: left;
+            background-color: transparent;
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            white-space: nowrap;
+
+            display: inline-block;
+            padding: 0 16px;
+            margin: 0;
+            font-family: 'Noto Sans', sans-serif;
+            -webkit-font-smoothing: antialiased;
+            color: #fff;
+            font-size: 14px;
+            vertical-align: middle;
+
+            
+
+            .neos-span {
+              margin-right: 5px;
+              float: left;
+              display: block;
+              margin-left: 0;
+              width: 25px;
+              i {
+                margin: 7px 0 0 4px;
+                display: block;
+              }
+              strong {
+                font-weight: 700;
+              }
+            }
+
+            .shortcut-keys {
+              float: right;
+              padding: 0 10px;
+              color: #adadad;
+            }
+          }
+
+          span {
+            float: right;
+            width: 100px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Shared/_KeyboardShortcutsDialog.scss
@@ -1,8 +1,12 @@
 .neos-show-shortcuts {
+  width: 75% !important;
+  left: 32.25% !important;
+
   .neos-subheader {
     padding: 0 16px 15px;
     margin: 0;
   }
+
   .neos-modal-body {
     .neos-column-body {
       width: 50%;
@@ -10,6 +14,7 @@
       -moz-box-sizing: border-box;
       box-sizing: border-box;
       float: left;
+
       ul {
         border: none;
         margin-bottom: 1em;
@@ -42,18 +47,18 @@
             font-size: 14px;
             vertical-align: middle;
 
-            
-
             .neos-span {
               margin-right: 5px;
               float: left;
               display: block;
               margin-left: 0;
               width: 25px;
+
               i {
                 margin: 7px 0 0 4px;
                 display: block;
               }
+
               strong {
                 font-weight: 700;
               }

--- a/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
@@ -503,6 +503,47 @@
 				<source>Create and copy</source>
 			</trans-unit>
 
+			<trans-unit id="keyboard.shortcuts.header" xml:space="preserve">
+				<source>Keyboard shortcuts</source>
+			</trans-unit>
+
+			<trans-unit id="keyboard.shortcuts.general" xml:space="preserve">
+				<source>General</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.contentEditing" xml:space="preserve">
+				<source>Content Editing</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.toggleFullScreen" xml:space="preserve">
+				<source>Toggle fullscreen mode</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.closeDialog" xml:space="preserve">
+				<source>Close any dialog box</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.toggleEditPreview" xml:space="preserve">
+				<source>Toggle Edit/Preview panel</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.openShortcutInfo" xml:space="preserve">
+				<source>Open the shortcut info</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.createNew" xml:space="preserve">
+				<source>Create new</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.copySelected" xml:space="preserve">
+				<source>Copy selected</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.cutSelected" xml:space="preserve">
+				<source>Cut selected</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.pasteCopied" xml:space="preserve">
+				<source>Paste copied</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.removeSelected" xml:space="preserve">
+				<source>Remove selected</source>
+			</trans-unit>
+			<trans-unit id="keyboard.shortcuts.selectNextElement" xml:space="preserve">
+				<source>Select next element</source>
+			</trans-unit>
+
 			<trans-unit id="content.menu.menuPanel.content" xml:space="preserve">
 				<source>Content</source>
 			</trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
@@ -88,13 +88,13 @@
 				<source>Unhide</source>
 			</trans-unit>
 			<trans-unit id="into" xml:space="preserve">
-				<source>into</source>
+				<source>into the current element</source>
 			</trans-unit>
 			<trans-unit id="before" xml:space="preserve">
-				<source>before</source>
+				<source>before the current element</source>
 			</trans-unit>
 			<trans-unit id="after" xml:space="preserve">
-				<source>after</source>
+				<source>after the current element</source>
 			</trans-unit>
 			<trans-unit id="loading" xml:space="preserve">
 				<source>Loading</source>
@@ -501,6 +501,9 @@
 			</trans-unit>
 			<trans-unit id="content.dimension.createDialog.createAndCopy" xml:space="preserve">
 				<source>Create and copy</source>
+			</trans-unit>
+			<trans-unit id="insertnodepanel.help.tips" xml:space="preserve">
+				<source>Tips: use left / right arrow keys to navigate and hit return to create the current node type or esc to close</source>
 			</trans-unit>
 
 			<trans-unit id="keyboard.shortcuts.header" xml:space="preserve">

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
@@ -38,6 +38,11 @@
 			{{/each}}
 		</div>
 		<div class="neos-modal-footer">
+			{{#if view._preselectedNodeType}}
+			<button data-original-title="{{unbound view._preselectedNodeType.label}} ({{unbound view._preselectedNodeType.shortcut}})" data-neos-toggle class="neos-button neos-button-primary" {{action "insertSameNode" target="view"}}>
+				<i class="{{unbound view._preselectedNodeType.icon}}"></i> {{translate id="insertNodeOfType" fallback="Insert a new "}} {{unbound view._preselectedNodeType.label}}
+			</button>
+			{{/if}}
 			<button class="neos-button" {{action "cancel" target="view"}}>{{translate id="cancel" fallback="Cancel"}}</button>
 		</div>
 	</div>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.html
@@ -3,7 +3,7 @@
 		<div class="neos-modal-header">
 			<button class="neos-close neos-button" title="{{translate id='close' fallback='Close'}}" {{action "cancel" target="view"}} data-neos-toggle></button>
 			<div class="neos-header">
-				{{translate id="createNew" fallback="Create new"}}
+				{{translate id="createNew" fallback="Create new"}} "<strong>{{view._preselectedNodeType.label}}</strong>"
 				{{#if view._position}}
 					{{boundTranslate idBinding="view._position" fallbackBinding="view._position"}}
 					<i {{bindAttr class="view._positionIconClass"}}></i>
@@ -19,10 +19,10 @@
 					</div>
 					<ul {{bindAttr class=":neos-clearfix"}}>
 						{{#each nodeTypeGroup.sortedNodeTypes}}
-							<li class="neos-content-new-selecttype-button">
+							<li {{bindAttr class="className"}} {{action "selectNodeType" nodeType on="mouseEnter" target="view"}}>
 								<button class="neos-content-new" {{bindAttr title="nodeType"}} {{action "insertNode" nodeType icon target="view"}} data-neos-tooltip>
 									{{#if icon}}
-										<i class="{{unbound icon}}"></i>
+										<i {{bindAttr class="icon"}}></i>
 									{{else}}
 										<i class="icon-sign-blank"></i>
 									{{/if}}
@@ -38,12 +38,7 @@
 			{{/each}}
 		</div>
 		<div class="neos-modal-footer">
-			{{#if view._preselectedNodeType}}
-			<button data-original-title="{{unbound view._preselectedNodeType.label}} ({{unbound view._preselectedNodeType.shortcut}})" data-neos-toggle class="neos-button neos-button-primary" {{action "insertSameNode" target="view"}}>
-				<i class="{{unbound view._preselectedNodeType.icon}}"></i> {{translate id="insertNodeOfType" fallback="Insert a new "}} {{unbound view._preselectedNodeType.label}}
-			</button>
-			{{/if}}
-			<button class="neos-button" {{action "cancel" target="view"}}>{{translate id="cancel" fallback="Cancel"}}</button>
+			<div class="neos-modal-footer-tips"> <i class="icon-info-circle"></i> {{translate id='insertnodepanel.help.tips' fallback='Tips: use left / right arrow keys to navigate and hit return to create the current node type'}}</div>
 		</div>
 	</div>
 </div>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/AbstractInsertNodePanel.js
@@ -78,13 +78,16 @@ define([
 
 		nodeTypeGroups: function() {
 			var that = this,
-				nodeTypeGroups = Ember.A();
+				nodeTypeGroups = Ember.A(),
+				groupPosition = 0;
 
 			Configuration.get('nodeTypes.groups').forEach(function(group) {
+				groupPosition++;
+				var position = group.position !== undefined ? group.position : groupPosition;
 				nodeTypeGroups.pushObject(Ember.Object.extend({
 					name: group.name,
 					label: I18n.translate(group.label),
-					position: group.position,
+					position: position,
 					collapsed: group.collapsed,
 					nodeTypes: Ember.A(),
 
@@ -102,7 +105,7 @@ define([
 
 					sortedNodeTypes: function() {
 						return this.get('nodeTypes').sort(function(a, b) {
-							return (Ember.get(a, 'position') || 9999) - (Ember.get(b, 'position') || 9999);
+							return (Ember.get(a, 'globalPosition') || 9999) - (Ember.get(b, 'globalPosition') || 9999);
 						});
 					}.property('nodeTypes.@each')
 				}).create());

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
@@ -20,7 +20,7 @@ define(
         });
 
         Mousetrap.bind(['mod+shift+v'], function () {
-          ContentCommands.paste();
+          ContentCommands.paste('after');
           return false;
         });
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
@@ -1,41 +1,99 @@
 define(
-[
-	'Library/jquery-with-dependencies',
-	'emberjs',
-	'LibraryExtensions/Mousetrap',
-	'InlineEditing/ContentCommands'
-],
-function($, Ember, Mousetrap, ContentCommands) {
-	return Ember.Object.create({
-		initializeContentModuleEvents: function() {
-			Mousetrap.bind(['alt+p'], function () {
-				T3.Content.Controller.Preview.togglePreview();
-				return false;
-			});
+  [
+    'Library/jquery-with-dependencies',
+    'emberjs',
+    'LibraryExtensions/Mousetrap',
+    'InlineEditing/ContentCommands',
+    '../EditPreviewPanel/EditPreviewPanelController',
+    'Shared/KeyboardShortcutsDialog',
+    '../FullScreenController',
+    'Shared/Configuration'
+  ],
+  function ($, Ember, Mousetrap, ContentCommands, EditPreviewPanelController, KeyboardShortcutsDialog, FullScreenController, Configuration) {
+    return Ember.Object.create({
+      initializeContentModuleEvents: function () {
+        var that = this;
 
-			Mousetrap.bind('ctrl+alt+a', function() {
-				ContentCommands.create();
-			});
+        Mousetrap.bind(['ctrl+shift+a', 'command+shift+a'], function () {
+          ContentCommands.create('after');
+          return false;
+        });
 
-			Mousetrap.bind('ctrl+alt+v', function() {
-				ContentCommands.paste();
-			});
+        Mousetrap.bind(['ctrl+shift+v', 'command+shift+v'], function () {
+          ContentCommands.paste();
+          return false;
+        });
 
-			Mousetrap.bind('ctrl+alt+c', function() {
-				ContentCommands.copy();
-			});
+        Mousetrap.bind(['ctrl+shift+c', 'command+shift+c'], function () {
+          ContentCommands.copy();
+          return false;
+        });
 
-			Mousetrap.bind('ctrl+alt+x', function() {
-				ContentCommands.cut();
-			});
+        Mousetrap.bind(['ctrl+shift+x', 'command+shift+x'], function () {
+          ContentCommands.cut();
+          return false;
+        });
 
-			Mousetrap.bind('ctrl+alt+d', function() {
-				ContentCommands.remove();
-			});
+        Mousetrap.bind(['ctrl+shift+d', 'command+shift+d'], function () {
+          ContentCommands.remove();
+          return false;
+        });
 
-			Mousetrap.bind('ctrl+alt+del', function() {
-				window.location.reload();
-			});
-		}
-	});
-});
+        $('.neos-open-shortcuts').on('click', function (e) {
+          e.preventDefault();
+          $(this).parents('.neos-user-menu').toggleClass('neos-open');
+          KeyboardShortcutsDialog.show();
+        });
+
+        Mousetrap.bind('?', function () {
+          KeyboardShortcutsDialog.show();
+          return false;
+        });
+
+        Mousetrap.bind(['ctrl+e', 'command+e'], function () {
+          EditPreviewPanelController.toggleEditPreviewPanelMode();
+          return false;
+        });
+
+        Mousetrap.bind(['ctrl+h', 'command+h'], function () {
+          FullScreenController.toggleFullScreen();
+          return false;
+        });
+
+        this.waitForSchema(function () {
+          that.waitForAloha(that.initAlohaEventListener);
+        });
+      },
+      initAlohaEventListener: function (Aloha) {
+        Aloha.ready(function () {
+          Aloha.bind('aloha-editable-activated', function (event) {
+            Mousetrap.unbind('?');
+          });
+
+          Aloha.bind('aloha-editable-deactivated', function (event) {
+            Mousetrap.bind('?', function () {
+              KeyboardShortcutsDialog.show();
+            });
+          });
+        });
+      },
+      waitForSchema: function (callback) {
+        if (Configuration.get('Schema') === undefined) {
+          Configuration.addObserver('Schema', callback);
+        } else {
+          callback();
+        }
+      },
+      waitForAloha: function (callback) {
+        if (window.Aloha === undefined || window.Aloha.__shouldInit) {
+          require({
+            context: 'aloha'
+          }, [
+            'aloha'
+          ], callback);
+        } else {
+          callback(Aloha);
+        }
+      }
+    });
+  });

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
@@ -15,12 +15,12 @@ define(
         var that = this;
 
         Mousetrap.bind(['mod+shift+a'], function () {
-          ContentCommands.create('after');
+          ContentCommands.create();
           return false;
         });
 
         Mousetrap.bind(['mod+shift+v'], function () {
-          ContentCommands.paste('after');
+          ContentCommands.paste();
           return false;
         });
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/InputEvents/KeyboardEvents.js
@@ -14,27 +14,27 @@ define(
       initializeContentModuleEvents: function () {
         var that = this;
 
-        Mousetrap.bind(['ctrl+shift+a', 'command+shift+a'], function () {
+        Mousetrap.bind(['mod+shift+a'], function () {
           ContentCommands.create('after');
           return false;
         });
 
-        Mousetrap.bind(['ctrl+shift+v', 'command+shift+v'], function () {
+        Mousetrap.bind(['mod+shift+v'], function () {
           ContentCommands.paste();
           return false;
         });
 
-        Mousetrap.bind(['ctrl+shift+c', 'command+shift+c'], function () {
+        Mousetrap.bind(['mod+shift+c'], function () {
           ContentCommands.copy();
           return false;
         });
 
-        Mousetrap.bind(['ctrl+shift+x', 'command+shift+x'], function () {
+        Mousetrap.bind(['mod+shift+x'], function () {
           ContentCommands.cut();
           return false;
         });
 
-        Mousetrap.bind(['ctrl+shift+d', 'command+shift+d'], function () {
+        Mousetrap.bind(['mod+shift+d'], function () {
           ContentCommands.remove();
           return false;
         });
@@ -50,12 +50,12 @@ define(
           return false;
         });
 
-        Mousetrap.bind(['ctrl+e', 'command+e'], function () {
+        Mousetrap.bind(['mod+e'], function () {
           EditPreviewPanelController.toggleEditPreviewPanelMode();
           return false;
         });
 
-        Mousetrap.bind(['ctrl+h', 'command+h'], function () {
+        Mousetrap.bind(['mod+h'], function () {
           FullScreenController.toggleFullScreen();
           return false;
         });

--- a/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/ContentCommands.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/InlineEditing/ContentCommands.js
@@ -60,6 +60,15 @@ function (Ember, $, vieInstance, NodeActions, NodeSelection, Notification, NodeT
 			return parentElement.length > 0 ? NodeTypeService.isOfType(parentElement.attr('typeof').substr(6), 'TYPO3.Neos:ContentCollection') : false;
 		},
 
+		_definePositon: function(node) {
+			var position = 'into';
+			var types = this.getAllowedChildNodeTypesForNode(node);
+			if (types.length === 0) {
+				position = 'after';
+			}
+			return position;
+		},
+
 		/**
 		 * Opens the create new node dialog. Given position, referenceNode
 		 * and index are optional.
@@ -68,11 +77,12 @@ function (Ember, $, vieInstance, NodeActions, NodeSelection, Notification, NodeT
 		 * @return {void}
 		 */
 		create: function(position) {
+			var selectedNode = this.get('_selectedNode');
+
 			if (typeof position === 'undefined') {
-				position = 'into';
+				position = this._definePositon(selectedNode);
 			}
 
-			var selectedNode = this.get('_selectedNode');
 			require({context: 'neos'}, ['InlineEditing/InsertNodePanel'], function(InsertNodePanel) {
 				if($('.neos-modal:visible').length > 0) {
 					$('.neos-modal .neos-close').trigger('click');
@@ -121,6 +131,9 @@ function (Ember, $, vieInstance, NodeActions, NodeSelection, Notification, NodeT
 		 */
 		paste: function(position) {
 			var referenceNode = this.get('_selectedNode');
+			if (typeof position === 'undefined') {
+				position = this._definePositon(referenceNode);
+			}
 			switch (position) {
 				case 'before':
 					return NodeActions.pasteBefore(referenceNode);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
@@ -38,7 +38,7 @@
 							<i class="icon-info"></i>
 						</span>
                         Open the shortcut info
-                        <div class="shortcut-keys">shift + ?, ?</div>
+                        <div class="shortcut-keys">?</div>
                     </div>
                 </li>
             </ul>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
@@ -5,99 +5,101 @@
     </div>
     <div class="neos-modal-body">
         <div class="neos-column-body">
-            <div class="neos-subheader">General</div>
-            <ul class="neos-clearfix">
+            <div class="neos-subheader">
+                General
+            </div>
+            <ul class="neos-shortcut-list neos-clearfix">
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
-							<i class="icon-resize-full"></i>
-						</span>
-                        Toggle fullscreen mode
-                        <div class="shortcut-keys">{{ctrlCmd}} + h</div>
+                        <div class="neos-shortcut-icon">
+                            <i class="icon-resize-full"></i>
+                        </div>
+                        <div class="neos-shortcut-label">Toggle fullscreen mode</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + h</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
-							<i class="icon-remove"></i>
-						</span>
-                        Close any dialog box
-                        <div class="shortcut-keys">esc</div>
+                        <div class="neos-shortcut-icon">
+                            <i class="icon-remove"></i>
+                        </div>
+                        <div class="neos-shortcut-label">Close any dialog box</div>
+                        <div class="neos-shortcut-keys">esc</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-                        <span class="neos-span" title="Full Screen"></span>
-                        Toggle Edit/Preview panel
-                        <div class="shortcut-keys">{{ctrlCmd}} + e</div>
+                        <div class="neos-shortcut-icon"></div>
+                        <div class="neos-shortcut-label">Toggle Edit/Preview panel</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + e</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-info"></i>
-						</span>
-                        Open the shortcut info
-                        <div class="shortcut-keys">?</div>
+						</div>
+                        <div class="neos-shortcut-label">Open the shortcut info</div>
+                        <div class="neos-shortcut-keys">?</div>
                     </div>
                 </li>
             </ul>
         </div>
         <div class="neos-column-body">
             <div class="neos-subheader">Content Editing</div>
-            <ul class="neos-clearfix">
+            <ul class="neos-shortcut-list neos-clearfix">
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-plus"></i>
-						</span>
-                        Create new
-                        <div class="shortcut-keys">{{ctrlCmd}} + shift + a</div>
+						</div>
+                        <div class="neos-shortcut-label">Create new</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + a</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-copy"></i>
-						</span>
-                        Copy selected
-                        <div class="shortcut-keys">{{ctrlCmd}} + shift + c</div>
+						</div>
+                        <div class="neos-shortcut-label">Copy selected</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + c</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-cut"></i>
-						</span>
-                        Cut selected
-                        <div class="shortcut-keys">{{ctrlCmd}} + shift + x</div>
+						</div>
+                        <div class="neos-shortcut-label">Cut selected</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + x</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-paste"></i>
-						</span>
-                        Paste copied
-                        <div class="shortcut-keys">{{ctrlCmd}} + shift + v</div>
+						</div>
+                        <div class="neos-shortcut-label">Paste copied</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + v</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-trash"></i>
-						</span>
-                        Remove selected
-                        <div class="shortcut-keys">{{ctrlCmd}} + shift + d</div>
+						</div>
+                        <div class="neos-shortcut-label">Remove selected</div>
+                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + d</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
-						<span class="neos-span" title="Full Screen">
+                        <div class="neos-shortcut-icon">
 							<i class="icon-long-arrow-right"></i>
-						</span>
-                        Select next element
-                        <div class="shortcut-keys">tab</div>
+						</div>
+                        <div class="neos-shortcut-label">Select next element</div>
+                        <div class="neos-shortcut-keys">tab</div>
                     </div>
                 </li>
             </ul>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
@@ -1,0 +1,108 @@
+<div class="neos-modal neos-modal-wide neos-show-shortcuts">
+    <div class="neos-modal-header">
+        <button class="neos-close neos-button" title="Close" {{action "hide" target="view"}}></button>
+        <div class="neos-header">Keyboard shortcuts</div>
+    </div>
+    <div class="neos-modal-body">
+        <div class="neos-column-body">
+            <div class="neos-subheader">General</div>
+            <ul class="neos-clearfix">
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-resize-full"></i>
+						</span>
+                        Toggle fullscreen mode
+                        <div class="shortcut-keys">{{ctrlCmd}} + h</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-remove"></i>
+						</span>
+                        Close any dialog box
+                        <div class="shortcut-keys">esc</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+                        <span class="neos-span" title="Full Screen"></span>
+                        Toggle Edit/Preview panel
+                        <div class="shortcut-keys">{{ctrlCmd}} + e</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-info"></i>
+						</span>
+                        Open the shortcut info
+                        <div class="shortcut-keys">shift + ?, ?</div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+        <div class="neos-column-body">
+            <div class="neos-subheader">Content Editing</div>
+            <ul class="neos-clearfix">
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-plus"></i>
+						</span>
+                        Create new
+                        <div class="shortcut-keys">{{ctrlCmd}} + shift + a</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-copy"></i>
+						</span>
+                        Copy selected
+                        <div class="shortcut-keys">{{ctrlCmd}} + shift + c</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-cut"></i>
+						</span>
+                        Cut selected
+                        <div class="shortcut-keys">{{ctrlCmd}} + shift + x</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-paste"></i>
+						</span>
+                        Paste copied
+                        <div class="shortcut-keys">{{ctrlCmd}} + shift + v</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-trash"></i>
+						</span>
+                        Remove selected
+                        <div class="shortcut-keys">{{ctrlCmd}} + shift + d</div>
+                    </div>
+                </li>
+                <li class="neos-shortcut">
+                    <div class="neos-shortcut-body">
+						<span class="neos-span" title="Full Screen">
+							<i class="icon-long-arrow-right"></i>
+						</span>
+                        Select next element
+                        <div class="shortcut-keys">tab</div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="neos-modal-backdrop neos-in"></div>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
@@ -15,7 +15,7 @@
                             <i class="icon-resize-full"></i>
                         </div>
                         <div class="neos-shortcut-label">Toggle fullscreen mode</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + h</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + h</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -31,7 +31,7 @@
                     <div class="neos-shortcut-body">
                         <div class="neos-shortcut-icon"></div>
                         <div class="neos-shortcut-label">Toggle Edit/Preview panel</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + e</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + e</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -54,7 +54,7 @@
 							<i class="icon-plus"></i>
 						</div>
                         <div class="neos-shortcut-label">Create new</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + a</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + shift + a</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -63,7 +63,7 @@
 							<i class="icon-copy"></i>
 						</div>
                         <div class="neos-shortcut-label">Copy selected</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + c</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + shift + c</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -72,7 +72,7 @@
 							<i class="icon-cut"></i>
 						</div>
                         <div class="neos-shortcut-label">Cut selected</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + x</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + shift + x</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -81,7 +81,7 @@
 							<i class="icon-paste"></i>
 						</div>
                         <div class="neos-shortcut-label">Paste copied</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + v</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + shift + v</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
@@ -90,7 +90,7 @@
 							<i class="icon-trash"></i>
 						</div>
                         <div class="neos-shortcut-label">Remove selected</div>
-                        <div class="neos-shortcut-keys">{{ctrlCmd}} + shift + d</div>
+                        <div class="neos-shortcut-keys">{{modKey}} + shift + d</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.html
@@ -1,12 +1,12 @@
 <div class="neos-modal neos-modal-wide neos-show-shortcuts">
     <div class="neos-modal-header">
         <button class="neos-close neos-button" title="Close" {{action "hide" target="view"}}></button>
-        <div class="neos-header">Keyboard shortcuts</div>
+        <div class="neos-header">{{translate id="keyboard.shortcuts.header" fallback="Keyboard shortcuts"}}</div>
     </div>
     <div class="neos-modal-body">
         <div class="neos-column-body">
             <div class="neos-subheader">
-                General
+                {{translate id="keyboard.shortcuts.general" fallback="General"}}
             </div>
             <ul class="neos-shortcut-list neos-clearfix">
                 <li class="neos-shortcut">
@@ -14,7 +14,7 @@
                         <div class="neos-shortcut-icon">
                             <i class="icon-resize-full"></i>
                         </div>
-                        <div class="neos-shortcut-label">Toggle fullscreen mode</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.toggleFullScreen" fallback="Toggle fullscreen mode"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + h</div>
                     </div>
                 </li>
@@ -23,14 +23,14 @@
                         <div class="neos-shortcut-icon">
                             <i class="icon-remove"></i>
                         </div>
-                        <div class="neos-shortcut-label">Close any dialog box</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.closeDialog" fallback="Close any dialog box"}}</div>
                         <div class="neos-shortcut-keys">esc</div>
                     </div>
                 </li>
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
                         <div class="neos-shortcut-icon"></div>
-                        <div class="neos-shortcut-label">Toggle Edit/Preview panel</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.toggleEditPreview" fallback="Toggle Edit/Preview panel"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + e</div>
                     </div>
                 </li>
@@ -39,21 +39,21 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-info"></i>
 						</div>
-                        <div class="neos-shortcut-label">Open the shortcut info</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.openShortcutInfo" fallback="Open the shortcut info"}}</div>
                         <div class="neos-shortcut-keys">?</div>
                     </div>
                 </li>
             </ul>
         </div>
         <div class="neos-column-body">
-            <div class="neos-subheader">Content Editing</div>
+            <div class="neos-subheader">{{translate id="keyboard.shortcuts.contentEditing" fallback="Content Editing"}}</div>
             <ul class="neos-shortcut-list neos-clearfix">
                 <li class="neos-shortcut">
                     <div class="neos-shortcut-body">
                         <div class="neos-shortcut-icon">
 							<i class="icon-plus"></i>
 						</div>
-                        <div class="neos-shortcut-label">Create new</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.createNew" fallback="Create new"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + shift + a</div>
                     </div>
                 </li>
@@ -62,7 +62,7 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-copy"></i>
 						</div>
-                        <div class="neos-shortcut-label">Copy selected</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.copySelected" fallback="Copy selected"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + shift + c</div>
                     </div>
                 </li>
@@ -71,7 +71,7 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-cut"></i>
 						</div>
-                        <div class="neos-shortcut-label">Cut selected</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.cutSelected" fallback="Cut selected"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + shift + x</div>
                     </div>
                 </li>
@@ -80,7 +80,7 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-paste"></i>
 						</div>
-                        <div class="neos-shortcut-label">Paste copied</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.pasteCopied" fallback="Paste copied"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + shift + v</div>
                     </div>
                 </li>
@@ -89,7 +89,7 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-trash"></i>
 						</div>
-                        <div class="neos-shortcut-label">Remove selected</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.removeSelected" fallback="Remove selected"}}</div>
                         <div class="neos-shortcut-keys">{{modKey}} + shift + d</div>
                     </div>
                 </li>
@@ -98,7 +98,7 @@
                         <div class="neos-shortcut-icon">
 							<i class="icon-long-arrow-right"></i>
 						</div>
-                        <div class="neos-shortcut-label">Select next element</div>
+                        <div class="neos-shortcut-label">{{translate id="keyboard.shortcuts.selectNextElement" fallback="Select next element"}}</div>
                         <div class="neos-shortcut-keys">tab</div>
                     </div>
                 </li>

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
@@ -2,12 +2,13 @@ define(
   [
     'emberjs',
     'Library/jquery-with-dependencies',
-    'text!./KeyboardShortcutsDialog.html'
+    'text!./KeyboardShortcutsDialog.html',
+    'Shared/Navigator'
   ],
-  function (Ember, $, template) {
+  function (Ember, $, template, Navigator) {
     var KeyboardShortcutsDialog = Ember.Object.create({
       _view: null,
-      ctrlCmd: 'ctrl',
+      modKey: Navigator.modKey(),
 
       show: function () {
         var that = this;
@@ -15,9 +16,7 @@ define(
           return;
         }
 
-        if (navigator.appVersion.indexOf("Mac") != -1) {
-          ctrlCmd = 'cmd';
-        }
+        modKey = Navigator.modKey();
 
         Mousetrap.bind('esc', function() {
           that.hide();

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
@@ -1,0 +1,50 @@
+define(
+  [
+    'emberjs',
+    'Library/jquery-with-dependencies',
+    'text!./KeyboardShortcutsDialog.html'
+  ],
+  function (Ember, $, template) {
+    var KeyboardShortcutsDialog = Ember.Object.create({
+      _view: null,
+      ctrlCmd: 'ctrl',
+
+      show: function () {
+        var that = this;
+        if (this.get('_view')) {
+          return;
+        }
+
+        if (navigator.appVersion.indexOf("Mac") != -1) {
+          ctrlCmd = 'cmd';
+        }
+
+        Mousetrap.bind('esc', function() {
+          that.hide();
+          return false;
+        });
+
+        this.set(
+          '_view',
+          Ember.View.create({
+            template: Ember.Handlebars.compile(template),
+            classNames: ['neos-overlay-component'],
+            hide: function () {
+              KeyboardShortcutsDialog.hide();
+            }
+          }).appendTo('#neos-application')
+        );
+      },
+
+      hide: function () {
+        if (this.get('_view')) {
+          this.get('_view').remove();
+          this.set('_view', null);
+          Mousetrap.unbind('esc');
+        }
+      }
+    });
+
+    return KeyboardShortcutsDialog;
+  }
+);

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/KeyboardShortcutsDialog.js
@@ -21,7 +21,6 @@ define(
 
         Mousetrap.bind('esc', function() {
           that.hide();
-          return false;
         });
 
         this.set(

--- a/TYPO3.Neos/Resources/Public/JavaScript/Shared/Navigator.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Shared/Navigator.js
@@ -1,0 +1,15 @@
+define(
+  [
+    'emberjs'
+  ],
+  function (Ember) {
+    return Ember.Object.create({
+      isMac: function() {
+        return navigator.appVersion.indexOf("Mac") != -1;
+      },
+      modKey: function() {
+        return this.isMac() ? 'cmd' : 'ctrl';
+      }
+    });
+  }
+);

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -14443,6 +14443,71 @@
   text-align: center;
   font-size: 0.8em;
 }
+.neos .neos-show-shortcuts .neos-subheader {
+  padding: 0 16px 15px;
+  margin: 0;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body {
+  width: 50%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  float: left;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul {
+  border: none;
+  margin-bottom: 1em;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li {
+  float: left;
+  margin: 0;
+  width: 100%;
+  vertical-align: top;
+  margin-bottom: 1em;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body {
+  width: 100%;
+  line-height: 25px;
+  height: 25px;
+  float: left;
+  text-align: left;
+  background-color: transparent;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  white-space: nowrap;
+  display: inline-block;
+  padding: 0 16px;
+  margin: 0;
+  font-family: 'Noto Sans', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  color: #fff;
+  font-size: 14px;
+  vertical-align: middle;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span {
+  margin-right: 5px;
+  float: left;
+  display: block;
+  margin-left: 0;
+  width: 25px;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span i {
+  margin: 7px 0 0 4px;
+  display: block;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span strong {
+  font-weight: 700;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .shortcut-keys {
+  float: right;
+  padding: 0 10px;
+  color: #adadad;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li span {
+  float: right;
+  width: 100px;
+}
 
 .neos-contentelement {
   /* Workaround for empty divs collapsing in Firefox / IE needed for Aloha placeholders */

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -14448,8 +14448,14 @@
   left: 32.25% !important;
 }
 .neos .neos-show-shortcuts .neos-subheader {
-  padding: 0 16px 15px;
+  height: 40px;
+  line-height: 40px;
+  padding-left: 16px;
   margin: 0;
+  position: relative;
+  border-bottom: 1px solid #3f3f3f;
+  overflow: hidden;
+  margin-bottom: 15px;
 }
 .neos .neos-show-shortcuts .neos-modal-body .neos-column-body {
   width: 50%;
@@ -14458,22 +14464,20 @@
   box-sizing: border-box;
   float: left;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul {
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list {
   border: none;
   margin-bottom: 1em;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li {
-  float: left;
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut {
   margin: 0;
   width: 100%;
   vertical-align: top;
   margin-bottom: 1em;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body {
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body {
   width: 100%;
-  line-height: 25px;
+  float: none;
   height: 25px;
-  float: left;
   text-align: left;
   background-color: transparent;
   -webkit-box-sizing: border-box;
@@ -14487,30 +14491,24 @@
   -webkit-font-smoothing: antialiased;
   color: #fff;
   font-size: 14px;
-  vertical-align: middle;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span {
-  margin-right: 5px;
-  float: left;
-  display: block;
-  margin-left: 0;
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body .neos-shortcut-icon,
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body .neos-shortcut-label,
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body .neos-shortcut-keys {
+  display: inline-block;
+  vertical-align: middle;
+  height: 25px;
+}
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body .neos-shortcut-icon {
+  margin: 0;
   width: 25px;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span i {
-  margin: 7px 0 0 4px;
-  display: block;
-}
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .neos-span strong {
-  font-weight: 700;
-}
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li .neos-shortcut-body .shortcut-keys {
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body .neos-shortcut-keys {
   float: right;
-  padding: 0 10px;
   color: #adadad;
 }
-.neos .neos-show-shortcuts .neos-modal-body .neos-column-body ul li span {
-  float: right;
-  width: 100px;
+.neos .neos-show-shortcuts .neos-modal-body .neos-column-body .neos-shortcut-list .neos-shortcut .neos-shortcut-body i {
+  color: #00b5ff;
 }
 
 .neos-contentelement {

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -12771,7 +12771,11 @@
   margin-left: 8px;
 }
 .neos .neos-insert-node-panel .neos-header i {
+  color: #00b5ff;
   vertical-align: baseline;
+}
+.neos .neos-insert-node-panel .neos-header strong {
+  font-weight: 700;
 }
 .neos .neos-insert-node-panel .neos-subheader {
   height: 40px;
@@ -12830,9 +12834,17 @@
   max-height: calc(100vh - 284px);
   overflow-y: auto;
 }
+.neos .neos-insert-node-panel .neos-modal-body > ul {
+  margin-top: 12px;
+}
 .neos .neos-insert-node-panel .neos-modal-footer {
   border-top: 1px solid #3f3f3f;
   margin-top: -1px;
+}
+.neos .neos-insert-node-panel .neos-modal-footer-tips {
+  text-align: center;
+  font-style: italic;
+  color: #adadad;
 }
 .neos .neos-insert-node-panel .neos-content-new-selecttype-button {
   position: relative;
@@ -12861,16 +12873,19 @@
   text-align: center;
   vertical-align: baseline;
 }
-.neos .neos-insert-node-panel .neos-content-new-selecttype-button:focus, .neos .neos-insert-node-panel .neos-content-new-selecttype-button:hover {
-  background-color: #00b5ff;
-}
-.neos .neos-insert-node-panel .neos-content-new-selecttype-button:focus button, .neos .neos-insert-node-panel .neos-content-new-selecttype-button:hover button {
+.neos .neos-insert-node-panel .neos-content-new-selecttype-button button:focus {
   outline: none;
 }
-.neos .neos-insert-node-panel .neos-content-new-selecttype-button:focus i, .neos .neos-insert-node-panel .neos-content-new-selecttype-button:hover i {
+.neos .neos-insert-node-panel .neos-content-new-selecttype-button--current {
+  background-color: #00b5ff;
+}
+.neos .neos-insert-node-panel .neos-content-new-selecttype-button--current button {
+  outline: none;
+}
+.neos .neos-insert-node-panel .neos-content-new-selecttype-button--current button i {
   color: #fff;
 }
-.neos .neos-insert-node-panel .neos-content-new-selecttype-button:focus .neos-help-message-button, .neos .neos-insert-node-panel .neos-content-new-selecttype-button:hover .neos-help-message-button {
+.neos .neos-insert-node-panel .neos-content-new-selecttype-button--current .neos-help-message-button {
   display: inline-block;
 }
 .neos .neos-insert-node-panel .neos-content-new-selecttype-button .neos-help-message-button {

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -14443,6 +14443,10 @@
   text-align: center;
   font-size: 0.8em;
 }
+.neos .neos-show-shortcuts {
+  width: 75% !important;
+  left: 32.25% !important;
+}
 .neos .neos-show-shortcuts .neos-subheader {
   padding: 0 16px 15px;
   margin: 0;


### PR DESCRIPTION
This change add support to select a node type with the keyboard left/right 
arrows and confirm the selection with return.
