### PR TITLE
TASK: Adapt to removed ``ResourcePublisher``

### DIFF
--- a/Neos.Fusion/Tests/Unit/TypoScriptObjects/ResourceUriImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/TypoScriptObjects/ResourceUriImplementationTest.php
@@ -14,7 +14,6 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
 use Neos\Flow\I18n\Service;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\ResourceManagement\Publishing\ResourcePublisher;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\Tests\UnitTestCase;
@@ -37,7 +36,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     protected $mockTsRuntime;
 
     /**
-     * @var ResourcePublisher
+     * @var ResourceManager
      */
     protected $mockResourceManager;
 


### PR DESCRIPTION
Although the test actually uses the ``ResourceManager`` the doc block says it's
the deprecated ``ResourcePublisher`` this is fixed as the publisher is
bound to be removed.
