### PR TITLE
BUGFIX: MediaModule asset edit should not fail

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/CreateContentContextTrait.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Controller;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Service\ContentContext;
 use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
@@ -86,7 +87,7 @@ trait CreateContentContextTrait
             'currentSite' => $site
         ];
 
-        if ($domain = $site->getFirstActiveDomain()) {
+        if ($site instanceof Site && $domain = $site->getFirstActiveDomain()) {
             $contextProperties['currentDomain'] = $domain;
         }
 

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Dto/AssetUsageInNodeProperties.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Model/Dto/AssetUsageInNodeProperties.php
@@ -47,7 +47,7 @@ class AssetUsageInNodeProperties extends UsageReference
      * @param NodeInterface $node
      * @param boolean $accessible
      */
-    public function __construct(AssetInterface $asset, Site $site, NodeInterface $documentNode = null, NodeInterface $node, $accessible)
+    public function __construct(AssetInterface $asset, Site $site = null, NodeInterface $documentNode = null, NodeInterface $node = null, $accessible = false)
     {
         parent::__construct($asset);
         $this->site = $site;


### PR DESCRIPTION
if no Site is defined.

**How to verify it**

- delete your sites in the site management
- got to the media browser and open an image

An exception occurres.

See: https://github.com/neos/neos-development-collection/issues/1483