### PR TITLE
BUGFIX: Two node publishing issues

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -395,7 +395,7 @@ class WorkspacesController extends AbstractModuleController
         if (($targetWorkspace = $workspace->getBaseWorkspace()) === null) {
             $targetWorkspace = $this->workspaceRepository->findOneByName('live');
         }
-        $workspace->publish($targetWorkspace);
+        $this->publishingService->publishNodes($this->publishingService->getUnpublishedNodes($workspace), $targetWorkspace);
         $this->addFlashMessage($this->translator->translateById('workspaces.allChangesInWorkspaceHaveBeenPublished', [htmlspecialchars($workspace->getTitle()), htmlspecialchars($targetWorkspace->getTitle())], null, null, 'Modules', 'TYPO3.Neos'));
         $this->redirect('index');
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -79,6 +79,7 @@ class Package extends BasePackage
 
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
+        $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodeDiscarded', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerNodeChange');
         $dispatcher->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', function ($node, $targetWorkspace) use ($bootstrap) {
             $cacheManager = $bootstrap->getObjectManager()->get(CacheManager::class);


### PR DESCRIPTION
- Flush routing cache when a node is discarded
- Use publishing service to publish workspace in workspaces module