### PR TITLE
BUGFIX: Fix the NodeTypes schema files and allow properties `search` and `options`

### DIFF
--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -4,121 +4,130 @@ additionalProperties:
   type: dictionary
   properties:
     'properties':
-      type: dictionary
-      additionalProperties:
-        # for each property...
-        type: dictionary
-        properties:
-          'ui':
-            # here, we specify ONLY the "ui" part of the schema, as the remaining parts
-            # are already specified in the NodeTypes schema of the TYPO3CR package
+      # for each property...
+      type:
+        -
+          type: 'null'
+        -
+          type: dictionary
+          additionalProperties:
             type: dictionary
-            additionalProperties: FALSE
             properties:
-
-              'label': { type: string, description: "Human-readable label for this property." }
-
-              'help':
-                type: dictionary
-                additionalProperties: FALSE
-                properties:
-                  'message': { type: string, description: "Help text for this property. Supports markdown." }
-
-              'reloadIfChanged': { type: boolean, description: "If this property changes, should a element refresh occur?" }
-
-              'reloadPageIfChanged': { type: boolean, description: "If this property changes, should a page reload occur?" }
-
-              'inlineEditable': { type: boolean, description: "Is this property inline editable, i.e. edited directly on the page through Aloha/Hallo?" }
-
-              'aloha':
+              'ui':
+                # here, we specify ONLY the "ui" part of the schema, as the remaining parts
+                # are already specified in the NodeTypes schema of the TYPO3CR package
                 type: dictionary
                 additionalProperties: FALSE
                 properties:
 
-                  'format':
-                    type: 'dictionary'
-                    additionalProperties: FALSE
-                    properties:
-                      'strong': { type: boolean }
-                      'b': { type: boolean }
-                      'em': { type: boolean }
-                      'i': { type: boolean }
-                      'u': { type: boolean }
-                      'del': { type: boolean }
-                      'sub': { type: boolean }
-                      'sup': { type: boolean }
-                      'p': { type: boolean }
-                      'h1': { type: boolean }
-                      'h2': { type: boolean }
-                      'h3': { type: boolean }
-                      'h4': { type: boolean }
-                      'h5': { type: boolean }
-                      'h6': { type: boolean }
-                      'pre': { type: boolean }
-                      'removeFormat': { type: boolean }
+                  'label': { type: string, description: "Human-readable label for this property." }
 
