### PR TITLE
BUGFIX: Check for existing node data property works with null

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
@@ -173,7 +173,7 @@ abstract class AbstractNodeData
 
             $this->persistRelatedEntities($value);
 
-            if (isset($this->properties[$propertyName]) && $this->properties[$propertyName] === $value) {
+            if (array_key_exists($propertyName, $this->properties) && $this->properties[$propertyName] === $value) {
                 return;
             }
 
@@ -218,7 +218,7 @@ abstract class AbstractNodeData
         if (is_object($this->contentObjectProxy)) {
             return ObjectAccess::isPropertyGettable($this->contentObjectProxy->getObject(), $propertyName);
         }
-        return isset($this->properties[$propertyName]);
+        return array_key_exists($propertyName, $this->properties);
     }
 
     /**

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -238,6 +238,34 @@ class NodeDataTest extends UnitTestCase
         $this->nodeData->removeProperty('title');
 
         $this->assertFalse($this->nodeData->hasProperty('title'));
+
+        $this->assertNotContains('title', $this->nodeData->getPropertyNames());
+
+        $this->assertArrayNotHasKey('title', $this->nodeData->getProperties());
+    }
+
+    /**
+     * @test
+     */
+    public function propertiesHandlesNullValuesCorrectly()
+    {
+        $this->nodeData->setProperty('value', null);
+
+        $this->assertTrue($this->nodeData->hasProperty('value'));
+
+        $this->assertNull($this->nodeData->getProperty('value'));
+
+        $this->assertContains('value', $this->nodeData->getPropertyNames());
+
+        $this->assertArrayHasKey('value', $this->nodeData->getProperties());
+
+        $this->nodeData->removeProperty('value');
+
+        $this->assertFalse($this->nodeData->hasProperty('value'));
+
+        $this->assertNotContains('value', $this->nodeData->getPropertyNames());
+
+        $this->assertArrayNotHasKey('value', $this->nodeData->getProperties());
     }
 
     /**


### PR DESCRIPTION
The ``AbstractNodeData::hasProperty()`` method checked
the existence of the given property with ``isset`` but that
leads to an exception if the property has a ``null`` value.
The check has been changed to ``array_key_exists``.

Same is done in the optimization check to avoid setting
existing values again in ``AbstractNodeData::setProperty``.

Resolves #1174