### PR TITLE
BUGFIX: Fix the infinite loop if a fusion object can not be resolved

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FusionPathProxy.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FusionPathProxy.php
@@ -17,6 +17,7 @@ use Neos\FluidAdaptor\Core\Parser\SyntaxTree\TemplateObjectAccessInterface;
 use Neos\Fusion\Core\ExceptionHandlers\ContextDependentHandler;
 use Neos\Fusion\Exception\UnsupportedProxyMethodException;
 use Neos\Fusion\FusionObjects\TemplateImplementation;
+use Neos\Fusion\Exception as FusionException;
 
 /**
  * A proxy object representing a Fusion path inside a Fluid Template. It allows
@@ -140,11 +141,12 @@ class FusionPathProxy implements TemplateObjectAccessInterface, \ArrayAccess, \I
      * Evaluates Fusion objects and eel expressions.
      *
      * @return FusionPathProxy|mixed
+     * @throws FusionException
      */
     public function objectAccess()
     {
         if (!$this->fusionRuntime->canRender($this->path)) {
-            return $this;
+            throw new FusionException('The configuration in the path "' . $this->path . '" can not be rendered.', 1490778362);
         }
 
         try {
@@ -201,7 +203,7 @@ class FusionPathProxy implements TemplateObjectAccessInterface, \ArrayAccess, \I
                 // Throwing an exception in __toString causes a fatal error, so if that happens we catch them and use the context dependent exception handler instead.
                 $contextDependentExceptionHandler = new ContextDependentHandler();
                 $contextDependentExceptionHandler->setRuntime($this->fusionRuntime);
-                return $contextDependentExceptionHandler->handleRenderingException($this->path, $exception);
+                return $contextDependentExceptionHandler->handleRenderingException($this->path, $exceptionHandlerException);
             } catch (\Exception $contextDepndentExceptionHandlerException) {
                 $this->systemLogger->logException($contextDepndentExceptionHandlerException, array('path' => $this->path));
                 return sprintf(


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
1. Fix the bug of infinite loop if a fusion object can not be resolved.
2. Fix the bug of undefined variable in __toString() method

**How I did it**
1. Throwing an exception instead of retuning the FusionPathProxy object self to fix the infinite loop.
2. The timestamp is used as the exception code in the thrown exception.
3. Change the variable name of "$exception" to "$exceptionHandlerException"

**How to verify it**
Reproduce the scenario that is mentioned in https://github.com/neos/neos-development-collection/issues/1370, and there should be an error message of NEOS, that it the fusion object can not be resolved. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
