### PR TITLE
TASK: Refactor the ``FusionView`` to use fusion in variable and method names

### DIFF
--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -39,8 +39,8 @@ class FusionView extends AbstractView
      * @var array
      */
     protected $supportedOptions = array(
-        'typoScriptPathPatterns' => array(array('resource://@package/Private/Fusion'), 'Fusion files will be recursively loaded from this paths.', 'array'),
-        'typoScriptPath' => array(null, 'The Fusion path which should be rendered; derived from the controller and action names or set by the user.', 'string'),
+        'fusionPathPatterns' => array(array('resource://@package/Private/Fusion'), 'Fusion files will be recursively loaded from this paths.', 'array'),
+        'fusionPath' => array(null, 'The Fusion path which should be rendered; derived from the controller and action names or set by the user.', 'string'),
         'packageKey' => array(null, 'The package key where the Fusion should be loaded from. If not given, is automatically derived from the current request.', 'string'),
         'debugMode' => array(false, 'Flag to enable debug mode of the Fusion runtime explicitly (overriding the global setting).', 'boolean'),
         'enableContentCache' => array(false, 'Flag to enable content caching inside Fusion (overriding the global setting).', 'boolean')
@@ -66,7 +66,7 @@ class FusionView extends AbstractView
     protected $parsedFusion;
 
     /**
-     * Runtime cache of the TypoScript path which should be rendered; derived from the controller
+     * Runtime cache of the Fusion path which should be rendered; derived from the controller
      * and action names or set by the user.
      *
      * @var string
@@ -81,7 +81,7 @@ class FusionView extends AbstractView
     protected $fallbackViewEnabled = true;
 
     /**
-     * The TypoScript Runtime
+     * The Fusion Runtime
      *
      * @var Runtime
      */
@@ -101,19 +101,19 @@ class FusionView extends AbstractView
     }
 
     /**
-     * Sets the TypoScript path to be rendered to an explicit value;
+     * Sets the Fusion path to be rendered to an explicit value;
      * to be used mostly inside tests.
      *
-     * @param string $typoScriptPath
+     * @param string $fusionPath
      * @return void
      */
-    public function setTypoScriptPath($typoScriptPath)
+    public function setFusionPath($fusionPath)
     {
-        $this->setOption('typoScriptPath', $typoScriptPath);
+        $this->setOption('fusionPath', $fusionPath);
     }
 
     /**
-     * The package key where the TypoScript should be loaded from. If not given,
+     * The package key where the Fusion should be loaded from. If not given,
      * is automatically derived from the current request.
      *
      * @param string $packageKey
@@ -128,18 +128,18 @@ class FusionView extends AbstractView
      * @param string $pathPattern
      * @return void
      */
-    public function setTypoScriptPathPattern($pathPattern)
+    public function setFusionPathPattern($pathPattern)
     {
-        $this->setOption('typoScriptPathPatterns', array($pathPattern));
+        $this->setOption('fusionPathPatterns', array($pathPattern));
     }
 
     /**
      * @param array $pathPatterns
      * @return void
      */
