### PR TITLE
BUGFIX: Don’t use deprecated hostpattern methods

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
+++ b/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
@@ -68,7 +68,7 @@ class MenuHelper
             /** @var $site Site */
             if ($site->hasActiveDomains()) {
                 $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {
-                    return $domain->getHostPattern();
+                    return $domain->getHostname();
                 })->toArray();
                 $active = in_array($requestUriHost, $activeHostPatterns, true);
                 if ($active) {

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -301,7 +301,7 @@ class LinkingService
         if ($site->hasActiveDomains()) {
             $requestUriHost = $request->getHttpRequest()->getBaseUri()->getHost();
             $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {
-                return $domain->getHostPattern();
+                return $domain->getHostname();
             })->toArray();
             if (!in_array($requestUriHost, $activeHostPatterns, true)) {
                 $uri = $this->createSiteUri($controllerContext, $site) . '/' . ltrim($uri, '/');


### PR DESCRIPTION
`getHostPattern` was deprecated in Neos 3.0
