### PR TITLE
TASK: Remove deprecated getters for ``userWorkspace`` and name

### DIFF
--- a/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
@@ -198,7 +198,7 @@ class NodeEvent extends Event
     {
         try {
             $context = $this->contextFactory->create(array(
-                'workspaceName' => $this->userService->getUserWorkspace()->getName(),
+                'workspaceName' => $this->userService->getPersonalWorkspace()->getName(),
                 'dimensions' => $this->dimension,
                 'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true
@@ -222,7 +222,7 @@ class NodeEvent extends Event
     {
         try {
             $context = $this->contextFactory->create(array(
-                'workspaceName' => $this->userService->getUserWorkspace()->getName(),
+                'workspaceName' => $this->userService->getPersonalWorkspace()->getName(),
                 'dimensions' => $this->dimension,
                 'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true

--- a/Neos.Neos/Classes/Service/BackendRedirectionService.php
+++ b/Neos.Neos/Classes/Service/BackendRedirectionService.php
@@ -99,7 +99,7 @@ class BackendRedirectionService
             return null;
         }
 
-        $workspaceName = $this->userService->getUserWorkspaceName();
+        $workspaceName = $this->userService->getPersonalWorkspace()->getName();
         $this->createWorkspaceAndRootNodeIfNecessary($workspaceName);
 
         $uriBuilder = new UriBuilder();

--- a/Neos.Neos/Classes/Service/UserService.php
+++ b/Neos.Neos/Classes/Service/UserService.php
@@ -94,33 +94,6 @@ class UserService
     }
 
     /**
-     * Returns the current user's personal workspace or null if no user is logged in.
-     * Deprecated, use getPersonalWorkspace() instead.
-     *
-     * @return Workspace
-     * @api
-     * @deprecated 2.1
-     */
-    public function getUserWorkspace()
-    {
-        return $this->getPersonalWorkspace();
-    }
-
-    /**
-     * Returns the name of the currently logged in user's personal workspace (even if that might not exist at that time).
-     * If no user is logged in this method returns null.
-     * Deprecated, use getPersonalWorkspaceName() instead.
-     *
-     * @return string
-     * @api
-     * @deprecated 2.1
-     */
-    public function getUserWorkspaceName()
-    {
-        return $this->getPersonalWorkspaceName();
-    }
-
-    /**
      * Returns the stored preferences of a user
      *
      * @param string $preference


### PR DESCRIPTION
These are fully replaced by
``\Neos\Neos\Service\UserService::getPersonalWorkspace``
and
``\Neos\Neos\Service\UserService::getPersonalWorkspaceName``