### PR TITLE
BUGFIX: Limit VIE to predicates with custom namespace

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/vie.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/vie.js
@@ -66,7 +66,9 @@ define(['Library/jquery-with-dependencies', 'Library/vie'], function($, VIE) {
 		return originalRdfaServiceWriteEntityFn.apply(this, arguments);
 	};
 
-	vieInstance.use(new vieInstance.RdfaService());
+	vieInstance.use(new vieInstance.RdfaService({
+		predicateSelector: '[property^="typo3:"],[rel^="typo3:"]'
+	}));
 	vieInstance.Util = VIE.Util;
 	return vieInstance;
 });


### PR DESCRIPTION
Instead of applying VIE to all elements with `[rel]` or `[property]` attributes,
only apply to those starting prefixed with the `typo3` namespace.

This prevents side effects for other tags like `<a href="#" rel="nofollow">Link</a>`.

Resolves #1449