### PR TITLE
BUGFIX: preview/edit modes share content cache

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
@@ -68,7 +68,6 @@ root {
 
 		entryIdentifier {
 			node = ${node}
-			editPreviewMode = ${documentNode.context.currentRenderingMode.name}
 		}
 		entryTags {
 			# Whenever the node changes the matched condition could change
@@ -89,4 +88,5 @@ root {
 #
 prototype(TYPO3.TypoScript:GlobalCacheIdentifiers) {
 	workspaceChain = ${documentNode.context.workspace.name + ',' + Array.join(Array.keys(documentNode.context.workspace.baseWorkspaces), ',')}
+	editPreviewMode = ${documentNode.context.currentRenderingMode.name}
 }

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/EditPreviewPanel/EditPreviewPanelController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/EditPreviewPanel/EditPreviewPanelController.js
@@ -65,7 +65,7 @@ define(
 				reloadRequired = false;
 
 			LocalStorage.setItem('editPreviewMode', identifier);
-			if (this.get('previousActiveMode') && this.get('previousActiveMode.typoScriptRenderingPath') !== this.get('currentlyActiveMode.typoScriptRenderingPath')) {
+			if (this.get('previousActiveMode') !== this.get('currentlyActiveMode')) {
 				reloadRequired = true;
 			}
 			if (reloadRequired) {


### PR DESCRIPTION
This change fixes an issue with the edit and preview modes in Neos which result in unexpected output if modes are based on the same Fusion object path.

Prior to this change, preview mode "Desktop" and the edit mode "In-Place" shared a Fusion content
cache. If a site integrator wanted to react on the current mode in her Fluid template (using the
{neos:rendering.inEditMode()} view helper calls) she will get wrong results, depending on which
mode has been called first with an empty cache.

This change now introduces the mode identifier as a new part of the content cache identifier.
Additionally, edit / preview mode buttons will now trigger a reload even for modes which are
based on the same Fusion object path.

Resolves #1249