### PR TITLE
BUGFIX: Initialization of asset usage strategies

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -151,9 +151,9 @@ class AssetService
         }
 
         $this->usageStrategies = [];
-        $assetUsageStrategieImplementations = $this->reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Media\Domain\Strategy\AssetUsageStrategyInterface');
-        foreach ($assetUsageStrategieImplementations as $assetUsageStrategieImplementationClassName) {
-            $this->usageStrategies[] = $this->objectManager->get($assetUsageStrategieImplementationClassName);
+        $assetUsageStrategyImplementations = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetUsageStrategyInterface::class);
+        foreach ($assetUsageStrategyImplementations as $assetUsageStrategyImplementationClassName) {
+            $this->usageStrategies[] = $this->objectManager->get($assetUsageStrategyImplementationClassName);
         }
 
         return $this->usageStrategies;

--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -71,7 +71,7 @@ class AssetService
     /**
      * @var array
      */
-    protected $usageStrategies = [];
+    protected $usageStrategies;
 
     /**
      * @Flow\Inject
@@ -150,6 +150,7 @@ class AssetService
             return $this->usageStrategies;
         }
 
+        $this->usageStrategies = [];
         $assetUsageStrategieImplementations = $this->reflectionService->getAllImplementationClassNamesForInterface('TYPO3\Media\Domain\Strategy\AssetUsageStrategyInterface');
         foreach ($assetUsageStrategieImplementations as $assetUsageStrategieImplementationClassName) {
             $this->usageStrategies[] = $this->objectManager->get($assetUsageStrategieImplementationClassName);


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/neos/neos-development-collection/pull/1323,
causing the asset usage strategies to never be initialized.

Closes #1425