### PR TITLE
TASK: Remove deprecated thumbnail behavior

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -56,12 +56,6 @@ class ThumbnailConfiguration
     protected $async;
 
     /**
-     * @Flow\InjectConfiguration("behaviourFlag")
-     * @var string
-     */
-    protected $behaviourFlag;
-
-    /**
      * @Flow\Inject
      * @var SystemLoggerInterface
      */
@@ -97,17 +91,7 @@ class ThumbnailConfiguration
      */
     public function getWidth()
     {
-        if ($this->width !== null) {
-            return $this->width;
-        }
-        if ($this->behaviourFlag === '1.2') {
-            // @deprecated since 2.0, simulate the behaviour of 1.2
-            if ($this->height === null && $this->isCroppingAllowed() && $this->getMaximumWidth() !== null && $this->getMaximumHeight() !== null) {
-                $this->logDeprecation();
-                return $this->getMaximumWidth();
-            }
-        }
-        return null;
+        return $this->width;
     }
 
     /**
@@ -123,17 +107,7 @@ class ThumbnailConfiguration
      */
     public function getHeight()
     {
-        if ($this->height !== null) {
-            return $this->height;
-        }
-        if ($this->behaviourFlag === '1.2') {
-            // @deprecated since 2.0, simulate the behaviour of 1.2
-            if ($this->width === null && $this->isCroppingAllowed() && $this->getMaximumWidth() !== null && $this->getMaximumHeight() !== null) {
-                $this->logDeprecation();
-                return $this->getMaximumHeight();
-            }
-        }
-        return null;
+        return $this->height;
     }
 
     /**
@@ -201,19 +175,5 @@ class ThumbnailConfiguration
         });
         ksort($data);
         return $data;
-    }
-
-    /**
-     * Log a deprecation message once
-     *
-     * @return void
-     */
-    protected function logDeprecation()
-    {
-        if (!static::$loggedDeprecation) {
-            static::$loggedDeprecation = true;
-            $this->logger->log('Neos.Media is configured to simulate the deprecated Neos 1.2 behaviour. Please check the setting "Neos.Media.behaviourFlag".',
-                LOG_DEBUG);
-        }
     }
 }

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -50,10 +50,6 @@ Neos:
           position: 'before Neos.Neos'
 
   Media:
-    # This setting simulates how Neos 1.2 handled image cropping with "maximumWidth" and "maximumHeight".
-    # This behaviour is deprecated and will be removed in Neos 3.0, "maximumWidth" and "maximumHeight"
-    # need to be replaced by "width" and "height" if you need fixed dimensions.
-    behaviourFlag: '1.2'
     # Enable asynchronous thumbnails
     asyncThumbnails: true
     # Thumbnail presets


### PR DESCRIPTION
The setting ``behaviorFlag`` simulated how Neos 1.2 handled
image cropping with "maximumWidth" and "maximumHeight".
This behaviour was deprecated and is now removed, "maximumWidth"
and "maximumHeight" need to be replaced by "width" and "height"
if you need fixed dimensions.