### PR TITLE
BUGFIX: Asset related nodes listing

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -100,9 +100,9 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
             }
             $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());
             if ($accessible) {
-                $context = $this->createContentContext($userWorkspaceName);
-            } else {
                 $context = $this->createContextMatchingNodeData($relatedNodeData);
+            } else {
+                $context = $this->createContentContext($userWorkspaceName);
             }
             $site = $context->getCurrentSite();
             $node = $this->nodeFactory->createFromNodeData($relatedNodeData, $context);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -95,7 +95,7 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
         $relatedNodes = [];
         foreach ($this->getRelatedNodes($asset) as $relatedNodeData) {
             /** @var NodeData $relatedNodeData */
-            if ($relatedNodeData->isInternal()) {
+            if ($relatedNodeData->isRemoved()) {
                 continue;
             }
             $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -19,6 +19,7 @@ use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Strategy\AbstractAssetUsageStrategy;
 use TYPO3\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\Service\UserService;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
@@ -137,6 +138,12 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
             }
         }
 
-        return $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);
+        return array_filter(
+            $this->nodeDataRepository->findNodesByRelatedEntities($relationMap),
+            function ($nodeData) {
+                /** @var NodeData $nodeData */
+                return strpos($nodeData->getPath(), SiteService::SITES_ROOT_PATH) === 0;
+            }
+        );
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -95,9 +95,6 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
         $relatedNodes = [];
         foreach ($this->getRelatedNodes($asset) as $relatedNodeData) {
             /** @var NodeData $relatedNodeData */
-            if ($relatedNodeData->isRemoved()) {
-                continue;
-            }
             $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());
             if ($accessible) {
                 $context = $this->createContextMatchingNodeData($relatedNodeData);
@@ -142,7 +139,7 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
             $this->nodeDataRepository->findNodesByRelatedEntities($relationMap),
             function ($nodeData) {
                 /** @var NodeData $nodeData */
-                return strpos($nodeData->getPath(), SiteService::SITES_ROOT_PATH) === 0;
+                return $nodeData->isRemoved() === false && strpos($nodeData->getPath(), SiteService::SITES_ROOT_PATH) === 0;
             }
         );
     }

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -36,10 +36,10 @@
 				<f:for each="{site.documentNodes}" as="documentNode">
 					<tr class="fold-{site.site.nodeName}">
 						<td>
-							<f:if condition="{documentNode.node.nodeType.ui.icon}">
-								<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label)}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
-							</f:if>
 							<f:if condition="{documentNode.node}">
+								<f:if condition="{documentNode.node.nodeType.ui.icon}">
+									<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label)}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
+								</f:if>
 								<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
 							</f:if>
 						</td>
@@ -61,10 +61,24 @@
 									<li>
 										<f:if condition="{relatedNode.accessible}">
 											<f:then>
-												<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank" title="{neos:backend.translate(id: 'edit.argument', arguments:'{0:\'\"{documentNode.node.label}\"\'}')}"><i class="icon-external-link"></i></neos:link.node>
+												<f:if condition="{relatedNode.contextDocumentNode}">
+													<f:then>
+														<f:if condition="{userWorkspace} == {relatedNode.nodeData.workspace}">
+															<f:then>
+																<neos:link.node node="{relatedNode.contextDocumentNode}" title="{neos:backend.translate(id: 'edit.argument', arguments:'{0: \'\"{documentNode.node.label}\"\'}')}" data="{neos-toggle: 'tooltip'}"><i class="icon-edit"></i></neos:link.node>
+															</f:then>
+															<f:else>
+																<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank" title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', arguments: '{0:\'{relatedNode.nodeData.workspace.title}\'}', source: 'Modules')}" data="{neos-toggle: 'tooltip'}"><i class="icon-external-link"></i></neos:link.node>
+															</f:else>
+														</f:if>
+													</f:then>
+													<f:else>
+														<i class="icon-warning" data-neos-toggle="tooltip" data-placement="left" title="{neos:backend.translate(id: 'media.relatedNodes.missingDocumentNode', source: 'Modules')}"></i>
+													</f:else>
+												</f:if>
 											</f:then>
 											<f:else>
-												<span><i class="icon-warning" data-neos-toggle="tooltip" data-placement="left" title="{neos:backend.translate(id: 'media.relatedNodes.nodeNotAccessible', source: 'Modules')}"></i></span>
+												<i class="icon-lock" title="{neos:backend.translate(id: 'workspaces.noAccessToWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
 											</f:else>
 										</f:if>
 									</li>
