### PR TITLE
BUGFIX: Make layout sliding query match properly

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/DefaultTypoScript.ts2
@@ -46,7 +46,7 @@ root {
 
 	layout {
 		@position = 'end 9997'
-		layout = ${q(node).property('layout') != null && q(node).property('layout') != '' ? q(node).property('layout') : q(node).parents('[subpageLayout]').first().property('subpageLayout')}
+		layout = ${q(node).property('layout') != null && q(node).property('layout') != '' ? q(node).property('layout') : q(node).parents('[subpageLayout][subpageLayout != ""]').first().property('subpageLayout')}
 		condition = ${this.layout != null && this.layout != ''}
 		renderPath = ${'/' + this.layout}
 	}


### PR DESCRIPTION
The page layout determination in `DefaultTypoScript.ts2` contains the query

`q(node).parents('[subpageLayout]').first().property('subpageLayout')`

However that immediately also matches nodes which have `subpageLayout` being an empty string, hence this being taken into account. This results in an empty value, even if there would be actual set layouts higher above.

The `.parents()` part need to be replaced with `.parents('[subpageLayout][subpageLayout != ""]')`

Fixes #1117