### PR TITLE
FEATURE: Add setting ``TYPO3.Neos.defaultSiteNodeName``

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -119,7 +119,7 @@ class LoginController extends AbstractAuthenticationController
             $this->redirect('index', 'Backend\Backend');
         }
         $currentDomain = $this->domainRepository->findOneByActiveRequest();
-        $currentSite = $currentDomain !== null ? $currentDomain->getSite() : $this->siteRepository->findFirstOnline();
+        $currentSite = $currentDomain !== null ? $currentDomain->getSite() : $this->siteRepository->findDefault();
         $this->view->assignMultiple([
             'styles' => array_filter($this->settings['userInterface']['backendLoginForm']['stylesheets']),
             'username' => $username,

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -66,6 +66,9 @@ class SiteRepository extends Repository
     /**
      * Find the default site and fallback to first online
      * if no default is found or the default is not online
+     *
+     * @return Site
+     * @throws NeosException
      */
     public function findDefault()
     {
@@ -74,11 +77,10 @@ class SiteRepository extends Repository
              * @var Site $defaultSite
              */
             $defaultSite = $this->findOneByNodeName($this->defaultSiteNodeName);
-            if ($defaultSite && $defaultSite->getState() === Site::STATE_ONLINE) {
-                return $defaultSite;
-            } else {
+            if (!$defaultSite instanceof Site || $defaultSite->getState() !== Site::STATE_ONLINE) {
                 throw new NeosException(sprintf('DefaultSiteNode %s not found or not active', $this->defaultSiteNodeName), 1476374818);
             }
+            return $defaultSite;
         } else {
             return $this->findOnline()->getFirst();
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -64,8 +64,10 @@ class SiteRepository extends Repository
     }
 
     /**
-     * Find the default site and fallback to first online
-     * if no default is found or the default is not online
+     * Find the site that was specified in the configuration ``defaultSiteNodeName``
+     *
+     * If the defaultSiteNodeName-setting is null the first active site is returned
+     * If the site is not found or not active an exception is thrown
      *
      * @return Site
      * @throws NeosException

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Repository/SiteRepository.php
@@ -72,17 +72,16 @@ class SiteRepository extends Repository
      */
     public function findDefault()
     {
-        if ($this->defaultSiteNodeName !== null) {
-            /**
-             * @var Site $defaultSite
-             */
-            $defaultSite = $this->findOneByNodeName($this->defaultSiteNodeName);
-            if (!$defaultSite instanceof Site || $defaultSite->getState() !== Site::STATE_ONLINE) {
-                throw new NeosException(sprintf('DefaultSiteNode %s not found or not active', $this->defaultSiteNodeName), 1476374818);
-            }
-            return $defaultSite;
-        } else {
+        if ($this->defaultSiteNodeName === null) {
             return $this->findOnline()->getFirst();
         }
+        /**
+         * @var Site $defaultSite
+         */
+        $defaultSite = $this->findOneByNodeName($this->defaultSiteNodeName);
+        if (!$defaultSite instanceof Site || $defaultSite->getState() !== Site::STATE_ONLINE) {
+            throw new NeosException(sprintf('DefaultSiteNode %s not found or not active', $this->defaultSiteNodeName), 1476374818);
+        }
+        return $defaultSite;
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/ContentContextFactory.php
@@ -120,7 +120,7 @@ class ContentContextFactory extends ContextFactory
             $defaultContextProperties['currentSite'] = $currentDomain->getSite();
             $defaultContextProperties['currentDomain'] = $currentDomain;
         } else {
-            $defaultContextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+            $defaultContextProperties['currentSite'] = $this->siteRepository->findDefault();
         }
 
         return $defaultContextProperties;

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -129,6 +129,10 @@ TYPO3:
         'TYPO3.TypoScript': TRUE
         'TYPO3.Neos': TRUE
 
+    # If a node name is specified here it will be used as default siteNode
+    # wich is displayed if no domain pattern matches the current request
+    defaultSiteNodeName: null
+
     routing:
       # Setting this to TRUE allows to use an empty uriSegment for default dimensions.
       # The only limitation is that all segments must be unique across all dimenions.

--- a/TYPO3.Neos/Configuration/Settings.yaml
+++ b/TYPO3.Neos/Configuration/Settings.yaml
@@ -130,7 +130,7 @@ TYPO3:
         'TYPO3.Neos': TRUE
 
     # If a node name is specified here it will be used as default siteNode
-    # wich is displayed if no domain pattern matches the current request
+    # which is displayed if no domain pattern matches the current request
     defaultSiteNodeName: null
 
     routing:


### PR DESCRIPTION
This change adds a setting defaultSiteNodeName wich allows to configure the behavior for requests without matching host name pattern.

If a request is not mapped to a site via domain pattern Neos currently uses the first active site. 
This is difficult in multisite environments especially since there is no manual order of the sites and currently there is no way to control which site is shown in this case.
