### PR TITLE
FEATURE: Customizable image quality

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/QualityImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/QualityImageAdjustment.php
@@ -1,0 +1,72 @@
+<?php
+namespace Neos\Media\Domain\Model\Adjustment;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Imagine\Image\ImageInterface;
+
+/**
+ * An adjustment for quality of an image
+ *
+ * @Flow\Entity
+ */
+class QualityImageAdjustment extends AbstractImageAdjustment
+{
+    /**
+     * @var integer
+     */
+    protected $position = 30;
+    /**
+     * @var integer
+     * @ORM\Column(nullable = TRUE)
+     */
+    protected $quality;
+    /**
+     * Returns quality
+     *
+     * @return integer
+     */
+    public function getQuality()
+    {
+        return $this->quality;
+    }
+    /**
+     * Sets quality
+     *
+     * @param integer $quality
+     * @return void
+     */
+    public function setQuality($quality)
+    {
+        $this->quality = $quality;
+    }
+    /**
+     * Applies this adjustment to the given Imagine Image object
+     *
+     * @param ImageInterface $image
+     * @return ImageInterface
+     */
+    public function applyToImage(ImageInterface $image)
+    {
+        return $image;
+    }
+    /**
+     * Check if this Adjustment can or should be applied to its ImageVariant.
+     *
+     * @param ImageInterface $image
+     * @return boolean
+     */
+    public function canBeApplied(ImageInterface $image)
+    {
+        return false;
+    }
+}

--- a/Neos.Media/Classes/Domain/Model/QualityTrait.php
+++ b/Neos.Media/Classes/Domain/Model/QualityTrait.php
@@ -1,0 +1,36 @@
+<?php
+namespace Neos\Media\Domain\Model;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Trait for methods regarding the quality of an asset
+ */
+trait QualityTrait
+{
+    /**
+     * @var integer
+     * @ORM\Column(nullable=true)
+     */
+    protected $quality = 90;
+    /**
+     * Returns the quality of the image
+     *
+     * @return integer
+     */
+    public function getQuality()
+    {
+        return $this->quality;
+    }
+}

--- a/Neos.Media/Classes/Domain/Model/Thumbnail.php
+++ b/Neos.Media/Classes/Domain/Model/Thumbnail.php
@@ -31,6 +31,7 @@ use Neos\Media\Domain\Strategy\ThumbnailGeneratorStrategy;
 class Thumbnail implements ImageInterface
 {
     use DimensionsTrait;
+    use QualityTrait;
 
     /**
      * @var ThumbnailGeneratorStrategy
@@ -187,6 +188,15 @@ class Thumbnail implements ImageInterface
     public function setHeight($height)
     {
         $this->height = (integer)$height;
+    }
+
+    /**
+     * @param integer $quality
+     * @return void
+     */
+    public function setQuality($quality)
+    {
+        $this->quality = (integer)$quality;
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -51,6 +51,11 @@ class ThumbnailConfiguration
     protected $allowUpScaling;
 
     /**
+     * @var integer
+     */
+    protected $quality;
+
+    /**
      * @var boolean
      */
     protected $async;
@@ -73,9 +78,10 @@ class ThumbnailConfiguration
      * @param integer $maximumHeight Desired maximum height of the image
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
+     * @param integer $quality Quality of the processed image
      * @param boolean $async Whether the thumbnail can be generated asynchronously
      */
-    public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false)
+    public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $quality = null, $async = false)
     {
         $this->width = $width ? (integer)$width : null;
         $this->maximumWidth = $maximumWidth ? (integer)$maximumWidth : null;
@@ -83,6 +89,7 @@ class ThumbnailConfiguration
         $this->maximumHeight = $maximumHeight ? (integer)$maximumHeight : null;
         $this->allowCropping = $allowCropping ? (boolean)$allowCropping : false;
         $this->allowUpScaling = $allowUpScaling ? (boolean)$allowUpScaling : false;
+        $this->quality = $quality ? (integer)$quality : null;
         $this->async = $async ? (boolean)$async : false;
     }
 
@@ -159,6 +166,14 @@ class ThumbnailConfiguration
     }
 
     /**
+     * @return int
+     */
+    public function getQuality()
+    {
+        return $this->quality;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -169,7 +184,8 @@ class ThumbnailConfiguration
             'height' => $this->getHeight(),
             'maximumHeight' => $this->getMaximumHeight(),
             'ratioMode' => $this->getRatioMode(),
-            'allowUpScaling' => $this->isUpScalingAllowed()
+            'allowUpScaling' => $this->isUpScalingAllowed(),
+            'quality' => $this->getQuality()
         ], function ($value) {
             return $value !== null;
         });

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -13,6 +13,7 @@ namespace Neos\Media\Domain\Model\ThumbnailGenerator;
 
 use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
