### PR TITLE
BUGFIX: Fix static compilation of ThumbnailGeneratorStrategy

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
@@ -58,7 +58,7 @@ class ThumbnailGeneratorStrategy
      * @param ObjectManagerInterface $objectManager
      * @return ThumbnailGeneratorInterface[]
      */
-    static public function getThumbnailGeneratorClassNames($objectManager)
+    public static function getThumbnailGeneratorClassNames($objectManager)
     {
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Strategy/ThumbnailGeneratorStrategy.php
@@ -27,8 +27,8 @@ use TYPO3\Media\Domain\Model\ThumbnailGenerator\ThumbnailGeneratorInterface;
 class ThumbnailGeneratorStrategy
 {
     /**
-     * @var ObjectManagerInterface
      * @Flow\Inject
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
@@ -54,11 +54,11 @@ class ThumbnailGeneratorStrategy
     /**
      * Returns all class names implementing the ThumbnailGeneratorInterface.
      *
+     * @Flow\CompileStatic
      * @param ObjectManagerInterface $objectManager
      * @return ThumbnailGeneratorInterface[]
-     * @Flow\CompileStatic
      */
-    protected static function getThumbnailGeneratorClassNames($objectManager)
+    static public function getThumbnailGeneratorClassNames($objectManager)
     {
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);


### PR DESCRIPTION
This fixes `ThumbnailGeneratorStrategy::getThumbnailGeneratorClassNames()` making the
method `public`.
Without this fix, the method is silently skipped from static compilation and will always
use reflection to determine classes implementing `ThumbnailGeneratorInterface`.

Note: With resolution of neos/flow-development-collection#662 this will prevent compilation
in Production context