### PR TITLE
BUGFIX: add missing label for the document group

### DIFF
--- a/TYPO3.Neos/Resources/Private/Translations/en/NodeTypes/Document.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/NodeTypes/Document.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 	<file original="" product-name="TYPO3.Neos" source-language="en" datatype="plaintext">
 		<body>
+			<trans-unit id="groups.document" xml:space="preserve">
+				<source>Document</source>
+			</trans-unit>
 			<trans-unit id="properties.title" xml:space="preserve">
 				<source>Title</source>
 			</trans-unit>


### PR DESCRIPTION
Currently the label is missing:

![image](https://cloud.githubusercontent.com/assets/837032/18599421/138ab352-7c61-11e6-9066-877973d872f3.png)