-    public function setTypoScriptPathPatterns(array $pathPatterns)
+    public function setFusionPathPatterns(array $pathPatterns)
     {
-        $this->setOption('typoScriptPathPatterns', $pathPatterns);
+        $this->setOption('fusionPathPatterns', $pathPatterns);
     }
 
     /**
@@ -172,7 +172,7 @@ class FusionView extends AbstractView
      */
     public function render()
     {
-        $this->initializeTypoScriptRuntime();
+        $this->initializeFusionRuntime();
         if ($this->fusionRuntime->canRender($this->getFusionPathForCurrentRequest()) || $this->fallbackViewEnabled === false) {
             return $this->renderFusion();
         } else {
@@ -181,13 +181,13 @@ class FusionView extends AbstractView
     }
 
     /**
-     * Load the TypoScript Files form the defined
+     * Load the Fusion Files form the defined
      * paths and construct a Runtime from the
      * parsed results
      *
      * @return void
      */
-    public function initializeTypoScriptRuntime()
+    public function initializeFusionRuntime()
     {
         if ($this->fusionRuntime === null) {
             $this->loadFusion();
@@ -202,14 +202,14 @@ class FusionView extends AbstractView
     }
 
     /**
-     * Load Fusion from the directories specified by $this->getOption('typoScriptPathPatterns')
+     * Load Fusion from the directories specified by $this->getOption('fusionPathPatterns')
      *
      * @return void
      */
     protected function loadFusion()
     {
         $mergedFusionCode = '';
-        $fusionPathPatterns = $this->getOption('typoScriptPathPatterns');
+        $fusionPathPatterns = $this->getOption('fusionPathPatterns');
         ksort($fusionPathPatterns);
         foreach ($fusionPathPatterns as $fusionPathPattern) {
             $fusionPathPattern = str_replace('@package', $this->getPackageKey(), $fusionPathPattern);
@@ -249,7 +249,7 @@ class FusionView extends AbstractView
     protected function getFusionPathForCurrentRequest()
     {
         if ($this->fusionPath === null) {
-            $fusionPath = $this->getOption('typoScriptPath');
+            $fusionPath = $this->getOption('fusionPath');
             if ($fusionPath !== null) {
                 $this->fusionPath = $fusionPath;
             } else {
@@ -265,16 +265,6 @@ class FusionView extends AbstractView
             }
         }
         return $this->fusionPath;
-    }
-
-    /**
-     * Determine whether we are able to find Fusion at the requested position
-     *
-     * @return boolean TRUE if Fusion exists at the current Fusion path; FALSE otherwise
-     */
-    protected function isTypoScriptFoundForCurrentRequest()
-    {
-        return (Arrays::getValueByPath($this->parsedFusion, str_replace('/', '.', $this->getFusionPathForCurrentRequest())) !== null);
     }
 
     /**

--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -15,7 +15,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\View\AbstractView;
 use Neos\Flow\Mvc\View\ViewInterface;
-use Neos\Utility\Arrays;
 use Neos\Utility\Files;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Runtime;

--- a/Neos.Fusion/Classes/View/TypoScriptView.php
+++ b/Neos.Fusion/Classes/View/TypoScriptView.php
@@ -13,8 +13,9 @@ namespace Neos\Fusion\View;
 
 /**
  * Deprecated View for using Fusion for standard MVC controllers. For more Details check `FusionView`
+ * This class will be removed with the release of Neos 4.0.
  *
- * @deprecated Will be removed with the next major version
+ * @deprecated since 3.0
  */
 class TypoScriptView extends FusionView
 {
@@ -25,7 +26,7 @@ class TypoScriptView extends FusionView
      * @param string $typoScriptPath
      * @return void
      */
-    public function setTypoScriptPathPath($typoScriptPath)
+    public function setTypoScriptPath($typoScriptPath)
     {
         parent::setFusionPath($typoScriptPath);
     }
@@ -34,7 +35,7 @@ class TypoScriptView extends FusionView
      * @param string $pathPattern
      * @return void
      */
-    public function setTypoScriptPathPathPattern($pathPattern)
+    public function setTypoScriptPathPattern($pathPattern)
     {
         parent::setFusionPathPattern($pathPattern);
     }
@@ -43,7 +44,7 @@ class TypoScriptView extends FusionView
      * @param array $pathPatterns
      * @return void
      */
-    public function setTypoScriptPathPathPatterns(array $pathPatterns)
+    public function setTypoScriptPathPatterns(array $pathPatterns)
     {
         parent::setFusionPathPatterns($pathPatterns);
     }
@@ -88,7 +89,6 @@ class TypoScriptView extends FusionView
      *
      * @param string $optionName
      * @return mixed
-     * @throws Exception
      */
     public function getOption($optionName)
     {

--- a/Neos.Fusion/Classes/View/TypoScriptView.php
+++ b/Neos.Fusion/Classes/View/TypoScriptView.php
@@ -18,4 +18,88 @@ namespace Neos\Fusion\View;
  */
 class TypoScriptView extends FusionView
 {
+    /**
+     * Sets the TypoScript path to be rendered to an explicit value;
+     * to be used mostly inside tests.
+     *
+     * @param string $typoScriptPath
+     * @return void
+     */
+    public function setTypoScriptPathPath($typoScriptPath)
+    {
+        parent::setFusionPath($typoScriptPath);
+    }
+
+    /**
+     * @param string $pathPattern
+     * @return void
+     */
+    public function setTypoScriptPathPathPattern($pathPattern)
+    {
+        parent::setFusionPathPattern($pathPattern);
+    }
+
+    /**
+     * @param array $pathPatterns
+     * @return void
+     */
+    public function setTypoScriptPathPathPatterns(array $pathPatterns)
+    {
+        parent::setFusionPathPatterns($pathPatterns);
+    }
+
+    /**
+     * Load the Fusion Files form the defined
+     * paths and construct a Runtime from the
+     * parsed results
+     *
+     * @return void
+     */
+    public function initializeTypoScriptRuntime()
+    {
+        parent::initializeFusionRuntime();
+    }
+
+    /**
+     * Set a specific option of this View
+     * Reset runtime cache if an option is changed
+     * The typoScript-options are mapped to their fusion counterparts
+     *
+     * @param string $optionName
+     * @param mixed $value
+     * @return void
+     */
+    public function setOption($optionName, $value)
+    {
+        switch ($optionName) {
+            case 'typoScriptPath':
+                $optionName = 'fusionPath';
+                break;
+            case 'typoScriptPathPatterns':
+                $optionName = 'fusionPathPatterns';
+                break;
+        }
+        parent::setOption($optionName, $value);
+    }
+
+    /**
+     * Get a specific option of this View
+     * The typoScript-options are mapped to their fusion counterparts
+     *
+     * @param string $optionName
+     * @return mixed
+     * @throws Exception
+     */
+    public function getOption($optionName)
+    {
+        switch ($optionName) {
+            case 'typoScriptPath':
+                $optionName = 'fusionPath';
+                break;
+            case 'typoScriptPathPatterns':
+                $optionName = 'fusionPathPatterns';
+                break;
+        }
+        return parent::getOption($optionName);
+    }
 }

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -103,7 +103,7 @@ class RenderViewHelper extends AbstractViewHelper
         } else {
             $this->initializeFusionView();
             $this->typoScriptView->setPackageKey($typoScriptPackageKey);
-            $this->typoScriptView->setTypoScriptPath($slashSeparatedPath);
+            $this->typoScriptView->setFusionPath($slashSeparatedPath);
             if ($context !== null) {
                 $this->typoScriptView->assignMultiple($context);
             }
@@ -125,7 +125,7 @@ class RenderViewHelper extends AbstractViewHelper
         $this->typoScriptView->setControllerContext($this->controllerContext);
         $this->typoScriptView->disableFallbackView();
         if ($this->hasArgument('typoScriptFilePathPattern')) {
-            $this->typoScriptView->setTypoScriptPathPattern($this->arguments['typoScriptFilePathPattern']);
+            $this->typoScriptView->setFusionPathPattern($this->arguments['typoScriptFilePathPattern']);
         }
     }
 }

--- a/Neos.Fusion/Migrations/Code/Version20161219130100.php
+++ b/Neos.Fusion/Migrations/Code/Version20161219130100.php
@@ -1,0 +1,38 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate name for the TypoScriptView to FusionView
+ */
+class Version20161219130100 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Fusion-20161219130100';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TypoScriptView', 'FusionView', ['php']);
+        $this->searchAndReplace('setTypoScriptPath', 'setFusionPath', ['php']);
+        $this->searchAndReplace('setTypoScriptPathPattern', 'setFusionPathPattern', ['php']);
+        $this->searchAndReplace('typoScriptPath', 'fusionPath', ['php']);
+        $this->searchAndReplace('typoScriptPathPatterns', 'fusionPathPatterns', ['php']);
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTest.php
@@ -56,7 +56,7 @@ abstract class AbstractFusionObjectTest extends FunctionalTestCase
         $view->setControllerContext($this->controllerContext);
         $view->disableFallbackView();
         $view->setPackageKey('Neos.Fusion');
-        $view->setTypoScriptPathPattern(__DIR__ . '/Fixtures/Fusion');
+        $view->setFusionPathPattern(__DIR__ . '/Fixtures/Fusion');
         $view->assign('fixtureDirectory', __DIR__ . '/Fixtures/');
 
         return $view;
@@ -88,7 +88,7 @@ abstract class AbstractFusionObjectTest extends FunctionalTestCase
     protected function assertTypoScriptPath($expected, $path)
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $this->assertSame($expected, $view->render(), 'Fusion at path "' . $path . '" produced wrong results.');
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
@@ -23,7 +23,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function basicRendering()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/test');
+        $view->setFusionPath('basicRendering/test');
         $this->assertEquals('XHello World', $view->render());
     }
 
@@ -33,7 +33,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function basicRenderingReusingTypoScriptVariables()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/reuseTypoScriptVariables');
+        $view->setFusionPath('basicRendering/reuseTypoScriptVariables');
         $this->assertEquals('XHello World', $view->render());
     }
 
@@ -51,7 +51,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function basicRenderingCrashing()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/crashing');
+        $view->setFusionPath('basicRendering/crashing');
         $this->assertEquals('XHello World', $view->render());
     }
 
