### PR TITLE
BUGFIX: Fix error in editAction in the siteController

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Administration/SitesController.php
@@ -140,7 +140,7 @@ class SitesController extends AbstractModuleController
 
         $this->view->assignMultiple(array(
             'site' => $site,
-            'sitePackageMetaData' => isset($sitePackage) ? $sitePackage->getPackageMetaData() : array(),
+            'sitePackage' => isset($sitePackage) ? $sitePackage : array(),
             'domains' => $this->domainRepository->findBySite($site),
             'assetCollections' => $this->assetCollectionRepository->findAll()
         ));

--- a/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
@@ -126,22 +126,16 @@
 								<th>{neos:backend.translate(id: 'packageKey', value: 'Package Key')}</th>
 								<td><span class="neos-label">{site.siteResourcesPackageKey}</span></td>
 							</tr>
-							<f:if condition="{sitePackageMetaData.title}">
-								<tr>
-									<th>{neos:backend.translate(id: 'title', value: 'Title')}</th>
-									<td>{sitePackageMetaData.title}</td>
-								</tr>
-							</f:if>
-							<f:if condition="{sitePackageMetaData.version}">
+							<f:if condition="{sitePackage.installedVersion}">
 								<tr>
 									<th>{neos:backend.translate(id: 'version', value: 'Version')}</th>
-									<td>{sitePackageMetaData.version}</td>
+									<td>{sitePackage.installedVersion}</td>
 								</tr>
 							</f:if>
-							<f:if condition="{sitePackageMetaData.description}">
+							<f:if condition="{sitePackage.composerManifest.description}">
 								<tr>
 									<th>{neos:backend.translate(id: 'description', value: 'Description')}</th>
-									<td>{sitePackageMetaData.description}</td>
+									<td>{sitePackage.composerManifest.description}</td>
 								</tr>
 							</f:if>
 						</tbody>


### PR DESCRIPTION
The editAction threw an error because a not existing title property in the sitePackageMetaData was accessed. Since getPackageMetaData is deprecated this is refactored to use the informations from the package domain model. The code to display the package title was removed since this property does not exist in composer files.