### PR TITLE
BUGFIX: Adding media element to tag or asset collection

### DIFF
--- a/Neos.Media.Browser/Resources/Public/JavaScript/collections-and-tagging.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/collections-and-tagging.js
@@ -30,7 +30,7 @@
 			drop: function (event, ui) {
 				var tag = $(this),
 					asset = $(ui.draggable[0]),
-					assetIdentifier = asset.data('asset-identifier'),
+					assetIdentifier = asset.data('asset-identifier') || asset.parent().data('asset-identifier'),
 					countElement = tag.children('span'),
 					count = parseInt(countElement.text());
 				assetField.val(assetIdentifier);
@@ -79,7 +79,7 @@
 			drop: function (event, ui) {
 				var assetCollection = $(this),
 					asset = $(ui.draggable[0]),
-					assetIdentifier = asset.data('asset-identifier'),
+					assetIdentifier = asset.data('asset-identifier') || asset.parent().data('asset-identifier'),
 					countElement = assetCollection.children('span'),
 					count = parseInt(countElement.text());
 				linkAssetToCollectionAssetField.val(assetIdentifier);


### PR DESCRIPTION
Adding a media asset to a tag or collection in the thumbnail in the media browser by dragging it fails.

Resolves #1413