### PR TITLE
!!! TASK: Adjust cache keys to the new namespace

### DIFF
--- a/Neos.ContentRepository/Configuration/Caches.yaml
+++ b/Neos.ContentRepository/Configuration/Caches.yaml
@@ -1,5 +1,5 @@
 # This cache is currently not cleared via FileMonitor,
 # therefore it is activated only in Production Context (see Production/Caches.yaml).
-TYPO3_TYPO3CR_FullNodeTypeConfiguration:
+Neos_ContentRepository_FullNodeTypeConfiguration:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\NullBackend

--- a/Neos.ContentRepository/Configuration/Objects.yaml
+++ b/Neos.ContentRepository/Configuration/Objects.yaml
@@ -27,4 +27,4 @@
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_TYPO3CR_FullNodeTypeConfiguration
+            value: Neos_ContentRepository_FullNodeTypeConfiguration

--- a/Neos.ContentRepository/Configuration/Production/Caches.yaml
+++ b/Neos.ContentRepository/Configuration/Production/Caches.yaml
@@ -1,2 +1,2 @@
-TYPO3_TYPO3CR_FullNodeTypeConfiguration:
+Neos_ContentRepository_FullNodeTypeConfiguration:
   backend: Neos\Cache\Backend\SimpleFileBackend

--- a/Neos.ContentRepository/Migrations/Code/Version20161219093512.php
+++ b/Neos.ContentRepository/Migrations/Code/Version20161219093512.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate name for the CR node type configuration
+ */
+class Version20161219093512 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.ContentRepository-20161219093512';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TYPO3_TYPO3CR_FullNodeTypeConfiguration', 'Neos_ContentRepository_FullNodeTypeConfiguration', ['php', 'yaml']);
+    }
+}

--- a/Neos.ContentRepository/composer.json
+++ b/Neos.ContentRepository/composer.json
@@ -84,7 +84,8 @@
             "Neos.Flow-20161125124112",
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
-            "Neos.Fusion-20161201202543"
+            "Neos.Fusion-20161201202543",
+            "Neos.Neos-20161201222211"
         ]
     }
 }

--- a/Neos.ContentRepository/composer.json
+++ b/Neos.ContentRepository/composer.json
@@ -86,7 +86,8 @@
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
             "Neos.Neos-20161201222211",
-            "Neos.Fusion-20161202215034"
+            "Neos.Fusion-20161202215034",
+            "Neos.ContentRepository-20161219093512"
         ]
     }
 }

--- a/Neos.ContentRepository/composer.json
+++ b/Neos.ContentRepository/composer.json
@@ -85,7 +85,8 @@
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
-            "Neos.Neos-20161201222211"
+            "Neos.Neos-20161201222211",
+            "Neos.Fusion-20161202215034"
         ]
     }
 }

--- a/Neos.Media/Classes/Domain/EventListener/ImageEventListener.php
+++ b/Neos.Media/Classes/Domain/EventListener/ImageEventListener.php
@@ -41,7 +41,7 @@ class ImageEventListener
             /** @var PersistentResource $resource */
             $resource = $eventArgs->getEntity()->getResource();
             if ($resource !== null) {
-                $this->cacheManager->getCache('TYPO3_Media_ImageSize')->remove($resource->getCacheEntryIdentifier());
+                $this->cacheManager->getCache('Neos_Media_ImageSize')->remove($resource->getCacheEntryIdentifier());
             }
         }
     }

--- a/Neos.Media/Configuration/Caches.yaml
+++ b/Neos.Media/Configuration/Caches.yaml
@@ -1,4 +1,4 @@
-TYPO3_Media_ImageSize:
+Neos_Media_ImageSize:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\SimpleFileBackend
   backendOptions:

--- a/Neos.Media/Configuration/Objects.yaml
+++ b/Neos.Media/Configuration/Objects.yaml
@@ -9,7 +9,7 @@ Neos\Media\Domain\Service\ImageService:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Media_ImageSize
+            value: Neos_Media_ImageSize
 
 # This is just to have a fallback default, you will probably want to create a ImageInterface type converter that converts to your implementation.
 Neos\Media\Domain\Model\ImageInterface:

--- a/Neos.Media/Migrations/Code/Version20161219094126.php
+++ b/Neos.Media/Migrations/Code/Version20161219094126.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate name for the media image size cache
+ */
+class Version20161219094126 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.Media-20161219094126';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TYPO3_Media_ImageSize', 'Neos_Media_ImageSize', ['php', 'yaml']);
+    }
+}

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -83,7 +83,8 @@
             "Neos.Flow-20161125124112",
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
-            "Neos.Fusion-20161201202543"
+            "Neos.Fusion-20161201202543",
+            "Neos.Neos-20161201222211"
         ]
     }
 }

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -84,7 +84,8 @@
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
-            "Neos.Neos-20161201222211"
+            "Neos.Neos-20161201222211",
+            "Neos.Fusion-20161202215034"
         ]
     }
 }

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -86,7 +86,8 @@
             "Neos.Fusion-20161201202543",
             "Neos.Neos-20161201222211",
             "Neos.Fusion-20161202215034",
-            "Neos.ContentRepository-20161219093512"
+            "Neos.ContentRepository-20161219093512",
+            "Neos.Media-20161219094126"
         ]
     }
 }

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -85,7 +85,8 @@
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
             "Neos.Neos-20161201222211",
-            "Neos.Fusion-20161202215034"
+            "Neos.Fusion-20161202215034",
+            "Neos.ContentRepository-20161219093512"
         ]
     }
 }

