### PR TITLE
Task: Rename TypoScript variables and methods in Fusion

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -62,7 +62,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
      */
     public function offsetGet($offset)
     {
-        return $this->tsValue($offset);
+        return $this->fusionValue($offset);
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/AbstractCollectionImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractCollectionImplementation.php
@@ -12,8 +12,7 @@ namespace Neos\Fusion\FusionObjects;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\Exception as TypoScriptException;
-use Neos\Fusion\Exception;
+use Neos\Fusion\Exception as FusionException;
 
 /**
  * Abstract implementation of a collection renderer for Fusion.
@@ -34,7 +33,7 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function getCollection()
     {
-        return $this->tsValue('collection');
+        return $this->fusionValue('collection');
     }
 
     /**
@@ -42,7 +41,7 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function getItemName()
     {
-        return $this->tsValue('itemName');
+        return $this->fusionValue('itemName');
     }
 
     /**
@@ -50,7 +49,7 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function getItemKey()
     {
-        return $this->tsValue('itemKey');
+        return $this->fusionValue('itemKey');
     }
 
     /**
@@ -60,7 +59,7 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function getIterationName()
     {
-        return $this->tsValue('iterationName');
+        return $this->fusionValue('iterationName');
     }
 
     /**
@@ -91,13 +90,13 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
         $this->numberOfRenderedNodes = 0;
         $itemName = $this->getItemName();
         if ($itemName === null) {
-            throw new Exception('The Collection needs an itemName to be set.', 1344325771);
+            throw new FusionException('The Collection needs an itemName to be set.', 1344325771);
         }
         $itemKey = $this->getItemKey();
         $iterationName = $this->getIterationName();
         $collectionTotalCount = count($collection);
         foreach ($collection as $collectionKey => $collectionElement) {
-            $context = $this->tsRuntime->getCurrentContext();
+            $context = $this->runtime->getCurrentContext();
             $context[$itemName] = $collectionElement;
             if ($itemKey !== null) {
                 $context[$itemKey] = $collectionKey;
@@ -106,9 +105,9 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
                 $context[$iterationName] = $this->prepareIterationInformation($collectionTotalCount);
             }
 
-            $this->tsRuntime->pushContextArray($context);
-            $result[] =  $this->tsRuntime->render($this->path . '/itemRenderer');
-            $this->tsRuntime->popContext();
+            $this->runtime->pushContextArray($context);
+            $result[] =  $this->runtime->render($this->path . '/itemRenderer');
+            $this->runtime->popContext();
             $this->numberOfRenderedNodes++;
         }
 

--- a/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
@@ -22,7 +22,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
     /**
      * @var Runtime
      */
-    protected $tsRuntime;
+    protected $runtime;
 
     /**
      * The Fusion path currently being rendered
@@ -36,7 +36,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      *
      * @var string
      */
-    protected $typoScriptObjectName;
+    protected $fusionObjectName;
 
     /**
      * @var array
@@ -46,15 +46,15 @@ abstract class AbstractFusionObject implements \ArrayAccess
     /**
      * Constructor
      *
-     * @param Runtime $tsRuntime
+     * @param Runtime $runtime
      * @param string $path
-     * @param string $typoScriptObjectName
+     * @param string $fusionObjectName
      */
-    public function __construct(Runtime $tsRuntime, $path, $typoScriptObjectName)
+    public function __construct(Runtime $runtime, $path, $fusionObjectName)
     {
-        $this->tsRuntime = $tsRuntime;
+        $this->runtime = $runtime;
         $this->path = $path;
-        $this->typoScriptObjectName = $typoScriptObjectName;
+        $this->fusionObjectName = $fusionObjectName;
     }
 
     /**
@@ -67,11 +67,36 @@ abstract class AbstractFusionObject implements \ArrayAccess
     /**
      * Get the Fusion runtime this object was created in.
      *
+     * @deprecated with 3.0 will be removed with 4.0
      * @return Runtime
      */
     public function getTsRuntime()
     {
-        return $this->tsRuntime;
+        return $this->getRuntime();
+    }
+
+    /**
+     * Get the Fusion runtime this object was created in.
+     *
+     * @return Runtime
+     */
+    public function getRuntime()
+    {
+        return $this->runtime;
+    }
+
+    /**
+     * Return the Fusion value relative to this Fusion object (with processors etc applied).
+     *
+     * Note that subsequent calls of tsValue() with the same Fusion path will return the same values since the
+     * first evaluated value will be cached in memory.
+     *
+     * @deprecated with 3.0 will be removed with 4.0
+     * @param string $path
+     * @return mixed
+     */
+    protected function tsValue($path) {
+        return $this->fusionValue($path);
     }
 
     /**
@@ -83,11 +108,11 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param string $path
      * @return mixed
      */
-    protected function tsValue($path)
+    protected function fusionValue($path)
     {
         $fullPath = $this->path . '/' . $path;
         if (!isset($this->tsValueCache[$fullPath])) {
-            $this->tsValueCache[$fullPath] = $this->tsRuntime->evaluate($fullPath, $this);
+            $this->tsValueCache[$fullPath] = $this->runtime->evaluate($fullPath, $this);
         }
         return $this->tsValueCache[$fullPath];
     }
@@ -100,7 +125,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return ($this->tsValue($offset) !== null);
+        return ($this->fusionValue($offset) !== null);
     }
 
     /**
@@ -111,7 +136,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
-        return $this->tsValue($offset);
+        return $this->fusionValue($offset);
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
@@ -95,7 +95,8 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param string $path
      * @return mixed
      */