@@ -86,24 +100,24 @@
 							<ul>
 								<f:for each="{documentNode.nodes}" as="relatedNode">
 									<li>
-										<f:if condition="{userWorkspace} == {relatedNode.nodeData.workspace}">
+										<f:if condition="{relatedNode.nodeData.workspace.personalWorkspace}">
 											<f:then>
-												<i class="icon-user" title="{neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'TYPO3.Neos')}" data-neos-toggle="tooltip"></i>
+												<i class="icon-user" title="{neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
 											</f:then>
 											<f:else>
-												<f:if condition="{relatedNode.accessible}">
+												<f:if condition="{relatedNode.nodeData.workspace.privateWorkspace}">
 													<f:then>
-														<f:if condition="{relatedNode.nodeData.workspace.privateWorkspace}">
-															<f:then>
-																<i class="icon-shield" title="{neos:backend.translate(id: 'workspaces.privateWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
-															</f:then>
-															<f:else>
-																<i class="icon-group" title="{neos:backend.translate(id: 'workspaces.internalWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
-															</f:else>
-														</f:if>
+														<i class="icon-user" title="{neos:backend.translate(id: 'workspaces.privateWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
 													</f:then>
 													<f:else>
-														<i class="icon-lock" title="{neos:backend.translate(id: 'workspaces.readonlyWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
+														<f:if condition="{relatedNode.nodeData.workspace.publicWorkspace}">
+															<f:then>
+																<i class="icon-group" title="{neos:backend.translate(id: 'workspaces.publicWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
+															</f:then>
+															<f:else>
+																<i class="icon-shield" title="{neos:backend.translate(id: 'workspaces.internalWorkspace', source: 'Modules')}" data-neos-toggle="tooltip"></i>
+															</f:else>
+														</f:if>
 													</f:else>
 												</f:if>
 											</f:else>

--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -59,12 +59,12 @@
 							<ul>
 								<f:for each="{documentNode.nodes}" as="relatedNode">
 									<li>
-										<f:if condition="{relatedNode.contextDocumentNode}">
+										<f:if condition="{relatedNode.accessible}">
 											<f:then>
-												<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank" title="{neos:backend.translate(id: 'edit')} \"{neos:backend.translate(id: documentNode.node.label)}\""><i class="icon-external-link"></i></neos:link.node>
+												<neos:link.node node="{relatedNode.contextDocumentNode}" target="_blank" title="{neos:backend.translate(id: 'edit.argument', arguments:'{0:\'\"{documentNode.node.label}\"\'}')}"><i class="icon-external-link"></i></neos:link.node>
 											</f:then>
 											<f:else>
-												<span><i class="icon-warning" data-neos-toggle="tooltip" data-placement="left" title="Broken node, missing document node"></i></span>
+												<span><i class="icon-warning" data-neos-toggle="tooltip" data-placement="left" title="{neos:backend.translate(id: 'media.relatedNodes.nodeNotAccessible', source: 'Modules')}"></i></span>
 											</f:else>
 										</f:if>
 									</li>

--- a/TYPO3.Neos/Resources/Private/Translations/de/Main.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/de/Main.xlf
@@ -78,6 +78,10 @@
       <trans-unit id="edit" xml:space="preserve" approved="yes">
 				<source>Edit</source>
 			<target xml:lang="de">Bearbeiten</target></trans-unit>
+			<trans-unit id="edit.argument" xml:space="preserve">
+				<source>Edit {0}</source>
+				<target xml:lang="de">{0} bearbeiten</target>
+			</trans-unit>
       <trans-unit id="hideUnhide" xml:space="preserve" approved="yes">
 				<source>Hide / Unhide</source>
 			<target xml:lang="de">Verbergen / Anzeigen</target></trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -57,6 +57,10 @@
       <trans-unit id="workspaces.readonlyWorkspace" xml:space="preserve" approved="yes">
 				<source>Read-only workspace</source>
 			<target xml:lang="de">Nur-Lese Arbeitsbereich</target></trans-unit>
+        <trans-unit id="workspaces.noAccessToWorkspace" xml:space="preserve">
+            <source>No access to workspace</source>
+            <target xml:lang="de">Kein Zugriff auf Arbeitsbereich</target>
+        </trans-unit>
       <trans-unit id="workspaces.workspace.title" xml:space="preserve" approved="yes">
 				<source>Title</source>
 			<target xml:lang="de">Titel</target></trans-unit>
