### PR TITLE
BUGFIX: Incorrect default sort direction in media browser

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Session/BrowserState.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Session/BrowserState.php
@@ -27,7 +27,7 @@ class BrowserState
         'activeTag' => null,
         'view' => 'Thumbnail',
         'sortBy' => 'Modified',
-        'sortDirection' => 'ASC',
+        'sortDirection' => 'DESC',
         'filter' => 'All'
     );
 


### PR DESCRIPTION
Changes the default sort direction in the media browser back to descending (latest modified first).

Regression introduced in c7aed058d3a363db8e51e8e9b84a557e90bffd0e

Resolves #1230
