### PR TITLE
BUGFIX: Undefined variable in AssetController

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -607,10 +607,7 @@ class AssetController extends ActionController
     public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
     {
         if (is_string($messageBody)) {
-            $translatedMessageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media') ?: $messageBody;
-            if ($translatedMessageBody !== null) {
-                $messageBody = $translatedMessageBody;
-            }
+            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media') ?: $messageBody;
         }
 
         $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'TYPO3.Media');

--- a/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Controller/AssetController.php
@@ -607,7 +607,7 @@ class AssetController extends ActionController
     public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = array(), $messageCode = null)
     {
         if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media') ?: $messageBody;
+            $translatedMessageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'TYPO3.Media') ?: $messageBody;
             if ($translatedMessageBody !== null) {
                 $messageBody = $translatedMessageBody;
             }


### PR DESCRIPTION
The upmerge from 2.2 to 2.3 introduced a regression because of
an undefined variable. This was probably introduced because of
a merge conflict with 427d0ed70e5365fa906f4196c936e4c9271d266e