@@ -61,7 +61,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function basicRenderingReusingTypoScriptVariablesWithEel()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/reuseTypoScriptVariablesWithEel');
+        $view->setFusionPath('basicRendering/reuseTypoScriptVariablesWithEel');
         $this->assertEquals('XHello World', $view->render());
     }
 
@@ -71,7 +71,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function complexExample()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/complexExample/toRender');
+        $view->setFusionPath('basicRendering/complexExample/toRender');
         $this->assertEquals('Static string post', $view->render());
     }
 
@@ -81,7 +81,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function complexExample2()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/complexExample2/toRender');
+        $view->setFusionPath('basicRendering/complexExample2/toRender');
         $this->assertEquals('Static string post', $view->render());
     }
 
@@ -115,7 +115,7 @@ class BasicRenderingTest extends AbstractFusionObjectTest
     public function contentIsNotTrimmed()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('basicRendering/contentIsNotTrimmed');
+        $view->setFusionPath('basicRendering/contentIsNotTrimmed');
         $this->assertEquals('X I want to have some space after me ', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
@@ -21,7 +21,7 @@ class CaseTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('cond', true);
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $this->assertEquals('Xtestconditiontrue', $view->render());
 
         $view->assign('cond', false);
@@ -46,7 +46,7 @@ class CaseTest extends AbstractFusionObjectTest
         $view->setOption('debugMode', true);
 
         $view->assign('cond', true);
-        $view->setTypoScriptPath('case/numericMatching');
+        $view->setFusionPath('case/numericMatching');
         $this->assertContains('Xtestconditiontrue', $view->render());
 
         $view->assign('cond', false);
@@ -124,7 +124,7 @@ class CaseTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('case/rendererHasAccessToThis');
+        $view->setFusionPath('case/rendererHasAccessToThis');
         $this->assertContains('foo', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
@@ -24,7 +24,7 @@ class CollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2'));
-        $view->setTypoScriptPath('collection/basicLoop');
+        $view->setFusionPath('collection/basicLoop');
         $this->assertEquals('Xelement1Xelement2', $view->render());
     }
 
@@ -36,7 +36,7 @@ class CollectionTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2'));
         $view->assign('other', 'var');
-        $view->setTypoScriptPath('collection/basicLoopOtherContextVariables');
+        $view->setFusionPath('collection/basicLoopOtherContextVariables');
         $this->assertEquals('Xelement1varXelement2var', $view->render());
     }
 
