### PR TITLE
BUGFIX: AbstractNodeData->hasProperty() also if NULL

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/AbstractNodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/AbstractNodeData.php
@@ -173,7 +173,7 @@ abstract class AbstractNodeData
 
             $this->persistRelatedEntities($value);
 
-            if (isset($this->properties[$propertyName]) && $this->properties[$propertyName] === $value) {
+            if (array_key_exists($propertyName, $this->properties) && $this->properties[$propertyName] === $value) {
                 return;
             }
 
@@ -218,7 +218,7 @@ abstract class AbstractNodeData
         if (is_object($this->contentObjectProxy)) {
             return ObjectAccess::isPropertyGettable($this->contentObjectProxy->getObject(), $propertyName);
         }
-        return isset($this->properties[$propertyName]);
+        return array_key_exists($propertyName, $this->properties);
     }
 
     /**
@@ -286,7 +286,7 @@ abstract class AbstractNodeData
         }
 
         $properties = array();
-        foreach (array_keys($this->properties) as $propertyName) {
+        foreach ($this->properties as $propertyName => $propertyValue) {
             $properties[$propertyName] = $this->getProperty($propertyName);
         }
         return $properties;


### PR DESCRIPTION
Even if the property is set to `null` `AbstractNodeData::hasProperty()` should return `true`.

upmerge of #1211 