### PR TITLE
!!! TASK: Change the autoInclude path for fusion

### DIFF
--- a/Neos.Neos/Classes/Aspects/FusionCachingAspect.php
+++ b/Neos.Neos/Classes/Aspects/FusionCachingAspect.php
@@ -28,7 +28,7 @@ class FusionCachingAspect
     protected $fusionCache;
 
     /**
-     * @Flow\Around("setting(Neos.Neos.typoScript.enableObjectTreeCache) && method(Neos\Neos\Domain\Service\FusionService->getMergedFusionObjectTree())")
+     * @Flow\Around("setting(Neos.Neos.fusion.enableObjectTreeCache) && method(Neos\Neos\Domain\Service\FusionService->getMergedFusionObjectTree())")
      * @param JoinPointInterface $joinPoint The current join point
      * @return mixed
      */

--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -99,7 +99,7 @@ class FusionService
     protected $appendFusionIncludes = array();
 
     /**
-     * @Flow\InjectConfiguration("typoScript.autoInclude")
+     * @Flow\InjectConfiguration("fusion.autoInclude")
      * @var array
      */
     protected $autoIncludeConfiguration = array();

--- a/Neos.Neos/Configuration/Production/Settings.yaml
+++ b/Neos.Neos/Configuration/Production/Settings.yaml
@@ -4,5 +4,5 @@
 
 Neos:
   Neos:
-    typoScript:
+    fusion:
       enableObjectTreeCache: true

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -212,7 +212,6 @@ Neos:
       # (and thus the composer dependencies of your packages).
       # This also allows disabling of autoIncludes if needed.
       autoInclude:
-      autoInclude:
         Neos.Fusion: true
         Neos.Neos: true
 

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -195,13 +195,13 @@ TYPO3:
 Neos:
 
   Neos:
-    typoScript:
-      # if set to TRUE, TypoScript is cached on a per-site basis.
-      # Depending on the size of your TypoScript, will improve rendering times 20-100+ ms.
+    fusion:
+      # if set to TRUE, Fusion is cached on a per-site basis.
+      # Depending on the size of your Fusion, will improve rendering times 20-100+ ms.
       # HOWEVER, the cache is NOT FLUSHED automatically (yet), so that's why we suggest that
       # you enable this setting only:
       #
-      # - if you do not change TypoScript in production context, but instead use e.g. TYPO3.Surf for automatic deployment
+      # - if you do not change Fusion in production context, but instead use e.g. TYPO3.Surf for automatic deployment
       # - in Production context
       enableObjectTreeCache: false
 

--- a/Neos.Neos/Migrations/Code/Version20161220163741.php
+++ b/Neos.Neos/Migrations/Code/Version20161220163741.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Core\Migrations;
  */
 
 /**
- * Migrate usages of TypoScriptService to FusionService
+ * Migrate usages of the Settings path Neos.Neos.typoScript to Neos.Neos.fusion
  */
 class Version20161220163741 extends AbstractMigration
 {

--- a/Neos.Neos/Migrations/Code/Version20161220163741.php
+++ b/Neos.Neos/Migrations/Code/Version20161220163741.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate usages of TypoScriptService to FusionService
+ */
+class Version20161220163741 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Neos-20161220163741';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->moveSettingsPaths('Neos.Neos.typoScript', 'Neos.Neos.fusion');
+    }
+}

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -107,7 +107,11 @@
             "Neos.Fusion-20161202215034",
             "Neos.ContentRepository-20161219093512",
             "Neos.Media-20161219094126",
-            "Neos.Neos-20161219094403"
+            "Neos.Neos-20161219094403",
+            "Neos.Fusion-20161219092345",
+            "Neos.Neos-20161219122512",
+            "Neos.Fusion-20161219130100",
+            "Neos.Neos-20161220163741"
         ]
     }
 }


### PR DESCRIPTION
This change also provides a migration to the no longer supported Setting ``Neos.Neos.typoScript`` to ``Neos.Neos.fusion``

Resolves #1344
