### PR TITLE
TASK: Rename ``TypoScriptView`` to ``FusionView``

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -20,7 +20,7 @@ use Neos\Neos\Controller\Exception\NodeNotFoundException;
 use Neos\Neos\Controller\Exception\UnresolvableShortcutException;
 use Neos\Neos\Domain\Model\UserInterfaceMode;
 use Neos\Neos\Domain\Service\NodeShortcutResolver;
-use Neos\Neos\View\TypoScriptView;
+use Neos\Neos\View\FusionView;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 
@@ -52,10 +52,10 @@ class NodeController extends ActionController
     /**
      * @var string
      */
-    protected $defaultViewObjectName = TypoScriptView::class;
+    protected $defaultViewObjectName = FusionView::class;
 
     /**
-     * @var TypoScriptView
+     * @var FusionView
      */
     protected $view;
 
@@ -99,7 +99,7 @@ class NodeController extends ActionController
             $this->overrideViewVariablesFromInternalArguments();
             $this->response->setHeader('Cache-Control', 'no-cache');
             if (!$this->view->canRenderWithNodeAndPath()) {
-                $this->view->setTypoScriptPath('rawContent');
+                $this->view->setFusionPath('rawContent');
             }
         }
 
@@ -132,7 +132,7 @@ class NodeController extends ActionController
         }
 
         if (($typoScriptPath = $this->request->getInternalArgument('__typoScriptPath')) !== null) {
-            $this->view->setTypoScriptPath($typoScriptPath);
+            $this->view->setFusionPath($typoScriptPath);
         }
     }
 

--- a/Neos.Neos/Classes/View/TypoScriptView.php
+++ b/Neos.Neos/Classes/View/TypoScriptView.php
@@ -1,0 +1,50 @@
+<?php
+namespace Neos\Neos\View;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A TypoScript view for Neos
+ * @deprecated
+ */
+class TypoScriptView extends FusionView
+{
+
+    /**
+     * Set the TypoScript path to use for rendering the node given in "value"
+     *
+     * @param string $typoScriptPath
+     * @return void
+     */
+    public function setTypoScriptPath($typoScriptPath)
+    {
+        parent::setFusionPath($typoScriptPath);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypoScriptPath()
+    {
+        return parent::getFusionPath();
+    }
+
+    /**
+     * @param NodeInterface $currentSiteNode
+     * @return \Neos\Fusion\Core\Runtime
+     */
+    protected function getTypoScriptRuntime(NodeInterface $currentSiteNode)
+    {
+        return parent::getFusionRuntime($currentSiteNode);
+    }
+}

--- a/Neos.Neos/Tests/Unit/View/FusionViewTest.php
+++ b/Neos.Neos/Tests/Unit/View/FusionViewTest.php
@@ -16,17 +16,17 @@ use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\FusionService;
-use Neos\Neos\View\TypoScriptView;
+use Neos\Neos\View\FusionView;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Fusion\Core\Runtime;
 
 /**
- * Testcase for the TypoScript View
+ * Testcase for the Fusion View
  *
  */
-class TypoScriptViewTest extends UnitTestCase
+class FusionViewTest extends UnitTestCase
 {
     /**
      * @var ContentContext
@@ -39,7 +39,7 @@ class TypoScriptViewTest extends UnitTestCase
     protected $mockSecurityContext;
 
     /**
-     * @var TypoScriptView
+     * @var FusionView
      */
     protected $mockView;
 
@@ -80,7 +80,7 @@ class TypoScriptViewTest extends UnitTestCase
         $mockFusionService = $this->createMock(FusionService::class);
         $mockFusionService->expects($this->any())->method('createRuntime')->will($this->returnValue($this->mockRuntime));
 
-        $this->mockView = $this->getAccessibleMock(TypoScriptView::class, array('getClosestDocumentNode'));
+        $this->mockView = $this->getAccessibleMock(FusionView::class, array('getClosestDocumentNode'));
         $this->mockView->expects($this->any())->method('getClosestDocumentNode')->will($this->returnValue($this->mockContextualizedNode));
 
         $this->inject($this->mockView, 'controllerContext', $mockControllerContext);
@@ -96,7 +96,7 @@ class TypoScriptViewTest extends UnitTestCase
      */
     public function attemptToRenderWithoutNodeInformationAtAllThrowsException()
     {
-        $view = $this->getAccessibleMock(TypoScriptView::class, array('dummy'));
+        $view = $this->getAccessibleMock(FusionView::class, array('dummy'));
         $view->render();
     }
 
@@ -106,7 +106,7 @@ class TypoScriptViewTest extends UnitTestCase
      */
     public function attemptToRenderWithInvalidNodeInformationThrowsException()
     {
-        $view = $this->getAccessibleMock(TypoScriptView::class, array('dummy'));
+        $view = $this->getAccessibleMock(FusionView::class, array('dummy'));
         $view->_set('variables', array('value' => 'foo'));
         $view->render();
     }
@@ -114,7 +114,7 @@ class TypoScriptViewTest extends UnitTestCase
     /**
      * @test
      */
-    public function renderPutsSiteNodeInTypoScriptContext()
+    public function renderPutsSiteNodeInFusionContext()
     {
         $this->setUpMockView();
         $this->mockRuntime->expects($this->once())->method('pushContextArray')->with($this->arrayHasKey('site'));
@@ -151,7 +151,7 @@ class TypoScriptViewTest extends UnitTestCase
 
         $mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $view = $this->getAccessibleMock(TypoScriptView::class, array('getClosestDocumentNode'));
+        $view = $this->getAccessibleMock(FusionView::class, array('getClosestDocumentNode'));
         $view->expects($this->any())->method('getClosestDocumentNode')->will($this->returnValue($mockContextualizedNode));
 
         $this->inject($view, 'securityContext', $mockSecurityContext);


### PR DESCRIPTION
The method names and internal variables that referred to TypoScript were
refactored aswell. 

Additionally a``TypoScriptView`` is provided that maps calls to the 
typoScript methods to their fusion-counterparts. 