### PR TITLE
BUGFIX: Fix the error during running the importResourcesCommand

### DIFF
--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -34,7 +34,7 @@ class MediaCommandController extends CommandController
     protected $persistenceManager;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy=false)
      * @var ObjectManager
      */
     protected $entityManager;
@@ -86,10 +86,10 @@ class MediaCommandController extends CommandController
         $sql = '
 			SELECT
 				r.persistence_object_identifier, r.filename, r.mediatype
-			FROM typo3_flow_resource_resource r
-			LEFT JOIN typo3_media_domain_model_asset a
+			FROM neos_flow_resourcemanagement_persistentresource r
+			LEFT JOIN neos_media_domain_model_asset a
 			ON a.resource = r.persistence_object_identifier
-			LEFT JOIN typo3_media_domain_model_thumbnail t
+			LEFT JOIN neos_media_domain_model_thumbnail t
 			ON t.resource = r.persistence_object_identifier
 			WHERE a.persistence_object_identifier IS NULL AND t.persistence_object_identifier IS NULL
 		';


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
1. Fix the error by checking Doctrine ORM Entity Manager during calling the command.
2. Rename the table names to the actual names in the database

**How I did it**
1. Add lazy=false in the annotation of entityManager
2. Check the actual table names of in the database and adapt the names in the code

**How to verify it**

**Checklist**
Run the command, and there will not show any error message

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
