### PR TITLE
BUGFIX: Allow more imprecision with DateTime in Test

### DIFF
--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeDataExportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeDataExportServiceTest.php
@@ -101,7 +101,7 @@ class NodeDataExportServiceTest extends FunctionalTestCase
         $this->assertNotNull($importedNode, 'Expected node not found');
         $this->assertSame($originalNode->getIdentifier(), $importedNode->getIdentifier());
         $this->assertSame($originalNode->getProperty('description'), $importedNode->getProperty('description'));
-        $this->assertEquals($originalNode->getProperty('someDate'), $importedNode->getProperty('someDate'));
+        $this->assertEquals($originalNode->getProperty('someDate'), $importedNode->getProperty('someDate'), 'The "someDate" property had a different value after import', 1);
     }
 
     /**


### PR DESCRIPTION
the ImportExport testing relies on comparison of DateTime
values, as the DateTime object is imported from a file and then
exported again, there can be differences on microsecond level.
With raising the allowed delta this does not lead to a failing
test.
