### PR TITLE
TASK: Rename default authentication backend provider name

### DIFF
--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -30,7 +30,7 @@ Neos:
     security:
       authentication:
         providers:
-          NeosDefaultProvider:
+          'Neos.Neos:Default':
             requestPatterns:
               'Neos.Media.Browser:BackendControllers':
                 pattern: ControllerObjectName

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -30,7 +30,7 @@ Neos:
     security:
       authentication:
         providers:
-          Typo3BackendProvider:
+          NeosDefaultProvider:
             requestPatterns:
               'Neos.Media.Browser:BackendControllers':
                 pattern: ControllerObjectName

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -30,7 +30,7 @@ Neos:
     security:
       authentication:
         providers:
-          'Neos.Neos:Default':
+          'Neos.Neos:Backend':
             requestPatterns:
               'Neos.Media.Browser:BackendControllers':
                 pattern: ControllerObjectName

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -72,7 +72,7 @@ class UserCommandController extends CommandController
      * will look for an account identified by "username" for that specific provider.
      *
      * @param string $username The username of the user to show. Usually refers to the account identifier of the user's Neos backend account.
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return void
      */
     public function showCommand($username, $authenticationProvider = null)
@@ -95,7 +95,7 @@ class UserCommandController extends CommandController
      * This command creates a new user which has access to the backend user interface.
      *
      * More specifically, this command will create a new user and a new account at the same time. The created account
-     * is, by default, a Neos backend account using the the "NeosDefaultProvider" for authentication. The given username
+     * is, by default, a Neos backend account using the the "Neos.Neos:Default" for authentication. The given username
      * will be used as an account identifier for that new account.
      *
      * If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -108,7 +108,7 @@ class UserCommandController extends CommandController
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param string $roles A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer"
-     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "Neos.Neos:Default"
      * @return void
      */
     public function createCommand($username, $password, $firstName, $lastName, $roles = null, $authenticationProvider = null)
@@ -164,7 +164,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user to be removed
      * @param boolean $assumeYes Assume "yes" as the answer to the confirmation dialog
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return void
      */
     public function deleteCommand($username, $assumeYes = false, $authenticationProvider = null)
@@ -193,7 +193,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be activated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
      * @return void
      */
     public function activateCommand($username, $authenticationProvider = null)
@@ -214,7 +214,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be deactivated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
      * @return void
      */
     public function deactivateCommand($username, $authenticationProvider = null)
@@ -236,7 +236,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username Username of the user to modify
      * @param string $password The new password
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
      * @return void
      */
     public function setPasswordCommand($username, $password, $authenticationProvider = null)
@@ -260,7 +260,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be added to the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return void
      */
     public function addRoleCommand($username, $role, $authenticationProvider = null)
@@ -290,7 +290,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return void
      */
     public function removeRoleCommand($username, $role, $authenticationProvider = null)

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -72,7 +72,7 @@ class UserCommandController extends CommandController
      * will look for an account identified by "username" for that specific provider.
      *
      * @param string $username The username of the user to show. Usually refers to the account identifier of the user's Neos backend account.
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return void
      */
     public function showCommand($username, $authenticationProvider = null)
@@ -95,7 +95,7 @@ class UserCommandController extends CommandController
      * This command creates a new user which has access to the backend user interface.
      *
      * More specifically, this command will create a new user and a new account at the same time. The created account
-     * is, by default, a Neos backend account using the the "Typo3BackendProvider" for authentication. The given username
+     * is, by default, a Neos backend account using the the "NeosDefaultProvider" for authentication. The given username
      * will be used as an account identifier for that new account.
      *
      * If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -108,7 +108,7 @@ class UserCommandController extends CommandController
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param string $roles A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer"
-     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "NeosDefaultProvider"
      * @return void
      */
     public function createCommand($username, $password, $firstName, $lastName, $roles = null, $authenticationProvider = null)
@@ -164,7 +164,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user to be removed
      * @param boolean $assumeYes Assume "yes" as the answer to the confirmation dialog
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return void
      */
     public function deleteCommand($username, $assumeYes = false, $authenticationProvider = null)
@@ -193,7 +193,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be activated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
      * @return void
      */
     public function activateCommand($username, $authenticationProvider = null)
