### PR TITLE
BUGFIX: fix typos in sample code of Translate NodeTypes documentation

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
@@ -54,7 +54,7 @@ as follows:
 			<body>
 				<trans-unit id="ui.help.message" xml:space="preserve">
 					<source>Your help message here</source>
-				</trans-uni>
+				</trans-unit>
 				<trans-unit id="tabs.myTab" xml:space="preserve">
 					<source>Your Tab Title</source>
 				</trans-unit>
@@ -66,7 +66,7 @@ as follows:
 				</trans-unit>
 				<trans-unit id="properties.myProperty.ui.help.message" xml:space="preserve">
 					<source>Your help message here</source>
-				</trans-uni>
+				</trans-unit>
 			</body>
 		</file>
 	</xliff>


### PR DESCRIPTION
It fixes small typos where trans-unit tag in sample code is not properly closed.

So it changes `</trans-uni>` to `</trans-unit>`