### PR TITLE
BUGFIX: Remove role check when deleting workspaces for users

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -302,12 +302,8 @@ class UserService
      */
     public function deleteUser(User $user)
     {
-        $backendUserRole = $this->policyService->getRole('TYPO3.Neos:AbstractEditor');
         foreach ($user->getAccounts() as $account) {
-            /** @var Account $account */
-            if ($account->hasRole($backendUserRole)) {
-                $this->deletePersonalWorkspace($account->getAccountIdentifier());
-            }
+            $this->deletePersonalWorkspace($account->getAccountIdentifier());
             $this->accountRepository->remove($account);
         }
 


### PR DESCRIPTION
This was broken by 5279a7489efcd3c5f5e411b6b5bda11ad1b4ca75.
Before, checks were done for the role TYPO3.Neos:Editor. However,
checking for AbstractEditor is pointless; workspaces are
now never deleted when a user is deleted. Since the deletePersonalWorkspace
method checks for existence anyway, there's no reason to do
this role check at all. If a user is deleted, his workspaces should be
deleted as well.

Fixes #1376.
