### PR TITLE
TASK: Improve documentation on plugin creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+.idea/copyright/profiles_settings.xml
+
+.idea/misc.xml
+
+.idea/modules.xml
+
+.idea/neos-development-collection.iml
+
+.idea/vcs.xml
+
+.idea/workspace.xml

--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -54,7 +54,7 @@ Configure Access Rights
 -----------------------
 
 To be able to call the actions of the controller you have to configure a matching set of rights.
-Add the following to *Configuration/Policy.yaml* of your package:
+Create a Policy.yaml file under *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* within following:
 
 .. code-block:: yaml
 
@@ -121,6 +121,12 @@ to keep things organized. Technically it has no relevance.
 
   mkdir Packages/Plugins
   mv Packages/Application/Sarkosh.CdCollection Packages/Plugins/Sarkosh.CdCollection
+
+If you do this optional step: flush the cache is important! After this, you can use the Plugin with same url ``http://neos.demo/flow/sarkosh.cdcollection``
+
+.. code-block:: bash
+
+  ./flow flow:cache:flush --force
 
 Converting a Flow Package Into a Neos Plugin
 ============================================


### PR DESCRIPTION
The file Policy.yaml is missing in Sarkosh.CdCollection, clearly point out
it needs to be created.

Also explain that the cache needs to be flushed before you can use the
plugin with optional move to Folder «Plugins».