### PR TITLE
BUGFIX: Make ``NodeData::createShadow`` public again

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -949,7 +949,7 @@ class NodeData extends AbstractNodeData
      * @param string $path The (original) path for the node data
      * @return NodeData
      */
-    protected function createShadow($path)
+    public function createShadow($path)
     {
         $shadowNode = new NodeData($path, $this->workspace, $this->identifier, $this->dimensionValues);
         $shadowNode->similarize($this);


### PR DESCRIPTION
The ``NodeData::createShadow`` method was changed to protected
visibility in 2.2, as it is vital to repair certain constellations
of nodes it is changed back to public.