### PR TITLE
BUGFIX: Render empty `alt` attribute in ImageViewHelper

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
@@ -10,6 +10,7 @@ namespace TYPO3\Media\ViewHelpers\Form;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
 use TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 /**

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Form/CheckboxViewHelper.php
@@ -10,6 +10,7 @@ namespace TYPO3\Media\ViewHelpers\Form;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 /**
  * View Helper which creates a simple checkbox (<input type="checkbox">).
@@ -41,7 +42,7 @@ namespace TYPO3\Media\ViewHelpers\Form;
  *
  * @api
  */
-class CheckboxViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper
+class CheckboxViewHelper extends AbstractFormFieldViewHelper
 {
     /**
      * @var string

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Format/RelativeDateViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Format/RelativeDateViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3\Media\ViewHelpers\Format;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Utility\Now;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -38,12 +39,12 @@ class RelativeDateViewHelper extends AbstractViewHelper
             throw new \InvalidArgumentException('No valid date given,', 1424647058);
         }
         // More than 11 months ago
-        $now = new \TYPO3\Flow\Utility\Now();
+        $now = new Now();
         if ($date < $now->modify('-11 months')) {
             return $date->format('Y M j');
         }
         // Same day of same year
-        $now = new \TYPO3\Flow\Utility\Now();
+        $now = new Now();
         if ($date->format('Y z') === $now->format('Y z')) {
             return $date->format('H:i');
         }

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Media\ViewHelpers;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
@@ -97,7 +98,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         $this->registerTagAttribute('ismap', 'string', 'Specifies an image as a server-side image-map. Rarely used. Look at usemap instead', false);
         $this->registerTagAttribute('usemap', 'string', 'Specifies an image as a client-side image-map', false);
         // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', 'TYPO3\Media\Domain\Model\AssetInterface', 'The asset to be rendered - DEPRECATED, use the "image" argument instead', false);
+        $this->registerArgument('asset', AssetInterface::class, 'The asset to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ImageViewHelper.php
@@ -141,6 +141,12 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
             ));
         }
 
+        // alt argument must be set because it is required (see $this->initializeArguments())
+        if ($this->arguments['alt'] === '') {
+            // has to be added explicitly because empty strings won't be added as attributes in general (see parent::initialize())
+            $this->tag->addAttribute('alt', '');
+        }
+
         return $this->tag->render();
     }
 }

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/ThumbnailViewHelper.php
@@ -12,9 +12,12 @@ namespace TYPO3\Media\ViewHelpers;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Media\Domain\Service\ThumbnailService;
 
 /**
  * Renders an <img> HTML tag from a given TYPO3.Media's asset instance
@@ -68,20 +71,20 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 class ThumbnailViewHelper extends AbstractTagBasedViewHelper
 {
     /**
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      * @Flow\Inject
      */
     protected $resourceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\ThumbnailService
+     * @var ThumbnailService
      */
     protected $thumbnailService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\AssetService
+     * @var AssetService
      */
     protected $assetService;
 

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ImageViewHelper.php
@@ -12,6 +12,8 @@ namespace TYPO3\Media\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
 
@@ -39,7 +41,7 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
  *
  * @see \TYPO3\Media\ViewHelpers\ImageViewHelper
  */
-class ImageViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
+class ImageViewHelper extends AbstractViewHelper
 {
     /**
      * @Flow\Inject
@@ -60,7 +62,7 @@ class ImageViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
     {
         parent::initializeArguments();
         // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', 'TYPO3\Media\Domain\Model\AssetInterface', 'The image to be rendered - DEPRECATED, use the "image" argument instead', false);
+        $this->registerArgument('asset', AssetInterface::class, 'The image to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**

--- a/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ThumbnailViewHelper.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/ViewHelpers/Uri/ThumbnailViewHelper.php
@@ -12,8 +12,12 @@ namespace TYPO3\Media\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
+use TYPO3\Media\Domain\Service\AssetService;
+use TYPO3\Media\Domain\Service\ThumbnailService;
 
 /**
  * Renders the src path of a thumbnail image of a given TYPO3.Media asset instance
@@ -39,23 +43,23 @@ use TYPO3\Media\Domain\Model\ThumbnailConfiguration;
  *
  * @see \TYPO3\Media\ViewHelpers\ThumbnailViewHelper
  */
-class ThumbnailViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper
+class ThumbnailViewHelper extends AbstractViewHelper
 {
     /**
-     * @var \TYPO3\Flow\Resource\ResourceManager
+     * @var ResourceManager
      * @Flow\Inject
      */
     protected $resourceManager;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\ThumbnailService
+     * @var ThumbnailService
      */
     protected $thumbnailService;
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Media\Domain\Service\AssetService
+     * @var AssetService
      */
     protected $assetService;
 


### PR DESCRIPTION
With this the ImageViewHelper will always include an alt attribute, even if
not given.

Includes some namespace imports only present in 2.2 branch.

Fixes #1075 
