### PR TITLE
BUGFIX: Make fusion-parser aspectable

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
@@ -582,7 +582,12 @@ class Parser implements ParserInterface
     protected function parseInclude($include)
     {
         $include = trim($include);
-        $parser = clone $this;
+        $parser = new Parser();
+        // transfer current namespaces to new parser
+        foreach ($this->objectTypeNamespaces as $key => $objectTypeNamespace) {
+            $parser->setObjectTypeNamespace($key, $objectTypeNamespace);
+        }
+
         if (strpos($include, 'resource://') !== 0) {
             // Resolve relative paths
             if ($this->contextPathAndFilename !== null) {


### PR DESCRIPTION
The fusion parser cloned itself previously to handle includes but to keep the defined namespaces.
That made the use of aspects impossible since they were only applied on the initially created instance of the parser.

This change fixes this by using a new instance of the parser for each include and transfers the namespaces explicitly to the new parser.