### PR TITLE
FEATURE: Create empty sites for existing site packages in sites backend module

### DIFF
--- a/TYPO3.Neos/Configuration/Policy.yaml
+++ b/TYPO3.Neos/Configuration/Policy.yaml
@@ -139,7 +139,7 @@ privilegeTargets:
       matcher: 'method(TYPO3\Neos\Controller\Module\Administration\PackagesController->(index|activate|deactivate|delete|freeze|unfreeze|batch)Action())'
 
     'TYPO3.Neos:Backend.Module.Administration.Sites':
-      matcher: 'method(TYPO3\Neos\Controller\Module\Administration\SitesController->(index|edit|updateSite|newSite|createSite|deleteSite|activateSite|deactivateSite|editDomain|updateDomain|newDomain|createDomain|deleteDomain|activateDomain|deactivateDomain)Action())'
+      matcher: 'method(TYPO3\Neos\Controller\Module\Administration\SitesController->(index|edit|updateSite|newSite|createSite|importSite|createSiteNode|createSitePackage|deleteSite|activateSite|deactivateSite|editDomain|updateDomain|newDomain|createDomain|deleteDomain|activateDomain|deactivateDomain)Action())'
 
     'TYPO3.Neos:Backend.Module.Administration.Configuration':
       matcher: 'method(TYPO3\Neos\Controller\Module\Administration\ConfigurationController->indexAction())'

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -3,55 +3,92 @@
 
 <f:section name="content">
 	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site')}</h2>
-	<f:form action="createSite">
 
-		<div class="neos-row-fluid">
+  <div class="neos-row-fluid">
+    <f:form action="createSite">
+      <fieldset class="neos-span3">
+        <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site')}</legend>
+        <f:if condition="{sitePackages -> f:count()} > 0">
+          <f:then>
+            <div class="neos-control-group">
+              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
+              <div class="neos-controls neos-select">
+                <f:form.select name="site" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+              </div>
+            </div>
+            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+          </f:then>
+          <f:else>
+            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
+            </p>
+          </f:else>
+        </f:if>
+      </fieldset>
+    </f:form>
 
