### PR TITLE
TASK: Use partyService instead of deprecated method ``securityContext…

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
@@ -46,20 +46,21 @@ class ModuleController extends ActionController
     protected $securityContext;
 
     /**
-     * @var MenuHelper
      * @Flow\Inject
+     * @var MenuHelper
      */
     protected $menuHelper;
 
     /**
-     * @var PartyService
      * @Flow\Inject
+     * @var PartyService
      */
     protected $partyService;
 
     /**
      * @param array $module
      * @return mixed
+     * @throws DisabledModuleException
      */
     public function indexAction(array $module)
     {

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Backend/ModuleController.php
@@ -22,6 +22,7 @@ use TYPO3\Flow\Utility\MediaTypes;
 use TYPO3\Neos\Controller\Backend\MenuHelper;
 use TYPO3\Neos\Controller\BackendUserTranslationTrait;
 use TYPO3\Neos\Controller\Exception\DisabledModuleException;
+use TYPO3\Party\Domain\Service\PartyService;
 
 /**
  * The TYPO3 Module
@@ -49,6 +50,12 @@ class ModuleController extends ActionController
      * @Flow\Inject
      */
     protected $menuHelper;
+
+    /**
+     * @var PartyService
+     * @Flow\Inject
+     */
+    protected $partyService;
 
     /**
      * @param array $module
@@ -102,7 +109,7 @@ class ModuleController extends ActionController
             }
             return $moduleResponse->getContent();
         } else {
-            $user = $this->securityContext->getPartyByType(\TYPO3\Neos\Domain\Model\User::class);
+            $user = $this->partyService->getAssignedPartyOfAccount($this->securityContext->getAccount());
 
             $sites = $this->menuHelper->buildSiteList($this->controllerContext);
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ContainerViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Backend/ContainerViewHelper.php
@@ -21,6 +21,7 @@ use TYPO3\Neos\Controller\Backend\MenuHelper;
 use TYPO3\Neos\Domain\Model\User;
 use TYPO3\Neos\Exception as NeosException;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\Party\Domain\Service\PartyService;
 
 /**
  * ViewHelper for the backend 'container'. Renders the required HTML to integrate
@@ -43,6 +44,12 @@ class ContainerViewHelper extends AbstractViewHelper
      * @var Context
      */
     protected $securityContext;
+
+    /**
+     * @Flow\Inject
+     * @var PartyService
+     */
+    protected $partyService;
 
     /**
      * @var MenuHelper
@@ -83,7 +90,7 @@ class ContainerViewHelper extends AbstractViewHelper
         $innerView->setFormat('html');
         $innerView->setPartialRootPath('resource://TYPO3.Neos/Private/Partials');
 
-        $user = $this->securityContext->getPartyByType(User::class);
+        $user = $this->partyService->getAssignedPartyOfAccount($this->securityContext->getAccount());
 
         $innerView->assignMultiple(array(
             'node' => $node,


### PR DESCRIPTION
This implements the neos-side of pr neos/flow-development-collection#457
wich removed the direct party account relation in flow.