-                  'table':
-                    additionalProperties: FALSE
-                    properties:
-                      'table': { type: boolean }
-
-                  'link':
-                    additionalProperties: FALSE
-                    properties:
-                      'a': { type: boolean }
-
-                  'list':
-                    additionalProperties: FALSE
-                    properties:
-                      'ol': { type: boolean }
-                      'ul': { type: boolean }
-
-                  'alignment':
-                    additionalProperties: FALSE
-                    properties:
-                      'right': { type: boolean }
-                      'left': { type: boolean }
-                      'center': { type: boolean }
-                      'justify': { type: boolean }
-                      'top': { type: boolean }
-                      'middle': { type: boolean }
-                      'bottom': { type: boolean }
-
-                  'formatlesspaste':
-                    additionalProperties: FALSE
-                    properties:
-                      'button': { type: boolean }
-                      'formatlessPasteOption': { type: boolean }
-                      'strippedElements':
-                        type: array
-                        items: { type: string, description: "List of HTML tags. If not set the default setting is used." }
-
-                  'autoparagraph': { type: boolean, description: "Automatically wrap non-wrapped text blocks in paragraph blocks." }
-
-                  'placeholder': { type: string, description: "Optional text that will be rendered in the aloha editor when there is no content." }
-
-              'inspector':
-                type: dictionary
-                additionalProperties: FALSE
-                properties:
-
-                  'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
-
-                  'position': { type: integer, description: 'Position inside the inspector group, small numbers are sorted on top' }
-
-                  'editor': { type: string, description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
-
-                  'editorOptions': { type: dictionary, description: 'options for the given editor' }
-
-                  'editorListeners':
+                  'help':
                     type: dictionary
-                    additionalProperties:
-                      type: dictionary
-                      additionalProperties: FALSE
-                      properties:
-                        'property': { type: ['string'], description: 'The name of an observed property in the same NodeType.' }
-                        'handler': { type: ['string'], description: 'The path to a handler JavaScript object, similar to custom editors and validators.' }
-                        'handlerOptions':  { type: dictionary, description: 'options for the given handler' }
+                    additionalProperties: FALSE
+                    properties:
+                      'message': { type: string, description: "Help text for this property. Supports markdown." }
+
+                  'reloadIfChanged': { type: boolean, description: "If this property changes, should a element refresh occur?" }
+
+                  'reloadPageIfChanged': { type: boolean, description: "If this property changes, should a page reload occur?" }
+
+                  'inlineEditable': { type: boolean, description: "Is this property inline editable, i.e. edited directly on the page through Aloha/Hallo?" }
+
+                  'aloha':
+                    type: dictionary
+                    additionalProperties: FALSE
+                    properties:
+
+                      'format':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'strong': { type: boolean }
+                          'b': { type: boolean }
+                          'em': { type: boolean }
+                          'i': { type: boolean }
+                          'u': { type: boolean }
+                          'del': { type: boolean }
+                          'sub': { type: boolean }
+                          'sup': { type: boolean }
+                          'p': { type: boolean }
+                          'h1': { type: boolean }
+                          'h2': { type: boolean }
+                          'h3': { type: boolean }
+                          'h4': { type: boolean }
+                          'h5': { type: boolean }
+                          'h6': { type: boolean }
+                          'pre': { type: boolean }
+                          'removeFormat': { type: boolean }
+
+                      'table':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'table': { type: boolean }
+
+                      'link':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'a': { type: boolean }
+
+                      'list':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'ol': { type: boolean }
+                          'ul': { type: boolean }
+
+                      'alignment':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'right': { type: boolean }
+                          'left': { type: boolean }
+                          'center': { type: boolean }
+                          'justify': { type: boolean }
+                          'top': { type: boolean }
+                          'middle': { type: boolean }
+                          'bottom': { type: boolean }
+
+                      'formatlesspaste':
+                        type: dictionary
+                        additionalProperties: FALSE
+                        properties:
+                          'button': { type: boolean }
+                          'formatlessPasteOption': { type: boolean }
+                          'strippedElements':
+                            type: array
+                            items: { type: string, description: "List of HTML tags. If not set the default setting is used." }
+
+                      'autoparagraph': { type: boolean, description: "Automatically wrap non-wrapped text blocks in paragraph blocks." }
+
+                      'placeholder': { type: string, description: "Optional text that will be rendered in the aloha editor when there is no content." }
+
+                  'inspector':
+                    type: dictionary
+                    additionalProperties: FALSE
+                    properties:
+
+                      'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
+
+                      'position': { type: integer, description: 'Position inside the inspector group, small numbers are sorted on top' }
+
+                      'editor': { type: string, description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
+
+                      'editorOptions': { type: dictionary, description: 'options for the given editor' }
+
+                      'editorListeners':
+                        type: dictionary
+                        additionalProperties:
+                          type: dictionary
+                          additionalProperties: FALSE
+                          properties:
+                            'property': { type: ['string'], description: 'The name of an observed property in the same NodeType.' }
+                            'handler': { type: ['string'], description: 'The path to a handler JavaScript object, similar to custom editors and validators.' }
+                            'handlerOptions':  { type: dictionary, description: 'options for the given handler' }
 
     'ui':
       # here, we specify ONLY the "ui" part of the schema, as the remaining parts

--- a/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -4,13 +4,14 @@ additionalProperties:
   type: dictionary
   properties:
     'properties':
+      type: dictionary
+
       # for each property...
-      type:
-        -
-          type: 'null'
-        -
-          type: dictionary
-          additionalProperties:
+      additionalProperties:
+        type:
+          -
+            type: 'null'
+          -
             type: dictionary
             properties:
               'ui':

--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -65,6 +65,16 @@ additionalProperties:
             # we intentionally do not specify which properties are allowed here;
             # as other packages (such as TYPO3.Neos) might do that instead.
 
+          'options':
+            type: dictionary
+            # we intentionally do not specify which properties are allowed here;
+            # as other packages might do that instead.
+
+          'search':
+            type: dictionary
+            # we intentionally do not specify which properties are allowed here;
+            # as other packages might do that instead.
+
     'ui':
       type: dictionary
       # we intentionally do not specify which properties are allowed here (except the one expected in TYPO3CR);
@@ -74,6 +84,13 @@ additionalProperties:
 
     'options':
       type: dictionary
+      # we intentionally do not specify which properties are allowed here;
+      # as other packages might do that instead.
+
+    'search':
+      type: dictionary
+      # we intentionally do not specify which properties are allowed here;
+      # as other packages might do that instead.
 
     'postprocessors':
       type: dictionary

--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -45,35 +45,39 @@ additionalProperties:
           'constraints': *constraints
 
     'properties':
-      type: ['dictionary', 'null']
-      additionalProperties:
+      type:
+        -
+          type: 'null'
+        -
+          type: dictionary
+          additionalProperties:
 
-        # for each property...
-        type: dictionary
-        additionalProperties: FALSE
-        properties:
-
-          'type': { type: string, description: "PHP type of this property. Either simple type or fully qualified PHP class name." }
-
-          'defaultValue': { type: any, description: "Default value of this property. Used at node creation time. Type must match specified 'type'." }
-
-          'validation':
-            type: ['dictionary', 'null']
-
-          'ui':
+            # for each property...
             type: dictionary
-            # we intentionally do not specify which properties are allowed here;
-            # as other packages (such as TYPO3.Neos) might do that instead.
+            additionalProperties: FALSE
+            properties:
 
-          'options':
-            type: dictionary
-            # we intentionally do not specify which properties are allowed here;
-            # as other packages might do that instead.
+              'type': { type: string, description: "PHP type of this property. Either simple type or fully qualified PHP class name." }
 
-          'search':
-            type: dictionary
-            # we intentionally do not specify which properties are allowed here;
-            # as other packages might do that instead.
+              'defaultValue': { type: any, description: "Default value of this property. Used at node creation time. Type must match specified 'type'." }
+
+              'validation':
+                type: ['dictionary', 'null']
+
+              'ui':
+                type: dictionary
+                # we intentionally do not specify which properties are allowed here;
+                # as other packages (such as TYPO3.Neos) might do that instead.
+
+              'options':
+                type: dictionary
+                # we intentionally do not specify which properties are allowed here;
+                # as other packages might do that instead.
+
+              'search':
+                type: dictionary
+                # we intentionally do not specify which properties are allowed here;
+                # as other packages might do that instead.
 
     'ui':
       type: dictionary

--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -45,14 +45,14 @@ additionalProperties:
           'constraints': *constraints
 
     'properties':
-      type:
-        -
-          type: 'null'
-        -
-          type: dictionary
-          additionalProperties:
+      type: dictionary
 
-            # for each property...
+      # for each property...
+      additionalProperties:
+        type:
+          -
+            type: 'null'
+          -
             type: dictionary
             additionalProperties: FALSE
             properties:


### PR DESCRIPTION
The NodeType schemas can now handle the case that a property in a NodeType definition can be either a dictionary or null.

Additionally the keys `search`  and `options` as extension point for package-configuration.

The key `search` is used by several search implementations and currently causes validation errors.
The key `options` is allowed to avoid such problems in the future and to create a place where packages can place custom configuration.