### PR TITLE
BUGFIX: Use setFusionPathPattern() in HistoryController

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
@@ -76,7 +76,7 @@ class HistoryController extends AbstractModuleController
     }
 
     /**
-     * Simply sets the TypoScript path pattern on the view.
+     * Simply sets the Fusion path pattern on the view.
      *
      * @param ViewInterface $view
      * @return void

--- a/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
@@ -84,6 +84,7 @@ class HistoryController extends AbstractModuleController
     protected function initializeView(ViewInterface $view)
     {
         parent::initializeView($view);
-        $view->setTypoScriptPathPattern('resource://Neos.Neos/Private/Fusion/Backend');
+        /** @var FusionView $view */
+        $view->setFusionPathPattern('resource://Neos.Neos/Private/Fusion/Backend');
     }
 }


### PR DESCRIPTION
The view was updated to `FusionView`, but `setTypoScriptPathPattern` was still called.
I updated it to the correct method `setFusionPathPattern`.