### PR TITLE
BUGFIX: Show changes in ContentCollection-Nodes in review-module

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -465,31 +465,29 @@ class WorkspacesController extends AbstractModuleController
         $siteChanges = [];
         foreach ($this->publishingService->getUnpublishedNodes($selectedWorkspace) as $node) {
             /** @var NodeInterface $node */
-            if (!$node->getNodeType()->isOfType('TYPO3.Neos:ContentCollection')) {
-                $pathParts = explode('/', $node->getPath());
-                if (count($pathParts) > 2) {
-                    $siteNodeName = $pathParts[2];
-                    $q = new FlowQuery([$node]);
-                    $document = $q->closest('[instanceof TYPO3.Neos:Document]')->get(0);
+            $pathParts = explode('/', $node->getPath());
+            if (count($pathParts) > 2) {
+                $siteNodeName = $pathParts[2];
+                $q = new FlowQuery([$node]);
+                $document = $q->closest('[instanceof TYPO3.Neos:Document]')->get(0);
 
-                    // $document will be null if we have a broken root line for this node. This actually should never happen, but currently can in some scenarios.
-                    if ($document !== null) {
-                        $documentPath = implode('/', array_slice(explode('/', $document->getPath()), 3));
-                        $relativePath = str_replace(sprintf(SiteService::SITES_ROOT_PATH . '/%s/%s', $siteNodeName, $documentPath), '', $node->getPath());
-                        if (!isset($siteChanges[$siteNodeName]['siteNode'])) {
-                            $siteChanges[$siteNodeName]['siteNode'] = $this->siteRepository->findOneByNodeName($siteNodeName);
-                        }
-                        $siteChanges[$siteNodeName]['documents'][$documentPath]['documentNode'] = $document;
-
-                        $change = [
-                            'node' => $node,
-                            'contentChanges' => $this->renderContentChanges($node),
-                        ];
-                        if ($node->getNodeType()->isOfType('TYPO3.Neos:Node')) {
-                            $change['configuration'] = $node->getNodeType()->getFullConfiguration();
-                        }
-                        $siteChanges[$siteNodeName]['documents'][$documentPath]['changes'][$relativePath] = $change;
+                // $document will be null if we have a broken root line for this node. This actually should never happen, but currently can in some scenarios.
+                if ($document !== null) {
+                    $documentPath = implode('/', array_slice(explode('/', $document->getPath()), 3));
+                    $relativePath = str_replace(sprintf(SiteService::SITES_ROOT_PATH . '/%s/%s', $siteNodeName, $documentPath), '', $node->getPath());
+                    if (!isset($siteChanges[$siteNodeName]['siteNode'])) {
+                        $siteChanges[$siteNodeName]['siteNode'] = $this->siteRepository->findOneByNodeName($siteNodeName);
                     }
+                    $siteChanges[$siteNodeName]['documents'][$documentPath]['documentNode'] = $document;
+
+                    $change = [
+                        'node' => $node,
+                        'contentChanges' => $this->renderContentChanges($node),
+                    ];
+                    if ($node->getNodeType()->isOfType('TYPO3.Neos:Node')) {
+                        $change['configuration'] = $node->getNodeType()->getFullConfiguration();
+                    }
+                    $siteChanges[$siteNodeName]['documents'][$documentPath]['changes'][$relativePath] = $change;
                 }
             }
         }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -473,6 +473,10 @@ class WorkspacesController extends AbstractModuleController
 
                 // $document will be null if we have a broken root line for this node. This actually should never happen, but currently can in some scenarios.
                 if ($document !== null) {
+                    $contentChanges = $this->renderContentChanges($node);
+                    if (empty($contentChanges) == 0 && $node->getNodeType()->isOfType('TYPO3.Neos:ContentCollection')) {
+                        continue;
+                    }
                     $documentPath = implode('/', array_slice(explode('/', $document->getPath()), 3));
                     $relativePath = str_replace(sprintf(SiteService::SITES_ROOT_PATH . '/%s/%s', $siteNodeName, $documentPath), '', $node->getPath());
                     if (!isset($siteChanges[$siteNodeName]['siteNode'])) {
@@ -482,7 +486,7 @@ class WorkspacesController extends AbstractModuleController
 
                     $change = [
                         'node' => $node,
-                        'contentChanges' => $this->renderContentChanges($node),
+                        'contentChanges' => $contentChanges,
                     ];
                     if ($node->getNodeType()->isOfType('TYPO3.Neos:Node')) {
                         $change['configuration'] = $node->getNodeType()->getFullConfiguration();


### PR DESCRIPTION
This change adds the visualization of changes on ``TYPO3.Neos:ContentCollection`` nodes that also have the type ``TYPO3.Neos:Content`` to the review module. 

Previously those changes were filtered out which prevented the visualization of changes and lead to the page beeing visualized as having changes without showing them in the review module.