@@ -214,7 +214,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be deactivated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
      * @return void
      */
     public function deactivateCommand($username, $authenticationProvider = null)
@@ -236,7 +236,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username Username of the user to modify
      * @param string $password The new password
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider"
      * @return void
      */
     public function setPasswordCommand($username, $password, $authenticationProvider = null)
@@ -260,7 +260,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be added to the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return void
      */
     public function addRoleCommand($username, $role, $authenticationProvider = null)
@@ -290,7 +290,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return void
      */
     public function removeRoleCommand($username, $role, $authenticationProvider = null)

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -72,7 +72,7 @@ class UserCommandController extends CommandController
      * will look for an account identified by "username" for that specific provider.
      *
      * @param string $username The username of the user to show. Usually refers to the account identifier of the user's Neos backend account.
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function showCommand($username, $authenticationProvider = null)
@@ -95,7 +95,7 @@ class UserCommandController extends CommandController
      * This command creates a new user which has access to the backend user interface.
      *
      * More specifically, this command will create a new user and a new account at the same time. The created account
-     * is, by default, a Neos backend account using the the "Neos.Neos:Default" for authentication. The given username
+     * is, by default, a Neos backend account using the the "Neos.Neos:Backend" for authentication. The given username
      * will be used as an account identifier for that new account.
      *
      * If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -108,7 +108,7 @@ class UserCommandController extends CommandController
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param string $roles A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer"
-     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use for the new account. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function createCommand($username, $password, $firstName, $lastName, $roles = null, $authenticationProvider = null)
@@ -164,7 +164,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user to be removed
      * @param boolean $assumeYes Assume "yes" as the answer to the confirmation dialog
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function deleteCommand($username, $assumeYes = false, $authenticationProvider = null)
@@ -193,7 +193,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be activated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function activateCommand($username, $authenticationProvider = null)
@@ -214,7 +214,7 @@ class UserCommandController extends CommandController
      * found.
      *
      * @param string $username The username of the user to be deactivated.
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function deactivateCommand($username, $authenticationProvider = null)
@@ -236,7 +236,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username Username of the user to modify
      * @param string $password The new password
-     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function setPasswordCommand($username, $password, $authenticationProvider = null)
@@ -260,7 +260,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be added to the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function addRoleCommand($username, $role, $authenticationProvider = null)
@@ -290,7 +290,7 @@ class UserCommandController extends CommandController
      *
      * @param string $username The username of the user
      * @param string $role Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return void
      */
     public function removeRoleCommand($username, $role, $authenticationProvider = null)

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -51,7 +51,7 @@ class UserService
      *
      * @var string
      */
-    protected $defaultAuthenticationProviderName = 'NeosDefaultProvider';
+    protected $defaultAuthenticationProviderName = 'Neos.Neos:Default';
 
     /**
      * @Flow\Inject
@@ -151,7 +151,7 @@ class UserService
      * Retrieves an existing user by the given username
      *
      * @param string $username The username
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return User The user, or null if the user does not exist
      * @throws Exception
      * @api
@@ -232,7 +232,7 @@ class UserService
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return User The created user instance
      * @api
      */
@@ -258,7 +258,7 @@ class UserService
      * @param string $password Password of the user to be created
      * @param User $user The pre-built user object to start with
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
      * @return User The same user object
      * @api
      */

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -51,7 +51,7 @@ class UserService
      *
      * @var string
      */
-    protected $defaultAuthenticationProviderName = 'Neos.Neos:Default';
+    protected $defaultAuthenticationProviderName = 'Neos.Neos:Backend';
 
     /**
      * @Flow\Inject
@@ -151,7 +151,7 @@ class UserService
      * Retrieves an existing user by the given username
      *
      * @param string $username The username
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return User The user, or null if the user does not exist
      * @throws Exception
      * @api
@@ -232,7 +232,7 @@ class UserService
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return User The created user instance
      * @api
      */
@@ -258,7 +258,7 @@ class UserService
      * @param string $password Password of the user to be created
      * @param User $user The pre-built user object to start with
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Default"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      * @return User The same user object
      * @api
      */

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -51,7 +51,7 @@ class UserService
      *
      * @var string
      */
