### PR TITLE
FEATURE: Add fusion-prototype ``TYPO3.TypoScript:RawCollection``

### DIFF
--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -126,6 +126,19 @@ Example using an expression ``itemRenderer``::
 		itemRenderer = ${element * 2}
 	}
 
+.. _TYPO3_TypoScript__RawCollection:
+
+TYPO3.TypoScript:RawCollection
+------------------------------
+
+Render each item in ``collection`` using ``itemRenderer`` and return the result as an array (opposed to *string* for :ref:`TYPO3_TypoScript__Collection`)
+
+:collection: (array/Iterable, **required**) The array or iterable to iterate over
+:itemName: (string, defaults to ``item``) Context variable name for each item
+:itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
+:iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
+:itemRenderer: (string) The renderer definition (simple value, expression or object) will be called once for every collection element
+
 .. _TYPO3_TypoScript__Case:
 
 TYPO3.TypoScript:Case

--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -104,7 +104,7 @@ Render each item in ``collection`` using ``itemRenderer``.
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (string) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
+:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
 
 Example using an object ``itemRenderer``::
 
@@ -137,7 +137,7 @@ Render each item in ``collection`` using ``itemRenderer`` and return the result 
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (string) The renderer definition (simple value, expression or object) will be called once for every collection element
+:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
 
 .. _TYPO3_TypoScript__Case:
 

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/AbstractCollectionImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/AbstractCollectionImplementation.php
@@ -64,18 +64,29 @@ abstract class AbstractCollectionImplementation extends AbstractTypoScriptObject
     }
 
     /**
-     * Evaluate the collection nodes
+     * Evaluate the collection nodes as concatenated string
      *
      * @return string
      * @throws TypoScriptException
      */
     public function evaluate()
     {
+        return implode('', $this->evaluateAsArray());
+    }
+
+    /**
+     * Evaluate the collection nodes as array
+     *
+     * @return array
+     * @throws TypoScriptException
+     */
+    public function evaluateAsArray()
+    {
         $collection = $this->getCollection();
 
-        $output = '';
+        $result = [];
         if ($collection === null) {
-            return '';
+            return $result;
         }
         $this->numberOfRenderedNodes = 0;
         $itemName = $this->getItemName();
@@ -96,12 +107,12 @@ abstract class AbstractCollectionImplementation extends AbstractTypoScriptObject
             }
 
             $this->tsRuntime->pushContextArray($context);
-            $output .= $this->tsRuntime->render($this->path . '/itemRenderer');
+            $result[] =  $this->tsRuntime->render($this->path . '/itemRenderer');
             $this->tsRuntime->popContext();
             $this->numberOfRenderedNodes++;
         }
 
-        return $output;
+        return $result;
     }
 
     /**

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/RawCollectionImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/RawCollectionImplementation.php
@@ -1,0 +1,33 @@
+<?php
+namespace TYPO3\TypoScript\TypoScriptObjects;
+
+/*
+ * This file is part of the TYPO3.TypoScript package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * Render a TypoScript collection of nodes as an array
+ *
+ * //tsPath collection *Collection
+ * //tsPath itemRenderer the TS object which is triggered for each element in the node collection
+ */
+class RawCollectionImplementation extends AbstractCollectionImplementation
+{
+    /**
+     * Evaluate the collection nodes
+     *
+     * @return string
+     */
+    public function evaluate()
+    {
+        return parent::evaluateAsArray();
+    }
+}

--- a/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
+++ b/TYPO3.TypoScript/Resources/Private/TypoScript/Root.ts2
@@ -11,6 +11,12 @@ prototype(TYPO3.TypoScript:Collection) {
 	itemKey = 'itemKey'
 	iterationName = 'iterator'
 }
