### PR TITLE
BUGFIX: ConvertUrisImplementation throws an error when trying to convert uris when requesting the site in a format different from html

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/LinkingService.php
@@ -148,7 +148,7 @@ class LinkingService
             $this->systemLogger->log(sprintf('Could not resolve "%s" to an existing node; The node was probably deleted.', $uri));
             return null;
         }
-        return $this->createNodeUri($controllerContext, $targetObject, null, null, $absolute);
+        return $this->createNodeUri($controllerContext, $targetObject, null, 'html', $absolute);
     }
 
     /**

--- a/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
+++ b/TYPO3.Neos/Tests/Unit/TypoScript/ConvertUrisImplementationTest.php
@@ -314,7 +314,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->addValueExpectation($value);
 
         $this->mockWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
-        $this->mockHttpRequest->expects($this->any())->method('getFormat')->will($this->returnValue('json.something'));
+        $this->mockActionRequest->expects($this->any())->method('getFormat')->will($this->returnValue('json.something'));
 
         $self = $this;
         $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveNodeUri')->will($this->returnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {


### PR DESCRIPTION
**What I did**
I changed the LinkingService to always create node uris in html format. This is required because otherwise requests with a format different from html will most likely throw an exception.

**How I did it**
I changed the requested format in the function call of "createNodeUri" in the TYPO3.Neos-LinkingService. An other option would be to make the required format customizable in the `TYPO3.Neos:ConvertUris` EEL-Helper.

**How to verify it**
- Create a custom format (in my case: json.search).
- Try to create a http uri for a node using the `TYPO3.Neos:ConvertUris` EEL-Helper:
  
  ```
  link = ${'node://' + someNode.identifier}
  link.@process.convertUris = TYPO3.Neos:ConvertUris
  ```

This will throw the following exception:

```
Could not resolve a route and its corresponding URI for the given parameters. 
This may be due to referring to a not existing package / controller / action 
while building a link or URI. Refer to log and check the backtrace for more details.

root<TYPO3.TypoScript:Case>/
  …
    link/
      __meta/
        process/
          convertUris<TYPO3.Neos:ConvertUris>/
```

**Checklist**
- [x] Code follows the PSR-2 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 2.1-Branch [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
