### PR TITLE
BUGFIX: Correct the NodeType schema of a nulled fusion.prototypeGenerator

### DIFF
--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -128,7 +128,7 @@ additionalProperties:
       additionalProperties: TRUE
       properties:
         prototypeGenerator:
-          - { type: null }
+          - { type: 'null' }
           - { type: string, format: class-name }
 
     'ui':


### PR DESCRIPTION
The type 'null' has to be written in quotes to be distinguished from the NULL value of yaml.