### PR TITLE
BUGFIX: Cancel in editing user settings links to user module

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Module/User/UserSettings/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/User/UserSettings/Edit.html
@@ -12,7 +12,7 @@
 		<f:render partial="Module/Shared/EditUser" arguments="{_all}"/>
 
 		<div class="neos-footer">
-			<neos:link.module path="management" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</neos:link.module>
+			<neos:link.module path="user" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</neos:link.module>
 			<f:form.submit value="{neos:backend.translate(id: 'userSettings.saveUser', source: 'Modules', value: 'Save user')}" class="neos-button neos-button-primary" />
 		</div>
 	</f:form>


### PR DESCRIPTION
Cancel in editing user settings links to user module instead of management module.