### PR TITLE
BUGFIX: Re-add CSS class in edit asset view

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/Edit.html
@@ -55,11 +55,11 @@
 							</f:if>
 							<tr>
 								<th>{neos:backend.translate(id: 'media.metadata.type', source: 'Modules', package: 'TYPO3.Neos')}</th>
-								<td>{asset.resource.mediatype}</td>
+								<td><span class="neos-label">{asset.resource.mediatype}</span></td>
 							</tr>
 							<tr>
 								<th>{neos:backend.translate(id: 'media.metadata.identifier', source: 'Modules', package: 'TYPO3.Neos')}</th>
-								<td>{asset.identifier}</td>
+								<td><span class="neos-label">{asset.identifier}</span></td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
This label class got lost during an upmerge in commit
a4f1091d25f2d53a1bd31566081ef16c517d47cf.