### PR TITLE
BUGFIX: on editing changes and backend reload, ensure the content area updates properly

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
@@ -54,8 +54,8 @@ prototype(TYPO3.Neos:Page) < prototype(TYPO3.TypoScript:Http.Message) {
 		}
 
 		neosBackendHeader = TYPO3.TypoScript:Value {
+			@position = 'end 10000'
 			value = TYPO3.TypoScript:Template {
-				@position = 'end 10000'
 				templatePath = 'resource://TYPO3.Neos/Private/Templates/TypoScriptObjects/NeosBackendHeaderData.html'
 				node = ${documentNode}
 
@@ -72,8 +72,8 @@ prototype(TYPO3.Neos:Page) < prototype(TYPO3.TypoScript:Http.Message) {
 
 
 		neosBackendEndpoints = TYPO3.TypoScript:Value {
+			@position = 'end 10001'
 			value = TYPO3.TypoScript:Template {
-				@position = 'end 10001'
 				templatePath = 'resource://TYPO3.Neos/Private/Templates/TypoScriptObjects/NeosBackendEndpoints.html'
 				node = ${documentNode}
 				account = ${Security.getAccount()}
@@ -141,8 +141,8 @@ prototype(TYPO3.Neos:Page) < prototype(TYPO3.TypoScript:Http.Message) {
 
 	# Required for the backend to work.
 	neosBackendContainer = TYPO3.TypoScript:Value {
+		@position = 'before closingBodyTag'
 		value = TYPO3.TypoScript:Template {
-			@position = 'before closingBodyTag'
 			templatePath = 'resource://TYPO3.Neos/Private/Templates/TypoScriptObjects/NeosBackendContainer.html'
 			node = ${documentNode}
 


### PR DESCRIPTION
## How to reproduce

- see #1238
- Changes applied in the inspector are only visible in the user interface
  after a manual browser reload. Appears on the Demo Website.


## Problem Description

* it turns out that the *content replacement* on-reload was broken.
* this led to the content area not-refreshing
* ... and also updated the publish button wrongly (as this data is loaded
  from the content area).

The content-replacement on-reload was broken because of wrong HTML ordering
in the Page prototype; i.e. the "neosBackendContainer" is supposed to be
rendered at the *end* of the page (directly before the closing body tag);
but it was rendered even before the body.

This error is a regression introduced by https://github.com/neos/neos-development-collection/pull/684 - while adding another level of indirection,
the @position element was moved downwards and not kept at the top-level.

Resolves #1238