### PR TITLE
!!! FEATURE: Configurable Fusion node type prototype generators

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultContentPrototypeGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultContentPrototypeGenerator.php
@@ -1,0 +1,30 @@
+<?php
+namespace TYPO3\Neos\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * Generate a TypoScript prototype definition based on TYPO3.Neos:Content
+ *
+ * @Flow\Scope("singleton")
+ * @api
+ */
+class DefaultContentPrototypeGenerator extends DefaultPrototypeGenerator
+{
+    /**
+     * The Name of the prototype that is extended
+     *
+     * @var string
+     */
+    protected $basePrototypeName = 'TYPO3.Neos:Content';
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultDocumentPrototypeGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultDocumentPrototypeGenerator.php
@@ -1,0 +1,30 @@
+<?php
+namespace TYPO3\Neos\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * Generate a TypoScript prototype definition based on TYPO3.Neos:Document
+ *
+ * @Flow\Scope("singleton")
+ * @api
+ */
+class DefaultDocumentPrototypeGenerator extends DefaultPrototypeGenerator
+{
+    /**
+     * The Name of the prototype that is extended
+     *
+     * @var string
+     */
+    protected $basePrototypeName = 'TYPO3.Neos:Document';
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPluginPrototypeGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPluginPrototypeGenerator.php
@@ -19,15 +19,8 @@ use TYPO3\TYPO3CR\Domain\Model\NodeType;
  *
  * @Flow\Scope("singleton")
  */
-class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
+class DefaultPluginPrototypeGenerator implements DefaultPrototypeGeneratorInterface
 {
-    /**
-     * The Name of the prototype that is extended
-     *
-     * @var string
-     */
-    protected $basePrototypeName = 'TYPO3.TypoScript:Template';
-
     /**
      * Generate a TypoScript prototype definition for a given node type
      *
@@ -44,21 +37,12 @@ class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
             return '';
         }
 
-        $output = 'prototype(' . $nodeType->getName() . ') < prototype(' . $this->basePrototypeName . ') {' . chr(10);
-
+        $output = 'prototype(' . $nodeType->getName() . ') < prototype(TYPO3.Neos:Plugin) {' . chr(10);
         list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
-        $templatePath = 'resource://' . $packageKey . '/Private/Templates/NodeTypes/' . $relativeName . '.html';
-        $output .= "\t" . 'templatePath = \'' . $templatePath . '\'' . chr(10);
-
-        foreach ($nodeType->getProperties() as $propertyName => $propertyConfiguration) {
-            if (isset($propertyName[0]) && $propertyName[0] !== '_') {
-                $output .= "\t" . $propertyName . ' = ${q(node).property("' . $propertyName . '")}' . chr(10);
-                if (isset($propertyConfiguration['type']) && isset($propertyConfiguration['ui']['inlineEditable']) && $propertyConfiguration['type'] === 'string' && $propertyConfiguration['ui']['inlineEditable'] === true) {
-                    $output .= "\t" . $propertyName . '.@process.convertUris = TYPO3.Neos:ConvertUris' . chr(10);
-                }
-            }
-        }
-
+        $output .= "\t" . 'package = "' . $packageKey . '"' . chr(10);
+        $output .= "\t" . 'subpackage = ""' . chr(10);
+        $output .= "\t" . 'controller = "Standard"' . chr(10);
+        $output .= "\t" . 'action = "index"' . chr(10);
         $output .= '}' . chr(10);
         return $output;
     }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
@@ -203,8 +203,8 @@ class TypoScriptService
      */
     protected function generateTypoScriptForNodeType(NodeType $nodeType)
     {
-        if ($nodeType->hasConfiguration('fusion.prototypeGenerator') && $nodeType->getConfiguration('fusion.prototypeGenerator') !== null) {
-            $generatorClassName = $nodeType->getConfiguration('fusion.prototypeGenerator');
+        if ($nodeType->hasConfiguration('options.fusion.prototypeGenerator') && $nodeType->getConfiguration('options.fusion.prototypeGenerator') !== null) {
+            $generatorClassName = $nodeType->getConfiguration('options.fusion.prototypeGenerator');
             if (!class_exists($generatorClassName)) {
                 throw new \TYPO3\Neos\Domain\Exception('Fusion prototype-generator Class ' . $generatorClassName . ' does not exist');
             }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
@@ -13,6 +13,7 @@ namespace TYPO3\Neos\Domain\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;
@@ -35,9 +36,9 @@ class TypoScriptService
 
     /**
      * @Flow\Inject
-     * @var DefaultPrototypeGeneratorInterface
+     * @var ObjectManagerInterface
      */
-    protected $defaultPrototypeGenerator;
+    protected $objectManager = null;
 
     /**
      * Pattern used for determining the TypoScript root file for a site
@@ -193,16 +194,27 @@ class TypoScriptService
     /**
      * Generate a TypoScript prototype definition for a given node type
      *
-     * A node will be rendered by TYPO3.Neos:Content by default with a template in
-     * resource://PACKAGE_KEY/Private/Templates/NodeTypes/NAME.html and forwards all public
-     * node properties to the template TypoScript object.
+     * A prototype will be rendererd with the generator-class defined in the
+     * nodeType-configuration 'fusion.prototypeGenerator'
      *
      * @param NodeType $nodeType
      * @return string
+     * @throws \TYPO3\Neos\Domain\Exception
      */
     protected function generateTypoScriptForNodeType(NodeType $nodeType)
     {
-        return $this->defaultPrototypeGenerator->generate($nodeType);
+        if ($nodeType->hasConfiguration('fusion.prototypeGenerator') && $nodeType->getConfiguration('fusion.prototypeGenerator') !== null) {
+            $generatorClassName = $nodeType->getConfiguration('fusion.prototypeGenerator');
+            if (!class_exists($generatorClassName)) {
+                throw new \TYPO3\Neos\Domain\Exception('Fusion prototype-generator Class ' . $generatorClassName . ' does not exist');
+            }
+            $generator = $this->objectManager->get($generatorClassName);
+            if (!$generator instanceof DefaultPrototypeGeneratorInterface) {
+                throw new \TYPO3\Neos\Domain\Exception('Fusion prototype-generator Class ' . $generatorClassName . ' does not implement interface ' . DefaultPrototypeGeneratorInterface::class);
+            }
+            return $generator->generate($nodeType);
+        }
+        return '';
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
@@ -13,7 +13,7 @@ namespace TYPO3\Neos\Domain\Service;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
-use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\ObjectManagement\ObjectManagerInterface;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\NodeType;

--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -2,8 +2,9 @@
 'TYPO3.Neos:Node':
   label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[[^:print:]]|\\s+/u', ' '))), 100, '...')}"
   abstract: TRUE
-  fusion:
-    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPrototypeGenerator
+  options:
+    fusion:
+      prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPrototypeGenerator
   ui:
     inspector:
       tabs:
@@ -128,8 +129,9 @@
     nodeTypes:
       '*': FALSE
       'TYPO3.Neos:Document': TRUE
-  fusion:
-    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultDocumentPrototypeGenerator
+  options:
+    fusion:
+      prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultDocumentPrototypeGenerator
   ui:
     label: 'Document'
     search:
@@ -237,8 +239,9 @@
   superTypes:
     'TYPO3.Neos:Content': TRUE
   abstract: TRUE
-  fusion:
-    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPluginPrototypeGenerator
+  options:
+    fusion:
+      prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPluginPrototypeGenerator
   ui:
     label: i18n
     group: 'plugins'
@@ -295,8 +298,9 @@
   constraints:
     nodeTypes:
       '*': FALSE
-  fusion:
-    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultContentPrototypeGenerator
+  options:
+    fusion:
+      prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultContentPrototypeGenerator
   ui:
     label: i18n
     icon: 'icon-square-o'

--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -2,6 +2,8 @@
 'TYPO3.Neos:Node':
   label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[[^:print:]]|\\s+/u', ' '))), 100, '...')}"
   abstract: TRUE
+  fusion:
+    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPrototypeGenerator
   ui:
     inspector:
       tabs:
@@ -126,6 +128,8 @@
     nodeTypes:
       '*': FALSE
       'TYPO3.Neos:Document': TRUE
+  fusion:
+    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultDocumentPrototypeGenerator
   ui:
     label: 'Document'
     search:
@@ -233,6 +237,8 @@
   superTypes:
     'TYPO3.Neos:Content': TRUE
   abstract: TRUE
+  fusion:
+    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultPluginPrototypeGenerator
   ui:
     label: i18n
     group: 'plugins'
@@ -289,6 +295,8 @@
   constraints:
     nodeTypes:
       '*': FALSE
+  fusion:
+    prototypeGenerator: TYPO3\Neos\Domain\Service\DefaultContentPrototypeGenerator
   ui:
     label: i18n
     icon: 'icon-square-o'

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -119,6 +119,32 @@ The following options are allowed:
     Alternatively the class of a node label generator implementing
     ``TYPO3\TYPO3CR\Domain\Model\NodeLabelGeneratorInterface`` can be specified as a nested option.
 
+``fusion``
+
+  ``prototypeGenerator``
+    The class that is used to generate the default fusion-prototype for this nodeType.
+
+    If this option is set to a className the class has to implement the interface
+    ``\TYPO3\Neos\Domain\Service\DefaultPrototypeGeneratorInterface`` and is used to generate the prototype-code for this node.
+
+    If ``fusion.prototypeGenerator`` is set to ``null`` no prototype is created for this type.
+
+    By default Neos has generators for all nodes of type ``TYPO3.Neos:Node`` and creates protoypes based on
+    ``TYPO3.TypoScript:Template``. A template path is assumed based on the package-prefix and the nodetype-name. All properties
+    of the node are passed to the template. For the nodeTypes of type ``TYPO3.Neos:Document``, ``TYPO3.Neos:Content`` and
+    ``TYPO3.Neos:Plugin`` the corresponding prototype is used as base-prototype.
+
+    Example::
+
+      prototype(Vendor.Site:Content.SpecialNodeType) < prototype(TYPO3.TypoScript:Content) {
+        templatePath = 'resource://Vendor.Site/Private/Templates/NodeTypes/Content.SpecialNodeType.html'
+        # all properties of the nodeType are passed to the template
+        date = ${q(node).property('date')}
+        # inline-editable strings additionally get the convertUris processor
+        title = ${q(node).property('title')}
+        title.@process.convertUris = TYPO3.Neos:ConvertUris
+      }
+
 ``ui``
   Configuration options related to the user interface representation of the node type
 

--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -119,22 +119,27 @@ The following options are allowed:
     Alternatively the class of a node label generator implementing
     ``TYPO3\TYPO3CR\Domain\Model\NodeLabelGeneratorInterface`` can be specified as a nested option.
 
-``fusion``
+``options``
+  Options for third party-code, the Content-Repository ignores those options but Neos or Packages may use this to adjust
+  their behavior.
 
-  ``prototypeGenerator``
-    The class that is used to generate the default fusion-prototype for this nodeType.
+  ``fusion``
+    Options to control the behavior of fusion-for a specific nodeType.
 
-    If this option is set to a className the class has to implement the interface
-    ``\TYPO3\Neos\Domain\Service\DefaultPrototypeGeneratorInterface`` and is used to generate the prototype-code for this node.
+    ``prototypeGenerator``
+      The class that is used to generate the default fusion-prototype for this nodeType.
 
-    If ``fusion.prototypeGenerator`` is set to ``null`` no prototype is created for this type.
+      If this option is set to a className the class has to implement the interface
+      ``\TYPO3\Neos\Domain\Service\DefaultPrototypeGeneratorInterface`` and is used to generate the prototype-code for this node.
 
-    By default Neos has generators for all nodes of type ``TYPO3.Neos:Node`` and creates protoypes based on
-    ``TYPO3.TypoScript:Template``. A template path is assumed based on the package-prefix and the nodetype-name. All properties
-    of the node are passed to the template. For the nodeTypes of type ``TYPO3.Neos:Document``, ``TYPO3.Neos:Content`` and
-    ``TYPO3.Neos:Plugin`` the corresponding prototype is used as base-prototype.
+      If ``options.fusion.prototypeGenerator`` is set to ``null`` no prototype is created for this type.
 
-    Example::
+      By default Neos has generators for all nodes of type ``TYPO3.Neos:Node`` and creates protoypes based on
+      ``TYPO3.TypoScript:Template``. A template path is assumed based on the package-prefix and the nodetype-name. All properties
+      of the node are passed to the template. For the nodeTypes of type ``TYPO3.Neos:Document``, ``TYPO3.Neos:Content`` and
+      ``TYPO3.Neos:Plugin`` the corresponding prototype is used as base-prototype.
+
+      Example::
 
       prototype(Vendor.Site:Content.SpecialNodeType) < prototype(TYPO3.TypoScript:Content) {
         templatePath = 'resource://Vendor.Site/Private/Templates/NodeTypes/Content.SpecialNodeType.html'

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -120,6 +120,16 @@ additionalProperties:
                         'handler': { type: ['string'], description: 'The path to a handler JavaScript object, similar to custom editors and validators.' }
                         'handlerOptions':  { type: dictionary, description: 'options for the given handler' }
 
+    'fusion':
+      # here we specify only the neos specific options of the NodeType schema,
+      # other options might be defined by cr or other packages
+      type: dictionary
+      additionalProperties: TRUE
+      properties:
+        prototypeGenerator:
+          - { type: null }
+          - { type: string, format: class-name }
+
     'ui':
       # here, we specify ONLY the "ui" part of the schema, as the remaining parts
       # are already specified in the NodeTypes schema of the TYPO3CR package

--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -75,6 +75,10 @@ additionalProperties:
     'options':
       type: dictionary
 
+    'fusion':
+      # we intentionally do not specify which properties are allowed here;
+      type: dictionary
+
     'postprocessors':
       type: dictionary
       additionalProperties:

--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -75,10 +75,6 @@ additionalProperties:
     'options':
       type: dictionary
 
-    'fusion':
-      # we intentionally do not specify which properties are allowed here;
-      type: dictionary
-
     'postprocessors':
       type: dictionary
       additionalProperties:


### PR DESCRIPTION
- If `fusion.prototypeGenerator` is set to a className the class has to implement the interface
  `\TYPO3\Neos\Domain\Service\DefaultPrototypeGeneratorInterface` and is used to generate the prototype-code
  for this node.
- If `fusion.prototypeGenerator` is set to `null` no prototype is created for this type.

For nodeTypes based on `TYPO3.Neos:Node`, `TYPO3.Neos:Document` or `TYPO3.Neos:Content` a backwards compatible implementation is added to the configuration and a new prototype generator for `TYPO3.Neos:Plugin` is added.