-			<fieldset class="neos-span5">
-				<legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site')}</legend>
-				<f:if condition="{sitePackages -> f:count()} > 0">
-					<f:then>
-						<div class="neos-control-group">
-							<label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
-							<div class="neos-controls neos-select">
-								<f:form.select name="site" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
-							</div>
-						</div>
-					</f:then>
-					<f:else>
-						<p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
-						</p>
-					</f:else>
-				</f:if>
-			</fieldset>
-			<fieldset class="neos-span5 neos-offset1">
-				<legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site')}</legend>
-				<f:if condition="{generatorServiceIsAvailable}">
-					<f:then>
-						<div class="neos-control-group{f:validation.ifHasErrors(for: 'packageKey', then: ' neos-error')}">
-							<label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key')}</label>
-							<div class="neos-controls">
-								<f:form.textfield name="packageKey" value="{packageKey}" id="package-key" class="neos-span12" placeholder="{neos:backend.translate(id: 'sites.validPackageKeyInfo', value: 'VendorName.MyPackageKey')}" />
-								<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'packageKey'}"/>
-							</div>
-						</div>
-						<div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
-							<label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name')}</label>
-							<div class="neos-controls">
-								<f:form.textfield name="siteName" value="{siteName}" id="site-name" />
-								<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
-							</div>
-						</div>
-					</f:then>
-					<f:else>
-						<p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.') -> f:format.raw()}</p>
-					</f:else>
-				</f:if>
-			</fieldset>
-		</div>
-		<div class="neos-footer">
-			<f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</f:link.action>
-			<f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
-		</div>
-	</f:form>
+    <f:form action="createSite">
+      <fieldset class="neos-span3 neos-offset1">
+        <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site')}</legend>
+        <f:if condition="{sitePackages -> f:count()} > 0">
+          <f:then>
+            <div class="neos-control-group">
+              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
+              <div class="neos-controls neos-select">
+                <f:form.select name="site" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+              </div>
+            </div>
+            <div class="neos-control-group{f:validation.ifHasErrors(for: 'nodeType', then: ' neos-error')}">
+              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType')}</label>
+              <div class="neos-controls neos-select">
+                <f:form.select name="nodeType" options="{documentNodeTypes}" optionLabelField="name" optionValueField="name" id="node-type" class="neos-span12" />
+              </div>
+            </div>
+            <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
+              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name')}</label>
+              <div class="neos-controls">
+                <f:form.textfield name="siteName" value="{siteName}" id="site-name" />
+                <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
+              </div>
+            </div>
+            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+          </f:then>
+          <f:else>
+            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
+            </p>
+          </f:else>
+        </f:if>
+      </fieldset>
+    </f:form>
+
+    <f:form action="createSite">
+      <fieldset class="neos-span3 neos-offset1">
+        <legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package')}</legend>
+        <f:if condition="{generatorServiceIsAvailable}">
+          <f:then>
+            <div class="neos-control-group{f:validation.ifHasErrors(for: 'packageKey', then: ' neos-error')}">
+              <label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key')}</label>
+              <div class="neos-controls">
+                <f:form.textfield name="packageKey" value="{packageKey}" id="package-key" class="neos-span12" placeholder="{neos:backend.translate(id: 'sites.validPackageKeyInfo', value: 'VendorName.MyPackageKey')}" />
+                <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'packageKey'}"/>
+              </div>
+            </div>
+            <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
+              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name')}</label>
+              <div class="neos-controls">
+                <f:form.textfield name="siteName" value="{siteName}" id="site-name" />
+                <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
+              </div>
+            </div>
+            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+          </f:then>
+          <f:else>
+            <p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.') -> f:format.raw()}</p>
+          </f:else>
+        </f:if>
+      </fieldset>
+    </f:form>
+  </div>
+  <div class="neos-footer">
+    <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</f:link.action>
+  </div>
 </f:section>

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -5,7 +5,7 @@
 	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site')}</h2>
 
   <div class="neos-row-fluid">
-    <f:form action="createSite">
+    <f:form action="importSite">
       <fieldset class="neos-span3">
         <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site')}</legend>
         <f:if condition="{sitePackages -> f:count()} > 0">
@@ -13,10 +13,10 @@
             <div class="neos-control-group">
               <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
               <div class="neos-controls neos-select">
-                <f:form.select name="site" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+                <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
             <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
@@ -26,7 +26,7 @@
       </fieldset>
     </f:form>
 
-    <f:form action="createSite">
+    <f:form action="createSiteNode">
       <fieldset class="neos-span3 neos-offset1">
         <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site')}</legend>
         <f:if condition="{sitePackages -> f:count()} > 0">
@@ -34,7 +34,7 @@
             <div class="neos-control-group">
               <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
               <div class="neos-controls neos-select">
-                <f:form.select name="site" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+                <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'nodeType', then: ' neos-error')}">
@@ -50,7 +50,7 @@
                 <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.createNode', value: 'Create empty Site')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
             <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
@@ -60,7 +60,7 @@
       </fieldset>
     </f:form>
 
-    <f:form action="createSite">
+    <f:form action="createSitePackage">
       <fieldset class="neos-span3 neos-offset1">
         <legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package')}</legend>
         <f:if condition="{generatorServiceIsAvailable}">
@@ -79,7 +79,7 @@
                 <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.create', value: 'Create Site')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.createPackage', value: 'Create Site-Package')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
             <p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.') -> f:format.raw()}</p>


### PR DESCRIPTION
Currently the backend module to create a new site only allows to import a site from an existing site-package or to create a new site-package if the kickstarter is installed.

This change allows to create a new site-node for an existing site-package in the administration-site module. Therefore a new section was added to the module where the user selects site-package-key and rootNode document-type and site-name.