-    protected function tsValue($path) {
+    protected function tsValue($path)
+    {
         return $this->fusionValue($path);
     }
 

--- a/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
@@ -28,7 +28,7 @@ class ArrayImplementation extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        $sortedChildTypoScriptKeys = $this->sortNestedTypoScriptKeys();
+        $sortedChildTypoScriptKeys = $this->sortNestedFusionKeys();
 
         if (count($sortedChildTypoScriptKeys) === 0) {
             return null;
@@ -37,9 +37,9 @@ class ArrayImplementation extends AbstractArrayFusionObject
         $output = '';
         foreach ($sortedChildTypoScriptKeys as $key) {
             try {
-                $output .= $this->tsValue($key);
+                $output .= $this->fusionValue($key);
             } catch (\Exception $e) {
-                $output .= $this->tsRuntime->handleRenderingException($this->path . '/' . $key, $e);
+                $output .= $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
             }
         }
 
@@ -55,10 +55,27 @@ class ArrayImplementation extends AbstractArrayFusionObject
      *
      * @see PositionalArraySorter
      *
+     * @deprecated with 3.0 will be removed with 4.0
      * @return array an ordered list of keys
      * @throws Fusion\Exception if the positional string has an unsupported format
      */
-    protected function sortNestedTypoScriptKeys()
+    protected function sortNestedTypoScriptKeys() {
+        return $this->sortNestedFusionKeys();
+    }
+
+    /**
+     * Sort the Fusion objects inside $this->properties depending on:
+     * - numerical ordering
+     * - position meta-property
+     *
+     * This will ignore all properties defined in "@ignoreProperties" in Fusion
+     *
+     * @see PositionalArraySorter
+     *
+     * @return array an ordered list of keys
+     * @throws Fusion\Exception if the positional string has an unsupported format
+     */
+    protected function sortNestedFusionKeys()
     {
         $arraySorter = new PositionalArraySorter($this->properties, '__meta.position');
         try {

--- a/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
@@ -59,7 +59,8 @@ class ArrayImplementation extends AbstractArrayFusionObject
      * @return array an ordered list of keys
      * @throws Fusion\Exception if the positional string has an unsupported format
      */
-    protected function sortNestedTypoScriptKeys() {
+    protected function sortNestedTypoScriptKeys()
+    {
         return $this->sortNestedFusionKeys();
     }
 

--- a/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
@@ -42,7 +42,7 @@ class AttributesImplementation extends AbstractArrayFusionObject
             }
 
             $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
-            $attributeValue = $this->tsValue($attributeName);
+            $attributeValue = $this->fusionValue($attributeName);
             if ($attributeValue === null || $attributeValue === false) {
                 // No op
             } elseif ($attributeValue === true || $attributeValue === '') {
@@ -71,7 +71,7 @@ class AttributesImplementation extends AbstractArrayFusionObject
      */
     protected function getAllowEmpty()
     {
-        $allowEmpty = $this->tsValue('__meta/allowEmpty');
+        $allowEmpty = $this->fusionValue('__meta/allowEmpty');
         if ($allowEmpty === null) {
             return true;
         } else {

--- a/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
@@ -41,7 +41,7 @@ class CaseImplementation extends ArrayImplementation
      */
     public function evaluate()
     {
-        $matcherKeys = $this->sortNestedTypoScriptKeys();
+        $matcherKeys = $this->sortNestedFusionKeys();
 
         foreach ($matcherKeys as $matcherName) {
             $renderedMatcher = $this->renderMatcher($matcherName);
@@ -69,7 +69,7 @@ class CaseImplementation extends ArrayImplementation
 
         if (isset($this->properties[$matcherKey]['__objectType'])) {
             // object type already set, so no need to set it
-            $renderedMatcher = $this->tsRuntime->render(
+            $renderedMatcher = $this->runtime->render(
                 sprintf('%s/%s', $this->path, $matcherKey)
             );
             return $renderedMatcher;
@@ -79,7 +79,7 @@ class CaseImplementation extends ArrayImplementation
             throw new UnsupportedObjectTypeAtPathException('"Case" Fusion object only supports nested Fusion objects; no Eel expressions.', 1372668077);
         } else {
             // No object type has been set, so we're using Neos.Fusion:Matcher as fallback
-            $renderedMatcher = $this->tsRuntime->render(
+            $renderedMatcher = $this->runtime->render(
                 sprintf('%s/%s<Neos.Fusion:Matcher>', $this->path, $matcherKey)
             );
             return $renderedMatcher;
@@ -96,7 +96,7 @@ class CaseImplementation extends ArrayImplementation
      */
     protected function matcherMatched($renderedMatcher)
     {
-        if ($this->tsRuntime->isDebugMode()) {
+        if ($this->runtime->isDebugMode()) {
             $renderedMatcher = preg_replace('/\s*<!--.*?-->\s*/', '', $renderedMatcher);
         }
         return $renderedMatcher !== self::MATCH_NORESULT;

--- a/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
@@ -38,7 +38,7 @@ class DebugImplementation extends ArrayImplementation
      */
     public function getTitle()
     {
-        return $this->tsValue('title');
+        return $this->fusionValue('title');
     }
 
     /**
@@ -46,7 +46,7 @@ class DebugImplementation extends ArrayImplementation
      */
     public function getPlaintext()
     {
-        return $this->tsValue('plaintext');
+        return $this->fusionValue('plaintext');
     }
 
     /**
@@ -64,7 +64,7 @@ class DebugImplementation extends ArrayImplementation
             if (in_array($key, $this->ignoreProperties)) {
                 continue;
             }
-            $debugData[$key] = $this->tsValue($key);
+            $debugData[$key] = $this->fusionValue($key);
         }
 
         if (count($debugData) === 0) {

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FluidView.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FluidView.php
@@ -18,7 +18,7 @@ use Neos\Fusion\FusionObjects\AbstractFusionObject;
 /**
  * Extended Fluid Template View for use in Fusion.
  */
-class FluidView extends StandaloneView implements TypoScriptAwareViewInterface
+class FluidView extends StandaloneView implements FusionAwareViewInterface
 {
     /**
      * @var string
@@ -57,9 +57,18 @@ class FluidView extends StandaloneView implements TypoScriptAwareViewInterface
     }
 
     /**
+     * @deprecated with 3.0 will be removed with 4.0
      * @return AbstractFusionObject
      */
     public function getTypoScriptObject()
+    {
+        return $this->getFusionObject();
+    }
+
+    /**
+     * @return AbstractFusionObject
+     */
+    public function getFusionObject()
     {
         return $this->typoScriptObject;
     }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FusionAwareViewInterface.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FusionAwareViewInterface.php
@@ -20,9 +20,18 @@ use Neos\Fusion\FusionObjects\AbstractFusionObject;
  * The Fusion FluidView is the reference implementation for this.
  * @see \Neos\Fusion\FusionObjects\Helpers\FluidView
  *
- * @deprecated with 3.0 will be removed with 4.0
  * @api
  */
-interface TypoScriptAwareViewInterface extends FusionAwareViewInterface
+interface FusionAwareViewInterface
 {
+    /**
+     * @deprecated with 3.0 will be removed with 4.0
+     * @return AbstractFusionObject
+     */
+    public function getTypoScriptObject();
+
+    /**
+     * @return AbstractFusionObject
+     */
+    public function getFusionObject();
 }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FusionAwareViewInterface.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FusionAwareViewInterface.php
@@ -22,14 +22,8 @@ use Neos\Fusion\FusionObjects\AbstractFusionObject;
  *
  * @api
  */
-interface FusionAwareViewInterface
+interface FusionAwareViewInterface extends TypoScriptAwareViewInterface
 {
-    /**
-     * @deprecated with 3.0 will be removed with 4.0
-     * @return AbstractFusionObject
-     */
-    public function getTypoScriptObject();
-
     /**
      * @return AbstractFusionObject
      */

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FusionPathProxy.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FusionPathProxy.php
@@ -73,7 +73,7 @@ class FusionPathProxy implements TemplateObjectAccessInterface, \ArrayAccess, \I
     public function __construct(TemplateImplementation $templateImplementation, $path, array $partialTypoScriptTree)
     {
         $this->templateImplementation = $templateImplementation;
-        $this->fusionRuntime = $templateImplementation->getTsRuntime();
+        $this->fusionRuntime = $templateImplementation->getRuntime();
         $this->path = $path;
         $this->partialTypoScriptTree = $partialTypoScriptTree;
     }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/TypoScriptAwareViewInterface.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/TypoScriptAwareViewInterface.php
@@ -10,9 +10,7 @@ namespace Neos\Fusion\FusionObjects\Helpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
-use Neos\Fusion\FusionObjects\AbstractFusionObject;
-
+    
 /**
  * You should implement this interface with a View that should allow access
  * to the Fusion object it is rendered from (and so the Fusion runtime).

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/TypoScriptAwareViewInterface.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/TypoScriptAwareViewInterface.php
@@ -10,7 +10,9 @@ namespace Neos\Fusion\FusionObjects\Helpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-    
+
+use Neos\Fusion\FusionObjects\AbstractFusionObject;
+
 /**
  * You should implement this interface with a View that should allow access
  * to the Fusion object it is rendered from (and so the Fusion runtime).
@@ -21,6 +23,11 @@ namespace Neos\Fusion\FusionObjects\Helpers;
  * @deprecated with 3.0 will be removed with 4.0
  * @api
  */
-interface TypoScriptAwareViewInterface extends FusionAwareViewInterface
+interface TypoScriptAwareViewInterface
 {
+    /**
+     * @deprecated with 3.0 will be removed with 4.0
+     * @return AbstractFusionObject
+     */
+    public function getTypoScriptObject();
 }

--- a/Neos.Fusion/Classes/FusionObjects/Http/ResponseHeadImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/Http/ResponseHeadImplementation.php
@@ -29,7 +29,7 @@ class ResponseHeadImplementation extends AbstractFusionObject
      */
     public function getHttpVersion()
     {
-        $httpVersion = $this->tsValue('httpVersion');
+        $httpVersion = $this->fusionValue('httpVersion');
         if ($httpVersion === null) {
             $httpVersion = 'HTTP/1.1';
         }
@@ -41,7 +41,7 @@ class ResponseHeadImplementation extends AbstractFusionObject
      */
     public function getStatusCode()
     {
-        $statusCode = $this->tsValue('statusCode');
+        $statusCode = $this->fusionValue('statusCode');
         if ($statusCode === null) {
             $statusCode = 200;
         }
@@ -56,7 +56,7 @@ class ResponseHeadImplementation extends AbstractFusionObject
      */
     public function getHeaders()
     {
-        $headers = $this->tsValue('headers');
+        $headers = $this->fusionValue('headers');
         if (!is_array($headers)) {
             $headers = array();
         }

--- a/Neos.Fusion/Classes/FusionObjects/MatcherImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MatcherImplementation.php
@@ -23,7 +23,7 @@ class MatcherImplementation extends RendererImplementation
      */
     public function getCondition()
     {
-        return (boolean)$this->tsValue('condition');
+        return (boolean)$this->fusionValue('condition');
     }
 
     /**
@@ -33,7 +33,7 @@ class MatcherImplementation extends RendererImplementation
      */
     public function getType()
     {
-        return $this->tsValue('type');
+        return $this->fusionValue('type');
     }
 
     /**
@@ -43,7 +43,7 @@ class MatcherImplementation extends RendererImplementation
      */
     public function getRenderPath()
     {
-        return $this->tsValue('renderPath');
+        return $this->fusionValue('renderPath');
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/RawArrayImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/RawArrayImplementation.php
@@ -26,7 +26,7 @@ class RawArrayImplementation extends ArrayImplementation
      */
     public function evaluate()
     {
-        $sortedChildTypoScriptKeys = $this->sortNestedTypoScriptKeys();
+        $sortedChildTypoScriptKeys = $this->sortNestedFusionKeys();
 
         if (count($sortedChildTypoScriptKeys) === 0) {
             return array();
@@ -34,8 +34,8 @@ class RawArrayImplementation extends ArrayImplementation
 
         $output = array();
         foreach ($sortedChildTypoScriptKeys as $key) {
-            $value = $this->tsValue($key);
-            if ($value === null && $this->tsRuntime->getLastEvaluationStatus() === Runtime::EVALUATION_SKIPPED) {
+            $value = $this->fusionValue($key);
+            if ($value === null && $this->runtime->getLastEvaluationStatus() === Runtime::EVALUATION_SKIPPED) {
                 continue;
             }
             $output[$key] = $value;

--- a/Neos.Fusion/Classes/FusionObjects/RendererImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/RendererImplementation.php
@@ -29,7 +29,7 @@ class RendererImplementation extends AbstractFusionObject
      */
     public function getType()
     {
-        return $this->tsValue('type');
+        return $this->fusionValue('type');
     }
 
     /**
@@ -39,7 +39,7 @@ class RendererImplementation extends AbstractFusionObject
      */
     public function getRenderPath()
     {
-        return $this->tsValue('renderPath');
+        return $this->fusionValue('renderPath');
     }
 
     /**
@@ -50,19 +50,19 @@ class RendererImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $rendererPath = sprintf('%s/renderer', $this->path);
-        $canRenderWithRenderer = $this->tsRuntime->canRender($rendererPath);
+        $canRenderWithRenderer = $this->runtime->canRender($rendererPath);
         $renderPath = $this->getRenderPath();
 
         if ($canRenderWithRenderer) {
-            $renderedElement = $this->tsRuntime->evaluate($rendererPath, $this);
+            $renderedElement = $this->runtime->evaluate($rendererPath, $this);
         } elseif ($renderPath !== null) {
             if (substr($renderPath, 0, 1) === '/') {
-                $renderedElement = $this->tsRuntime->render(substr($renderPath, 1));
+                $renderedElement = $this->runtime->render(substr($renderPath, 1));
             } else {
-                $renderedElement = $this->tsRuntime->render($this->path . '/' . str_replace('.', '/', $renderPath));
+                $renderedElement = $this->runtime->render($this->path . '/' . str_replace('.', '/', $renderPath));
             }
         } else {
-            $renderedElement = $this->tsRuntime->render(
+            $renderedElement = $this->runtime->render(
                 sprintf('%s/element<%s>', $this->path, $this->getType())
             );
         }

--- a/Neos.Fusion/Classes/FusionObjects/ResourceUriImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ResourceUriImplementation.php
@@ -16,7 +16,7 @@ use Neos\Flow\I18n\Service;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
-use Neos\Fusion\Exception as TypoScriptException;
+use Neos\Fusion\Exception as FusionException;
 
 /**
  * A Fusion object to create resource URIs
@@ -50,7 +50,7 @@ class ResourceUriImplementation extends AbstractFusionObject
      */
     public function getPath()
     {
-        return $this->tsValue('path');
+        return $this->fusionValue('path');
     }
 
     /**
@@ -60,7 +60,7 @@ class ResourceUriImplementation extends AbstractFusionObject
      */
     public function getPackage()
     {
-        return $this->tsValue('package');
+        return $this->fusionValue('package');
     }
 
     /**
@@ -70,7 +70,7 @@ class ResourceUriImplementation extends AbstractFusionObject
      */
     public function getResource()
     {
-        return $this->tsValue('resource');
+        return $this->fusionValue('resource');
     }
 
     /**
@@ -80,14 +80,14 @@ class ResourceUriImplementation extends AbstractFusionObject
      */
     public function isLocalize()
     {
-        return (boolean)$this->tsValue('localize');
+        return (boolean)$this->fusionValue('localize');
     }
 
     /**
      * Returns the absolute URL of a resource
      *
      * @return string
-     * @throws TypoScriptException
+     * @throws FusionException
      */
     public function evaluate()
     {
@@ -98,25 +98,25 @@ class ResourceUriImplementation extends AbstractFusionObject
                 $uri = $this->resourceManager->getPublicPersistentResourceUri($resource);
             }
             if ($uri === false) {
-                throw new TypoScriptException('The specified resource is invalid', 1386458728);
+                throw new FusionException('The specified resource is invalid', 1386458728);
             }
             return $uri;
         }
         $path = $this->getPath();
         if ($path === null) {
-            throw new TypoScriptException('Neither "resource" nor "path" were specified', 1386458763);
+            throw new FusionException('Neither "resource" nor "path" were specified', 1386458763);
         }
         if (strpos($path, 'resource://') === 0) {
             $matches = array();
             if (preg_match('#^resource://([^/]+)/Public/(.*)#', $path, $matches) !== 1) {
-                throw new TypoScriptException(sprintf('The specified path "%s" does not point to a public resource.', $path), 1386458851);
+                throw new FusionException(sprintf('The specified path "%s" does not point to a public resource.', $path), 1386458851);
             }
             $package = $matches[1];
             $path = $matches[2];
         } else {
             $package = $this->getPackage();
             if ($package === null) {
-                $controllerContext = $this->tsRuntime->getControllerContext();
+                $controllerContext = $this->runtime->getControllerContext();
                 /** @var $actionRequest ActionRequest */
                 $actionRequest = $controllerContext->getRequest();
                 $package = $actionRequest->getControllerPackageKey();

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -36,7 +36,7 @@ class TagImplementation extends AbstractFusionObject
      */
     public function getTagName()
     {
-        $tagName = $this->tsValue('tagName');
+        $tagName = $this->fusionValue('tagName');
         if ($tagName === null) {
             $tagName = 'div';
         }
@@ -50,7 +50,7 @@ class TagImplementation extends AbstractFusionObject
      */
     public function getOmitClosingTag()
     {
-        return $this->tsValue('omitClosingTag');
+        return $this->fusionValue('omitClosingTag');
     }
 
     /**
@@ -61,7 +61,7 @@ class TagImplementation extends AbstractFusionObject
      */
     public function isSelfClosingTag($tagName)
     {
-        return in_array($tagName, self::$SELF_CLOSING_TAGS, true) || (boolean)$this->tsValue('selfClosingTag');
+        return in_array($tagName, self::$SELF_CLOSING_TAGS, true) || (boolean)$this->fusionValue('selfClosingTag');
     }
 
     /**
@@ -76,8 +76,8 @@ class TagImplementation extends AbstractFusionObject
         $selfClosingTag = $this->isSelfClosingTag($tagName);
         $content = '';
         if (!$omitClosingTag && !$selfClosingTag) {
-            $content = $this->tsValue('content');
+            $content = $this->fusionValue('content');
         }
-        return '<' . $tagName . $this->tsValue('attributes') . ($selfClosingTag ? ' /' : '') . '>' . (!$omitClosingTag && !$selfClosingTag ? $content . '</' . $tagName . '>' : '');
+        return '<' . $tagName . $this->fusionValue('attributes') . ($selfClosingTag ? ' /' : '') . '>' . (!$omitClosingTag && !$selfClosingTag ? $content . '</' . $tagName . '>' : '');
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/TemplateImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TemplateImplementation.php
@@ -31,7 +31,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
      */
     public function getTemplatePath()
     {
-        return $this->tsValue('templatePath');
+        return $this->fusionValue('templatePath');
     }
 
     /**
@@ -41,7 +41,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
      */
     public function getPartialRootPath()
     {
-        return $this->tsValue('partialRootPath');
+        return $this->fusionValue('partialRootPath');
     }
 
     /**
@@ -51,7 +51,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
      */
     public function getLayoutRootPath()
     {
-        return $this->tsValue('layoutRootPath');
+        return $this->fusionValue('layoutRootPath');
     }
 
     /**
@@ -61,7 +61,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
      */
     public function getSectionName()
     {
-        return $this->tsValue('sectionName');
+        return $this->fusionValue('sectionName');
     }
 
     /**
@@ -80,7 +80,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        $actionRequest =  $this->tsRuntime->getControllerContext()->getRequest();
+        $actionRequest =  $this->runtime->getControllerContext()->getRequest();
         if (!$actionRequest instanceof ActionRequest) {
             $actionRequest = null;
         }
@@ -95,7 +95,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
 				`prototype(%s) < prototype(Neos.Fusion:Template) {
 					templatePath = 'resource://Vendor.Package/Private/Templates/MyObject.html'
 				}`
-			", $templatePath, $this->typoScriptObjectName));
+			", $templatePath, $this->fusionObjectName));
         }
         $fluidTemplate->setTemplatePathAndFilename($templatePath);
 
@@ -126,7 +126,7 @@ class TemplateImplementation extends AbstractArrayFusionObject
             if (!is_array($value)) {
                 // if a value is a SIMPLE TYPE, e.g. neither an Eel expression nor a Fusion object,
                     // we can just evaluate it (to handle processors) and then assign it to the template.
-                $evaluatedValue = $this->tsValue($key);
+                $evaluatedValue = $this->fusionValue($key);
                 $fluidTemplate->assign($key, $evaluatedValue);
             } else {
                 // It is an array; so we need to create a "proxy" for lazy evaluation, as it could be a

--- a/Neos.Fusion/Classes/FusionObjects/UriBuilderImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/UriBuilderImplementation.php
@@ -40,7 +40,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getPackage()
     {
-        return $this->tsValue('package');
+        return $this->fusionValue('package');
     }
 
     /**
@@ -50,7 +50,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getSubpackage()
     {
-        return $this->tsValue('subpackage');
+        return $this->fusionValue('subpackage');
     }
 
     /**
@@ -60,7 +60,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getController()
     {
-        return $this->tsValue('controller');
+        return $this->fusionValue('controller');
     }
 
     /**
@@ -70,7 +70,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getAction()
     {
-        return $this->tsValue('action');
+        return $this->fusionValue('action');
     }
 
     /**
@@ -80,7 +80,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getArguments()
     {
-        return $this->tsValue('arguments');
+        return $this->fusionValue('arguments');
     }
 
     /**
@@ -90,7 +90,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getFormat()
     {
-        return $this->tsValue('format');
+        return $this->fusionValue('format');
     }
 
     /**
@@ -100,7 +100,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getSection()
     {
-        return $this->tsValue('section');
+        return $this->fusionValue('section');
     }
 
     /**
@@ -110,7 +110,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getAdditionalParams()
     {
-        return $this->tsValue('additionalParams');
+        return $this->fusionValue('additionalParams');
     }
 
     /**
@@ -120,7 +120,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function getArgumentsToBeExcludedFromQueryString()
     {
-        return $this->tsValue('argumentsToBeExcludedFromQueryString');
+        return $this->fusionValue('argumentsToBeExcludedFromQueryString');
     }
 
     /**
@@ -130,7 +130,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function isAddQueryString()
     {
-        return (boolean)$this->tsValue('addQueryString');
+        return (boolean)$this->fusionValue('addQueryString');
     }
 
     /**
@@ -140,7 +140,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function isAbsolute()
     {
-        return (boolean)$this->tsValue('absolute');
+        return (boolean)$this->fusionValue('absolute');
     }
 
     /**
@@ -148,7 +148,7 @@ class UriBuilderImplementation extends AbstractFusionObject
      */
     public function evaluate()
     {
-        $controllerContext = $this->tsRuntime->getControllerContext();
+        $controllerContext = $this->runtime->getControllerContext();
         $uriBuilder = $controllerContext->getUriBuilder()->reset();
 
         $format = $this->getFormat();
@@ -190,7 +190,7 @@ class UriBuilderImplementation extends AbstractFusionObject
                 $this->getSubpackage()
             );
         } catch (\Exception $exception) {
-            return $this->tsRuntime->handleRenderingException($this->path, $exception);
+            return $this->runtime->handleRenderingException($this->path, $exception);
         }
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/ValueImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ValueImplementation.php
@@ -26,7 +26,7 @@ class ValueImplementation extends AbstractFusionObject
      */
     public function getValue()
     {
-        return $this->tsValue('value');
+        return $this->fusionValue('value');
     }
 
     /**

--- a/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
+++ b/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
@@ -11,7 +11,7 @@ namespace Neos\Fusion\ViewHelpers;
  * source code.
  */
 
-use Neos\Fusion\FusionObjects\Helpers\TypoScriptAwareViewInterface;
+use Neos\Fusion\FusionObjects\Helpers\FusionAwareViewInterface;
 
 /**
  * This trait is to be used in ViewHelpers that need to get information from the Fusion runtime context.

--- a/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
+++ b/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
@@ -37,8 +37,8 @@ trait FusionContextTrait
         $value = null;
 
         $view = $this->viewHelperVariableContainer->getView();
-        if ($view instanceof TypoScriptAwareViewInterface) {
-            $typoScriptObject = $view->getTypoScriptObject();
+        if ($view instanceof FusionAwareViewInterface) {
+            $typoScriptObject = $view->getFusionObject();
             $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
             if (isset($currentContext[$variableName])) {
                 $value = $currentContext[$variableName];
@@ -55,11 +55,11 @@ trait FusionContextTrait
     protected function hasContextVariable($variableName)
     {
         $view = $this->viewHelperVariableContainer->getView();
-        if (!$view instanceof TypoScriptAwareViewInterface) {
+        if (!$view instanceof FusionAwareViewInterface) {
             return false;
         }
 
-        $typoScriptObject = $view->getTypoScriptObject();
+        $typoScriptObject = $view->getFusionObject();
         $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
 
         return array_key_exists($variableName, $currentContext);

--- a/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
+++ b/Neos.Fusion/Classes/ViewHelpers/FusionContextTrait.php
@@ -39,7 +39,7 @@ trait FusionContextTrait
         $view = $this->viewHelperVariableContainer->getView();
         if ($view instanceof TypoScriptAwareViewInterface) {
             $typoScriptObject = $view->getTypoScriptObject();
-            $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+            $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
             if (isset($currentContext[$variableName])) {
                 $value = $currentContext[$variableName];
             }
@@ -60,7 +60,7 @@ trait FusionContextTrait
         }
 
         $typoScriptObject = $view->getTypoScriptObject();
-        $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+        $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
 
         return array_key_exists($variableName, $currentContext);
     }

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -51,7 +51,7 @@ class RenderViewHelper extends AbstractViewHelper
     /**
      * @var FusionView
      */
-    protected $typoScriptView;
+    protected $fusionView;
 
     /**
      * Initialize the arguments.
@@ -84,31 +84,31 @@ class RenderViewHelper extends AbstractViewHelper
         $slashSeparatedPath = str_replace('.', '/', $path);
 
         if ($typoScriptPackageKey === null) {
-            /** @var $typoScriptObject AbstractFusionObject */
-            $typoScriptObject = $this->viewHelperVariableContainer->getView()->getTypoScriptObject();
+            /** @var $fusionObject AbstractFusionObject */
+            $fusionObject = $this->viewHelperVariableContainer->getView()->getFusionObject();
             if ($context !== null) {
-                $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
+                $currentContext = $fusionObject->getRuntime()->getCurrentContext();
                 foreach ($context as $key => $value) {
                     $currentContext[$key] = $value;
                 }
-                $typoScriptObject->getRuntime()->pushContextArray($currentContext);
+                $fusionObject->getRuntime()->pushContextArray($currentContext);
             }
-            $absolutePath = $typoScriptObject->getPath() . '/' . $slashSeparatedPath;
+            $absolutePath = $fusionObject->getPath() . '/' . $slashSeparatedPath;
 
-            $output = $typoScriptObject->getRuntime()->render($absolutePath);
+            $output = $fusionObject->getRuntime()->render($absolutePath);
 
             if ($context !== null) {
-                $typoScriptObject->getRuntime()->popContext();
+                $fusionObject->getRuntime()->popContext();
             }
         } else {
             $this->initializeFusionView();
-            $this->typoScriptView->setPackageKey($typoScriptPackageKey);
-            $this->typoScriptView->setFusionPath($slashSeparatedPath);
+            $this->fusionView->setPackageKey($typoScriptPackageKey);
+            $this->fusionView->setFusionPath($slashSeparatedPath);
             if ($context !== null) {
-                $this->typoScriptView->assignMultiple($context);
+                $this->fusionView->assignMultiple($context);
             }
 
-            $output = $this->typoScriptView->render();
+            $output = $this->fusionView->render();
         }
 
         return $output;
@@ -121,11 +121,11 @@ class RenderViewHelper extends AbstractViewHelper
      */
     protected function initializeFusionView()
     {
-        $this->typoScriptView = new FusionView();
-        $this->typoScriptView->setControllerContext($this->controllerContext);
-        $this->typoScriptView->disableFallbackView();
+        $this->fusionView = new FusionView();
+        $this->fusionView->setControllerContext($this->controllerContext);
+        $this->fusionView->disableFallbackView();
         if ($this->hasArgument('typoScriptFilePathPattern')) {
-            $this->typoScriptView->setFusionPathPattern($this->arguments['typoScriptFilePathPattern']);
+            $this->fusionView->setFusionPathPattern($this->arguments['typoScriptFilePathPattern']);
         }
     }
 }

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -87,18 +87,18 @@ class RenderViewHelper extends AbstractViewHelper
             /** @var $typoScriptObject AbstractFusionObject */
             $typoScriptObject = $this->viewHelperVariableContainer->getView()->getTypoScriptObject();
             if ($context !== null) {
-                $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+                $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
                 foreach ($context as $key => $value) {
                     $currentContext[$key] = $value;
                 }
-                $typoScriptObject->getTsRuntime()->pushContextArray($currentContext);
+                $typoScriptObject->getRuntime()->pushContextArray($currentContext);
             }
             $absolutePath = $typoScriptObject->getPath() . '/' . $slashSeparatedPath;
 
-            $output = $typoScriptObject->getTsRuntime()->render($absolutePath);
+            $output = $typoScriptObject->getRuntime()->render($absolutePath);
 
             if ($context !== null) {
-                $typoScriptObject->getTsRuntime()->popContext();
+                $typoScriptObject->getRuntime()->popContext();
             }
         } else {
             $this->initializeFusionView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/SimpleTypes.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/SimpleTypes.fusion
@@ -16,7 +16,7 @@ simpleTypes.wrappedString = Value {
 }
 
 
-// with the following lines, we test that TsRuntime::evaluate works on all three data types:
+// with the following lines, we test that Runtime::evaluate works on all three data types:
 // 1. Eel, 2. Plain Values, 3. Fusion Objects
 // (without processors. Processors are tested in Processor.fusion)
 simpleTypes.stringAsEel = ${'A simple string value is not a Fusion object'}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/FusionObjects/ThrowingImplementation.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/FusionObjects/ThrowingImplementation.php
@@ -21,7 +21,7 @@ class ThrowingImplementation extends AbstractFusionObject
      */
     protected function getShouldThrow()
     {
-        return $this->tsValue('shouldThrow');
+        return $this->fusionValue('shouldThrow');
     }
 
     /**

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/WrappedNestedObjectRenderer.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/WrappedNestedObjectRenderer.php
@@ -28,7 +28,7 @@ class WrappedNestedObjectRenderer extends AbstractArrayFusionObject
      */
     public function getPrepend()
     {
-        return $this->tsValue('prepend');
+        return $this->fusionValue('prepend');
     }
 
     /**
@@ -38,7 +38,7 @@ class WrappedNestedObjectRenderer extends AbstractArrayFusionObject
      */
     public function getAppend()
     {
-        return $this->tsValue('append');
+        return $this->fusionValue('append');
     }
 
     /**
@@ -48,6 +48,6 @@ class WrappedNestedObjectRenderer extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        return $this->getPrepend() . $this->tsRuntime->evaluate($this->path . '/value') . $this->getAppend();
+        return $this->getPrepend() . $this->runtime->evaluate($this->path . '/value') . $this->getAppend();
     }
 }

--- a/Neos.Fusion/Tests/Functional/View/Fixtures/TestRenderer.php
+++ b/Neos.Fusion/Tests/Functional/View/Fixtures/TestRenderer.php
@@ -24,7 +24,7 @@ class TestRenderer extends AbstractArrayFusionObject
      */
     public function getTest()
     {
-        return $this->tsValue('test');
+        return $this->fusionValue('test');
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/ArrayImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/ArrayImplementationTest.php
@@ -25,10 +25,10 @@ class ArrayImplementationTest extends UnitTestCase
      */
     public function evaluateWithEmptyArrayRendersNull()
     {
-        $mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $path = 'array/test';
         $typoScriptObjectName = 'Neos.Fusion:Array';
-        $renderer = new ArrayImplementation($mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new ArrayImplementation($mockRuntime, $path, $typoScriptObjectName);
         $result = $renderer->evaluate();
         $this->assertNull($result);
     }
@@ -117,15 +117,15 @@ class ArrayImplementationTest extends UnitTestCase
      */
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
-        $mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
-        $mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($path) use (&$renderedPaths) {
+        $mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;
         }));
 
         $path = '';
         $typoScriptObjectName = 'Neos.Fusion:Array';
-        $renderer = new ArrayImplementation($mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new ArrayImplementation($mockRuntime, $path, $typoScriptObjectName);
         foreach ($subElements as $key => $value) {
             $renderer[$key] = $value;
         }

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/AttributesImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/AttributesImplementationTest.php
@@ -24,12 +24,12 @@ class AttributesImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     public function setUp()
     {
         parent::setUp();
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
     public function attributeExamples()
@@ -54,13 +54,13 @@ class AttributesImplementationTest extends UnitTestCase
     public function evaluateTests($properties, $expectedOutput)
     {
         $path = 'attributes/test';
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($path, $properties) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($path, $properties) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             return ObjectAccess::getPropertyPath($properties, str_replace('/', '.', $relativePath));
         }));
 
         $typoScriptObjectName = 'Neos.Fusion:Attributes';
-        $renderer = new AttributesImplementation($this->mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new AttributesImplementation($this->mockRuntime, $path, $typoScriptObjectName);
         if ($properties !== null) {
             foreach ($properties as $name => $value) {
                 ObjectAccess::setProperty($renderer, $name, $value);

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/CaseImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/CaseImplementationTest.php
@@ -28,8 +28,8 @@ class CaseImplementationTest extends \Neos\Flow\Tests\UnitTestCase
         $path = 'page/body/content/main';
         $ignoredProperties = array('nodePath');
 
-        $mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($path, $ignoredProperties) {
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($path, $ignoredProperties) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case '__meta/ignoreProperties':
@@ -39,7 +39,7 @@ class CaseImplementationTest extends \Neos\Flow\Tests\UnitTestCase
         }));
 
         $typoScriptObjectName = 'Neos.Neos:PrimaryContent';
-        $renderer = new CaseImplementation($mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new CaseImplementation($mockRuntime, $path, $typoScriptObjectName);
         $renderer->setIgnoreProperties($ignoredProperties);
 
         $renderer['nodePath'] = 'main';
@@ -47,7 +47,7 @@ class CaseImplementationTest extends \Neos\Flow\Tests\UnitTestCase
             'condition' => 'true'
         );
 
-        $mockTsRuntime->expects($this->once())->method('render')->with('page/body/content/main/default<Neos.Fusion:Matcher>')->will($this->returnValue('rendered matcher'));
+        $mockRuntime->expects($this->once())->method('render')->with('page/body/content/main/default<Neos.Fusion:Matcher>')->will($this->returnValue('rendered matcher'));
 
         $result = $renderer->evaluate();
 

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/Http/ResponseHeadImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/Http/ResponseHeadImplementationTest.php
@@ -25,12 +25,12 @@ class ResponseHeadImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     public function setUp()
     {
         parent::setUp();
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
     public function responseHeadExamples()
@@ -50,7 +50,7 @@ class ResponseHeadImplementationTest extends UnitTestCase
     {
         $path = 'responseHead/test';
 
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath) use ($path, $httpVersion, $statusCode, $headers) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath) use ($path, $httpVersion, $statusCode, $headers) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'httpVersion':
@@ -64,7 +64,7 @@ class ResponseHeadImplementationTest extends UnitTestCase
         }));
 
         $typoScriptObjectName = 'Neos.Fusion:Http.ResponseHead';
-        $renderer = new ResponseHeadImplementation($this->mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new ResponseHeadImplementation($this->mockRuntime, $path, $typoScriptObjectName);
 
         $result = $renderer->evaluate();
         $this->assertEquals($expectedOutput, $result);

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/ResourceUriImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/ResourceUriImplementationTest.php
@@ -34,7 +34,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     /**
      * @var ResourcePublisher
@@ -58,16 +58,16 @@ class ResourceUriImplementationTest extends UnitTestCase
 
     public function setUp()
     {
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
 
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->mockControllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->mockActionRequest));
 
-        $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
+        $this->mockRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
 
-        $this->resourceUriImplementation = new ResourceUriImplementation($this->mockTsRuntime, 'resourceUri/test', 'Neos.Fusion:ResourceUri');
+        $this->resourceUriImplementation = new ResourceUriImplementation($this->mockRuntime, 'resourceUri/test', 'Neos.Fusion:ResourceUri');
 
         $this->mockResourceManager = $this->getMockBuilder(ResourceManager::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->resourceUriImplementation, 'resourceManager', $this->mockResourceManager);
@@ -92,7 +92,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     public function evaluateReturnsResourceUriForAGivenResource()
     {
         $validResource = $this->getMockBuilder(PersistentResource::class)->disableOriginalConstructor()->getMock();
-        $this->mockTsRuntime->expects($this->atLeastOnce())->method('evaluate')->with('resourceUri/test/resource')->will($this->returnCallback(function ($evaluatePath, $that) use ($validResource) {
+        $this->mockRuntime->expects($this->atLeastOnce())->method('evaluate')->with('resourceUri/test/resource')->will($this->returnCallback(function ($evaluatePath, $that) use ($validResource) {
             return $validResource;
         }));
         $this->mockResourceManager->expects($this->atLeastOnce())->method('getPublicPersistentResourceUri')->with($validResource)->will($this->returnValue('the/resolved/resource/uri'));
@@ -106,7 +106,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateThrowsExceptionIfNeitherResourceNorPathAreSpecified()
     {
-        $this->mockTsRuntime->expects($this->atLeastOnce())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->atLeastOnce())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             return null;
         }));
 
@@ -119,7 +119,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateThrowsExceptionIfSpecifiedPathPointsToAPrivateResource()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -136,7 +136,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateDeterminesCurrentPackageIfARelativePathIsSpecified()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -155,7 +155,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateUsesSpecifiedPackageIfARelativePathIsGiven()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -177,7 +177,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateReturnsResourceUriForAGivenResourcePath()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -195,7 +195,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateIgnoresPackagePropertyIfAResourcePathIsGiven()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -216,7 +216,7 @@ class ResourceUriImplementationTest extends UnitTestCase
      */
     public function evaluateLocalizesFilenameIfLocalize()
     {
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'localize':

--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/TagImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/TagImplementationTest.php
@@ -23,12 +23,12 @@ class TagImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     public function setUp()
     {
         parent::setUp();
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
     public function tagExamples()
@@ -51,7 +51,7 @@ class TagImplementationTest extends UnitTestCase
     public function evaluateTests($properties, $attributes, $content, $expectedOutput)
     {
         $path = 'tag/test';
-        $this->mockTsRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($properties, $path, $attributes, $content) {
+        $this->mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($evaluatePath, $that) use ($properties, $path, $attributes, $content) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'attributes':
@@ -63,7 +63,7 @@ class TagImplementationTest extends UnitTestCase
         }));
 
         $typoScriptObjectName = 'Neos.Fusion:Tag';
-        $renderer = new TagImplementation($this->mockTsRuntime, $path, $typoScriptObjectName);
+        $renderer = new TagImplementation($this->mockRuntime, $path, $typoScriptObjectName);
 
         $result = $renderer->evaluate();
         $this->assertEquals($expectedOutput, $result);

--- a/Neos.Neos/Classes/Fusion/AbstractMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/AbstractMenuImplementation.php
@@ -70,7 +70,7 @@ abstract class AbstractMenuImplementation extends TemplateImplementation
     public function getRenderHiddenInIndex()
     {
         if ($this->renderHiddenInIndex === null) {
-            $this->renderHiddenInIndex = (boolean)$this->tsValue('renderHiddenInIndex');
+            $this->renderHiddenInIndex = (boolean)$this->fusionValue('renderHiddenInIndex');
         }
 
         return $this->renderHiddenInIndex;
@@ -84,7 +84,7 @@ abstract class AbstractMenuImplementation extends TemplateImplementation
     public function getItems()
     {
         if ($this->items === null) {
-            $typoScriptContext = $this->tsRuntime->getCurrentContext();
+            $typoScriptContext = $this->runtime->getCurrentContext();
             $this->currentNode = isset($typoScriptContext['activeNode']) ? $typoScriptContext['activeNode'] : $typoScriptContext['documentNode'];
             $this->currentLevel = 1;
             $this->items = $this->buildItems();

--- a/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
@@ -42,7 +42,7 @@ class ContentElementEditableImplementation extends AbstractFusionObject
      */
     public function getValue()
     {
-        return $this->tsValue('value');
+        return $this->fusionValue('value');
     }
 
     /**
@@ -55,13 +55,13 @@ class ContentElementEditableImplementation extends AbstractFusionObject
         $content = $this->getValue();
 
         /** @var $node NodeInterface */
-        $node = $this->tsValue('node');
+        $node = $this->fusionValue('node');
         if (!$node instanceof NodeInterface) {
             return $content;
         }
 
         /** @var $property string */
-        $property = $this->tsValue('property');
+        $property = $this->fusionValue('property');
 
         /** @var $contentContext ContentContext */
         $contentContext = $node->getContext();

--- a/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
@@ -42,7 +42,7 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
      */
     public function getValue()
     {
-        return $this->tsValue('value');
+        return $this->fusionValue('value');
     }
 
     /**
@@ -55,7 +55,7 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
         $content = $this->getValue();
 
         /** @var $node NodeInterface */
-        $node = $this->tsValue('node');
+        $node = $this->fusionValue('node');
         if (!$node instanceof NodeInterface) {
             return $content;
         }
@@ -74,7 +74,7 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
             $content = '';
         }
 
-        if ($this->tsValue('renderCurrentDocumentMetadata')) {
+        if ($this->fusionValue('renderCurrentDocumentMetadata')) {
             return $this->contentElementWrappingService->wrapCurrentDocumentMetadata($node, $content, $this->getContentElementTypoScriptPath());
         }
 

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -67,7 +67,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
      */
     public function evaluate()
     {
-        $text = $this->tsValue('value');
+        $text = $this->fusionValue('value');
 
         if ($text === '' || $text === null) {
             return '';
@@ -77,31 +77,31 @@ class ConvertUrisImplementation extends AbstractFusionObject
             throw new Exception(sprintf('Only strings can be processed by this TypoScript object, given: "%s".', gettype($text)), 1382624080);
         }
 
-        $node = $this->tsValue('node');
+        $node = $this->fusionValue('node');
 
         if (!$node instanceof NodeInterface) {
             throw new Exception(sprintf('The current node must be an instance of NodeInterface, given: "%s".', gettype($text)), 1382624087);
         }
 
-        if ($node->getContext()->getWorkspace()->getName() !== 'live' && !($this->tsValue('forceConversion'))) {
+        if ($node->getContext()->getWorkspace()->getName() !== 'live' && !($this->fusionValue('forceConversion'))) {
             return $text;
         }
 
         $unresolvedUris = array();
         $linkingService = $this->linkingService;
-        $controllerContext = $this->tsRuntime->getControllerContext();
+        $controllerContext = $this->runtime->getControllerContext();
 
-        $absolute = $this->tsValue('absolute');
+        $absolute = $this->fusionValue('absolute');
 
         $processedContent = preg_replace_callback(LinkingService::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $linkingService, $controllerContext, &$unresolvedUris, $absolute) {
             switch ($matches[1]) {
                 case 'node':
                     $resolvedUri = $linkingService->resolveNodeUri($matches[0], $node, $controllerContext, $absolute);
-                    $this->tsRuntime->addCacheTag('node', $matches[2]);
+                    $this->runtime->addCacheTag('node', $matches[2]);
                     break;
                 case 'asset':
                     $resolvedUri = $linkingService->resolveAssetUri($matches[0]);
-                    $this->tsRuntime->addCacheTag('asset', $matches[2]);
+                    $this->runtime->addCacheTag('asset', $matches[2]);
                     break;
                 default:
                     $resolvedUri = null;
@@ -134,12 +134,12 @@ class ConvertUrisImplementation extends AbstractFusionObject
      */
     protected function replaceLinkTargets($processedContent)
     {
-        $externalLinkTarget = trim($this->tsValue('externalLinkTarget'));
-        $resourceLinkTarget = trim($this->tsValue('resourceLinkTarget'));
+        $externalLinkTarget = trim($this->fusionValue('externalLinkTarget'));
+        $resourceLinkTarget = trim($this->fusionValue('resourceLinkTarget'));
         if ($externalLinkTarget === '' && $resourceLinkTarget === '') {
             return $processedContent;
         }
-        $controllerContext = $this->tsRuntime->getControllerContext();
+        $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
         $processedContent = preg_replace_callback(
             '~<a.*?href="(.*?)".*?>~i',

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -41,7 +41,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      */
     public function getDimension()
     {
-        return $this->tsValue('dimension');
+        return $this->fusionValue('dimension');
     }
 
     /**
@@ -49,7 +49,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      */
     public function getPresets()
     {
-        return $this->tsValue('presets');
+        return $this->fusionValue('presets');
     }
 
     /**
@@ -57,7 +57,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      */
     public function getIncludeAllPresets()
     {
-        return $this->tsValue('includeAllPresets');
+        return $this->fusionValue('includeAllPresets');
     }
 
     /**

--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -39,7 +39,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getAsset()
     {
-        return $this->tsValue('asset');
+        return $this->fusionValue('asset');
     }
 
     /**
@@ -49,7 +49,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getWidth()
     {
-        return $this->tsValue('width');
+        return $this->fusionValue('width');
     }
 
     /**
@@ -59,7 +59,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getMaximumWidth()
     {
-        return $this->tsValue('maximumWidth');
+        return $this->fusionValue('maximumWidth');
     }
 
     /**
@@ -69,7 +69,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getHeight()
     {
-        return $this->tsValue('height');
+        return $this->fusionValue('height');
     }
 
     /**
@@ -79,7 +79,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getMaximumHeight()
     {
-        return $this->tsValue('maximumHeight');
+        return $this->fusionValue('maximumHeight');
     }
 
     /**
@@ -89,7 +89,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getAllowCropping()
     {
-        return $this->tsValue('allowCropping');
+        return $this->fusionValue('allowCropping');
     }
 
     /**
@@ -99,7 +99,7 @@ class ImageUriImplementation extends AbstractFusionObject
      */
     public function getAllowUpScaling()
     {
-        return $this->tsValue('allowUpScaling');
+        return $this->fusionValue('allowUpScaling');
     }
 
     /**

--- a/Neos.Neos/Classes/Fusion/MenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuImplementation.php
@@ -62,7 +62,7 @@ class MenuImplementation extends AbstractMenuImplementation
      */
     public function getEntryLevel()
     {
-        return $this->tsValue('entryLevel');
+        return $this->fusionValue('entryLevel');
     }
 
     /**
@@ -72,7 +72,7 @@ class MenuImplementation extends AbstractMenuImplementation
      */
     public function getFilter()
     {
-        $filter = $this->tsValue('filter');
+        $filter = $this->fusionValue('filter');
         if ($filter === null) {
             $filter = 'Neos.Neos:Document';
         }
@@ -87,7 +87,7 @@ class MenuImplementation extends AbstractMenuImplementation
     public function getMaximumLevels()
     {
         if ($this->maximumLevels === null) {
-            $this->maximumLevels = $this->tsValue('maximumLevels');
+            $this->maximumLevels = $this->fusionValue('maximumLevels');
             if ($this->maximumLevels > self::MAXIMUM_LEVELS_LIMIT) {
                 $this->maximumLevels = self::MAXIMUM_LEVELS_LIMIT;
             }
@@ -104,7 +104,7 @@ class MenuImplementation extends AbstractMenuImplementation
     public function getLastLevel()
     {
         if ($this->lastLevel === null) {
-            $this->lastLevel = $this->tsValue('lastLevel');
+            $this->lastLevel = $this->fusionValue('lastLevel');
             if ($this->lastLevel > self::MAXIMUM_LEVELS_LIMIT) {
                 $this->lastLevel = self::MAXIMUM_LEVELS_LIMIT;
             }
@@ -119,7 +119,7 @@ class MenuImplementation extends AbstractMenuImplementation
     public function getStartingPoint()
     {
         if ($this->startingPoint === null) {
-            $this->startingPoint = $this->tsValue('startingPoint');
+            $this->startingPoint = $this->fusionValue('startingPoint');
         }
 
         return $this->startingPoint;
@@ -130,7 +130,7 @@ class MenuImplementation extends AbstractMenuImplementation
      */
     public function getItemCollection()
     {
-        return $this->tsValue('itemCollection');
+        return $this->fusionValue('itemCollection');
     }
 
     /**
@@ -219,7 +219,7 @@ class MenuImplementation extends AbstractMenuImplementation
      */
     protected function findMenuStartingPoint()
     {
-        $typoScriptContext = $this->tsRuntime->getCurrentContext();
+        $typoScriptContext = $this->runtime->getCurrentContext();
         $startingPoint = $this->getStartingPoint();
 
         if (!isset($typoScriptContext['node']) && !$startingPoint) {

--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -41,7 +41,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getNode()
     {
-        return $this->tsValue('node');
+        return $this->fusionValue('node');
     }
 
     /**
@@ -51,7 +51,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getArguments()
     {
-        return $this->tsValue('arguments');
+        return $this->fusionValue('arguments');
     }
 
     /**
@@ -61,7 +61,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getFormat()
     {
-        return $this->tsValue('format');
+        return $this->fusionValue('format');
     }
 
     /**
@@ -71,7 +71,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getSection()
     {
-        return (string)$this->tsValue('section');
+        return (string)$this->fusionValue('section');
     }
 
     /**
@@ -81,7 +81,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getAdditionalParams()
     {
-        return $this->tsValue('additionalParams');
+        return $this->fusionValue('additionalParams');
     }
 
     /**
@@ -91,7 +91,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getArgumentsToBeExcludedFromQueryString()
     {
-        return $this->tsValue('argumentsToBeExcludedFromQueryString');
+        return $this->fusionValue('argumentsToBeExcludedFromQueryString');
     }
 
     /**
@@ -101,7 +101,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getAddQueryString()
     {
-        return (boolean)$this->tsValue('addQueryString');
+        return (boolean)$this->fusionValue('addQueryString');
     }
 
     /**
@@ -111,7 +111,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function isAbsolute()
     {
-        return (boolean)$this->tsValue('absolute');
+        return (boolean)$this->fusionValue('absolute');
     }
 
     /**
@@ -121,7 +121,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getBaseNodeName()
     {
-        return $this->tsValue('baseNodeName');
+        return $this->fusionValue('baseNodeName');
     }
 
     /**
@@ -134,7 +134,7 @@ class NodeUriImplementation extends AbstractFusionObject
     {
         $baseNode = null;
         $baseNodeName = $this->getBaseNodeName() ?: 'documentNode';
-        $currentContext = $this->tsRuntime->getCurrentContext();
+        $currentContext = $this->runtime->getCurrentContext();
         if (isset($currentContext[$baseNodeName])) {
             $baseNode = $currentContext[$baseNodeName];
         } else {
@@ -143,7 +143,7 @@ class NodeUriImplementation extends AbstractFusionObject
 
         try {
             return $this->linkingService->createNodeUri(
-                $this->tsRuntime->getControllerContext(),
+                $this->runtime->getControllerContext(),
                 $this->getNode(),
                 $baseNode,
                 $this->getFormat(),

--- a/Neos.Neos/Classes/Fusion/PluginImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginImplementation.php
@@ -58,7 +58,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function getPackage()
     {
-        return $this->tsValue('package');
+        return $this->fusionValue('package');
     }
 
     /**
@@ -66,7 +66,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function getSubpackage()
     {
-        return $this->tsValue('subpackage');
+        return $this->fusionValue('subpackage');
     }
 
     /**
@@ -74,7 +74,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function getController()
     {
-        return $this->tsValue('controller');
+        return $this->fusionValue('controller');
     }
 
     /**
@@ -82,7 +82,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function getAction()
     {
-        return $this->tsValue('action');
+        return $this->fusionValue('action');
     }
 
     /**
@@ -90,7 +90,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function getArgumentNamespace()
     {
-        return $this->tsValue('argumentNamespace');
+        return $this->fusionValue('argumentNamespace');
     }
 
     /**
@@ -101,7 +101,7 @@ class PluginImplementation extends AbstractArrayFusionObject
     protected function buildPluginRequest()
     {
         /** @var $parentRequest ActionRequest */
-        $parentRequest = $this->tsRuntime->getControllerContext()->getRequest();
+        $parentRequest = $this->runtime->getControllerContext()->getRequest();
         $pluginRequest = new ActionRequest($parentRequest);
         $pluginRequest->setArgumentNamespace('--' . $this->getPluginNamespace());
         $this->passArgumentsToPluginRequest($pluginRequest);
@@ -135,7 +135,7 @@ class PluginImplementation extends AbstractArrayFusionObject
         }
 
         foreach ($this->properties as $key => $value) {
-            $pluginRequest->setArgument('__' . $key, $this->tsValue($key));
+            $pluginRequest->setArgument('__' . $key, $this->fusionValue($key));
         }
         return $pluginRequest;
     }
@@ -147,11 +147,11 @@ class PluginImplementation extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        $currentContext = $this->tsRuntime->getCurrentContext();
+        $currentContext = $this->runtime->getCurrentContext();
         $this->node = $currentContext['node'];
         $this->documentNode = $currentContext['documentNode'];
         /** @var $parentResponse Response */
-        $parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
+        $parentResponse = $this->runtime->getControllerContext()->getResponse();
         $pluginResponse = new Response($parentResponse);
 
         $this->dispatcher->dispatch($this->buildPluginRequest(), $pluginResponse);

--- a/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
@@ -44,7 +44,7 @@ class PluginViewImplementation extends PluginImplementation
     protected function buildPluginRequest()
     {
         /** @var $parentRequest ActionRequest */
-        $parentRequest = $this->tsRuntime->getControllerContext()->getRequest();
+        $parentRequest = $this->runtime->getControllerContext()->getRequest();
         $pluginRequest = new ActionRequest($parentRequest);
 
         if (!$this->pluginViewNode instanceof NodeInterface) {
@@ -107,10 +107,10 @@ class PluginViewImplementation extends PluginImplementation
      */
     public function evaluate()
     {
-        $currentContext = $this->tsRuntime->getCurrentContext();
+        $currentContext = $this->runtime->getCurrentContext();
         $this->pluginViewNode = $currentContext['node'];
         /** @var $parentResponse Response */
-        $parentResponse = $this->tsRuntime->getControllerContext()->getResponse();
+        $parentResponse = $this->runtime->getControllerContext()->getResponse();
         $pluginResponse = new Response($parentResponse);
 
         $pluginRequest = $this->buildPluginRequest();

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -16,7 +16,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Neos\Service\ContentElementWrappingService;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Fusion\FusionObjects\Helpers\TypoScriptAwareViewInterface;
+use Neos\Fusion\FusionObjects\Helpers\FusionAwareViewInterface;
 
 /**
  * A view helper for manually wrapping content editables.
@@ -60,15 +60,15 @@ class WrapViewHelper extends AbstractViewHelper
     public function render(NodeInterface $node = null)
     {
         $view = $this->viewHelperVariableContainer->getView();
-        if (!$view instanceof TypoScriptAwareViewInterface) {
+        if (!$view instanceof FusionAwareViewInterface) {
             throw new ViewHelperException('This ViewHelper can only be used in a TypoScript content element. You have to specify the "node" argument if it cannot be resolved from the TypoScript context.', 1385737102);
         }
-        $typoScriptObject = $view->getTypoScriptObject();
-        $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
+        $fusionObject = $view->getFusionObject();
+        $currentContext = $fusionObject->getRuntime()->getCurrentContext();
 
         if ($node === null) {
             $node = $currentContext['node'];
         }
-        return $this->contentElementWrappingService->wrapContentObject($node, $this->renderChildren(), $typoScriptObject->getPath());
+        return $this->contentElementWrappingService->wrapContentObject($node, $this->renderChildren(), $fusionObject->getPath());
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -64,7 +64,7 @@ class WrapViewHelper extends AbstractViewHelper
             throw new ViewHelperException('This ViewHelper can only be used in a TypoScript content element. You have to specify the "node" argument if it cannot be resolved from the TypoScript context.', 1385737102);
         }
         $typoScriptObject = $view->getTypoScriptObject();
-        $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+        $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
 
         if ($node === null) {
             $node = $currentContext['node'];

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
@@ -36,7 +36,7 @@ abstract class AbstractRenderingStateViewHelper extends AbstractViewHelper
         $view = $this->viewHelperVariableContainer->getView();
         if ($view instanceof TypoScriptAwareViewInterface) {
             $typoScriptObject = $view->getTypoScriptObject();
-            $currentContext = $typoScriptObject->getTsRuntime()->getCurrentContext();
+            $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
             if (isset($currentContext['node'])) {
                 $baseNode = $currentContext['node'];
             }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
@@ -16,7 +16,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Fusion\FusionObjects\Helpers\TypoScriptAwareViewInterface;
+use Neos\Fusion\FusionObjects\Helpers\FusionAwareViewInterface;
 
 /**
  * Abstract ViewHelper for all Neos rendering state helpers.
@@ -34,8 +34,8 @@ abstract class AbstractRenderingStateViewHelper extends AbstractViewHelper
     {
         $baseNode = null;
         $view = $this->viewHelperVariableContainer->getView();
-        if ($view instanceof TypoScriptAwareViewInterface) {
-            $typoScriptObject = $view->getTypoScriptObject();
+        if ($view instanceof FusionAwareViewInterface) {
+            $typoScriptObject = $view->getFusionObject();
             $currentContext = $typoScriptObject->getRuntime()->getCurrentContext();
             if (isset($currentContext['node'])) {
                 $baseNode = $currentContext['node'];

--- a/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
@@ -315,29 +315,29 @@ class RenderingTest extends AbstractNodeTest
     /**
      * Simulate the rendering
      *
-     * @param string $additionalTypoScriptFile
+     * @param string $additionalFusionFile
      * @param boolean $debugMode
      * @return string
      */
-    protected function simulateRendering($additionalTypoScriptFile = null, $debugMode = false)
+    protected function simulateRendering($additionalFusionFile = null, $debugMode = false)
     {
-        $typoScriptRuntime = $this->createRuntimeWithFixtures($additionalTypoScriptFile);
-        $typoScriptRuntime->setEnableContentCache(false);
+        $fusionRuntime = $this->createRuntimeWithFixtures($additionalFusionFile);
+        $fusionRuntime->setEnableContentCache(false);
         if ($debugMode) {
-            $typoScriptRuntime->injectSettings(array('debugMode' => true, 'rendering' => array('exceptionHandler' => \Neos\Fusion\Core\ExceptionHandlers\ThrowingHandler::class)));
+            $fusionRuntime->injectSettings(array('debugMode' => true, 'rendering' => array('exceptionHandler' => \Neos\Fusion\Core\ExceptionHandlers\ThrowingHandler::class)));
         }
         $contentContext = $this->node->getContext();
         if (!$contentContext instanceof ContentContext) {
             $this->fail('Node context must be of type ContentContext');
         }
-        $typoScriptRuntime->pushContextArray(array(
+        $fusionRuntime->pushContextArray(array(
             'node' => $this->node,
             'documentNode' => $this->node,
             'site' => $contentContext->getCurrentSiteNode(),
             'fixturesDirectory' => __DIR__ . '/Fixtures'
         ));
-        $output = $typoScriptRuntime->render('page1');
-        $typoScriptRuntime->popContext();
+        $output = $fusionRuntime->render('page1');
+        $fusionRuntime->popContext();
 
         return $output;
     }
@@ -345,16 +345,16 @@ class RenderingTest extends AbstractNodeTest
     /**
      * Create a TypoScript runtime with the test base TypoScript and an optional additional fixture
      *
-     * @param string $additionalTypoScriptFile
+     * @param string $additionalFusionFile
      * @return \Neos\Fusion\Core\Runtime
      */
-    protected function createRuntimeWithFixtures($additionalTypoScriptFile = null)
+    protected function createRuntimeWithFixtures($additionalFusionFile = null)
     {
         $fusionService = new FusionService();
         $fusionService->setSiteRootFusionPattern(__DIR__ . '/Fixtures/BaseTypoScript.fusion');
 
-        if ($additionalTypoScriptFile !== null) {
-            $fusionService->setAppendFusionIncludes(array($additionalTypoScriptFile));
+        if ($additionalFusionFile !== null) {
+            $fusionService->setAppendFusionIncludes(array($additionalFusionFile));
         }
 
         $controllerContext = $this->buildMockControllerContext();

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -64,7 +64,7 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * @var Runtime
      */
-    protected $tsRuntime;
+    protected $runtime;
 
     /**
      * @var ContentContext
@@ -115,12 +115,12 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($this->viewHelper, 'controllerContext', $controllerContext);
 
         $typoScriptObject = $this->getAccessibleMock(TemplateImplementation::class, array('dummy'), array(), '', false);
-        $this->tsRuntime = new Runtime(array(), $controllerContext);
-        $this->tsRuntime->pushContextArray(array(
+        $this->runtime = new Runtime(array(), $controllerContext);
+        $this->runtime->pushContextArray(array(
             'documentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home'),
             'alternativeDocumentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')
         ));
-        $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
+        $this->inject($typoScriptObject, 'runtime', $this->runtime);
         /** @var AbstractTemplateView|\PHPUnit_Framework_MockObject_MockObject $mockView */
         $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($typoScriptObject));
@@ -180,9 +180,9 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     public function viewHelperRendersUriViaStringPointingToSubNodes()
     {
-        $this->tsRuntime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
+        $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
         $this->assertSame('<a href="/en/home/about-us/history.html">History</a>', $this->viewHelper->render('../history'));
-        $this->tsRuntime->popContext();
+        $this->runtime->popContext();
         $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('about-us/mission'));
         $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('./about-us/mission'));
     }

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -123,7 +123,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
         /** @var AbstractTemplateView|\PHPUnit_Framework_MockObject_MockObject $mockView */
         $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
-        $mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($typoScriptObject));
+        $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($typoScriptObject));
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -115,7 +115,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         ));
         $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
         $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
-        $mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($typoScriptObject));
+        $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($typoScriptObject));
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -59,7 +59,7 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * @var Runtime
      */
-    protected $tsRuntime;
+    protected $runtime;
 
     /**
      * @var ContentContext
@@ -108,12 +108,12 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($this->viewHelper, 'controllerContext', $controllerContext);
 
         $typoScriptObject = $this->getAccessibleMock(TemplateImplementation::class, array('dummy'), array(), '', false);
-        $this->tsRuntime = new Runtime(array(), $controllerContext);
-        $this->tsRuntime->pushContextArray(array(
+        $this->runtime = new Runtime(array(), $controllerContext);
+        $this->runtime->pushContextArray(array(
             'documentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home'),
             'alternativeDocumentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')
         ));
-        $this->inject($typoScriptObject, 'tsRuntime', $this->tsRuntime);
+        $this->inject($typoScriptObject, 'runtime', $this->runtime);
         $mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($typoScriptObject));
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
@@ -165,9 +165,9 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     public function viewHelperRendersUriViaStringPointingToSubNodes()
     {
-        $this->tsRuntime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
+        $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
         $this->assertOutputLinkValid('en/home/about-us/history.html', $this->viewHelper->render('../history'));
-        $this->tsRuntime->popContext();
+        $this->runtime->popContext();
         $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('about-us/mission'));
         $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('./about-us/mission'));
     }

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -78,7 +78,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     public function setUp()
     {
-        $this->convertUrisImplementation = $this->getAccessibleMock(ConvertUrisImplementation::class, array('tsValue'), array(), '', false);
+        $this->convertUrisImplementation = $this->getAccessibleMock(ConvertUrisImplementation::class, array('fusionValue'), array(), '', false);
 
         $this->mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
@@ -105,14 +105,14 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
         $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
-        $this->convertUrisImplementation->_set('tsRuntime', $this->mockTsRuntime);
+        $this->convertUrisImplementation->_set('runtime', $this->mockTsRuntime);
     }
 
     protected function addValueExpectation($value, $node = null, $forceConversion = false, $externalLinkTarget = null, $resourceLinkTarget = null, $absolute = false)
     {
         $this->convertUrisImplementation
             ->expects($this->atLeastOnce())
-            ->method('tsValue')
+            ->method('fusionValue')
             ->will($this->returnValueMap(array(
                 array('value', $value),
                 array('node', $node ?: $this->mockNode),

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -44,7 +44,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     /**
      * @var NodeDataRepository
@@ -103,9 +103,9 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->mockLinkingService = $this->createMock(LinkingService::class);
         $this->convertUrisImplementation->_set('linkingService', $this->mockLinkingService);
 
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
-        $this->convertUrisImplementation->_set('runtime', $this->mockTsRuntime);
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
+        $this->convertUrisImplementation->_set('runtime', $this->mockRuntime);
     }
 
     protected function addValueExpectation($value, $node = null, $forceConversion = false, $externalLinkTarget = null, $resourceLinkTarget = null, $absolute = false)

--- a/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
@@ -35,7 +35,7 @@ class PluginImplementationTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     /**
      * @var ControllerContext
@@ -59,9 +59,9 @@ class PluginImplementationTest extends UnitTestCase
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->mockControllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->mockActionRequest));
 
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
-        $this->pluginImplementation->_set('runtime', $this->mockTsRuntime);
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
+        $this->pluginImplementation->_set('runtime', $this->mockRuntime);
 
         $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->getMock();
         $this->pluginImplementation->_set('dispatcher', $this->mockDispatcher);

--- a/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
@@ -61,7 +61,7 @@ class PluginImplementationTest extends UnitTestCase
 
         $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $this->mockTsRuntime->expects($this->any())->method('getControllerContext')->will($this->returnValue($this->mockControllerContext));
-        $this->pluginImplementation->_set('tsRuntime', $this->mockTsRuntime);
+        $this->pluginImplementation->_set('runtime', $this->mockTsRuntime);
 
         $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->getMock();
         $this->pluginImplementation->_set('dispatcher', $this->mockDispatcher);

--- a/Neos.Neos/Tests/Unit/Service/ContentElementEditableServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/ContentElementEditableServiceTest.php
@@ -49,12 +49,12 @@ class ContentElementEditableServiceTest extends UnitTestCase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     /**
      * @var array
      */
-    protected $mockTsContext;
+    protected $mockContext;
 
     /**
      * @var NodeInterface
@@ -85,15 +85,15 @@ class ContentElementEditableServiceTest extends UnitTestCase
         $this->mockHtmlAugmenter = $this->getMockBuilder(HtmlAugmenter::class)->getMock();
         $this->inject($this->contentElementEditableService, 'htmlAugmenter', $this->mockHtmlAugmenter);
 
-        $this->mockTsRuntime = $this->getMockBuilder(\Neos\Fusion\Core\Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(\Neos\Fusion\Core\Runtime::class)->disableOriginalConstructor()->getMock();
         $this->mockContentContext = $this->getMockBuilder(\Neos\Neos\Domain\Service\ContentContext::class)->disableOriginalConstructor()->getMock();
 
         $this->mockNode = $this->getMockBuilder(\Neos\ContentRepository\Domain\Model\NodeInterface::class)->getMock();
         $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContentContext));
         $this->mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue(new NodeType('Acme.Test:Headline', [], [])));
 
-        $this->mockTsContext = array('node' => $this->mockNode);
-        $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
+        $this->mockContext = array('node' => $this->mockNode);
+        $this->mockRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockContext));
     }
 
     /**

--- a/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -110,7 +110,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
 
         $this->mockTsContext = array('node' => $this->mockNode);
         $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
-        $this->mockTemplateImplementation->expects($this->any())->method('getTsRuntime')->will($this->returnValue($this->mockTsRuntime));
+        $this->mockTemplateImplementation->expects($this->any())->method('getRuntime')->will($this->returnValue($this->mockTsRuntime));
         $this->mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $this->mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($this->mockTemplateImplementation));
 

--- a/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -57,12 +57,12 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
     /**
      * @var Runtime
      */
-    protected $mockTsRuntime;
+    protected $mockRuntime;
 
     /**
      * @var array
      */
-    protected $mockTsContext;
+    protected $mockContext;
 
     /**
      * @var NodeInterface
@@ -100,7 +100,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
 
         $this->mockTemplateImplementation = $this->getMockBuilder(TemplateImplementation::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
         $this->mockContentContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
@@ -108,9 +108,9 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->mockNode->expects($this->any())->method('getContext')->will($this->returnValue($this->mockContentContext));
         $this->mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue(new NodeType('Acme.Test:Headline', [], [])));
 
-        $this->mockTsContext = array('node' => $this->mockNode);
-        $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
-        $this->mockTemplateImplementation->expects($this->any())->method('getRuntime')->will($this->returnValue($this->mockTsRuntime));
+        $this->mockContext = array('node' => $this->mockNode);
+        $this->mockRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockContext));
+        $this->mockTemplateImplementation->expects($this->any())->method('getRuntime')->will($this->returnValue($this->mockRuntime));
         $this->mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
         $this->mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($this->mockTemplateImplementation));
 

--- a/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -99,7 +99,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->inject($this->editableViewHelper, 'contentElementEditableService', $this->mockContentElementEditableService);
 
         $this->mockTemplateImplementation = $this->getMockBuilder(TemplateImplementation::class)->disableOriginalConstructor()->getMock();
-        
+
         $this->mockTsRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
         $this->mockContentContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
@@ -112,7 +112,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->mockTsRuntime->expects($this->any())->method('getCurrentContext')->will($this->returnValue($this->mockTsContext));
         $this->mockTemplateImplementation->expects($this->any())->method('getTsRuntime')->will($this->returnValue($this->mockTsRuntime));
         $this->mockView = $this->getAccessibleMock(FluidView::class, array(), array(), '', false);
-        $this->mockView->expects($this->any())->method('getTypoScriptObject')->will($this->returnValue($this->mockTemplateImplementation));
+        $this->mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($this->mockTemplateImplementation));
 
         $this->editableViewHelper->initializeArguments();
     }


### PR DESCRIPTION
Internal variables and methods that contained TypoScipt are renamed. For renamed methods a fallback method with deprecation note was added.

The major changes are:
- `AbstractFusionObject`: Rename internal variables `tsRuntime` and `typoScriptObjectName` and methods `getTsRuntime` and `tsValue`. The old method names are deprecated. 
- `ArrayImplementation`: Rename method `sortNestedTypoScriptKeys`. The old method name is deprecated. 
- `TypoScriptAwareViewInterface`: The interface is deprecated and extended by the new FusionAwareViewInterface that defines the method name `getFusionObject`.
- `FluidView`: Rename method `getTypoScriptObject`. The old method name is deprecated. 