### PR TITLE
BUGFIX: Prevent nesting level too deep error in checkbox view helper

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
@@ -93,7 +93,7 @@ class CheckboxViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormField
             }
             if (is_array($propertyValue)) {
                 if ($checked === null) {
-                    $checked = in_array($this->arguments['value'], $propertyValue);
+                    $checked = in_array($this->arguments['value'], $propertyValue, true);
                 }
                 $nameAttribute .= '[]';
             } elseif ($multiple === true) {


### PR DESCRIPTION
To prevent a recursive comparison which can lead to this error, strict comparison is used which only compares the reference.

This issue occurs in the edit asset collection view in the media module.