### PR TITLE
BUGFIX: Return ``null`` for empty node properties

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -891,7 +891,7 @@ class Node implements NodeInterface, CacheAwareInterface
     {
         $value = $this->nodeData->getProperty($propertyName);
         if (empty($value)) {
-            return $value;
+            return null;
         }
 
         $nodeType = $this->getNodeType();


### PR DESCRIPTION
Node properties that are empty now return ``null`` without propertyMapping instead of the value stored in the properties-json. This fixes a problem if an asset was selected but later on deleted that previously lead to the asset property returning an empty string.