### PR TITLE
TASK: Add PHP 7.1 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
       dist: trusty
       addons:
         postgresql: "9.5"
+    - php: 7.1
+      env: DB=mysql
+    - php: 7.1
+      env: DB=mysql BEHAT=true
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
Now that PHP 7.1 is released, we should make sure we are compatible.