### PR TITLE
BUGFIX: Routing cache is not correctly flushed when a node is discarded

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -70,6 +70,9 @@ class Package extends BasePackage
                 $bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
             }
         });
+        $dispatcher->connect('TYPO3\TYPO3CR\Domain\Service\PublishingService', 'nodeDiscarded', function (NodeInterface $node) use ($bootstrap) {
+            $bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
+        });
         $dispatcher->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodePathChanged', function (NodeInterface $node, $oldPath, $newPath, $recursion) {
             if (!$recursion) {
                 NodeUriPathSegmentGenerator::setUniqueUriPathSegment($node);


### PR DESCRIPTION
This bug is easy to reproduce in the current LTS version:

* Create a new page (e.g. called "Test"). 
* Discard the new page
* Create another new page also called "Test"

Due to the fact that the routing cache is not flushed in step 2, neos will show a 404 error because the cache entry for "Test" points to a non existing node.