-    protected $defaultAuthenticationProviderName = 'Typo3BackendProvider';
+    protected $defaultAuthenticationProviderName = 'NeosDefaultProvider';
 
     /**
      * @Flow\Inject
@@ -151,7 +151,7 @@ class UserService
      * Retrieves an existing user by the given username
      *
      * @param string $username The username
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return User The user, or null if the user does not exist
      * @throws Exception
      * @api
@@ -232,7 +232,7 @@ class UserService
      * @param string $firstName First name of the user to be created
      * @param string $lastName Last name of the user to be created
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return User The created user instance
      * @api
      */
@@ -258,7 +258,7 @@ class UserService
      * @param string $password Password of the user to be created
      * @param User $user The pre-built user object to start with
      * @param array $roleIdentifiers A list of role identifiers to assign
-     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "Typo3BackendProvider"
+     * @param string $authenticationProviderName Name of the authentication provider to use. Example: "NeosDefaultProvider"
      * @return User The same user object
      * @api
      */

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -569,7 +569,7 @@ Neos:
     security:
       authentication:
         providers:
-          NeosDefaultProvider:
+          'Neos.Neos:Default':
             label: 'Neos Backend'
             provider: PersistedUsernamePasswordProvider
             requestPatterns:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -569,7 +569,7 @@ Neos:
     security:
       authentication:
         providers:
-          Typo3BackendProvider:
+          NeosDefaultProvider:
             label: 'Neos Backend'
             provider: PersistedUsernamePasswordProvider
             requestPatterns:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -569,7 +569,7 @@ Neos:
     security:
       authentication:
         providers:
-          'Neos.Neos:Default':
+          'Neos.Neos:Backend':
             label: 'Neos Backend'
             provider: PersistedUsernamePasswordProvider
             requestPatterns:

--- a/Neos.Neos/Documentation/Operations/CommandLine.rst
+++ b/Neos.Neos/Documentation/Operations/CommandLine.rst
@@ -37,7 +37,7 @@ Here is an example:
 
   OPTIONS:
     --authentication-provider Name of the authentication provider to use. Example:
-                         "NeosDefaultProvider
+                         "Neos.Neos:Default
 
   DESCRIPTION:
     This command allows for adding a specific role to an existing user.

--- a/Neos.Neos/Documentation/Operations/CommandLine.rst
+++ b/Neos.Neos/Documentation/Operations/CommandLine.rst
@@ -37,7 +37,7 @@ Here is an example:
 
   OPTIONS:
     --authentication-provider Name of the authentication provider to use. Example:
-                         "Neos.Neos:Default
+                         "Neos.Neos:Backend
 
   DESCRIPTION:
     This command allows for adding a specific role to an existing user.

--- a/Neos.Neos/Documentation/Operations/CommandLine.rst
+++ b/Neos.Neos/Documentation/Operations/CommandLine.rst
@@ -37,7 +37,7 @@ Here is an example:
 
   OPTIONS:
     --authentication-provider Name of the authentication provider to use. Example:
-                         "Typo3BackendProvider
+                         "NeosDefaultProvider
 
   DESCRIPTION:
     This command allows for adding a specific role to an existing user.

--- a/Neos.Neos/Documentation/References/CommandReference.rst
+++ b/Neos.Neos/Documentation/References/CommandReference.rst
@@ -2006,7 +2006,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
 
 
 
@@ -2042,7 +2042,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Neos.Neos:Default
+  Name of the authentication provider to use. Example: "Neos.Neos:Backend"
 
 
 
@@ -2058,7 +2058,7 @@ Options
 This command creates a new user which has access to the backend user interface.
 
 More specifically, this command will create a new user and a new account at the same time. The created account
-is, by default, a Neos backend account using the the "Neos.Neos:Default" for authentication. The given username
+is, by default, a Neos backend account using the the "Neos.Neos:Backend" for authentication. The given username
 will be used as an account identifier for that new account.
 
 If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -2086,7 +2086,7 @@ Options
 ``--roles``
   A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer
 ``--authentication-provider``
-  Name of the authentication provider to use for the new account. Example: "Neos.Neos:Default
+  Name of the authentication provider to use for the new account. Example: "Neos.Neos:Backend"
 
 
 
@@ -2117,7 +2117,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
 
 
 