--- a/Neos.Neos/Classes/Domain/EventListener/AccountPostEventListener.php
+++ b/Neos.Neos/Classes/Domain/EventListener/AccountPostEventListener.php
@@ -67,6 +67,6 @@ class AccountPostEventListener
      */
     protected function flushConfigurationCache()
     {
-        $this->cacheManager->getCache('TYPO3_Neos_Configuration_Version')->flush();
+        $this->cacheManager->getCache('Neos_Neos_Configuration_Version')->flush();
     }
 }

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -48,12 +48,12 @@ class Package extends BasePackage
 
         $flushConfigurationCache = function () use ($bootstrap) {
             $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
-            $cacheManager->getCache('TYPO3_Neos_Configuration_Version')->flush();
+            $cacheManager->getCache('Neos_Neos_Configuration_Version')->flush();
         };
 
         $flushXliffServiceCache = function () use ($bootstrap) {
             $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
-            $cacheManager->getCache('TYPO3_Neos_XliffToJsonTranslations')->flush();
+            $cacheManager->getCache('Neos_Neos_XliffToJsonTranslations')->flush();
         };
 
         $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', function ($fileMonitorIdentifier, array $changedFiles) use ($flushConfigurationCache, $flushXliffServiceCache) {

--- a/Neos.Neos/Configuration/Caches.yaml
+++ b/Neos.Neos/Configuration/Caches.yaml
@@ -1,4 +1,4 @@
-TYPO3_Neos_Configuration_Version:
+Neos_Neos_Configuration_Version:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\FileBackend
 
@@ -6,11 +6,11 @@ TYPO3_Neos_TypoScript:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
 
-TYPO3_Neos_XliffToJsonTranslations:
+Neos_Neos_XliffToJsonTranslations:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
 
-TYPO3_Neos_LoginTokenCache:
+Neos_Neos_LoginTokenCache:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\SimpleFileBackend
   backendOptions:

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -6,7 +6,7 @@ Neos\Neos\ViewHelpers\Backend\ConfigurationCacheVersionViewHelper:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Neos_Configuration_Version
+            value: Neos_Neos_Configuration_Version
 
 Neos\ContentRepository\Domain\Service\ContextFactoryInterface:
   className: Neos\Neos\Domain\Service\ContentContextFactory
@@ -56,7 +56,7 @@ Neos\Neos\Service\XliffService:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Neos_XliffToJsonTranslations
+            value: Neos_Neos_XliffToJsonTranslations
 
 Neos\Neos\Controller\Backend\BackendController:
   properties:
@@ -66,7 +66,7 @@ Neos\Neos\Controller\Backend\BackendController:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Neos_LoginTokenCache
+            value: Neos_Neos_LoginTokenCache
 
 Neos\Neos\Controller\LoginController:
   properties:
@@ -76,4 +76,4 @@ Neos\Neos\Controller\LoginController:
         factoryMethodName: getCache
         arguments:
           1:
-            value: TYPO3_Neos_LoginTokenCache
+            value: Neos_Neos_LoginTokenCache

--- a/Neos.Neos/Migrations/Code/Version20161219094403.php
+++ b/Neos.Neos/Migrations/Code/Version20161219094403.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate several cache keys for the Neos.Neos package
+ */
+class Version20161219094403 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.Neos-20161219094403';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('TYPO3_Neos_Configuration_Version', 'Neos_Neos_Configuration_Version', ['php', 'yaml']);
+        $this->searchAndReplace('TYPO3_Neos_XliffToJsonTranslations', 'Neos_Neos_XliffToJsonTranslations', ['php', 'yaml']);
+        $this->searchAndReplace('TYPO3_Neos_LoginTokenCache', 'Neos_Neos_LoginTokenCache', ['php', 'yaml']);
+    }
+}

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -105,7 +105,8 @@
             "Neos.Fusion-20161201202543",
             "Neos.Neos-20161201222211",
             "Neos.Fusion-20161202215034",
-            "Neos.ContentRepository-20161219093512"
+            "Neos.ContentRepository-20161219093512",
+            "Neos.Media-20161219094126"
         ]
     }
 }

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -104,7 +104,8 @@
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
             "Neos.Neos-20161201222211",
-            "Neos.Fusion-20161202215034"
+            "Neos.Fusion-20161202215034",
+            "Neos.ContentRepository-20161219093512"
         ]
     }
 }

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -103,7 +103,8 @@
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
             "Neos.Fusion-20161201202543",
-            "Neos.Neos-20161201222211"
+            "Neos.Neos-20161201222211",
+            "Neos.Fusion-20161202215034"
         ]
     }
 }

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -102,7 +102,8 @@
             "Neos.Flow-20161125124112",
             "Neos.Neos-20161125122412",
             "TYPO3.FluidAdaptor-20161130112935",
-            "Neos.Fusion-20161201202543"
+            "Neos.Fusion-20161201202543",
+            "Neos.Neos-20161201222211"
         ]
     }
 }

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -106,7 +106,8 @@
             "Neos.Neos-20161201222211",
             "Neos.Fusion-20161202215034",
             "Neos.ContentRepository-20161219093512",
-            "Neos.Media-20161219094126"
+            "Neos.Media-20161219094126",
+            "Neos.Neos-20161219094403"
         ]
     }
 }


### PR DESCRIPTION
This change provides core migrations to adjust the cache keys to the new vendor namespace. This change is considered as breaking as the old cache keys are no longer supported