### PR TITLE
TASK: Process all resources in ThumbnailGenerator

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Media\Domain\Model\ThumbnailGenerator;
 
 /*

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Media\Domain\Model\ThumbnailGenerator;
 
 /*
@@ -12,7 +13,7 @@ namespace Neos\Media\Domain\Model\ThumbnailGenerator;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\Thumbnail;
@@ -70,7 +71,7 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
                 )
             );
 
-            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments);
+            $processedImageInfo = $this->processResource($thumbnail->getOriginalAsset()->getResource(), $adjustments);
 
             $thumbnail->setResource($processedImageInfo['resource']);
             $thumbnail->setWidth($processedImageInfo['width']);
@@ -79,5 +80,15 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
             $message = sprintf('Unable to generate thumbnail for the given image (filename: %s, SHA1: %s)', $thumbnail->getOriginalAsset()->getResource()->getFilename(), $thumbnail->getOriginalAsset()->getResource()->getSha1());
             throw new Exception\NoThumbnailAvailableException($message, 1433109654, $exception);
         }
+    }
+
+    /**
+     * @param PersistentResource $resource
+     * @param array $adjustments
+     * @return array
+     */
+    protected function processResource(PersistentResource $resource, array $adjustments)
+    {
+        return $this->imageService->processImage($resource, $adjustments);
     }
 }

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -92,11 +92,6 @@ class ThumbnailService
             if ($asset->getWidth() === null && $asset->getHeight() === null) {
                 return $asset;
             }
-            $maximumWidth = ($configuration->getMaximumWidth() > $asset->getWidth()) ? $asset->getWidth() : $configuration->getMaximumWidth();
-            $maximumHeight = ($configuration->getMaximumHeight() > $asset->getHeight()) ? $asset->getHeight() : $configuration->getMaximumHeight();
-            if ($configuration->isUpScalingAllowed() === false && $maximumWidth === $asset->getWidth() && $maximumHeight === $asset->getHeight()) {
-                return $asset;
-            }
         }
 
         $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);


### PR DESCRIPTION
This change allows to modify the processing behavior in custom ``ThumbnailGenerator`` implementations.

The ``ThumbnailService`` will not check the size of the image anymore and return the asset in some cases without triggering the processing pipeline.

This only increases computation a bit as the ``ResizeImageAdjustment`` will also check for the image dimensions and do nothing if they don’t change. Which is the same as the ``ThumbnailService`` previously did.

Previously images which were smaller than the requested image size were not processed and didn't trigger the thumbnail refresh event.

Resolves #1469