### PR TITLE
BUGFIX: Ignore null for references property in NodeConverter

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
@@ -214,7 +214,7 @@ class NodeConverter extends AbstractTypeConverter
                                 $nodePropertyValue[] = $referencedNode;
                             }
                         }
-                    } else {
+                    } elseif ($nodeIdentifiers !== null) {
                         throw new TypeConverterException(sprintf('node type "%s" expects an array of identifiers for its property "%s"', $nodeType->getName(), $nodePropertyName), 1383587419);
                     }
                 break;


### PR DESCRIPTION
This change makes the NodeConverter accept null for references properties,
a behavior also present for other property types (e.g. DateTime).

Fixes #1142