### PR TITLE
BUGFIX: Unpublished new nodes still have shadow nodes after removal

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -995,12 +995,21 @@ class NodeData extends AbstractNodeData
             if ($this->persistenceManager->isNewObject($nodeData) === false) {
                 $this->nodeDataRepository->remove($nodeData);
             }
-        } else {
-            if ($this->persistenceManager->isNewObject($nodeData)) {
-                $this->nodeDataRepository->add($nodeData);
-            } else {
-                $this->nodeDataRepository->update($nodeData);
+            return;
+        }
+
+        // If the node is marked to be removed but didn't exist in a base workspace yet, we can delete it for real, without creating a shadow node:
+        if ($nodeData->isRemoved() && $this->nodeDataRepository->findOneByIdentifier($nodeData->getIdentifier(), $this->workspace->getBaseWorkspace()) === null) {
+            if ($this->persistenceManager->isNewObject($nodeData) === false) {
+                $this->nodeDataRepository->remove($nodeData);
             }
+            return;
+        }
+
+        if ($this->persistenceManager->isNewObject($nodeData)) {
+            $this->nodeDataRepository->add($nodeData);
+        } else {
+            $this->nodeDataRepository->update($nodeData);
         }
     }
 

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/RemoveNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/RemoveNode.feature
@@ -34,3 +34,22 @@ Feature: Remove node
       | Workspace |
       | live      |
     Then I should have 0 nodes
+
+  @fixtures
+  Scenario: Remove a node in user workspace and don't publish the changes
+    When I get a node by path "/sites/typo3cr/company" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I remove the node
+    Then the unpublished node count in workspace "user-admin" should be 4
+
+  @fixtures
+  Scenario: Create and remove a node in a personal workspace without publishing it should leave no traces
+    Given I have the following nodes:
+      | Path                | Node Type                  | Properties        | Workspace  |
+      | /sites/typo3cr/test | TYPO3.TYPO3CR.Testing:Page | {"title": "Test"} | user-admin |
+    When I get a node by path "/sites/typo3cr/test" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I remove the node
+    Then the unpublished node count in workspace "user-admin" should be 0

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -600,7 +600,7 @@ trait NodeOperationsTrait
     /**
      * @Then /^The node language dimension should be "([^"]*)"$/
      */
-    public function theNodeLanguagehouldBe($language)
+    public function theNodeLanguageShouldBe($language)
     {
         if ($this->isolated === true) {
             $this->callStepInSubProcess(__METHOD__, sprintf(' %s %s', 'string', escapeshellarg($language)));


### PR DESCRIPTION
When an editor creates a new page and then deletes the page again,
the workspace module will show pending changes because shadow nodes
exist for that delete page. Because the page has never been published,
Neos should just really delete the respective nodes from the user's
workspace instead of creating shadow nodes.

This change checks if a node marked for removal exists at all in one
of the base workspaces and if it doesn't, removes it completely instead
of creating a shadow node.

Resolves #1163