### PR TITLE
TASK: Improve documentation on plugin creation

### DIFF
--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -54,7 +54,7 @@ Configure Access Rights
 -----------------------
 
 To be able to call the actions of the controller you have to configure a matching set of rights.
-Create a Policy.yaml file under *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* within following:
+Create a *Policy.yaml* file under *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* within following:
 
 .. code-block:: yaml
 
@@ -122,13 +122,13 @@ to keep things organized. Technically it has no relevance.
   mkdir Packages/Plugins
   mv Packages/Application/Sarkosh.CdCollection Packages/Plugins/Sarkosh.CdCollection
 
-If you do this optional but organizing step, flush the cache is important:
+If you do this, it is important to rescan the available packages:
 
 .. code-block:: bash
 
-  ./flow flow:cache:flush --force
+  ./flow flow:package:rescan
 
-After this, you can use the Plugin with same url ``http://neos.demo/flow/sarkosh.cdcollection``
+After this, you can use the Plugin with the same url ``http://neos.demo/flow/sarkosh.cdcollection``
 
 Converting a Flow Package Into a Neos Plugin
 ============================================

--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -54,7 +54,7 @@ Configure Access Rights
 -----------------------
 
 To be able to call the actions of the controller you have to configure a matching set of rights.
-Create a *Policy.yaml* file under *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* within following:
+Create a *Policy.yaml* file in *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* containing:
 
 .. code-block:: yaml
 

--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -54,7 +54,7 @@ Configure Access Rights
 -----------------------
 
 To be able to call the actions of the controller you have to configure a matching set of rights.
-Add the following to *Configuration/Policy.yaml* of your package:
+Create a Policy.yaml file under *Packages/Application/Sarkosh.CdCollection/Configuration/Policy.yaml* within following:
 
 .. code-block:: yaml
 
@@ -121,6 +121,14 @@ to keep things organized. Technically it has no relevance.
 
   mkdir Packages/Plugins
   mv Packages/Application/Sarkosh.CdCollection Packages/Plugins/Sarkosh.CdCollection
+
+If you do this optional but organizing step, flush the cache is important:
+
+.. code-block:: bash
+
+  ./flow flow:cache:flush --force
+
+After this, you can use the Plugin with same url ``http://neos.demo/flow/sarkosh.cdcollection``
 
 Converting a Flow Package Into a Neos Plugin
 ============================================


### PR DESCRIPTION
The file Policy.yaml is missing in Sarkosh.CdCollection, clearly point out
it needs to be created.

Also explain that packages need to be rescanned (or the cache needs to
be flushed) before you can use the plugin after the optional move to a
"Plugins" folder.