### PR TITLE
BUGFIX: Adapt to changes in ``ConfigurationManager``

### DIFF
--- a/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
+++ b/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
@@ -139,6 +139,6 @@ class NeosSpecificRequirementsStep extends AbstractStep
         $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Imagine.driver', $formValues['imagineDriver']);
         $this->configurationSource->save(FLOW_PATH_CONFIGURATION . ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $this->distributionSettings);
 
-        $this->configurationManager->flushConfigurationCache();
+        $this->configurationManager->refreshConfiguration();
     }
 }


### PR DESCRIPTION
Some internals of the Flow ``ConfigurationManager`` changed,
making ``clearConfigurationCache`` the wrong method to call
in the setup, which could lead to broken configuration.
