### PR TITLE
BUGFIX: Adjust exception page title

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Error/NeosBackendMessage.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Error/NeosBackendMessage.html
@@ -1,7 +1,7 @@
 <f:layout name="Default" />
 
 <f:section name="head">
-	<title>TYPO3 Neos Error</title>
+	<title>Neos Error</title>
 	<link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Error.css', package: 'TYPO3.Neos')}" />
 	<f:if condition="{isBackend}">
 		<f:render partial="NeosBackendHeaderData" arguments="{_all}" />


### PR DESCRIPTION
Remove "TYPO3" from error page title tag and NeosBackendMessage title tag