### PR TITLE
!!! TASK: Rename fusion content cache key to ``Neos_Fusion_Content``

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/FileMonitorListener.php
+++ b/Neos.Fusion/Classes/Core/Cache/FileMonitorListener.php
@@ -53,7 +53,7 @@ class FileMonitorListener
         );
 
         if (in_array($fileMonitorIdentifier, $fileMonitorsThatTriggerContentCacheFlush)) {
-            $this->flowCacheManager->getCache('TYPO3_TypoScript_Content')->flush();
+            $this->flowCacheManager->getCache('Neos_Fusion_Content')->flush();
         }
     }
 }

--- a/Neos.Fusion/Configuration/Caches.yaml
+++ b/Neos.Fusion/Configuration/Caches.yaml
@@ -1,3 +1,3 @@
-TYPO3_TypoScript_Content:
+Neos_Fusion_Content:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\FileBackend

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -16,4 +16,4 @@ Neos\Fusion\Core\Cache\ContentCache:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_TypoScript_Content
+            value: Neos_Fusion_Content

--- a/Neos.Fusion/Configuration/Testing/Caches.yaml
+++ b/Neos.Fusion/Configuration/Testing/Caches.yaml
@@ -1,3 +1,3 @@
-TYPO3_TypoScript_Content:
+Neos_Fusion_Content:
   backend: Neos\Cache\Backend\TransientMemoryBackend
   backendOptions: ~

--- a/Neos.Fusion/Migrations/Code/Version20161202215034.php
+++ b/Neos.Fusion/Migrations/Code/Version20161202215034.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate name for the Fusion content cache to Neos_Fusion_Content
+ */
+class Version20161202215034 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.Fusion-20161202215034';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TYPO3_TypoScript_Content', 'Neos_Fusion_Content', ['php', 'yaml']);
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -37,7 +37,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
     {
         // Re-inject the original cache since some tests might replace it with a mock object
         $cacheManager = $this->objectManager->get(CacheManager::class);
-        $cacheFrontend = $cacheManager->getCache('TYPO3_TypoScript_Content');
+        $cacheFrontend = $cacheManager->getCache('Neos_Fusion_Content');
         $this->inject($this->contentCache, 'cache', $cacheFrontend);
     }
 

--- a/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -309,7 +309,7 @@ Change the cache backend
 By default, all cache entries are stored on the local filesystem. You can change this in ``Caches.yaml``,
 the example below will use the Redis backend for the content cache::
 
-	TYPO3_TypoScript_Content:
+	Neos_Fusion_Content:
 	  backend: TYPO3\Flow\Cache\Backend\RedisBackend
 
 .. note::

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -291,8 +291,8 @@ class FeatureContext extends MinkContext
     public function clearContentCache()
     {
         $directories = array_merge(
-            glob(FLOW_PATH_DATA . 'Temporary/*/Cache/Data/TYPO3_TypoScript_Content'),
-            glob(FLOW_PATH_DATA . 'Temporary/*/*/Cache/Data/TYPO3_TypoScript_Content')
+            glob(FLOW_PATH_DATA . 'Temporary/*/Cache/Data/Neos_Fusion_Content'),
+            glob(FLOW_PATH_DATA . 'Temporary/*/*/Cache/Data/Neos_Fusion_Content')
         );
         if (is_array($directories)) {
             foreach ($directories as $directory) {


### PR DESCRIPTION
This changes the fusion content cache key to ``Neos_Fusion_Content`` and also provides a code migration to adjust the name in yaml and php files