### PR TITLE
BUGFIX: Allow closing of mediabrowser

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
@@ -376,7 +376,6 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 			var that = this;
 			window.Typo3MediaBrowserCallbacks = {
 				close: function () {
-					SecondaryInspectorController.hide(that.get('_mediaBrowserEditView'));
 					that._initializeMediaBrowserEditView();
 				}
 			};


### PR DESCRIPTION
When opening the media browser by clicking
the thumbnail in the inspector the close action
of the mediabrowser triggered a recusion.

Resolves: #1155