### PR TITLE
BUGFIX: Fix edit preview mode switching

### DIFF
--- a/Neos.Neos/Classes/Domain/Model/UserInterfaceMode.php
+++ b/Neos.Neos/Classes/Domain/Model/UserInterfaceMode.php
@@ -119,9 +119,9 @@ class UserInterfaceMode
 
     /**
      * @return string
-     * @deprecated
+     * @deprecated since 3.0
      */
-    public function getTyoScriptPath()
+    public function getTypoScriptPath()
     {
         return $this->getFusionPath();
     }
@@ -129,6 +129,7 @@ class UserInterfaceMode
     /**
      * @param string $typoScriptPath
      * @return void
+     * @deprecated since 3.0
      */
     public function setTypoScriptPath($typoScriptPath)
     {

--- a/Neos.Neos/Classes/Domain/Model/UserInterfaceMode.php
+++ b/Neos.Neos/Classes/Domain/Model/UserInterfaceMode.php
@@ -119,6 +119,24 @@ class UserInterfaceMode
 
     /**
      * @return string
+     * @deprecated
+     */
+    public function getTyoScriptPath()
+    {
+        return $this->getFusionPath();
+    }
+
+    /**
+     * @param string $typoScriptPath
+     * @return void
+     */
+    public function setTypoScriptPath($typoScriptPath)
+    {
+        $this->setFusionPath($typoScriptPath);
+    }
+
+    /**
+     * @return string
      */
     public function getTitle()
     {

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -40,7 +40,7 @@ root {
 
 	editPreviewMode {
 		@position = 'end 9996'
-		possibleEditPreviewModePath = ${documentNode.context.currentRenderingMode.typoScriptPath}
+		possibleEditPreviewModePath = ${documentNode.context.currentRenderingMode.fusionPath}
 		condition = ${documentNode.context.inBackend && this.possibleEditPreviewModePath != null && this.possibleEditPreviewModePath != ''}
 		renderPath = ${'/' + this.possibleEditPreviewModePath}
 	}


### PR DESCRIPTION
The current path in the UserInterfaceMode object was renamed to fusion and thus the switching of the rendering mode that relied on the expression ``${documentNode.context.currentRenderingMode.typoScriptPath}`` did not work any more.

This change alters the used expression to  ``${documentNode.context.currentRenderingMode.fusionPath}`` and
additionally provides deprecated methods ``getTyoScriptPath`` and ``setTypoScriptPath`` for the UserInterface mode as backwards compatibility layer.