### PR TITLE
TASK: Do not use deprecated ``PropertyMappingConfigurationBuilder``

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -19,7 +19,6 @@ use Neos\Error\Messages\Message;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Property\PropertyMappingConfigurationBuilder;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Context;
 use Neos\Media\Domain\Model\AssetInterface;
@@ -82,12 +81,6 @@ class WorkspacesController extends AbstractModuleController
      * @var ContentContextFactory
      */
     protected $contextFactory;
-
-    /**
-     * @Flow\Inject
-     * @var PropertyMappingConfigurationBuilder
-     */
-    protected $propertyMappingConfigurationBuilder;
 
     /**
      * @Flow\Inject
@@ -384,7 +377,7 @@ class WorkspacesController extends AbstractModuleController
      */
     public function publishOrDiscardNodesAction(array $nodes, $action, Workspace $selectedWorkspace = null)
     {
-        $propertyMappingConfiguration = $this->propertyMappingConfigurationBuilder->build();
+        $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
         foreach ($nodes as $key => $node) {
             $nodes[$key] = $this->propertyMapper->convert($node, NodeInterface::class, $propertyMappingConfiguration);

--- a/Neos.Neos/Classes/Service/Controller/WorkspaceController.php
+++ b/Neos.Neos/Classes/Service/Controller/WorkspaceController.php
@@ -13,7 +13,6 @@ namespace Neos\Neos\Service\Controller;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Property\PropertyMappingConfigurationBuilder;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Service\View\NodeView;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -60,12 +59,6 @@ class WorkspaceController extends AbstractServiceController
      * @var PropertyMapper
      */
     protected $propertyMapper;
-
-    /**
-     * @Flow\Inject
-     * @var PropertyMappingConfigurationBuilder
-     */
-    protected $propertyMappingConfigurationBuilder;
 
     /**
      * @return void


### PR DESCRIPTION
The ``PropertyMappingConfigurationBuilder`` should no longer be used
and can be replaced by calling the
``PropertyMapper::buildPropertyMappingConfiguration`` method.