### PR TITLE
BUGFIX: Check for null values after translation of FlashMessages

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -549,10 +549,10 @@ class AssetController extends ActionController
     public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
     {
         if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media');
+            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media') ?: $messageBody;
         }
-        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'TYPO3.Media');
 
+        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'TYPO3.Media');
         parent::addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -273,10 +273,10 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
     public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
     {
         if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Modules', 'TYPO3.Neos');
+            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Modules', 'TYPO3.Neos') ?: $messageBody;
         }
-        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Modules', 'TYPO3.Neos');
 
+        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Modules', 'TYPO3.Neos');
         parent::addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
     }
 }


### PR DESCRIPTION
To make sure that after translation no null value is given as argument
to ``parent::addFlashMessage`` we should prevent null values.