### PR TITLE
BUGFIX: If thumbnail refresh fails, handle gracefully

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ThumbnailService.php
@@ -136,7 +136,12 @@ class ThumbnailService
             $this->persistenceManager->whiteListObject($thumbnail);
             $this->thumbnailCache[$assetIdentifier][$configurationHash] = $thumbnail;
         } elseif ($thumbnail->getResource() === null && $async === false) {
-            $this->refreshThumbnail($thumbnail);
+            try {
+                $this->refreshThumbnail($thumbnail);
+            } catch (NoThumbnailAvailableException $exception) {
+                $this->systemLogger->logException($exception);
+                return null;
+            }
         }
 
         return $thumbnail;


### PR DESCRIPTION
If refreshing a thumbnail fails (e.g. because a PDF cannot be converted
correctly), the media module dies with an exception screen.

This change catches and logs the error, and returns null as result. This
leads to a missing thumbnail, but the media management stays usable.
