### PR TITLE
BUGFIX: Avoid stuck tooltip in node tree

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -169,7 +169,7 @@ define(
 					if (PublishableNodes.get('publishableEntitySubjects').indexOf('<' + node.data.key + '>') !== -1) {
 						$(nodeSpan).addClass('neos-dynatree-dirty');
 					}
-					$('a[title]', nodeSpan).tooltip({container: '#neos-application'});
+					$('a[title]', nodeSpan).tooltip({container: '#neos-application', trigger: 'hover'});
 				}
 			}));
 

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
@@ -226,7 +226,7 @@ define(
 						if (PublishableNodes.get('workspaceWidePublishableEntitySubjects').findBy('documentNodeContextPath', node.data.key)) {
 							$(nodeSpan).addClass('neos-dynatree-dirty');
 						}
-						$('a[title]', nodeSpan).tooltip({container: '#neos-application'});
+						$('a[title]', nodeSpan).tooltip({container: '#neos-application', trigger: 'hover'});
 					}
 				}));
 

--- a/TYPO3.Neos/Scripts/Gruntfile.js
+++ b/TYPO3.Neos/Scripts/Gruntfile.js
@@ -172,6 +172,7 @@ module.exports = function (grunt) {
 						src = src.replace('data-toggle', 'data-neos-toggle');
 
 						// Tooltip
+						src = src.replace(/trigger: 'hover focus'/g, "trigger: 'hover'");
 						src = src.replace(/in top bottom left right/g, 'neos-in neos-top neos-bottom neos-left neos-right');
 						src = src.replace(/\.addClass\(placement\)/g, ".addClass('neos-' + placement)");
 						src = src.replace('delay: 0', "delay: { 'show': 500, 'hide': 100 }");

--- a/TYPO3.Neos/Scripts/Gruntfile.js
+++ b/TYPO3.Neos/Scripts/Gruntfile.js
@@ -172,7 +172,6 @@ module.exports = function (grunt) {
 						src = src.replace('data-toggle', 'data-neos-toggle');
 
 						// Tooltip
-						src = src.replace(/trigger: 'hover focus'/g, "trigger: 'hover'");
 						src = src.replace(/in top bottom left right/g, 'neos-in neos-top neos-bottom neos-left neos-right');
 						src = src.replace(/\.addClass\(placement\)/g, ".addClass('neos-' + placement)");
 						src = src.replace('delay: 0', "delay: { 'show': 500, 'hide': 100 }");


### PR DESCRIPTION
This switches (bootstrap) tooltips from being triggered on hover
and focus to just hover. This avoids the tooltip being activated e.g.
by expand a subtree.

Should fix #1386
