### PR TITLE
BUGFIX: getPersonalWorkspace()->getName() replaced with getPersonalWorkspaceName()

### DIFF
--- a/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
@@ -198,7 +198,7 @@ class NodeEvent extends Event
     {
         try {
             $context = $this->contextFactory->create(array(
-                'workspaceName' => $this->userService->getPersonalWorkspace()->getName(),
+                'workspaceName' => $this->userService->getPersonalWorkspaceName(),
                 'dimensions' => $this->dimension,
                 'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true
@@ -222,7 +222,7 @@ class NodeEvent extends Event
     {
         try {
             $context = $this->contextFactory->create(array(
-                'workspaceName' => $this->userService->getPersonalWorkspace()->getName(),
+                'workspaceName' => $this->userService->getPersonalWorkspaceName(),
                 'dimensions' => $this->dimension,
                 'currentSite' => $this->getCurrentSite(),
                 'invisibleContentShown' => true

--- a/Neos.Neos/Classes/Service/BackendRedirectionService.php
+++ b/Neos.Neos/Classes/Service/BackendRedirectionService.php
@@ -99,7 +99,7 @@ class BackendRedirectionService
             return null;
         }
 
-        $workspaceName = $this->userService->getPersonalWorkspace()->getName();
+        $workspaceName = $this->userService->getPersonalWorkspaceName();
         $this->createWorkspaceAndRootNodeIfNecessary($workspaceName);
 
         $uriBuilder = new UriBuilder();


### PR DESCRIPTION
f13a82c2d9d5a3185889d21c4cbfca4dbdfde579 introduced a regression: No workspace is created for new users.

This fixes it.