### PR TITLE
BUGFIX: Clickable labels in the media views

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
@@ -11,7 +11,7 @@
 				<fieldset>
 					<legend>{neos:backend.translate(id: 'media.basics', source: 'Modules', package: 'TYPO3.Neos')}</legend>
 					<label for="title">{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}</label>
-					<f:form.textfield property="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}"/>
+					<f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}"/>
 					<label for="caption">{neos:backend.translate(id: 'media.field.caption', source: 'Modules', package: 'TYPO3.Neos')}</label>
 					<f:form.textarea property="caption" id="caption" rows="3" placeholder="{neos:backend.translate(id: 'media.field.caption', source: 'Modules', package: 'TYPO3.Neos')}"/>
 					<f:if condition="{tags}">

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/EditAssetCollection.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/EditAssetCollection.html
@@ -11,7 +11,7 @@
 				<fieldset>
 					<legend>{neos:backend.translate(id: 'media.basics', source: 'Modules', package: 'TYPO3.Neos')}</legend>
 					<label for="title">{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}</label>
-					<f:form.textfield property="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}" />
+					<f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}" />
 					<f:if condition="{tags}">
 						<label>{neos:backend.translate(id: 'media.tags', source: 'Modules', package: 'TYPO3.Neos')}</label>
 						<f:for each="{tags}" as="tag">

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/New.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/New.html
@@ -11,7 +11,7 @@
 				<label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'media.maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'media.chooseFile', source: 'Modules', package: 'TYPO3.Neos')} <i class="icon-file"></i></label>
 				<f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
 				<label for="title">{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}</label>
-				<f:form.textfield property="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}" />
+				<f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'media.field.title', source: 'Modules', package: 'TYPO3.Neos')}" />
 				<label for="caption">{neos:backend.translate(id: 'media.field.caption', source: 'Modules', package: 'TYPO3.Neos')}</label>
 				<f:form.textarea property="caption" rows="3" id="caption" placeholder="{neos:backend.translate(id: 'media.field.caption', source: 'Modules', package: 'TYPO3.Neos')}" />
 				<f:if condition="{tags}">


### PR DESCRIPTION
Since Fluid generates the ``name`` attribute based on the object relation, some of the fields need to be assigned a id to match their label tag.