+use Neos\Media\Domain\Model\Adjustment\QualityImageAdjustment;
 use Neos\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\Thumbnail;
@@ -57,24 +58,30 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
     public function refresh(Thumbnail $thumbnail)
     {
         try {
-            $adjustments = array(
+            $adjustments = [
                 new ResizeImageAdjustment(
-                    array(
+                    [
                         'width' => $thumbnail->getConfigurationValue('width'),
                         'maximumWidth' => $thumbnail->getConfigurationValue('maximumWidth'),
                         'height' => $thumbnail->getConfigurationValue('height'),
                         'maximumHeight' => $thumbnail->getConfigurationValue('maximumHeight'),
                         'ratioMode' => $thumbnail->getConfigurationValue('ratioMode'),
                         'allowUpScaling' => $thumbnail->getConfigurationValue('allowUpScaling'),
-                    )
+                    ]
+                ),
+                new QualityImageAdjustment(
+                    [
+                        'quality' => $thumbnail->getConfigurationValue('quality')
+                    ]
                 )
-            );
+            ];
 
             $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments);
 
             $thumbnail->setResource($processedImageInfo['resource']);
             $thumbnail->setWidth($processedImageInfo['width']);
             $thumbnail->setHeight($processedImageInfo['height']);
+            $thumbnail->setQuality($processedImageInfo['quality']);
         } catch (\Exception $exception) {
             $message = sprintf('Unable to generate thumbnail for the given image (filename: %s, SHA1: %s)', $thumbnail->getOriginalAsset()->getResource()->getFilename(), $thumbnail->getOriginalAsset()->getResource()->getSha1());
             throw new Exception\NoThumbnailAvailableException($message, 1433109654, $exception);

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -20,6 +20,7 @@ use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\ResourceManagement\Exception;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\Utility\Environment;
+use Neos\Media\Domain\Model\Adjustment\QualityImageAdjustment;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Imagine\Box;
 use Neos\Flow\Annotations as Flow;
@@ -143,8 +144,23 @@ class ImageService
             $imagineImage = $this->applyAdjustments($imagineImage, $adjustments, $adjustmentsApplied);
         }
 
+        $qualityAdjustments = array_filter($adjustments, function ($v) {
+            return $v instanceof QualityImageAdjustment;
+        }, ARRAY_FILTER_USE_BOTH);
+        if (count($qualityAdjustments) > 0) {
+            /** @var QualityImageAdjustment $qualityAdjustment */
+            $qualityAdjustment = array_pop($qualityAdjustments);
+            $quality = $qualityAdjustment->getQuality();
+            if ($quality >= 1 && $quality <= 100) {
+                $additionalOptions['quality'] = $qualityAdjustment->getQuality();
+                $adjustmentsApplied = true;
+            }
+        }
+
+        $additionalOptions = $this->getOptionsMergedWithDefaults($additionalOptions);
+
         if ($adjustmentsApplied === true) {
-            $imagineImage->save($transformedImageTemporaryPathAndFilename, $this->getOptionsMergedWithDefaults($additionalOptions));
+            $imagineImage->save($transformedImageTemporaryPathAndFilename, $additionalOptions);
             $imageSize = $imagineImage->getSize();
 
             // TODO: In the future the collectionName of the new resource should be configurable.
@@ -169,7 +185,8 @@ class ImageService
         $result = array(
             'width' => $imageSize->getWidth(),
             'height' => $imageSize->getHeight(),
-            'resource' => $resource
+            'resource' => $resource,
+            'quality' => $additionalOptions['quality']
         );
 
         return $result;

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -94,7 +94,11 @@ class ThumbnailService
             }
             $maximumWidth = ($configuration->getMaximumWidth() > $asset->getWidth()) ? $asset->getWidth() : $configuration->getMaximumWidth();
             $maximumHeight = ($configuration->getMaximumHeight() > $asset->getHeight()) ? $asset->getHeight() : $configuration->getMaximumHeight();
-            if ($configuration->isUpScalingAllowed() === false && $maximumWidth === $asset->getWidth() && $maximumHeight === $asset->getHeight()) {
+            if ($configuration->isUpScalingAllowed() === false
+                && $configuration->getQuality() !== null
+                && $maximumWidth === $asset->getWidth()
+                && $maximumHeight === $asset->getHeight()
+            ) {
                 return $asset;
             }
         }
