### PR TITLE
BUGFIX: Path parameter correctly annotated as string

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Runtime.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Runtime.php
@@ -264,7 +264,7 @@ class Runtime
      * Handle an Exception thrown while rendering TypoScript according to
      * settings specified in TYPO3.TypoScript.rendering.exceptionHandler
      *
-     * @param array $typoScriptPath
+     * @param string $typoScriptPath
      * @param \Exception $exception
      * @param boolean $useInnerExceptionHandler
      * @return string


### PR DESCRIPTION
For `\TYPO3\TypoScript\Core\Runtime->handleRenderingException()`.

Fixed for 3.0 in #1389.