### PR TITLE
BUGFIX: Use type cast in PostgreSQL migration 20161125125249

### DIFF
--- a/Neos.Neos/Migrations/Postgresql/Version20161125125249.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20161125125249.php
@@ -19,11 +19,11 @@ class Version20161125125249 extends AbstractMigration
 
         $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET nodetype=REPLACE(nodetype, 'TYPO3.Neos:', 'Neos.Neos:')");
 
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'TYPO3\\\\Media\\\\', 'Neos\\\\Media\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'TYPO3\\\\Flow\\\\', 'Neos\\\\Flow\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'TYPO3\\\\Neos\\\\', 'Neos\\\\Neos\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'TYPO3\\\\Party\\\\', 'Neos\\\\Party\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'TYPO3\\\\TYPO3CR\\\\', 'Neos\\\\ContentRepository\\\\')");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'TYPO3\\\\Media\\\\', 'Neos\\\\Media\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'TYPO3\\\\Flow\\\\', 'Neos\\\\Flow\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'TYPO3\\\\Neos\\\\', 'Neos\\\\Neos\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'TYPO3\\\\Party\\\\', 'Neos\\\\Party\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'TYPO3\\\\TYPO3CR\\\\', 'Neos\\\\ContentRepository\\\\') AS jsonb)");
     }
 
     /**
@@ -36,10 +36,10 @@ class Version20161125125249 extends AbstractMigration
 
         $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET nodetype=REPLACE(nodetype, 'Neos.Neos:', 'TYPO3.Neos:')");
 
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'Neos\\\\Media\\\\', 'TYPO3\\\\Media\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'Neos\\\\Flow\\\\', 'TYPO3\\\\Flow\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'Neos\\\\Neos\\\\', 'TYPO3\\\\Neos\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'Neos\\\\Party\\\\', 'TYPO3\\\\Party\\\\')");
-        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=REPLACE(properties, 'Neos\\\\ContentRepository\\\\', 'TYPO3\\\\TYPO3CR\\\\')");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'Neos\\\\Media\\\\', 'TYPO3\\\\Media\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'Neos\\\\Flow\\\\', 'TYPO3\\\\Flow\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'Neos\\\\Neos\\\\', 'TYPO3\\\\Neos\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'Neos\\\\Party\\\\', 'TYPO3\\\\Party\\\\') AS jsonb)");
+        $this->addSql("UPDATE neos_contentrepository_domain_model_nodedata SET properties=CAST(REPLACE(CAST(properties AS TEXT), 'Neos\\\\ContentRepository\\\\', 'TYPO3\\\\TYPO3CR\\\\') AS jsonb)");
     }
 }


### PR DESCRIPTION
The properties column is of type jsonb, so REPLACE needs to use CAST.