### PR TITLE
BUGFIX: NodePropertiesStrategy in Neos should only handle site nodes

### DIFF
--- a/TYPO3.Media/Documentation/DeveloperInformation/index.rst
+++ b/TYPO3.Media/Documentation/DeveloperInformation/index.rst
@@ -8,6 +8,9 @@ It is possible to extend the media handling by defining asset usage strategies. 
 strategies can tell the media package if an asset is in used, how many times it is
 used and how it is used.
 
+An asset usage strategy is already implemented for Neos ContentRepository nodes under the sites root,
+like document and content nodes. For all other usage scenarios, you need to build your own strategy.
+
 To define your own custom usage strategy you have to implement the
 ``TYPO3\Media\Domain\Strategy\AssetUsageStrategyInterface``. For convenience you can
 extend the ``TYPO3\Media\Domain\Strategy\AbstractAssetUsageStrategy``.

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -19,6 +19,7 @@ use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Strategy\AbstractAssetUsageStrategy;
 use TYPO3\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
+use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\Service\UserService;
 use TYPO3\Eel\FlowQuery\FlowQuery;
 use TYPO3\Neos\Controller\CreateContentContextTrait;
@@ -132,6 +133,6 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
             }
         }
 
-        return $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);
+        return $this->nodeDataRepository->findNodesByRelatedEntities($relationMap, SiteService::SITES_ROOT_PATH);
     }
 }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -1415,38 +1415,39 @@ class NodeDataRepository extends Repository
     /**
      * Searches for possible relations to the given entity identifiers in NodeData.
      * Will return all possible NodeData objects that contain this identifiers.
+     * See buildQueryBuilderForRelationMap for the relationMap definition.
      *
      * Note: This is an internal method that is likely to be replaced in the future.
-     *
-     * $objectTypeMap = array(
-     *    'TYPO3\Media\Domain\Model\Asset' => array('some-uuid-here'),
-     *    'TYPO3\Media\Domain\Model\ImageVariant' => array('some-uuid-here', 'another-uuid-here')
-     * )
      *
      * @param array $relationMap
      * @return array
      */
     public function findNodesByRelatedEntities($relationMap)
     {
-        /** @var QueryBuilder $queryBuilder */
-        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $this->buildQueryBuilderForRelationMap($relationMap)->getQuery()->getResult();
+    }
 
-        $queryBuilder->select('n')
-            ->from(NodeData::class, 'n');
+    /**
+     * Searches for possible relations to the given entity identifiers in NodeData using a path prefix.
+     * Will return all possible NodeData objects that contain this identifiers.
+     * See buildQueryBuilderForRelationMap for the relationMap definition.
+     *
+     * Note: This is an internal method that is likely to be replaced in the future.
+     *
+     * @param string $pathPrefix
+     * @param array $relationMap
+     * @return array
+     */
+    public function findNodesByPathPrefixAndRelatedEntities($pathPrefix, $relationMap)
+    {
+        $queryBuilder = $this->buildQueryBuilderForRelationMap($relationMap);
 
-        $constraints = [];
-        $parameters = [];
-        foreach ($relationMap as $relatedObjectType => $relatedIdentifiers) {
-            foreach ($relatedIdentifiers as $relatedIdentifier) {
-                $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
-                $parameters['entity' . md5($relatedIdentifier)] = '%"__identifier": "' . strtolower($relatedIdentifier) . '"%';
-            }
+        if (trim($pathPrefix) !== '') {
+            $queryBuilder->andWhere('n.path LIKE :pathPrefix');
+            $queryBuilder->setParameter('pathPrefix', trim($pathPrefix) . '%');
         }
-        $queryBuilder->where(implode(' OR ', $constraints));
-        $queryBuilder->setParameters($parameters);
-        $possibleNodeData = $queryBuilder->getQuery()->getResult();
 
-        return $possibleNodeData;
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**
@@ -1613,5 +1614,40 @@ class NodeDataRepository extends Repository
         }
 
         return $workspaces;
+    }
+
+    /**
+     * Returns a query builder for a query on node data using the given
+     * relation map.
+     *
+     * $objectTypeMap = array(
+     *    'TYPO3\Media\Domain\Model\Asset' => array('some-uuid-here'),
+     *    'TYPO3\Media\Domain\Model\ImageVariant' => array('some-uuid-here', 'another-uuid-here')
+     * )
+     *
+     * @param array $relationMap
+     * @return QueryBuilder
+     */
+    protected function buildQueryBuilderForRelationMap($relationMap)
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+
+        $queryBuilder->select('n')
+            ->from(NodeData::class, 'n');
+
+        $constraints = [];
+        $parameters = [];
+
+        foreach ($relationMap as $relatedObjectType => $relatedIdentifiers) {
+            foreach ($relatedIdentifiers as $relatedIdentifier) {
+                $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
+                $parameters['entity' . md5($relatedIdentifier)] = '%"__identifier": "' . strtolower($relatedIdentifier) . '"%';
+            }
+        }
+
+        $queryBuilder->where(implode(' OR ', $constraints));
+        $queryBuilder->setParameters($parameters);
+        return $queryBuilder;
     }
 }


### PR DESCRIPTION
Currently the AssetUsageInNodePropertiesStrategy handles
all asset references in all nodes in the node data table.
The handling than is specific for nodes under the `/site` root node
and fails when a node references an asset that is located under another root.

This fixes the issue by only selecting site nodes.

**What I did**
Filter the nodes by site root.

**How to verify it**
Add an asset reference to a node that is not under sites.
The edit view of an asset fails.
