### PR TITLE
BUGFIX: Changing NodeType is broken

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
@@ -56,7 +56,7 @@ class NodeService implements NodeServiceInterface
     {
         $nodeType = $node->getNodeType();
         foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
-            if (trim($node->getProperty($propertyName)) === '') {
+            if ((is_scalar($value) && trim($node->getProperty($propertyName)) === '') || $value === null) {
                 $node->setProperty($propertyName, $defaultValue);
             }
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/NodeService.php
@@ -56,7 +56,8 @@ class NodeService implements NodeServiceInterface
     {
         $nodeType = $node->getNodeType();
         foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
-            if ((is_scalar($value) && trim($node->getProperty($propertyName)) === '') || $value === null) {
+            $value = $node->getProperty($propertyName);
+            if ((is_scalar($value) && trim($value) === '') || $value === null) {
                 $node->setProperty($propertyName, $defaultValue);
             }
         }


### PR DESCRIPTION
Without this change, it's impossible to change the NodeType (from the inspector) for a NodeType with a default value for a non-scalar property (e.g. DateTime). The service tries to trim a non-scalar value, and throws an error. 

This change checks if the value is a scalar before trimming and adds a check for null value.