### PR TITLE
BUGFIX: Discard selected nodes which were moved corrupts workspace

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -501,6 +501,8 @@ class WorkspacesController extends AbstractModuleController
         ksort($siteChanges);
         foreach ($siteChanges as $siteKey => $site) {
             foreach ($site['documents'] as $documentKey => $document) {
+                $liveDocumentNode = $liveContext->getNodeByIdentifier($document['documentNode']->getIdentifier());
+                $siteChanges[$siteKey]['documents'][$documentKey]['isMoved'] = $liveDocumentNode && $document['documentNode']->getPath() !== $liveDocumentNode->getPath();
                 foreach ($document['changes'] as $changeKey => $change) {
                     $liveNode = $liveContext->getNodeByIdentifier($change['node']->getIdentifier());
                     $siteChanges[$siteKey]['documents'][$documentKey]['changes'][$changeKey]['isNew'] = is_null($liveNode);
@@ -509,7 +511,6 @@ class WorkspacesController extends AbstractModuleController
             }
             ksort($siteChanges[$siteKey]['documents']);
         }
-
         return $siteChanges;
     }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -503,6 +503,7 @@ class WorkspacesController extends AbstractModuleController
             foreach ($site['documents'] as $documentKey => $document) {
                 $liveDocumentNode = $liveContext->getNodeByIdentifier($document['documentNode']->getIdentifier());
                 $siteChanges[$siteKey]['documents'][$documentKey]['isMoved'] = $liveDocumentNode && $document['documentNode']->getPath() !== $liveDocumentNode->getPath();
+                $siteChanges[$siteKey]['documents'][$documentKey]['isNew'] = $liveDocumentNode === null;
                 foreach ($document['changes'] as $changeKey => $change) {
                     $liveNode = $liveContext->getNodeByIdentifier($change['node']->getIdentifier());
                     $siteChanges[$siteKey]['documents'][$documentKey]['changes'][$changeKey]['isNew'] = is_null($liveNode);

--- a/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeAttributes.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeAttributes.html
@@ -1,16 +1,16 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
 <f:if condition="{change.node.removed}">
-    <f:then>class="neos-content-change legend-deleted" title="{neos:backend.translate(id: 'workspaces.legend.deleted', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
+    <f:then>class="neos-content-change legend-deleted" data-nodepath="{change.node.path}" title="{neos:backend.translate(id: 'workspaces.legend.deleted', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
     <f:else>
         <f:if condition="{change.isNew}">
-            <f:then>class="neos-content-change legend-created" title="{neos:backend.translate(id: 'workspaces.legend.created', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
+            <f:then>class="neos-content-change legend-created" data-nodepath="{change.node.path}" title="{neos:backend.translate(id: 'workspaces.legend.created', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
             <f:else>
                 <f:if condition="{change.isMoved}">
-                    <f:then>class="neos-content-change legend-moved" title="{neos:backend.translate(id: 'workspaces.legend.moved', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
+                    <f:then>class="neos-content-change legend-moved" data-nodepath="{change.node.path}" title="{neos:backend.translate(id: 'workspaces.legend.moved', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
                     <f:else>
                         <f:if condition="{change.node.hidden}">
-                            <f:then>class="neos-content-change legend-hidden" title="{neos:backend.translate(id: 'workspaces.legend.hidden', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
-                            <f:else>class="neos-content-change legend-edited" title="{neos:backend.translate(id: 'workspaces.legend.edited', source: 'Modules', package: 'TYPO3.Neos')}"</f:else>
+                            <f:then>class="neos-content-change legend-hidden" data-nodepath="{change.node.path}" title="{neos:backend.translate(id: 'workspaces.legend.hidden', source: 'Modules', package: 'TYPO3.Neos')}"</f:then>
+                            <f:else>class="neos-content-change legend-edited" data-nodepath="{change.node.path}" title="{neos:backend.translate(id: 'workspaces.legend.edited', source: 'Modules', package: 'TYPO3.Neos')}"</f:else>
                         </f:if>
                     </f:else>
                 </f:if>

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -28,7 +28,7 @@
 						<tbody>
 						<f:for each="{siteChanges}" as="site">
 							<f:for each="{site.documents}" key="documentPath" as="document">
-								<tr class="neos-document" data-nodepath="{document.documentNode.path}" data-ismoved="{f:if(condition: document.isMoved, then: 'true', else: 'false')}">
+								<tr class="neos-document" data-nodepath="{document.documentNode.path}" data-ismoved="{f:if(condition: document.isMoved, then: 'true', else: 'false')}" data-isnew="{f:if(condition: document.isNew, then: 'true', else: 'false')}">
 									<td colspan="2" class="neos-priority1 path-caption">
 										<div class="neos-row-fluid">
 											<div class="neos-span2">
@@ -49,7 +49,7 @@
 									</td>
 								</tr>
 								<f:for each="{document.changes}" key="relativePath" as="change">
-									<tr class="neos-change fold-{document.documentNode.identifier}" data-nodepath="{change.node.path}" data-ismoved="{f:if(condition: change.isMoved, then: 'true', else: 'false')}">
+									<tr class="neos-change fold-{document.documentNode.identifier}" data-nodepath="{change.node.path}" data-ismoved="{f:if(condition: change.isMoved, then: 'true', else: 'false')}" data-isnew="{f:if(condition: change.isNew, then: 'true', else: 'false')}">
 										<td class="check neos-priority1">
 											<label for="{change.node.identifier}" class="neos-checkbox"><f:form.checkbox name="nodes[]" value="{change.node.contextPath}" id="{change.node.identifier}" /><span></span></label>
 										</td>
@@ -108,7 +108,7 @@
 						$('tbody input[type="checkbox"]').prop('checked', value);
 					});
 					$('tbody input[type="checkbox"]').change(function() {
-						if ($(this).closest('tr').data('ismoved') === true) {
+						if ($(this).closest('tr').data('ismoved') === true || $(this).closest('tr').data('isnew') === true) {
 							var currentNodePath = $(this).closest('tr').attr('data-nodepath') + '/';
 							var checked = $(this).prop('checked');
 
@@ -117,8 +117,8 @@
 									return nodePath.indexOf($(element).data('nodepath')) === 0;
 								}
 							}
-							var movedParentDocuments = $(this).closest('table').find('.neos-document[data-ismoved="true"]').filter(nodePathStartsWith(currentNodePath));
-							$(movedParentDocuments).each(function(index, movedParentDocument) {
+							var movedOrNewParentDocuments = $(this).closest('table').find('.neos-document[data-ismoved="true"], .neos-document[data-isnew="true"]').filter(nodePathStartsWith(currentNodePath));
+							$(movedOrNewParentDocuments).each(function(index, movedParentDocument) {
 								$('tr[data-nodepath^="' + $(movedParentDocument).data('nodepath') + '"] td.check input').prop('checked', checked);
 							});
 						}

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -49,7 +49,7 @@
 									</td>
 								</tr>
 								<f:for each="{document.changes}" key="relativePath" as="change">
-									<tr class="neos-change fold-{document.documentNode.identifier}">
+									<tr class="neos-change fold-{document.documentNode.identifier}" data-nodepath="{change.node.path}" data-ismoved="{f:if(condition: change.isMoved, then: 'true', else: 'false')}">
 										<td class="check neos-priority1">
 											<label for="{change.node.identifier}" class="neos-checkbox"><f:form.checkbox name="nodes[]" value="{change.node.contextPath}" id="{change.node.identifier}" /><span></span></label>
 										</td>
@@ -108,6 +108,14 @@
 						$('tbody input[type="checkbox"]').prop('checked', value);
 					});
 					$('tbody input[type="checkbox"]').change(function() {
+						if ($(this).closest('tr').attr('data-ismoved') == 'true') {
+							var currentNodePath = $(this).closest('tr').attr('data-nodepath') + '/';
+							var checked = $(this).prop('checked');
+							$('tr[data-nodepath^="' + currentNodePath + '"] td.check input').each(function(index, element) {
+								$(element).prop('checked', checked);
+							});
+						}
+
 						if ($('tbody input[type="checkbox"]:checked').length > 0) {
 							$('.batch-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled')
 						} else {

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -28,7 +28,7 @@
 						<tbody>
 						<f:for each="{siteChanges}" as="site">
 							<f:for each="{site.documents}" key="documentPath" as="document">
-								<tr>
+								<tr class="neos-document" data-nodepath="{document.documentNode.path}" data-ismoved="{f:if(condition: document.isMoved, then: 'true', else: 'false')}">
 									<td colspan="2" class="neos-priority1 path-caption">
 										<div class="neos-row-fluid">
 											<div class="neos-span2">
@@ -108,11 +108,18 @@
 						$('tbody input[type="checkbox"]').prop('checked', value);
 					});
 					$('tbody input[type="checkbox"]').change(function() {
-						if ($(this).closest('tr').attr('data-ismoved') == 'true') {
+						if ($(this).closest('tr').data('ismoved') === true) {
 							var currentNodePath = $(this).closest('tr').attr('data-nodepath') + '/';
 							var checked = $(this).prop('checked');
-							$('tr[data-nodepath^="' + currentNodePath + '"] td.check input').each(function(index, element) {
-								$(element).prop('checked', checked);
+
+							function nodePathStartsWith(nodePath) {
+								return function(index, element) {
+									return nodePath.indexOf($(element).data('nodepath')) === 0;
+								}
+							}
+							var movedParentDocuments = $(this).closest('table').find('.neos-document[data-ismoved="true"]').filter(nodePathStartsWith(currentNodePath));
+							$(movedParentDocuments).each(function(index, movedParentDocument) {
+								$('tr[data-nodepath^="' + $(movedParentDocument).data('nodepath') + '"] td.check input').prop('checked', checked);
 							});
 						}
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
@@ -15,7 +15,6 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
-use TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface;
 use TYPO3\TYPO3CR\Exception\WorkspaceException;
 use TYPO3\TYPO3CR\Service\Utility\NodePublishingDependencySolver;
 
@@ -141,26 +140,58 @@ class PublishingService implements PublishingServiceInterface
     /**
      * Discards the given node.
      *
-     * @param NodeInterface $node
+     * If the node has been moved, this method will also discard all changes of child nodes of the given node.
+     *
+     * @param NodeInterface $node The node to discard
      * @return void
      * @throws \TYPO3\TYPO3CR\Exception\WorkspaceException
      * @api
      */
     public function discardNode(NodeInterface $node)
     {
+        $this->doDiscardNode($node);
+    }
+
+    /**
+     * Method which does the actual work of discarding, includes a protection against endless recursions and
+     * multiple discarding of the same node.
+     *
+     * @param NodeInterface $node The node to discard
+     * @param array &$alreadyDiscardedNodeIdentifiers List of node identifiers which already have been discarded during one discardNode() run
+     * @return void
+     * @throws \TYPO3\TYPO3CR\Exception\WorkspaceException
+     */
+    protected function doDiscardNode(NodeInterface $node, array &$alreadyDiscardedNodeIdentifiers = [])
+    {
         if ($node->getWorkspace()->getBaseWorkspace() === null) {
             throw new WorkspaceException('Nodes in a in a workspace without a base workspace cannot be discarded.', 1395841899);
         }
+        if ($node->getPath() === '/') {
+            return;
+        }
+        if (array_search($node->getIdentifier(), $alreadyDiscardedNodeIdentifiers) !== false) {
+            return;
+        }
+
+        $alreadyDiscardedNodeIdentifiers[] = $node->getIdentifier();
 
         $possibleShadowNodeData = $this->nodeDataRepository->findOneByMovedTo($node->getNodeData());
-        if ($possibleShadowNodeData !== null) {
+        if ($possibleShadowNodeData instanceof NodeData) {
+            if ($possibleShadowNodeData->getMovedTo() !== null) {
+                $parentBasePath = $node->getPath();
+                $affectedChildNodeDataInSameWorkspace = $this->nodeDataRepository->findByParentAndNodeType($parentBasePath, null, $node->getWorkspace(), null, false, true);
+                foreach ($affectedChildNodeDataInSameWorkspace as $affectedChildNodeData) {
+                    /** @var NodeData $affectedChildNodeData */
+                    $affectedChildNode = $this->nodeFactory->createFromNodeData($affectedChildNodeData, $node->getContext());
+                    $this->doDiscardNode($affectedChildNode, $alreadyDiscardedNodeIdentifiers);
+                }
+            }
+
             $this->nodeDataRepository->remove($possibleShadowNodeData);
         }
 
-        if ($node->getPath() !== '/') {
-            $this->nodeDataRepository->remove($node);
-            $this->emitNodeDiscarded($node);
-        }
+        $this->nodeDataRepository->remove($node);
+        $this->emitNodeDiscarded($node);
     }
 
     /**
@@ -172,8 +203,9 @@ class PublishingService implements PublishingServiceInterface
      */
     public function discardNodes(array $nodes)
     {
+        $discardedNodeIdentifiers = [];
         foreach ($nodes as $node) {
-            $this->discardNode($node);
+            $this->doDiscardNode($node, $discardedNodeIdentifiers);
         }
     }
 


### PR DESCRIPTION
The "discard selected nodes" feature in the Workspace Review module
leaves orphaned nodes after discarding moved document nodes. The result
is a seemingly empty workspace which in fact still contains nodes.
The workspace can't be deleted. The discarded document node still may
appear in the Content Module's navigation but won't render.

Steps to reproduce based on the Neos demo site:

- start with a clean user workspace
- move the page Download into the page Try me
- go to the review module (Publish Menu -> Review changes)
- select all changes
- press "Discard selected changes"

The document node has been removed, but the child nodes, including the
corresponding shadow nodes, still exist in the database.

Closes #953