@@ -47,7 +47,7 @@ class CollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', null);
-        $view->setTypoScriptPath('collection/basicLoop');
+        $view->setFusionPath('collection/basicLoop');
         $this->assertEquals('', $view->render());
     }
 
@@ -58,7 +58,7 @@ class CollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2', 'element3', 'element4'));
-        $view->setTypoScriptPath('collection/iteration');
+        $view->setFusionPath('collection/iteration');
         $this->assertEquals('Xelement1-0-1-1--1-Xelement2-1-2----1Xelement3-2-3---1-Xelement4-3-4--1--1', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
@@ -48,7 +48,7 @@ class ConditionsTest extends AbstractFusionObjectTest
     public function conditionsWork($path, $expected)
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $view->assign('foo', 'Foo');
         $this->assertSame($expected, $view->render());
     }
@@ -72,7 +72,7 @@ class ConditionsTest extends AbstractFusionObjectTest
     public function everythingButFalseIsEvaluated($conditionValue, $expected)
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('conditions/variableCondition');
+        $view->setFusionPath('conditions/variableCondition');
         $view->assign('condition', $conditionValue);
         $this->assertSame($expected, $view->render());
     }
@@ -83,7 +83,7 @@ class ConditionsTest extends AbstractFusionObjectTest
     public function conditionsInFusionObjectsWithSubEvaluationUsedInProcessorRenderCorrectly()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('conditions/supportForTypoScriptObjectWithSubEvaluationUsedInProcessor');