@@ -929,10 +933,10 @@
       <trans-unit id="media.relatedNodes.referencesTo" xml:space="preserve" approved="yes">
 				<source>References to "{asset}"</source>
 			<target xml:lang="de">Verweise auf "{asset}"</target><alt-trans><target xml:lang="de">Verweist auf "{asset}"</target></alt-trans></trans-unit>
-		<trans-unit id="media.relatedNodes.nodeNotAccessible" xml:space="preserve" approved="no">
-			<source>Node is not accessible for current user</source>
-			<target xml:lang="de">Der Zugriff auf das Element ist für den aktuellen Nutzer nicht möglich</target>
-		</trans-unit>
+        <trans-unit id="media.relatedNodes.missingDocumentNode" xml:space="preserve">
+            <source>Related document node is missing.</source>
+            <target xml:lang="de">Zugehöriges Dokument kann nicht gefunden werden.</target>
+        </trans-unit>
       <trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
 				<source>Replace "{filename}"</source>
 			<target xml:lang="de" state="translated">Datei "{filename}" ersetzen</target></trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -929,6 +929,10 @@
       <trans-unit id="media.relatedNodes.referencesTo" xml:space="preserve" approved="yes">
 				<source>References to "{asset}"</source>
 			<target xml:lang="de">Verweise auf "{asset}"</target><alt-trans><target xml:lang="de">Verweist auf "{asset}"</target></alt-trans></trans-unit>
+		<trans-unit id="media.relatedNodes.nodeNotAccessible" xml:space="preserve" approved="no">
+			<source>Node is not accessible for current user</source>
+			<target xml:lang="de">Der Zugriff auf das Element ist für den aktuellen Nutzer nicht möglich</target>
+		</trans-unit>
       <trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
 				<source>Replace "{filename}"</source>
 			<target xml:lang="de" state="translated">Datei "{filename}" ersetzen</target></trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Main.xlf
@@ -78,6 +78,9 @@
 			<trans-unit id="edit" xml:space="preserve">
 				<source>Edit</source>
 			</trans-unit>
+			<trans-unit id="edit.argument" xml:space="preserve">
+				<source>Edit {0}</source>
+			</trans-unit>
 			<trans-unit id="hideUnhide" xml:space="preserve">
 				<source>Hide / Unhide</source>
 			</trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -926,6 +926,9 @@
 			<trans-unit id="media.relatedNodes.referencesTo" xml:space="preserve">
 				<source>References to "{asset}"</source>
 			</trans-unit>
+			<trans-unit id="media.relatedNodes.nodeNotAccessible" xml:space="preserve">
+				<source>Node is not accessible for current user</source>
+			</trans-unit>
 			<trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
 				<source>Replace "{filename}"</source>
 			</trans-unit>

--- a/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/TYPO3.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -59,6 +59,9 @@
 			<trans-unit id="workspaces.readonlyWorkspace" xml:space="preserve">
 				<source>Read-only workspace</source>
 			</trans-unit>
+			<trans-unit id="workspaces.noAccessToWorkspace" xml:space="preserve">
+				<source>No access to workspace</source>
+			</trans-unit>
 			<trans-unit id="workspaces.workspace.title" xml:space="preserve">
 				<source>Title</source>
 			</trans-unit>
@@ -926,8 +929,8 @@
 			<trans-unit id="media.relatedNodes.referencesTo" xml:space="preserve">
 				<source>References to "{asset}"</source>
 			</trans-unit>
-			<trans-unit id="media.relatedNodes.nodeNotAccessible" xml:space="preserve">
-				<source>Node is not accessible for current user</source>
+			<trans-unit id="media.relatedNodes.missingDocumentNode" xml:space="preserve">
+				<source>Related document node is missing.</source>
 			</trans-unit>
 			<trans-unit id="media.replaceAsset.replaceFilename" xml:space="preserve">
 				<source>Replace "{filename}"</source>


### PR DESCRIPTION
multiple fixes for the asset related node listing.
1. Internal nodedata will be skipped since they don't result in any nodes by themselves (i.e. nodes marked as deleted)
2. Changed linking of nearest document of asset related node:
   - only will be linked to if node in question is accessible (so the document is too)
   - linked directly to the user workspace ("open in backend") - the user can edit the node in question directly without searching it again in the backend
   - added translation if node is not accessible
   - new translation `edit.argument` with an argument (useful e.g. for `de` where the word order differs from `en`)
3. Only find nodes in the `sites` tree (`/sites/.*`) to prevent exceptions if other trees in the CR use the asset (exception 1430075362 would be thrown)
