### PR TITLE
BUGFIX: Only show remove button when image selected in ImageEditor

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.html
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.html
@@ -18,9 +18,11 @@
 		<button id="{{unbound view._browseButtonId}}" class="neos-button neos-inspector-image-upload-files" {{bindAttr disabled="view._uploadInProgress:neos-disabled"}}>
 			{{view._fileChooserLabel}}
 		</button>
-		<button class="neos-button neos-inspector-image-remove-button" {{bindAttr disabled="view._uploadInProgress"}} {{action "remove" target="view"}}>
-			{{view.removeButtonLabel}}
-		</button>
+		{{#if view.value}}
+			<button class="neos-button neos-inspector-image-remove-button" {{bindAttr disabled="view._uploadInProgress"}} {{action "remove" target="view"}}>
+				{{view.removeButtonLabel}}
+			</button>
+		{{/if}}
 		{{#if view.shouldRenderCrop}}
 			{{view view.SecondaryInspectorButton viewClassBinding="view._cropView" isVisibleBinding="view._uploadPreviewNotShown" class="neos-inspector-image-crop-button" labelBinding="view.cropLabel"}}
 		{{/if}}


### PR DESCRIPTION
Do not show the "remove" button in ImageEditor when no image is selected.