### PR TITLE
TASK: Adjust test timezone to Africa/Tunis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - mv ../neos-development-collection Packages/Neos
 before_script:
   - phpenv config-rm xdebug.ini
-  - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'date.timezone = "Africa/Tunis"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo 'opcache.fast_shutdown = 0' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo 'opcache.enable_cli = 0' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo 'zend.enable_gc = 0' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini


### PR DESCRIPTION
The tests are currently supposed to be run in a UTC+1 timezone, due to DST
we switch to a timezone that doesn't observe DST. 
Africa/Tunis is a choice that fullfills these constraints.