### PR TITLE
FEATURE: Add a NodeLink prototype

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -813,6 +813,24 @@ Example::
 		node = ${q(node).parent().get(0)}
 	}
 
+.. _Neos_Neos__NodeLink:
+
+NodeLink
+-------
+
+Render a hyperlink to a node.
+
+:\*: All :ref:`Neos_Neos__NodeUri` properties
+:content: (string) The inner content of the link
+:attributes: (:ref:`Neos_Fusion__Attributes`) Image tag attributes
+
+Example::
+
+	backLink = Neos.Neos:NodeLink {
+		node = ${q(node).parent().get(0)}
+		content = 'Return to previous page'
+	}
+
 .. _Neos_Neos__ImageUri:
 
 ImageUri

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
@@ -7,3 +7,46 @@ prototype(Neos.Neos:NodeUri) {
 	argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
 	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
+
+# Renders a <a> tag linking to a node
+# LinkNode object works exactly the same way as neos:link.node ViewHelper in
+# the Neos.Neos package
+prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
+	node = 'pass-the-node'
+
+	absolute = FALSE
+	additionalParams = Neos.Fusion:RawArray
+	addQueryString = FALSE
+	arguments = Neos.Fusion:RawArray
+	argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
+	baseNodeName = 'documentNode'
+	format = NULL
+	section = ''
+	@context.node = ${this.node}
+	@context.absolute = ${this.absolute}
+	@context.additionalParams = ${this.additionalParams}
+	@context.addQueryString = ${this.addQueryString}
+	@context.arguments = ${this.arguments}
+	@context.argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
+	@context.baseNodeName = ${this.baseNodeName}
+	@context.format = ${this.format}
+	@context.section = ${this.section}
+
+	tagName = 'a'
+	content = ${this.node.label}
+
+	attributes {
+		href = Neos.Neos:NodeUri {
+			node = ${node}
+			absolute = ${absolute}
+			additionalParams = ${additionalParams}
+			addQueryString = ${addQueryString}
+			arguments = ${arguments}
+			argumentsToBeExcludedFromQueryString = ${argumentsToBeExcludedFromQueryString}
+			baseNodeName = ${baseNodeName}
+			format = ${format}
+			section = ${section}
+		}
+	}
+}
+


### PR DESCRIPTION
Add a NodeLink prototype which renders a hyperlink to a given node.

The prototype creates the URI by using Neos.Neos.NodeUri and therefore accepts all arguments Neos.Neos.NodeUri accepts. The hyperlink gets rendered by Neos.Fusion:Tag.

Add corresponding manual entry, too.