### PR TITLE
TASK: Do not throw exception if no image is present

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -104,7 +104,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
     /**
      * Renders an HTML img tag with a thumbnail image, created from a given image.
      *
-     * @param ImageInterface|null $image The image to be rendered as an image
+     * @param ImageInterface $image The image to be rendered as an image
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
      * @param integer $height Desired height of the image

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -104,7 +104,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
     /**
      * Renders an HTML img tag with a thumbnail image, created from a given image.
      *
-     * @param ImageInterface $image The image to be rendered as an image
+     * @param ImageInterface|null $image The image to be rendered as an image
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
      * @param integer $height Desired height of the image
@@ -119,6 +119,10 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
     {
         if ($image === null && $this->hasArgument('asset')) {
             $image = $this->arguments['asset'];
+        }
+
+        if ($image === null || empty($image)) {
+            return '';
         }
 
         if ($preset) {

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -121,7 +121,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
             $image = $this->arguments['asset'];
         }
 
-        if ($image === null || empty($image)) {
+        if ($image === null) {
             return '';
         }
 

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
@@ -68,7 +68,7 @@ class ImageViewHelper extends AbstractViewHelper
     /**
      * Renders the path to a thumbnail image, created from a given image.
      *
-     * @param ImageInterface $image
+     * @param ImageInterface|null $image
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
      * @param integer $height Desired height of the image
@@ -83,6 +83,10 @@ class ImageViewHelper extends AbstractViewHelper
     {
         if ($image === null && $this->hasArgument('asset')) {
             $image = $this->arguments['asset'];
+        }
+
+        if ($image === null || empty($image)) {
+            return '';
         }
 
         if ($preset) {

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
@@ -68,7 +68,7 @@ class ImageViewHelper extends AbstractViewHelper
     /**
      * Renders the path to a thumbnail image, created from a given image.
      *
-     * @param ImageInterface|null $image
+     * @param ImageInterface $image The image to retrieve the path from
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
      * @param integer $height Desired height of the image
@@ -85,7 +85,7 @@ class ImageViewHelper extends AbstractViewHelper
             $image = $this->arguments['asset'];
         }
 
-        if ($image === null || empty($image)) {
+        if ($image === null) {
             return '';
         }
 

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -11,10 +11,10 @@ namespace TYPO3\Media\Tests\Unit\ViewHelpers;
  * source code.
  */
 
-use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3\Media\ViewHelpers\ImageViewHelper;
 
-require_once(__DIR__ . '/../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
+require_once(__DIR__ . '/../../../../../Framework/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
 
 class ImageViewHelperTest extends ViewHelperBaseTestcase
 {

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace TYPO3\Media\Tests\Unit\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
+
+class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase
+{
+    /**
+     * var \TYPO3\Media\ViewHelpers\ImageViewHelper
+     */
+    protected $viewHelper;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = new \TYPO3\Media\ViewHelpers\ImageViewHelper();
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->viewHelper->initializeArguments();
+    }
+
+    /**
+     * @test
+     */
+    public function doNotThrowExceptionIfImageIsNull()
+    {
+        $this->viewHelper->initialize();
+        $actualResult = $this->viewHelper->render(null);
+
+        $this->assertEquals('', $actualResult);
+    }
+}

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -11,9 +11,12 @@ namespace TYPO3\Media\Tests\Unit\ViewHelpers;
  * source code.
  */
 
+use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
+use TYPO3\Media\ViewHelpers\ImageViewHelper;
+
 require_once(__DIR__ . '/../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
 
-class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase
+class ImageViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
      * var \TYPO3\Media\ViewHelpers\ImageViewHelper
@@ -23,7 +26,7 @@ class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcas
     public function setUp()
     {
         parent::setUp();
-        $this->viewHelper = new \TYPO3\Media\ViewHelpers\ImageViewHelper();
+        $this->viewHelper = new ImageViewHelper();
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $this->viewHelper->initializeArguments();
     }

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace TYPO3\Media\Tests\Unit\ViewHelpers\Uri;
+
+/*
+ * This file is part of the TYPO3.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/../../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
+
+class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase
+{
+    /**
+     * var \TYPO3\Media\ViewHelpers\ImageViewHelper
+     */
+    protected $viewHelper;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = new \TYPO3\Media\ViewHelpers\ImageViewHelper();
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->viewHelper->initializeArguments();
+    }
+
+    /**
+     * @test
+     */
+    public function doNotThrowExceptionIfImageIsEmptyString()
+    {
+        $this->viewHelper->initialize();
+        $actualResult = $this->viewHelper->render(null);
+
+        $this->assertEquals('', $actualResult);
+    }
+}

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -11,9 +11,12 @@ namespace TYPO3\Media\Tests\Unit\ViewHelpers\Uri;
  * source code.
  */
 
+use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
+use TYPO3\Media\ViewHelpers\ImageViewHelper;
+
 require_once(__DIR__ . '/../../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
 
-class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase
+class ImageViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
      * var \TYPO3\Media\ViewHelpers\ImageViewHelper
@@ -23,7 +26,7 @@ class ImageViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcas
     public function setUp()
     {
         parent::setUp();
-        $this->viewHelper = new \TYPO3\Media\ViewHelpers\ImageViewHelper();
+        $this->viewHelper = new ImageViewHelper();
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $this->viewHelper->initializeArguments();
     }

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -11,10 +11,10 @@ namespace TYPO3\Media\Tests\Unit\ViewHelpers\Uri;
  * source code.
  */
 
-use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3\Media\ViewHelpers\ImageViewHelper;
 
-require_once(__DIR__ . '/../../../../../../Framework/TYPO3.Fluid/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
+require_once(__DIR__ . '/../../../../../../Framework/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php');
 
 class ImageViewHelperTest extends ViewHelperBaseTestcase
 {

--- a/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/TYPO3.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -34,7 +34,7 @@ class ImageViewHelperTest extends ViewHelperBaseTestcase
     /**
      * @test
      */
-    public function doNotThrowExceptionIfImageIsEmptyString()
+    public function doNotThrowExceptionIfImageIsNull()
     {
         $this->viewHelper->initialize();
         $actualResult = $this->viewHelper->render(null);


### PR DESCRIPTION
**What I did**
`ImageViewHelper` (including the URI variant) will now recover if no image is present. 

**How I did it**
If the image argument is empty, the ViewHelper will now return empty.

**How to verify it**
Use the ViewHelper and and do not check if the image exists. No exception should be thrown.

**Checklist**
- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
