### PR TITLE
FEATURE: Allow to register custom meta in Fusion runtime

### DIFF
--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -17,6 +17,13 @@ Neos:
       # meta-property in Fusion, and it is especially useful for e.g. the "Neos.Fusion:ResourceUri"
       # Fusion Object, which should just return NULL silently if an exception occurs.
       innerExceptionHandler: 'Neos\Fusion\Core\ExceptionHandlers\BubblingHandler'
+
+    externalMetaHandlers: []
+#      'Your\Package\CustomMetaHandler':
+#        enable: true
+#        connectTo:
+#          css: true
+
     debugMode: FALSE
     enableContentCache: TRUE
 


### PR DESCRIPTION
This change add a way to register custom meta (like @css, ...) in the
Fusion runtime and connect them to custom handler. This feature can be
used to monitor Fusion rendering, extracting dynamic stylesheet, ...