### PR TITLE
BUGFIX: Let DateStringConverter accept ``DateTimeInterface``

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/DateStringConverter.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/Mapping/DateStringConverter.php
@@ -28,7 +28,7 @@ class DateStringConverter extends AbstractTypeConverter
      * @var array<string>
      * @api
      */
-    protected $sourceTypes = array(\DateTime::class);
+    protected $sourceTypes = array(\DateTimeInterface::class);
 
     /**
      * The target type this converter can convert to.


### PR DESCRIPTION
This lowers the matching possibility for this specialized type
converter to avoid it being used accidentally on DateTime instances
instead of the Flow ``StringConverter``.

This indirectly fixes a problem with tests exhibited in master
because Flow master has a changed ``StringConverter`` that is now
assigned a lower priority for ``DateTime`` objects than this
converter, which is unexpected.