### PR TITLE
BUGFIX: Personal workspace is always deleted when user is deleted

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -302,8 +302,7 @@ class UserService
      */
     public function deleteUser(User $user)
     {
-        $backendUserRole = $this->policyService->getRole('TYPO3.Neos:Editor');
-
+        $backendUserRole = $this->policyService->getRole('TYPO3.Neos:AbstractEditor');
         foreach ($user->getAccounts() as $account) {
             /** @var Account $account */
             if ($account->hasRole($backendUserRole)) {


### PR DESCRIPTION
The ``TYPO3.Neos:Editor`` role isn't always necessary for a user to have a personal workspace.

If there doesn't exist a workspace for that user, it will be handled in ``deletePersonalWorkspace()`` anyway.