### PR TITLE
TASK: Remove deprecated magic ``__call`` method in NodeType

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -208,8 +208,7 @@ class NodeType
             $superTypes[$inheritedSuperTypeName] = $inheritedSuperType;
         }
 
-        // the method getSuperTypes() is a magic getter
-        $superTypesInSuperType = $superType->getSuperTypes() ?: [];
+        $superTypesInSuperType = $superType->getConfiguration('superTypes') ?: [];
         foreach ($superTypesInSuperType as $inheritedSuperTypeName => $inheritedSuperType) {
             if (!$inheritedSuperType) {
                 unset($superTypes[$inheritedSuperTypeName]);

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -699,25 +699,4 @@ class NodeType
     {
         return $this->getName();
     }
-
-    /**
-     * Magic get* and has* method for all properties inside $configuration.
-     *
-     * @param string $methodName
-     * @param array $arguments
-     * @return mixed
-     * @deprecated Use hasConfiguration() or getConfiguration() instead
-     */
-    public function __call($methodName, array $arguments)
-    {
-        if (substr($methodName, 0, 3) === 'get') {
-            $configurationKey = lcfirst(substr($methodName, 3));
-            return $this->getConfiguration($configurationKey);
-        } elseif (substr($methodName, 0, 3) === 'has') {
-            $configurationKey = lcfirst(substr($methodName, 3));
-            return $this->hasConfiguration($configurationKey);
-        }
-
-        trigger_error('Call to undefined method ' . get_class($this) . '::' . $methodName, E_USER_ERROR);
-    }
 }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -283,42 +283,6 @@ class NodeTypeTest extends UnitTestCase
     }
 
     /**
-     * Tests for the deprecated __call method to verify backwards compatibility
-     */
-
-    /**
-     * @test
-     */
-    public function configurationCanBeReturnedViaMagicGetter()
-    {
-        $baseType = new NodeType('Neos.ContentRepository:Base', array(), array(
-            'someKey' => 'someValue'
-        ));
-        $this->assertTrue($baseType->hasSomeKey());
-        $this->assertSame('someValue', $baseType->getSomeKey());
-    }
-
-    /**
-     * @test
-     */
-    public function magicHasReturnsFalseIfPropertyDoesNotExist()
-    {
-        $baseType = new NodeType('Neos.ContentRepository:Base', array(), array());
-        $this->assertFalse($baseType->hasFooKey());
-    }
-
-    /**
-     * @test
-     */
-    public function magicGettersInitializesTheNodeType()
-    {
-        $nodeType = $this->getAccessibleMock(NodeType::class, array('initialize'), array(), '', false);
-        $nodeType->_set('configuration', array('someProperty' => 'someValue'));
-        $nodeType->expects($this->once())->method('initialize');
-        $nodeType->getSomeProperty();
-    }
-
-    /**
      * @test
      */
     public function defaultValuesForPropertiesHandlesDateTypes()


### PR DESCRIPTION
You can use ``hasConfiguration`` and ``getConfiguration`` as
replacement for the functionality the magic method offered.