### PR TITLE
BUGFIX: Do not escape special characters in breadcrumb item label

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/BreadcrumbMenu.html
+++ b/TYPO3.Neos/Resources/Private/Templates/TypoScriptObjects/BreadcrumbMenu.html
@@ -6,7 +6,7 @@
 		<li{ts:render(path: '{item.state}.attributes', context: {item: item}) -> f:format.raw()}>
 			<f:if condition="{item.state} == 'current'">
 				<f:then>
-					{item.label}
+					{item.label -> f:format.raw()}
 				</f:then>
 				<f:else>
 					<neos:link.node node="{item.node}" />


### PR DESCRIPTION
**What I did**

Prevent escaping of special characters in breadcrumb ite lables.

**How I did it**

Piped output for the label through the f:format.raw() ViewHelper.

**How to verify it**

* Create  page with special characters in the title
* Use the Prototype **TYPO3.Neos:BreadcrumbMenu** in your layout
* View the page in the frontend, the label for the current page should not contain special chars anymore

**Checklist**

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)