+        $view->setFusionPath('conditions/supportForTypoScriptObjectWithSubEvaluationUsedInProcessor');
         $this->assertEquals('basic appended', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -51,7 +51,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
         $view->assign('object', $object);
-        $view->setTypoScriptPath('contentCache/cachedSegment');
+        $view->setFusionPath('contentCache/cachedSegment');
 
             // This render call should create the cache entry
         $firstRenderResult = $view->render();
@@ -74,7 +74,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/nestedCacheSegments');
+        $view->setFusionPath('contentCache/nestedCacheSegments');
 
         $view->assign('site', 'site1');
         $view->assign('object', $object);
@@ -100,7 +100,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentOnTopLevel');
+        $view->setFusionPath('contentCache/uncachedSegmentOnTopLevel');
 
         $view->assign('object', $object);
 
@@ -121,7 +121,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentWithWronglyConfiguredContext');
+        $view->setFusionPath('contentCache/uncachedSegmentWithWronglyConfiguredContext');
 
         $view->assign('object', $object);
         $view->assign('otherContextVariable', $otherContextVariable);
@@ -142,7 +142,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentInCachedSegment');
+        $view->setFusionPath('contentCache/uncachedSegmentInCachedSegment');
 
         $view->assign('object', $object);
 
@@ -165,7 +165,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentInCachedSegment');
+        $view->setFusionPath('contentCache/uncachedSegmentInCachedSegment');
 
         $view->assign('object', $object);
 
@@ -192,7 +192,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/cacheSegmentsWithTags');
+        $view->setFusionPath('contentCache/cacheSegmentsWithTags');
 
         $view->assign('object', $object);
         $view->assign('site', 'site1');
@@ -222,7 +222,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/cacheSegmentsWithTags');
+        $view->setFusionPath('contentCache/cacheSegmentsWithTags');
 
         $view->assign('object', $object);
         $view->assign('site', 'site1');
@@ -256,7 +256,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/cachedSegmentWithProcessor');
+        $view->setFusionPath('contentCache/cachedSegmentWithProcessor');
 
         $view->assign('object', $object);
 
@@ -276,7 +276,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentWithProcessor');
+        $view->setFusionPath('contentCache/uncachedSegmentWithProcessor');
 
         $view->assign('object', $object);
 
@@ -296,7 +296,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/cachedSegmentWithCondition');
+        $view->setFusionPath('contentCache/cachedSegmentWithCondition');
 
         $view->assignMultiple(array(
             'object' => $object,
@@ -324,7 +324,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentWithCondition');
+        $view->setFusionPath('contentCache/uncachedSegmentWithCondition');
 
         $view->assignMultiple(array(
             'object' => $object
@@ -357,7 +357,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/nestedCacheSegmentsWithInnerException');
+        $view->setFusionPath('contentCache/nestedCacheSegmentsWithInnerException');
 
         $view->assign('object', $object);
 
@@ -377,7 +377,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/nestedCacheSegmentsWithConditionalException');
+        $view->setFusionPath('contentCache/nestedCacheSegmentsWithConditionalException');
 
         $view->assign('object', $object);
         $view->assign('throwException', false);
@@ -399,7 +399,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/maximumLifetimeInNestedEmbedAndCachedSegments');
+        $view->setFusionPath('contentCache/maximumLifetimeInNestedEmbedAndCachedSegments');
 
         $mockCache = $this->createMock(\Neos\Cache\Frontend\FrontendInterface::class);
         $this->inject($this->contentCache, 'cache', $mockCache);
@@ -455,7 +455,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/entryIdentifiersAreMergedWithGlobalIdentifiers');
+        $view->setFusionPath('contentCache/entryIdentifiersAreMergedWithGlobalIdentifiers');
 
         $view->assign('object', $object);
         $view->assign('site', 'site1');
@@ -497,7 +497,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/globalIdentifiersAreUsedWithBlankEntryIdentifiers');
+        $view->setFusionPath('contentCache/globalIdentifiersAreUsedWithBlankEntryIdentifiers');
 
         $view->assign('site', 'site1');
 
@@ -552,7 +552,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/entryIdentifierPrototypeCanBeOverwritten');
+        $view->setFusionPath('contentCache/entryIdentifierPrototypeCanBeOverwritten');
 
         $view->assign('object', $object);
         $view->assign('site', 'site1');
@@ -584,7 +584,7 @@ class ContentCacheTest extends AbstractFusionObjectTest
 
         $view = $this->buildView();
         $view->setOption('enableContentCache', true);
-        $view->setTypoScriptPath('contentCache/uncachedSegmentInCachedSegmentCanOverrideContextVariables');
+        $view->setFusionPath('contentCache/uncachedSegmentInCachedSegmentCanOverrideContextVariables');
 
         $view->assign('object', $object);
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
@@ -24,7 +24,7 @@ class ContextOverrideTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assignMultiple(array('var1' => 'var1', 'var2' => 'var2'));
-        $view->setTypoScriptPath('contextOverride/test');
+        $view->setFusionPath('contextOverride/test');
         $this->assertEquals('Xvar1var2Xvar1var2Xvar1var2XfooofooofoooboooboooboooXvar2Xvar2Y', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
@@ -23,7 +23,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugEmptyValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/empty');
+        $view->setFusionPath('debug/empty');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals($lines[1], 'NULL');
     }
@@ -34,7 +34,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugNullValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/null');
+        $view->setFusionPath('debug/null');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals($lines[1], 'NULL');
     }
@@ -45,7 +45,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugNullValueWithTitle()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/nullWithTitle');
+        $view->setFusionPath('debug/nullWithTitle');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals('Title', $lines[0]);
         $this->assertEquals('NULL', $lines[1]);
@@ -57,7 +57,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugEelExpression()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/eelExpression');
+        $view->setFusionPath('debug/eelExpression');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals('string "hello world" (11)', $lines[1]);
     }
@@ -68,7 +68,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugTsObjectExpression()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/tsObjectExpression');
+        $view->setFusionPath('debug/tsObjectExpression');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals('string "hello world" (11)', $lines[1]);
     }
@@ -79,7 +79,7 @@ class DebugTest extends AbstractFusionObjectTest
     public function debugMultipleValues()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('debug/multipleValues');
+        $view->setFusionPath('debug/multipleValues');
         $lines = explode(chr(10), $view->render());
         $this->assertEquals('array(2)', $lines[1]);
         $this->assertEquals(' string "foo" (3) => string "foo" (3)', $lines[2]);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
@@ -23,7 +23,7 @@ class ExceptionHandlerTest extends AbstractFusionObjectTest
     public function exceptionalEelExpressionInPropertyIsHandledCorrectly()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('exceptionHandler/eelExpressionInProperty');
+        $view->setFusionPath('exceptionHandler/eelExpressionInProperty');
         $this->assertStringStartsWith('StartException while rendering exceptionHandler', $view->render());
     }
 
@@ -34,7 +34,7 @@ class ExceptionHandlerTest extends AbstractFusionObjectTest
     public function exceptionalEelExpressionInOverrideIsHandledCorrectly()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('exceptionHandler/eelExpressionInOverride');
+        $view->setFusionPath('exceptionHandler/eelExpressionInOverride');
         $output = $view->render();
         $this->assertStringStartsWith('StartException while rendering exceptionHandler', $output);
         $this->assertContains('myCollection', $output, 'The override path should be visible in the message TypoScript path');
@@ -50,7 +50,7 @@ class ExceptionHandlerTest extends AbstractFusionObjectTest
     public function exceptionHandlerIsEvaluatedForNestedFusionObjects()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('exceptionHandler/nestedHandlerIsEvaluated');
+        $view->setFusionPath('exceptionHandler/nestedHandlerIsEvaluated');
         $output = $view->render();
         $this->assertNotNull($output);
         $this->assertStringStartsWith('Exception while rendering', $output);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -35,7 +35,7 @@ class ExpressionsTest extends AbstractFusionObjectTest
     public function expressionsWork($path, $expected)
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $view->assign('foo', 'Bar');
         $this->assertSame($expected, $view->render());
     }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
