### PR TITLE
BUGFIX: Return ``null`` if image property comes back empty

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -878,9 +878,16 @@ class Node implements NodeInterface, CacheAwareInterface
     {
         $value = $this->nodeData->getProperty($propertyName);
         $nodeType = $this->getNodeType();
-        $expectedPropertyType = $nodeType->getPropertyType($propertyName);
 
-        if ($expectedPropertyType === 'Neos\Media\Domain\Model\ImageInterface' && empty($value)) {
+        if ($nodeType !== null) {
+            $expectedPropertyType = $nodeType->getPropertyType($propertyName);
+        }
+
+        if (
+            isset($expectedPropertyType) &&
+            $expectedPropertyType === 'Neos\Media\Domain\Model\ImageInterface' &&
+            empty($value)
+        ) {
             return null;
         }
 

--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -877,16 +877,21 @@ class Node implements NodeInterface, CacheAwareInterface
     public function getProperty($propertyName, $returnNodesAsIdentifiers = false)
     {
         $value = $this->nodeData->getProperty($propertyName);
-        if (empty($value)) {
+        $nodeType = $this->getNodeType();
+        $expectedPropertyType = $nodeType->getPropertyType($propertyName);
+
+        if ($expectedPropertyType === 'Neos\Media\Domain\Model\ImageInterface' && empty($value)) {
             return null;
         }
 
-        $nodeType = $this->getNodeType();
+        if (empty($value)) {
+            return $value;
+        }
+
         if (!$nodeType->hasConfiguration('properties.' . $propertyName)) {
             return $value;
         }
 
-        $expectedPropertyType = $nodeType->getPropertyType($propertyName);
         if ($expectedPropertyType === 'references') {
             return ($returnNodesAsIdentifiers ? $value : $this->resolvePropertyReferences($value));
         }


### PR DESCRIPTION
Images removed within the backend no longer return an empty string instead of ``null``. This also fixes regression 2a1c89c7a4ee43c934d9e154fc9164cefc736a06 which returns ``null`` even if a default value like empty string or false is set.