### PR TITLE
TASK: Remove deprecated ``asset`` argument

### DIFF
--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -97,8 +97,6 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         $this->registerTagAttribute('alt', 'string', 'Specifies an alternate text for an image', true);
         $this->registerTagAttribute('ismap', 'string', 'Specifies an image as a server-side image-map. Rarely used. Look at usemap instead', false);
         $this->registerTagAttribute('usemap', 'string', 'Specifies an image as a client-side image-map', false);
-        // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', AssetInterface::class, 'The asset to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**
@@ -117,10 +115,6 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
     {
-        if ($image === null && $this->hasArgument('asset')) {
-            $image = $this->arguments['asset'];
-        }
-
         if ($image === null) {
             return '';
         }

--- a/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -61,8 +61,6 @@ class ImageViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        // @deprecated since 2.0 use the "image" argument instead
-        $this->registerArgument('asset', AssetInterface::class, 'The image to be rendered - DEPRECATED, use the "image" argument instead', false);
     }
 
     /**
@@ -81,10 +79,6 @@ class ImageViewHelper extends AbstractViewHelper
      */
     public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null)
     {
-        if ($image === null && $this->hasArgument('asset')) {
-            $image = $this->arguments['asset'];
-        }
-
         if ($image === null) {
             return '';
         }

--- a/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -49,12 +49,12 @@
                             <tr>
                                 <td>
                                     <f:if condition="{contentChanges.original}">
-                                        <m:image asset="{contentChanges.original}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
+                                        <m:image image="{contentChanges.original}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
                                     </f:if>
                                 </td>
                                 <td>
                                     <f:if condition="{contentChanges.changed}">
-                                        <m:image asset="{contentChanges.changed}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
+                                        <m:image image="{contentChanges.changed}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
                                     </f:if>
                                 </td>
                             </tr>

--- a/Neos.Neos/Resources/Private/Templates/Service/Assets/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Assets/Index.html
@@ -10,7 +10,7 @@
 				<li class="asset">
 					<label class="asset-label">{asset.label}</label>
 					(<span class="asset-identifier">{asset.identifier}</span>)
-					<a rel="thumbnail" href="{media:uri.image(asset: asset, preset: 'Neos.Media.Browser:Thumbnail', async: asyncThumbnails)}">{neos:backend.translate(id: 'thumbnail', value: 'thumbnail')}</a>
+					<a rel="thumbnail" href="{media:uri.image(image: asset, preset: 'Neos.Media.Browser:Thumbnail', async: asyncThumbnails)}">{neos:backend.translate(id: 'thumbnail', value: 'thumbnail')}</a>
 					<f:link.action rel="asset-show" controller="Service\Assets" action="show" arguments="{identifier: asset.identifier}" format="html">{neos:backend.translate(id: 'show', value: 'show')}</f:link.action>
 				</li></f:for>
 			</ul>

--- a/Neos.Neos/Resources/Private/Templates/Service/Assets/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Assets/Show.html
@@ -9,7 +9,7 @@
 			<div class="asset">
 				<label class="asset-label">{asset.label}</label>
 				(<span class="asset-identifier">{asset.identifier}</span>)
-				<a rel="preview" href="{media:uri.image(asset: asset, preset: 'Neos.Media.Browser:Thumbnail', async: asyncThumbnails)}">{neos:backend.translate(id: 'preview', value: 'Preview')}</a>
+				<a rel="preview" href="{media:uri.image(image: asset, preset: 'Neos.Media.Browser:Thumbnail', async: asyncThumbnails)}">{neos:backend.translate(id: 'preview', value: 'Preview')}</a>
 			</div>
 		</div>
 	</body>

--- a/Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Partials/SimpleImage.html
+++ b/Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Partials/SimpleImage.html
@@ -21,7 +21,7 @@
 </f:if>
 
 <f:section name="imageRendering">
-	<media:image asset="{image}" alt="{alternativeText}" title="{title}" width="{width}"
+	<media:image image="{image}" alt="{alternativeText}" title="{title}" width="{width}"
 				 maximumWidth="{maximumWidth}" height="{height}" maximumHeight="{maximumHeight}"
 				 allowUpScaling="{allowUpScaling}" allowCropping="{allowCropping}" />
 </f:section>


### PR DESCRIPTION
Remove the deprecated ``asset`` argument within the ImageViewHelpers and also replace ``asset`` with ``image`` within various templates.