@@ -24,7 +24,7 @@ class FusionArrayTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('array/basicOrdering');
+        $view->setFusionPath('array/basicOrdering');
         $this->assertEquals('Xtest10Xtest100', $view->render());
     }
 
@@ -35,7 +35,7 @@ class FusionArrayTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('array/positionalOrdering');
+        $view->setFusionPath('array/positionalOrdering');
         $this->assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
@@ -46,7 +46,7 @@ class FusionArrayTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('array/startEndOrdering');
+        $view->setFusionPath('array/startEndOrdering');
         $this->assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
@@ -57,7 +57,7 @@ class FusionArrayTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('array/advancedStartEndOrdering');
+        $view->setFusionPath('array/advancedStartEndOrdering');
         $this->assertEquals('XeXdXfoobarXfXgX100XbXaXc', $view->render());
     }
 
@@ -68,7 +68,7 @@ class FusionArrayTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
 
-        $view->setTypoScriptPath('array/ignoreProperties');
+        $view->setFusionPath('array/ignoreProperties');
         $this->assertEquals('XbeforeXafter', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
@@ -23,7 +23,7 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTest
     public function overwritingSimpleValueWithProcessorWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('nestedOverwritesAndProcessors/deepProcessorAppliesToSimpleValue');
+        $view->setFusionPath('nestedOverwritesAndProcessors/deepProcessorAppliesToSimpleValue');
         $this->assertEquals('<div class="Xclass processed" tea="green"></div>', $view->render());
     }
 
@@ -33,7 +33,7 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTest
     public function applyingProcessorToExpressionWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('nestedOverwritesAndProcessors/deepProcessorAppliesToEel');
+        $view->setFusionPath('nestedOverwritesAndProcessors/deepProcessorAppliesToEel');
         $this->assertEquals('<div class="Xclass" tea="green infused"></div>', $view->render());
     }
 
@@ -43,7 +43,7 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTest
     public function applyingProcessorToNonExistingValueWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('nestedOverwritesAndProcessors/deepProcessorAppliesWithNoBaseValue');
+        $view->setFusionPath('nestedOverwritesAndProcessors/deepProcessorAppliesWithNoBaseValue');
         $this->assertEquals('<div class="Xclass" tea="green" coffee="harvey"></div>', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -63,7 +63,7 @@ class ProcessorTest extends AbstractFusionObjectTest
     public function processorsCanBeUnset($path)
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $this->assertEquals('Foobaz', $view->render());
     }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
@@ -22,7 +22,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function baseClassHasModifiedValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritance/base');
+        $view->setFusionPath('prototypeInheritance/base');
         $this->assertEquals('BaseModified', $view->render());
     }
 
@@ -32,7 +32,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function subWithOverrideHasOverriddenValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritance/subWithOverride');
+        $view->setFusionPath('prototypeInheritance/subWithOverride');
         $this->assertEquals('Sub', $view->render());
     }
 
@@ -42,7 +42,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function subWithoutOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritance/subWithoutOverride');
+        $view->setFusionPath('prototypeInheritance/subWithoutOverride');
         $this->assertEquals('BaseModified', $view->render());
     }
 
@@ -52,7 +52,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function advancedBaseObjectHasModifiedValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritanceAdvanced/base');
+        $view->setFusionPath('prototypeInheritanceAdvanced/base');
         $this->assertEquals('prepend_beforeOverride|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
@@ -62,7 +62,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function advancedSubWithoutOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritanceAdvanced/subWithoutOverride');
+        $view->setFusionPath('prototypeInheritanceAdvanced/subWithoutOverride');
         $this->assertEquals('prepend_beforeOverride|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
@@ -72,7 +72,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function advancedSubWithOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritanceAdvanced/subWithOverride');
+        $view->setFusionPath('prototypeInheritanceAdvanced/subWithOverride');
         $this->assertEquals('prepend_inSub|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
@@ -82,7 +82,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTest
     public function contextDependentPrototypesTakeInheritanceIntoAccount()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('prototypeInheritanceContentDependent/element');
+        $view->setFusionPath('prototypeInheritanceContentDependent/element');
         $this->assertEquals('NEW VALUE in base class', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
@@ -23,7 +23,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function mulitpleKeysWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/multipleKeys');
+        $view->setFusionPath('quotedKeys/multipleKeys');
         $result = $view->render();
 
         $this->assertSame(count($result), 6);
@@ -38,7 +38,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function singleQuotedWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/single');
+        $view->setFusionPath('quotedKeys/single');
         $this->assertSame($view->render(), 1);
     }
 
@@ -48,7 +48,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function doubleQuotedWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/double');
+        $view->setFusionPath('quotedKeys/double');
         $this->assertSame($view->render(), 1);
     }
 
@@ -58,7 +58,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function nestedQuotedWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/nested/keys');
+        $view->setFusionPath('quotedKeys/nested/keys');
         $this->assertSame($view->render(), 1);
     }
 
@@ -68,7 +68,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function specialCharactersWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/@special/_!');
+        $view->setFusionPath('quotedKeys/@special/_!');
         $this->assertSame($view->render(), 1);
     }
 