+prototype(TYPO3.TypoScript:RawCollection) {
+  @class = 'TYPO3\\TypoScript\\TypoScriptObjects\\RawCollectionImplementation'
+  itemName = 'item'
+  itemKey = 'itemKey'
+  iterationName = 'iterator'
+}
 
 # Render an HTTP response header
 #

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/CollectionTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/CollectionTest.php
@@ -12,7 +12,7 @@ namespace TYPO3\TypoScript\Tests\Functional\TypoScriptObjects;
  */
 
 /**
- * Testcase for the CollectionTest Array
+ * Testcase for the Collection TS object
  *
  */
 class CollectionTest extends AbstractTypoScriptObjectTest

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/RawCollection.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/RawCollection.ts2
@@ -1,0 +1,27 @@
+prototype(TYPO3.TypoScript:RawCollection).@class = 'TYPO3\\TypoScript\\TypoScriptObjects\\RawCollectionImplementation'
+prototype(TYPO3.TypoScript:TestRenderer).@class = 'TYPO3\\TypoScript\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+rawCollection.basicLoop = TYPO3.TypoScript:RawCollection {
+	collection = ${collection}
+	itemName = 'element'
+	itemRenderer = TYPO3.TypoScript:TestRenderer {
+		test = ${element}
+	}
+}
+
+rawCollection.basicLoopOtherContextVariables = TYPO3.TypoScript:RawCollection {
+	collection = ${collection}
+	itemName = 'element'
+	itemRenderer = TYPO3.TypoScript:TestRenderer {
+		test = ${element + other}
+	}
+}
+
+rawCollection.iteration = TYPO3.TypoScript:RawCollection {
+	collection = ${collection}
+	itemName = 'element'
+	iterationName = 'iteration'
+	itemRenderer = TYPO3.TypoScript:TestRenderer {
+		test = ${element + '-' + iteration.index + '-' + iteration.cycle + '-' + iteration.isFirst + '-' + iteration.isLast + '-' + iteration.isOdd + '-' + iteration.isEven}
+	}
+}

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/RawCollectionTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/RawCollectionTest.php
@@ -12,7 +12,7 @@ namespace TYPO3\TypoScript\Tests\Functional\TypoScriptObjects;
  */
 
 /**
- * Testcase for the CollectionTest Array
+ * Testcase for the RawCollection TS object
  *
  */
 class RawCollectionTest extends AbstractTypoScriptObjectTest

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/RawCollectionTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/RawCollectionTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace TYPO3\TypoScript\Tests\Functional\TypoScriptObjects;
+
+/*
+ * This file is part of the TYPO3.TypoScript package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the CollectionTest Array
+ *
+ */
+class RawCollectionTest extends AbstractTypoScriptObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicCollectionWorks()
+    {
+        $view = $this->buildView();
+        $view->assign('collection', array('element1', 'element2'));
+        $view->setTypoScriptPath('rawCollection/basicLoop');
+        $this->assertEquals(['Xelement1','Xelement2'], $view->render());
+    }
+
+
+    /**
+     * @test
+     */
+    public function basicCollectionWorksAndStillContainsOtherContextVariables()
+    {
+        $view = $this->buildView();
+        $view->assign('collection', array('element1', 'element2'));
+        $view->assign('other', 'var');
+        $view->setTypoScriptPath('rawCollection/basicLoopOtherContextVariables');
+        $this->assertEquals(['Xelement1var','Xelement2var'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function emptyCollectionReturnsEmptyArray()
+    {
+        $view = $this->buildView();
+        $view->assign('collection', null);
+        $view->setTypoScriptPath('rawCollection/basicLoop');
+        $this->assertEquals([], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function iterationInformationIsAddedToCollection()
+    {
+        $view = $this->buildView();
+        $view->assign('collection', array('element1', 'element2', 'element3', 'element4'));
+        $view->setTypoScriptPath('rawCollection/iteration');
+        $this->assertEquals(['Xelement1-0-1-1--1-','Xelement2-1-2----1','Xelement3-2-3---1-','Xelement4-3-4--1--1'], $view->render());
+    }
+}


### PR DESCRIPTION
Other than ``TYPO3.TypoScript:Collection`` the ``TYPO3.TypoScript:RawCollection`` returns
an array of the rendered items instead of a concatenated string.