### PR TITLE
BUGFIX: Remove outdated CommonMarkConverter setup

### DIFF
--- a/TYPO3.Neos/Configuration/Objects.yaml
+++ b/TYPO3.Neos/Configuration/Objects.yaml
@@ -58,9 +58,6 @@ TYPO3\Neos\Service\XliffService:
           1:
             value: TYPO3_Neos_XliffToJsonTranslations
 
-League\CommonMark\CommonMarkConverter:
-  className: League\CommonMark\CommonMarkConverter
-
 TYPO3\Neos\Controller\Backend\BackendController:
   properties:
     loginTokenCache:


### PR DESCRIPTION
Removed in neos/neos-development-collection#1208 the configuration
for CommonMarkConverter in Objects.yaml was left in place.