@@ -78,7 +78,7 @@ class QuotedKeysTest extends AbstractFusionObjectTest
     public function prototypeAndQuotedKeysWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('quotedKeys/prototype/test');
+        $view->setFusionPath('quotedKeys/prototype/test');
         $this->assertSame($view->render(), 'X1');
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
@@ -24,7 +24,7 @@ class RawCollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2'));
-        $view->setTypoScriptPath('rawCollection/basicLoop');
+        $view->setFusionPath('rawCollection/basicLoop');
         $this->assertEquals(['Xelement1','Xelement2'], $view->render());
     }
 
@@ -37,7 +37,7 @@ class RawCollectionTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2'));
         $view->assign('other', 'var');
-        $view->setTypoScriptPath('rawCollection/basicLoopOtherContextVariables');
+        $view->setFusionPath('rawCollection/basicLoopOtherContextVariables');
         $this->assertEquals(['Xelement1var','Xelement2var'], $view->render());
     }
 
@@ -48,7 +48,7 @@ class RawCollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', null);
-        $view->setTypoScriptPath('rawCollection/basicLoop');
+        $view->setFusionPath('rawCollection/basicLoop');
         $this->assertEquals([], $view->render());
     }
 
@@ -59,7 +59,7 @@ class RawCollectionTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('collection', array('element1', 'element2', 'element3', 'element4'));
-        $view->setTypoScriptPath('rawCollection/iteration');
+        $view->setFusionPath('rawCollection/iteration');
         $this->assertEquals(['Xelement1-0-1-1--1-','Xelement2-1-2----1','Xelement3-2-3---1-','Xelement4-3-4--1--1'], $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
@@ -21,7 +21,7 @@ class RendererTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->assign('cond', true);
-        $view->setTypoScriptPath($path);
+        $view->setFusionPath($path);
         $this->assertEquals($expectation, $view->render());
     }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
@@ -24,7 +24,7 @@ class ReservedKeysTest extends AbstractFusionObjectTest
     public function usingReservedKeysThrowsException()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPathPattern(__DIR__ . '/Fixtures/ReservedKeysTypoScript');
+        $view->setFusionPathPattern(__DIR__ . '/Fixtures/ReservedKeysTypoScript');
         $view->render();
     }
 
@@ -34,7 +34,7 @@ class ReservedKeysTest extends AbstractFusionObjectTest
     public function nonReservedKeysWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('reservedKeys');
+        $view->setFusionPath('reservedKeys');
         $this->assertEquals($view->render(), array('__custom' => 1));
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
@@ -39,9 +39,9 @@ class SimpleTypesTest extends AbstractFusionObjectTest
     public function booleanSimpleTypeWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('simpleTypes/booleanFalse');
+        $view->setFusionPath('simpleTypes/booleanFalse');
         $this->assertSame(false, $view->render());
-        $view->setTypoScriptPath('simpleTypes/booleanTrue');
+        $view->setFusionPath('simpleTypes/booleanTrue');
         $this->assertTrue($view->render());
     }
 
@@ -51,7 +51,7 @@ class SimpleTypesTest extends AbstractFusionObjectTest
     public function nullSimpleTypeWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('simpleTypes/null');
+        $view->setFusionPath('simpleTypes/null');
         $this->assertNull($view->render());
     }
 
@@ -61,7 +61,7 @@ class SimpleTypesTest extends AbstractFusionObjectTest
     public function processorOnSimpleTypeWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('simpleTypes/wrappedString');
+        $view->setFusionPath('simpleTypes/wrappedString');
         $this->assertSame('Hello, Foo', $view->render());
     }
 
@@ -72,7 +72,7 @@ class SimpleTypesTest extends AbstractFusionObjectTest
     public function renderingObjectWithMissingImplementationThrowsException()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('simpleTypes/missingImplementation');
+        $view->setFusionPath('simpleTypes/missingImplementation');
         $view->render();
     }
 
@@ -83,7 +83,7 @@ class SimpleTypesTest extends AbstractFusionObjectTest
     public function renderingNonExistingPathThrowsException()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('simpleTypes/nonExistingValue');
+        $view->setFusionPath('simpleTypes/nonExistingValue');
         $view->render();
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -23,7 +23,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithAttributesFromNonTsObjectWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/plainAttributes');
+        $view->setFusionPath('tag/plainAttributes');
         $this->assertSame('<link rel="stylesheet" type="text/css" />', $view->render());
     }
 
@@ -33,7 +33,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithAttributesFromTsObjectWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/objectAttributes');
+        $view->setFusionPath('tag/objectAttributes');
         $this->assertSame('<test sum="4" />', $view->render());
     }
 
