### PR TITLE
BUGFIX: Hide node tree tooltips on page scroll

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Navigate/_NavigatePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Navigate/_NavigatePanel.scss
@@ -54,6 +54,12 @@
 		left: $menuButtonWidth;
 	}
 
+  // fix https://github.com/neos/neos-development-collection/issues/1387
+  .neos-tooltip {
+    position: fixed;
+  }
+
+
 	@import "NodeTree";
 	@import "ContextStructureTree";
 

--- a/TYPO3.Neos/Resources/Private/Styles/Navigate/_NavigatePanel.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Navigate/_NavigatePanel.scss
@@ -54,12 +54,6 @@
 		left: $menuButtonWidth;
 	}
 
-  // fix https://github.com/neos/neos-development-collection/issues/1387
-  .neos-tooltip {
-    position: fixed;
-  }
-
-
 	@import "NodeTree";
 	@import "ContextStructureTree";
 

--- a/TYPO3.Neos/Resources/Private/Styles/_Global.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/_Global.scss
@@ -152,6 +152,11 @@ body {
 	}
 }
 
+// fix https://github.com/neos/neos-development-collection/issues/1387
+#neos-application {
+  position: fixed;
+}
+
 #neos-document-metadata {
 	display: none;
 }


### PR DESCRIPTION
When a tooltip is triggered in the node tree and the page is then scrolled,
tooltips stay in place instead of moving with the page.

If the tree itself is scrolled, they will not move, but disappear since the
mouse pointer leaves the hover area.

Should fix #1387
