### PR TITLE
FEATURE: Support node-uris in ``neos:link.node`` and ``neos.uri.node`` ViewHelper

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
@@ -129,7 +129,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
     /**
      * Renders the link. Renders the linked node's label if there's no child content.
      *
-     * @param mixed $node A node object or a string node path or NULL to resolve the current document node
+     * @param mixed $node A node object or a string node path(absolute or relative) a string node://-uri or NULL to resolve the current document node
      * @param string $format Format to use for the URL, for example "html" or "json"
      * @param boolean $absolute If set, an absolute URI is rendered
      * @param array $arguments Additional arguments to be passed to the UriBuilder (for example pagination parameters)
@@ -147,6 +147,9 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
         $baseNode = null;
         if (!$node instanceof NodeInterface) {
             $baseNode = $this->getContextVariable($baseNodeName);
+            if (is_string($node) && substr($node, 0, 7) === 'node://') {
+                $node = $this->linkingService->convertUriToObject($node, $baseNode);
+            }
         }
 
         try {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Link/NodeViewHelper.php
@@ -71,6 +71,14 @@ use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
  * (depending on current workspace, current node, format etc.)
  * </output>
  *
+ * <code title="Target node given as node://-uri">
+ * <neos:link.node node="node://30e893c1-caef-0ca5-b53d-e5699bb8e506">Corporate imprint</neos:link.node>
+ * </code>
+ * <output>
+ * <a href="contact/imprint.html">Corporate imprint</a>
+ * (depending on current workspace, current node, format etc.)
+ * </output>
+ *
  * <code title="Target node given as relative node path">
  * <neos:link.node node="~/about/us">About us</neos:link.node>
  * </code>
@@ -129,7 +137,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
     /**
      * Renders the link. Renders the linked node's label if there's no child content.
      *
-     * @param mixed $node A node object or a string node path(absolute or relative) a string node://-uri or NULL to resolve the current document node
+     * @param mixed $node A node object, a string node path (absolute or relative), a string node://-uri or NULL
      * @param string $format Format to use for the URL, for example "html" or "json"
      * @param boolean $absolute If set, an absolute URI is rendered
      * @param array $arguments Additional arguments to be passed to the UriBuilder (for example pagination parameters)

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
@@ -93,7 +93,7 @@ class NodeViewHelper extends AbstractViewHelper
     /**
      * Renders the URI.
      *
-     * @param mixed $node A node object or a string node path (absolute or relative) or NULL to resolve the current document node
+     * @param mixed $node A node object or a string node path (absolute or relative) a string node://-uri or NULL to resolve the current document node
      * @param string $format Format to use for the URL, for example "html" or "json"
      * @param boolean $absolute If set, an absolute URI is rendered
      * @param array $arguments Additional arguments to be passed to the UriBuilder (for example pagination parameters)
@@ -110,6 +110,9 @@ class NodeViewHelper extends AbstractViewHelper
         $baseNode = null;
         if (!$node instanceof NodeInterface) {
             $baseNode = $this->getContextVariable($baseNodeName);
+            if (is_string($node) && substr($node, 0, 7) === 'node://') {
+                $node = $this->linkingService->convertUriToObject($node, $baseNode);
+            }
         }
 
         try {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Uri/NodeViewHelper.php
@@ -78,6 +78,14 @@ use TYPO3\TypoScript\ViewHelpers\TypoScriptContextTrait;
  * about/us.html
  * (depending on current workspace, current node, format etc.)
  * </output>
+ *
+ * <code title="Target node given as node://-uri">
+ * <neos:uri.node node="node://30e893c1-caef-0ca5-b53d-e5699bb8e506" />
+ * </code>
+ * <output>
+ * about/us.html
+ * (depending on current workspace, current node, format etc.)
+ * </output>
  * @api
  */
 class NodeViewHelper extends AbstractViewHelper
@@ -93,7 +101,7 @@ class NodeViewHelper extends AbstractViewHelper
     /**
      * Renders the URI.
      *
-     * @param mixed $node A node object or a string node path (absolute or relative) a string node://-uri or NULL to resolve the current document node
+     * @param mixed $node A node object, a string node path (absolute or relative), a string node://-uri or NULL
      * @param string $format Format to use for the URL, for example "html" or "json"
      * @param boolean $absolute If set, an absolute URI is rendered
      * @param array $arguments Additional arguments to be passed to the UriBuilder (for example pagination parameters)

--- a/TYPO3.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -212,6 +212,16 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function viewHelperRendersUriViaNodeUriPathString()
+    {
+        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('node://3239baee-3e7f-785c-0853-f4302ef32570'));
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('node://30e893c1-caef-0ca5-b53d-e5699bb8e506'));
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2'));
+    }
+
+    /**
+     * @test
+     */
     public function viewHelperRespectsAbsoluteParameter()
     {
         $this->assertSame('<a href="http://neos.test/en/home.html">Home</a>', $this->viewHelper->render(null, null, true));

--- a/TYPO3.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/TYPO3.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -197,6 +197,16 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function viewHelperRendersUriViaNodeUriPathString()
+    {
+        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('node://3239baee-3e7f-785c-0853-f4302ef32570'));
+        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('node://30e893c1-caef-0ca5-b53d-e5699bb8e506'));
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2'));
+    }
+
+    /**
+     * @test
+     */
     public function viewHelperRespectsAbsoluteParameter()
     {
         $this->assertOutputLinkValid('http://neos.test/en/home.html', $this->viewHelper->render(null, null, true));


### PR DESCRIPTION
The ``neos:link.node`` and ``neos.uri.node`` ViewHelpers already support the nodePath as alternative to the node-object this change adds support for the ``node://``-uris of neos.