@@ -43,7 +43,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithAttributesFromArraysWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/arrayAttributes');
+        $view->setFusionPath('tag/arrayAttributes');
         $this->assertSame('<div class="a b"></div>', $view->render());
     }
 
@@ -53,7 +53,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithContentFromNonTsObjectWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/plainContent');
+        $view->setFusionPath('tag/plainContent');
         $this->assertSame('<span>test</span>', $view->render());
     }
 
@@ -63,7 +63,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithContentFromTsObjectWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/objectContent');
+        $view->setFusionPath('tag/objectContent');
         $this->assertSame('<span>4</span>', $view->render());
     }
 
@@ -73,7 +73,7 @@ class TagTest extends AbstractFusionObjectTest
     public function registeredSelfClosingTagWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/registeredSelfClosingTag');
+        $view->setFusionPath('tag/registeredSelfClosingTag');
         $this->assertSame('<br />', $view->render());
     }
 
@@ -83,7 +83,7 @@ class TagTest extends AbstractFusionObjectTest
     public function omitClosingTagWorks()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/omitClosingTag');
+        $view->setFusionPath('tag/omitClosingTag');
         $this->assertSame('<test>', $view->render());
     }
 
@@ -93,7 +93,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithEelExpressionUsingThis()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/withThis');
+        $view->setFusionPath('tag/withThis');
         $this->assertSame('<title databar="baz" datafoo="baz_baz">foo</title>', $view->render());
     }
 
@@ -103,7 +103,7 @@ class TagTest extends AbstractFusionObjectTest
     public function tagWithIgnorePropertiesInAttributes()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('tag/withIgnorePropertiesInAttributes');
+        $view->setFusionPath('tag/withIgnorePropertiesInAttributes');
         $this->assertSame('<title datafoo="baz_baz">foo</title>', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
@@ -23,7 +23,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function basicFluidTemplateCanBeUsedForRendering()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/basicTemplate');
+        $view->setFusionPath('template/basicTemplate');
         $this->assertEquals('Test Templatefoo', $view->render());
     }
 
@@ -33,7 +33,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function basicFluidTemplateContainsEelVariables()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/basicTemplateWithEelVariable');
+        $view->setFusionPath('template/basicTemplateWithEelVariable');
         $this->assertEquals('Test Templatefoobar', $view->render());
     }
 
@@ -43,7 +43,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function customPartialPathCanBeSetOnRendering()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/partial');
+        $view->setFusionPath('template/partial');
         $this->assertEquals('Test Template--partial contents', $view->render());
     }
 
@@ -53,7 +53,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function customLayoutPathCanBeSetOnRendering()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/layout');
+        $view->setFusionPath('template/layout');
         $this->assertEquals('layout start -- Test Template -- layout end', $view->render());
     }
 
@@ -63,7 +63,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function typoScriptExceptionInObjectAccessIsHandledCorrectly()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/offsetAccessException');
+        $view->setFusionPath('template/offsetAccessException');
         $this->assertStringStartsWith('Test TemplateException while rendering template', $view->render());
     }
 
@@ -73,7 +73,7 @@ class TemplateTest extends AbstractFusionObjectTest
     public function expressionCanBeOverridenWithSimpleValueForTemplate()
     {
         $view = $this->buildView();
-        $view->setTypoScriptPath('template/overrideWithSimpleValueInTemplate');
+        $view->setFusionPath('template/overrideWithSimpleValueInTemplate');
         $this->assertSame('3', $view->render(), 'JSON encoded value should be a number');
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
@@ -33,7 +33,7 @@ class UriBuilderTest extends AbstractFusionObjectTest
             ));
 
         $view = $this->buildView();
-        $view->setTypoScriptPath('uriBuilder/foo');
+        $view->setFusionPath('uriBuilder/foo');
         $this->assertContains('/neos/flow/test/http/foo', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
+++ b/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
@@ -58,7 +58,7 @@ class FusionViewTest extends FunctionalTestCase
     public function typoScriptViewUsesGivenPathIfSet()
     {
         $view = $this->buildView('Foo\Bar\Controller\TestController', 'index');
-        $view->setTypoScriptPath('foo/bar');
+        $view->setFusionPath('foo/bar');
         $this->assertEquals('Xfoobar', $view->render());
     }
 
@@ -101,7 +101,7 @@ class FusionViewTest extends FunctionalTestCase
         $view = new FusionView();
         $view->setControllerContext($this->mockControllerContext);
         $this->inject($view, 'fallbackView', $this->mockFallbackView);
-        $view->setTypoScriptPathPattern(__DIR__ . '/Fixtures/Fusion');
+        $view->setFusionPathPattern(__DIR__ . '/Fixtures/Fusion');
 
         return $view;
     }


### PR DESCRIPTION
The previous method are move into the ``TypoScriptView`` that maps them
to the new ones. Also the ``setOption`` and ``getOption`` of the ``TypoScriptView`` still
support the `typoScript*`-options but map them internally.
