### PR TITLE
TASK: Prefix `uriPathSegment` field inspector validator

### DIFF
--- a/TYPO3.Neos/Configuration/NodeTypes.yaml
+++ b/TYPO3.Neos/Configuration/NodeTypes.yaml
@@ -166,7 +166,7 @@
         'TYPO3.Neos/Validation/StringLengthValidator':
           minimum: 1
           maximum: 255
-        regularExpression:
+        'TYPO3.Neos/Validation/RegularExpressionValidator':
           regularExpression: '/^[a-z0-9\-]+$/i'
     _hidden:
       ui:


### PR DESCRIPTION
I changed the non prefixed `regularExpression`-validator to the correct `TYPO3.Neos/Validation/RegularExpressionValidator`-validator

**How to test**

You could easily try to change the `uriPathSegment` on every document node type.