@@ -2154,7 +2154,7 @@ Options
 ``--assume-yes``
   Assume "yes" as the answer to the confirmation dialog
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Neos.Neos:Default
+  Name of the authentication provider to use. Example: "Neos.Neos:Backend"
 
 
 
@@ -2202,7 +2202,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Neos.Neos:Default
+  Name of the authentication provider to use. Example: "Neos.Neos:Backend"
 
 
 
@@ -2235,7 +2235,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Backend"
 
 
 
@@ -2267,7 +2267,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Neos.Neos:Default
+  Name of the authentication provider to use. Example: "Neos.Neos:Backend"
 
 
 

--- a/Neos.Neos/Documentation/References/CommandReference.rst
+++ b/Neos.Neos/Documentation/References/CommandReference.rst
@@ -2006,7 +2006,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider
+  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
 
 
 
@@ -2042,7 +2042,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Typo3BackendProvider
+  Name of the authentication provider to use. Example: "NeosDefaultProvider
 
 
 
@@ -2058,7 +2058,7 @@ Options
 This command creates a new user which has access to the backend user interface.
 
 More specifically, this command will create a new user and a new account at the same time. The created account
-is, by default, a Neos backend account using the the "Typo3BackendProvider" for authentication. The given username
+is, by default, a Neos backend account using the the "NeosDefaultProvider" for authentication. The given username
 will be used as an account identifier for that new account.
 
 If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -2086,7 +2086,7 @@ Options
 ``--roles``
   A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer
 ``--authentication-provider``
-  Name of the authentication provider to use for the new account. Example: "Typo3BackendProvider
+  Name of the authentication provider to use for the new account. Example: "NeosDefaultProvider
 
 
 
@@ -2117,7 +2117,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider
+  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
 
 
 
@@ -2154,7 +2154,7 @@ Options
 ``--assume-yes``
   Assume "yes" as the answer to the confirmation dialog
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Typo3BackendProvider
+  Name of the authentication provider to use. Example: "NeosDefaultProvider
 
 
 
@@ -2202,7 +2202,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Typo3BackendProvider
+  Name of the authentication provider to use. Example: "NeosDefaultProvider
 
 
 
@@ -2235,7 +2235,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "Typo3BackendProvider
+  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
 
 
 
@@ -2267,7 +2267,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "Typo3BackendProvider
+  Name of the authentication provider to use. Example: "NeosDefaultProvider
 
 
 

--- a/Neos.Neos/Documentation/References/CommandReference.rst
+++ b/Neos.Neos/Documentation/References/CommandReference.rst
@@ -2006,7 +2006,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
 
 
 
@@ -2042,7 +2042,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "NeosDefaultProvider
+  Name of the authentication provider to use. Example: "Neos.Neos:Default
 
 
 
@@ -2058,7 +2058,7 @@ Options
 This command creates a new user which has access to the backend user interface.
 
 More specifically, this command will create a new user and a new account at the same time. The created account
-is, by default, a Neos backend account using the the "NeosDefaultProvider" for authentication. The given username
+is, by default, a Neos backend account using the the "Neos.Neos:Default" for authentication. The given username
 will be used as an account identifier for that new account.
 
 If an authentication provider name is specified, the new account will be created for that provider instead.
@@ -2086,7 +2086,7 @@ Options
 ``--roles``
   A comma separated list of roles to assign. Examples: "Editor, Acme.Foo:Reviewer
 ``--authentication-provider``
-  Name of the authentication provider to use for the new account. Example: "NeosDefaultProvider
+  Name of the authentication provider to use for the new account. Example: "Neos.Neos:Default
 
 
 
@@ -2117,7 +2117,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
 
 
 
@@ -2154,7 +2154,7 @@ Options
 ``--assume-yes``
   Assume "yes" as the answer to the confirmation dialog
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "NeosDefaultProvider
+  Name of the authentication provider to use. Example: "Neos.Neos:Default
 
 
 
@@ -2202,7 +2202,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "NeosDefaultProvider
+  Name of the authentication provider to use. Example: "Neos.Neos:Default
 
 
 
@@ -2235,7 +2235,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use for finding the user. Example: "NeosDefaultProvider
+  Name of the authentication provider to use for finding the user. Example: "Neos.Neos:Default
 
 
 