@@ -170,6 +174,7 @@ class ThumbnailService
             isset($presetConfiguration['maximumHeight']) ? $presetConfiguration['maximumHeight'] : null,
             isset($presetConfiguration['allowCropping']) ? $presetConfiguration['allowCropping'] : false,
             isset($presetConfiguration['allowUpScaling']) ? $presetConfiguration['allowUpScaling'] : false,
+            isset($presetConfiguration['quality']) ? $presetConfiguration['quality'] : null,
             $async
         );
         return $thumbnailConfiguration;

--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -109,11 +109,12 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      * @param integer $maximumHeight Desired maximum height of the image
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
+     * @param integer $quality Quality of the image
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
      * @return string an <img...> html tag
      */
-    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $quality = null, $async = false, $preset = null)
     {
         if ($image === null) {
             return '';
@@ -122,7 +123,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $quality, $async);
         }
         $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $this->controllerContext->getRequest());
 

--- a/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
@@ -116,15 +116,16 @@ class ThumbnailViewHelper extends AbstractTagBasedViewHelper
      * @param boolean $allowCropping Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting thumbnail size might exceed the size of the original asset
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
+     * @param integer $quality Quality of the image
      * @param string $preset Preset used to determine image configuration
      * @return string an <img...> html tag
      */
-    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
+    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $quality = null, $async = false, $preset = null)
     {
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $quality, $async);
         }
         $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $this->controllerContext->getRequest());
 

--- a/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -73,11 +73,12 @@ class ImageViewHelper extends AbstractViewHelper
      * @param integer $maximumHeight Desired maximum height of the image
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
+     * @param integer $quality Quality of the image
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
      * @return string the relative image path, to be used as src attribute for <img /> tags
      */
-    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $quality = null, $async = false, $preset = null)
     {
         if ($image === null) {
             return '';
@@ -86,7 +87,7 @@ class ImageViewHelper extends AbstractViewHelper
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $quality, $async);
         }
         return $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $this->controllerContext->getRequest())['src'];
     }

--- a/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
@@ -73,16 +73,17 @@ class ThumbnailViewHelper extends AbstractViewHelper
      * @param integer $maximumHeight Desired maximum height of the thumbnail
      * @param boolean $allowCropping Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting thumbnail size might exceed the size of the original asset
+     * @param integer $quality Quality of the image
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
      * @return string the relative thumbnail path, to be used as src attribute for <img /> tags
      */
-    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
+    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $quality = null, $async = false, $preset = null)
     {
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $quality, $async);
         }
         return $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $this->controllerContext->getRequest())['src'];
     }

--- a/Neos.Media/Migrations/Mysql/Version20170220155800.php
+++ b/Neos.Media/Migrations/Mysql/Version20170220155800.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add quality column to tables abstractimageadjustment and thumbnail.
+ */
+class Version20170220155800 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return '';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment ADD quality INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE neos_media_domain_model_thumbnail ADD quality INT DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment DROP quality');
+        $this->addSql('ALTER TABLE neos_media_domain_model_thumbnail DROP quality');
+    }
+}

--- a/Neos.Media/Migrations/Postgresql/Version20170220155800.php
+++ b/Neos.Media/Migrations/Postgresql/Version20170220155800.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add quality column to tables abstractimageadjustment and thumbnail.
+ */
+class Version20170220155800 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return '';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "postgresql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment ADD quality INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE neos_media_domain_model_thumbnail ADD quality INT DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "postgresql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment DROP quality');
+        $this->addSql('ALTER TABLE neos_media_domain_model_thumbnail DROP quality');
+    }
+}

--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -102,6 +102,12 @@ class ImageUriImplementation extends AbstractFusionObject
         return $this->fusionValue('allowUpScaling');
     }
 
+
+    public function getQuality()
+    {
+        return $this->tsValue('quality');
+    }
+
     /**
      * Returns a processed image path
      *
@@ -114,7 +120,7 @@ class ImageUriImplementation extends AbstractFusionObject
         if (!$asset instanceof AssetInterface) {
             throw new \Exception('No asset given for rendering.', 1415184217);
         }
-        $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling());
+        $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getQuality());
         $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration);
         if ($thumbnailData === null) {
             return '';


### PR DESCRIPTION
I added a adjustment for the image quality that can be used to override the global configuration.
Sometimes you might want to add a preview image with lower quality as a thumbnail, but you couldn't. I added the quality property to Neos:ImageUri to make this possible.

```
    previewImageUri = TYPO3.Neos:ImageUri {
        asset = ${q(node).property('image')}
        maximumWidth = 2560
        maximumHeight = 1280
        quality = 25
        @if.image = ${q(node).property('image')}
    }
```

Resolves #768