### PR TITLE
!!! TASK: Deprecate and rename TypoScript classes

### DIFF
--- a/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
+++ b/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
@@ -14,12 +14,12 @@ namespace Neos\Fusion\ViewHelpers;
 use Neos\Fusion\FusionObjects\Helpers\TypoScriptAwareViewInterface;
 
 /**
- * This trait is to be used in ViewHelpers that need to get information from the TypoScript runtime context.
+ * This trait is to be used in ViewHelpers that need to get information from the Fusion runtime context.
  * It will only work when the ViewHelper in question is used in a TypoScriptAwareViewInterface.
  *
  * A property "viewHelperVariableContainer" is expected in classes that use this, which will be the case for any Fluid ViewHelper.
  */
-trait TypoScriptContextTrait
+trait FusionContextTrait
 {
 
     /**

--- a/Neos.Fusion/Migrations/Code/Version20161219092345.php
+++ b/Neos.Fusion/Migrations/Code/Version20161219092345.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate name for the Fusion cache to Neos_Neos_Fusion
+ */
+class Version20161219092345 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.Fusion-20161219092345';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TYPO3_Neos_TypoScript', 'Neos_Neos_Fusion', ['php', 'yaml']);
+    }
+}

--- a/Neos.Neos/Classes/Aspects/FusionCachingAspect.php
+++ b/Neos.Neos/Classes/Aspects/FusionCachingAspect.php
@@ -19,13 +19,13 @@ use Neos\Cache\Frontend\VariableFrontend;
  * @Flow\Scope("singleton")
  * @Flow\Aspect
  */
-class TypoScriptCachingAspect
+class FusionCachingAspect
 {
     /**
      * @Flow\Inject
      * @var VariableFrontend
      */
-    protected $typoScriptCache;
+    protected $fusionCache;
 
     /**
      * @Flow\Around("setting(Neos.Neos.typoScript.enableObjectTreeCache) && method(Neos\Neos\Domain\Service\FusionService->getMergedFusionObjectTree())")
@@ -37,13 +37,13 @@ class TypoScriptCachingAspect
         $currentSiteNode = $joinPoint->getMethodArgument('startNode');
         $cacheIdentifier = str_replace('.', '_', $currentSiteNode->getContext()->getCurrentSite()->getSiteResourcesPackageKey());
 
-        if ($this->typoScriptCache->has($cacheIdentifier)) {
-            $typoScriptObjectTree = $this->typoScriptCache->get($cacheIdentifier);
+        if ($this->fusionCache->has($cacheIdentifier)) {
+            $fusionObjectTree = $this->fusionCache->get($cacheIdentifier);
         } else {
-            $typoScriptObjectTree = $joinPoint->getAdviceChain()->proceed($joinPoint);
-            $this->typoScriptCache->set($cacheIdentifier, $typoScriptObjectTree);
+            $fusionObjectTree = $joinPoint->getAdviceChain()->proceed($joinPoint);
+            $this->fusionCache->set($cacheIdentifier, $fusionObjectTree);
         }
 
-        return $typoScriptObjectTree;
+        return $fusionObjectTree;
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -18,7 +18,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Service\AuthorizationService;
-use Neos\Fusion\ViewHelpers\TypoScriptContextTrait;
+use Neos\Fusion\ViewHelpers\FusionContextTrait;
 use Neos\Neos\Service\ContentElementEditableService;
 
 /**
@@ -35,7 +35,7 @@ use Neos\Neos\Service\ContentElementEditableService;
  */
 class EditableViewHelper extends AbstractTagBasedViewHelper
 {
-    use TypoScriptContextTrait;
+    use FusionContextTrait;
 
     /**
      * @Flow\Inject

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -18,7 +18,7 @@ use Neos\Neos\Exception as NeosException;
 use Neos\Neos\Service\LinkingService;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Fusion\ViewHelpers\TypoScriptContextTrait;
+use Neos\Fusion\ViewHelpers\FusionContextTrait;
 
 /**
  * A view helper for creating links with URIs pointing to nodes.
@@ -107,7 +107,7 @@ use Neos\Fusion\ViewHelpers\TypoScriptContextTrait;
  */
 class NodeViewHelper extends AbstractTagBasedViewHelper
 {
-    use TypoScriptContextTrait;
+    use FusionContextTrait;
 
     /**
      * @var string

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -18,7 +18,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Neos\Service\LinkingService;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Fusion\ViewHelpers\TypoScriptContextTrait;
+use Neos\Fusion\ViewHelpers\FusionContextTrait;
 
 /**
  * A view helper for creating URIs pointing to nodes.
@@ -90,7 +90,7 @@ use Neos\Fusion\ViewHelpers\TypoScriptContextTrait;
  */
 class NodeViewHelper extends AbstractViewHelper
 {
-    use TypoScriptContextTrait;
+    use FusionContextTrait;
 
     /**
      * @Flow\Inject

--- a/Neos.Neos/Configuration/Caches.yaml
+++ b/Neos.Neos/Configuration/Caches.yaml
@@ -2,7 +2,7 @@ TYPO3_Neos_Configuration_Version:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\FileBackend
 
-TYPO3_Neos_TypoScript:
+Neos_Neos_Fusion:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
 

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -14,9 +14,9 @@ Neos\ContentRepository\Domain\Service\ContextFactoryInterface:
 Neos\ContentRepository\Domain\Service\PublishingServiceInterface:
   className: Neos\Neos\Service\PublishingService
 
-Neos\Neos\Aspects\TypoScriptCachingAspect:
+Neos\Neos\Aspects\FusionCachingAspect:
   properties:
-    typoScriptCache:
+    fusionCache:
       object:
         factoryObjectName: Neos\Flow\Cache\CacheManager
         factoryMethodName: getCache

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -22,7 +22,7 @@ Neos\Neos\Aspects\FusionCachingAspect:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Neos_TypoScript
+            value: Neos_Neos_Fusion
 
 'Neos\ContentRepository\Domain\Service\ContentDimensionPresetSourceInterface':
   className: Neos\Neos\Domain\Service\ConfigurationContentDimensionPresetSource


### PR DESCRIPTION
This changes adjusts several classes to our new name Fusion. Therefore the ``TypoScriptContextTrait`` and the ``TypoScriptCachingAspect`` as well as the fusion cache key are renamed.
Also the current ``TypoScriptView`` will now be flagged as deprecated in favor for the new introduced ``FusionView``