### PR TITLE
BUGFIX: Correct the uriPathSegment regex-validation

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -173,6 +173,7 @@
           minimum: 1
           maximum: 255
         regularExpression:
+        'Neos.Neos/Validation/RegularExpressionValidator':
           regularExpression: '/^[a-z0-9\-]+$/i'
     _hidden:
       ui:


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


I changed the _not existing_ `regularExpression`-validator to the correct `TYPO3.Neos/Validation/RegularExpressionValidator`-validator

**How I did it**

You could easily try to change the uriPathSegment on every document-nodetype

**ATTENTION:**
I created an other PR against 2.2 because I should create a PR against the lowest maintained branch, but the namespace is not the same so I created this one too, I didn't know how I should do it properly.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
