### PR TITLE
BUGFIX: Set correct timezoneOffset in DateTime-picker

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/DateTimeEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/DateTimeEditor.js
@@ -97,8 +97,14 @@ function (Ember, $, I18n, template) {
 			if (includeTimezoneOffset !== true) {
 				return datetime;
 			}
-			var offset = new Date().getTimezoneOffset(),
-				timezone = (offset < 0 ? '+' : '-') + pad(parseInt(Math.abs(offset / 60)), 2) + ':' + pad(Math.abs(offset % 60), 2);
+			var dateTimeForOffset = $.fn.datetimepicker.DPGlobal.formatDate(
+				date,
+				$.fn.datetimepicker.DPGlobal.parseFormat('m d, Y H:i:s', 'php'),
+				'en',
+				'php'
+			);
+			var offset = new Date(dateTimeForOffset).getTimezoneOffset();
+			var timezone = (offset < 0 ? '+' : '-') + pad(parseInt(Math.abs(offset / 60)), 2) + ':' + pad(Math.abs(offset % 60), 2);
 			return datetime + timezone;
 		},
 


### PR DESCRIPTION
Fixes the bug that the DateTime-picker gets an hour off after
daylight-saving-time switch.

Fixes: #851
