### PR TITLE
BUGFIX: make moving a content node across document nodes work from the tree

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/AbstractNodeTree.js
@@ -855,7 +855,21 @@ define(
 				}
 				var that = this;
 				try {
-					sourceNode.move(targetNode, position === 'into' ? 'over' : position);
+					// If moving within the same document
+					if (document.contains(sourceNode.span)) {
+						sourceNode.move(targetNode, position === 'into' ? 'over' : position);
+					} else {
+						switch (position) {
+							case 'before':
+								sourceNode = targetNode.getParent().addChild(sourceNode.data, targetNode);
+							break;
+							case 'after':
+								sourceNode = targetNode.getParent().addChild(sourceNode.data, targetNode.getNextSibling());
+							break;
+							case 'into':
+								sourceNode = targetNode.addChild(sourceNode.data);
+						}
+					}
 					sourceNode.activate();
 					sourceNode.setLazyNodeStatus(this.statusCodes.loading);
 					NodeEndpoint.move(


### PR DESCRIPTION
**What I did**

Moving a content node across document nodes used to give a JS error:
![image](https://cloud.githubusercontent.com/assets/837032/22254950/0ac9dd9e-e267-11e6-8d81-efe7906e4106.png)

**How I did it**

The error happens inside DynaTree, the code which we do not control. The only way I found to prevent it is to check for existence of child nodes before calling DynaTree's move.

**How to verify it**

Cut some content node from the tree on one page and paste it on another.