@@ -2267,7 +2267,7 @@ Options
 ^^^^^^^
 
 ``--authentication-provider``
-  Name of the authentication provider to use. Example: "NeosDefaultProvider
+  Name of the authentication provider to use. Example: "Neos.Neos:Default
 
 
 

--- a/Neos.Neos/Migrations/Code/Version20170115114620.php
+++ b/Neos.Neos/Migrations/Code/Version20170115114620.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate usages of the Settings path Neos.Flow.security.authentication.providers.Typo3BackendProvider to Neos.Flow.security.authentication.providers.NeosDefaultProvider
+ */
+class Version20170115114620 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Neos-20170115114620';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->moveSettingsPaths('Neos.Flow.security.authentication.providers.Typo3BackendProvider', 'Neos.Flow.security.authentication.providers.NeosDefaultProvider');
+        $this->searchAndReplace('Typo3BackendProvider', 'NeosDefaultProvider');
+    }
+}

--- a/Neos.Neos/Migrations/Code/Version20170115114620.php
+++ b/Neos.Neos/Migrations/Code/Version20170115114620.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Core\Migrations;
  */
 
 /**
- * Migrate usages of the Settings path Neos.Flow.security.authentication.providers.Typo3BackendProvider to Neos.Flow.security.authentication.providers.NeosDefaultProvider
+ * Migrate usages of the Settings path Neos.Flow.security.authentication.providers.Typo3BackendProvider to Neos.Flow.security.authentication.providers[Neos.Neos:Default]
  */
 class Version20170115114620 extends AbstractMigration
 {
@@ -29,7 +29,7 @@ class Version20170115114620 extends AbstractMigration
      */
     public function up()
     {
-        $this->moveSettingsPaths('Neos.Flow.security.authentication.providers.Typo3BackendProvider', 'Neos.Flow.security.authentication.providers.NeosDefaultProvider');
-        $this->searchAndReplace('Typo3BackendProvider', 'NeosDefaultProvider');
+        $this->searchAndReplace('Typo3BackendProvider', 'Neos.Neos:Default', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+        $this->searchAndReplace('Typo3BackendProvider', "'Neos.Neos:Default'", ['yaml']);
     }
 }

--- a/Neos.Neos/Migrations/Code/Version20170115114620.php
+++ b/Neos.Neos/Migrations/Code/Version20170115114620.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Core\Migrations;
  */
 
 /**
- * Migrate usages of the Settings path Neos.Flow.security.authentication.providers.Typo3BackendProvider to Neos.Flow.security.authentication.providers[Neos.Neos:Default]
+ * Migrate usages of the Settings path Neos.Flow.security.authentication.providers.Typo3BackendProvider to Neos.Flow.security.authentication.providers[Neos.Neos:Backend]
  */
 class Version20170115114620 extends AbstractMigration
 {
@@ -29,7 +29,7 @@ class Version20170115114620 extends AbstractMigration
      */
     public function up()
     {
-        $this->searchAndReplace('Typo3BackendProvider', 'Neos.Neos:Default', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
-        $this->searchAndReplace('Typo3BackendProvider', "'Neos.Neos:Default'", ['yaml']);
+        $this->searchAndReplace('Typo3BackendProvider', 'Neos.Neos:Backend', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+        $this->searchAndReplace('Typo3BackendProvider', "'Neos.Neos:Backend'", ['yaml']);
     }
 }

--- a/Neos.Neos/Migrations/Mysql/Version20170115114801.php
+++ b/Neos.Neos/Migrations/Mysql/Version20170115114801.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Rename Typo3BackendProvider to NeosDefaultProvider
+ */
+class Version20170115114801 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'NeosDefaultProvider' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'NeosDefaultProvider'");
+    }
+}

--- a/Neos.Neos/Migrations/Mysql/Version20170115114801.php
+++ b/Neos.Neos/Migrations/Mysql/Version20170115114801.php
@@ -5,7 +5,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Rename Typo3BackendProvider to Neos.Neos:Default
+ * Rename Typo3BackendProvider to Neos.Neos:Backend
  */
 class Version20170115114801 extends AbstractMigration
 {
@@ -14,7 +14,7 @@ class Version20170115114801 extends AbstractMigration
      */
     public function getDescription()
     {
-        return 'Rename Typo3BackendProvider to Neos.Neos:Default';
+        return 'Rename Typo3BackendProvider to Neos.Neos:Backend';
     }
 
     /**
@@ -25,7 +25,7 @@ class Version20170115114801 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Default' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Backend' WHERE authenticationprovidername = 'Typo3BackendProvider'");
     }
 
     /**
@@ -36,6 +36,6 @@ class Version20170115114801 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Default'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Backend'");
     }
 }

--- a/Neos.Neos/Migrations/Mysql/Version20170115114801.php
+++ b/Neos.Neos/Migrations/Mysql/Version20170115114801.php
@@ -5,7 +5,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Rename Typo3BackendProvider to NeosDefaultProvider
+ * Rename Typo3BackendProvider to Neos.Neos:Default
  */
 class Version20170115114801 extends AbstractMigration
 {
@@ -17,7 +17,7 @@ class Version20170115114801 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'NeosDefaultProvider' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Default' WHERE authenticationprovidername = 'Typo3BackendProvider'");
     }
 
     /**
@@ -28,6 +28,6 @@ class Version20170115114801 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'NeosDefaultProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Default'");
     }
 }

--- a/Neos.Neos/Migrations/Mysql/Version20170115114801.php
+++ b/Neos.Neos/Migrations/Mysql/Version20170115114801.php
@@ -10,6 +10,14 @@ use Doctrine\DBAL\Schema\Schema;
 class Version20170115114801 extends AbstractMigration
 {
     /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Rename Typo3BackendProvider to Neos.Neos:Default';
+    }
+
+    /**
      * @param Schema $schema
      * @return void
      */

--- a/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
@@ -5,7 +5,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Rename Typo3BackendProvider to NeosDefaultProvider
+ * Rename Typo3BackendProvider to Neos.Neos:Default
  */
 class Version20170115115240 extends AbstractMigration
 {
@@ -17,7 +17,7 @@ class Version20170115115240 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'NeosDefaultProvider' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Default' WHERE authenticationprovidername = 'Typo3BackendProvider'");
     }
 
     /**
@@ -28,6 +28,6 @@ class Version20170115115240 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'NeosDefaultProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Default'");
     }
 }

--- a/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
@@ -5,7 +5,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Rename Typo3BackendProvider to Neos.Neos:Default
+ * Rename Typo3BackendProvider to Neos.Neos:Backend
  */
 class Version20170115115240 extends AbstractMigration
 {
@@ -14,7 +14,7 @@ class Version20170115115240 extends AbstractMigration
      */
     public function getDescription()
     {
-        return 'Rename Typo3BackendProvider to Neos.Neos:Default';
+        return 'Rename Typo3BackendProvider to Neos.Neos:Backend';
     }
 
     /**
@@ -25,7 +25,7 @@ class Version20170115115240 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Default' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Neos.Neos:Backend' WHERE authenticationprovidername = 'Typo3BackendProvider'");
     }
 
     /**
@@ -36,6 +36,6 @@ class Version20170115115240 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
-        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Default'");
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'Neos.Neos:Backend'");
     }
 }

--- a/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Rename Typo3BackendProvider to NeosDefaultProvider
+ */
+class Version20170115115240 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'NeosDefaultProvider' WHERE authenticationprovidername = 'Typo3BackendProvider'");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql("UPDATE neos_flow_security_account SET authenticationprovidername = 'Typo3BackendProvider' WHERE authenticationprovidername = 'NeosDefaultProvider'");
+    }
+}

--- a/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20170115115240.php
@@ -10,6 +10,14 @@ use Doctrine\DBAL\Schema\Schema;
 class Version20170115115240 extends AbstractMigration
 {
     /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Rename Typo3BackendProvider to Neos.Neos:Default';
+    }
+
+    /**
      * @param Schema $schema
      * @return void
      */


### PR DESCRIPTION
Remove ``TYPO3`` reference from default authentication backend provider name and rename to ``Neos.Neos:Backend``.

#related https://github.com/neos/Neos.Demo/pull/23
#related https://github.com/Flowpack/Flowpack.Neos.FrontendLogin/pull/15