### PR TITLE
BUGFIX: Only show pointer cursor for label tags with for attribute

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_reset.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_reset.scss
@@ -122,7 +122,7 @@ input[type="submit"] {
     -webkit-appearance: button; // Corrects inability to style clickable `input` types in iOS.
     cursor: pointer; // Improves usability and consistency of cursor style between image-type `input` and others.
 }
-label,
+label[for],
 select,
 button,
 input[type="button"],


### PR DESCRIPTION
Instead of showing a pointer cursor for all labels, only show for those that actually have a ``for`` attribute making them clickable.