### PR TITLE
BUGFIX: Correct ViewHelper documentation block

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/FileTypeIconViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/FileTypeIconViewHelper.php
@@ -23,11 +23,11 @@ use TYPO3\Media\Domain\Service\FileTypeIconService;
  * = Examples =
  *
  * <code title="Rendering an asset filetype icon">
- * <typo3.media:fileTypeIcon asset="{assetObject}" alt="a filetype icon" height="16" />
+ * <typo3.media:fileTypeIcon file="{assetObject}" height="16" />
  * </code>
  * <output>
  * (depending on the asset, no scaling applied)
- * <img src="_Resources/Static/Packages/TYPO3/Media/Icons/16px/jpg.png" height="16" alt="a filetype icon" />
+ * <img src="_Resources/Static/Packages/TYPO3/Media/Icons/16px/jpg.png" height="16" alt="filetype alt text" />
  * </output>
  *
  */


### PR DESCRIPTION
The ViewHelper does not have the argument `asset` or `alt`, but `file` must be given.

**Checklist**
- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
