### PR TITLE
FEATURE: Add extension point for domain specific languages to fusion

### DIFF
--- a/Neos.Fusion/Classes/Core/DslFactory.php
+++ b/Neos.Fusion/Classes/Core/DslFactory.php
@@ -1,0 +1,58 @@
+<?php
+namespace Neos\Fusion\Core;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Core\DslInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Fusion;
+
+/**
+ * This dsl factory takes care of instantiating a Fusion dsl transpilers.
+ *
+ * @Flow\Scope("singleton")
+ */
+class DslFactory
+{
+    /**
+     * @Flow\InjectConfiguration("dsl")
+     * @var
+     */
+    protected $dslSettings;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManger;
+
+    /**
+     * @param string $identifier
+     * @return DslInterface
+     * @throws Fusion/Exception
+     */
+    public function create($identifier)
+    {
+        if (isset($this->dslSettings) && is_array($this->dslSettings) && isset($this->dslSettings[$identifier])) {
+            $dslObjectName = $this->dslSettings[$identifier];
+            if (!class_exists($dslObjectName)) {
+                throw new Fusion\Exception(sprintf('The fusion dsl-object %s was not found.', $dslObjectName), 1490776462);
+            }
+            $dslObject = new $dslObjectName();
+            if (!$dslObject instanceof DslInterface) {
+                throw new Fusion\Exception(sprintf('The fusion dsl-object was of type %s but was supposed to be of type %s', get_class($dslObject), DslInterface::class), 1490776470);
+            }
+            return new $dslObject();
+        }
+        throw new Fusion\Exception(sprintf('The fusion dsl-object for the key %s was not configured', $identifier), 1490776550);
+    }
+}

--- a/Neos.Fusion/Classes/Core/DslInterface.php
+++ b/Neos.Fusion/Classes/Core/DslInterface.php
@@ -1,0 +1,31 @@
+<?php
+namespace Neos\Fusion\Core;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion;
+
+/**
+ * Contract for a Fusion DSL parser
+ *
+ * @api
+ */
+interface DslInterface
+{
+    /**
+     * Transpile the given dsl-code to fusion-code
+     *
+     * @param string $code
+     * @return string
+     * @throws Fusion\Exception
+     */
+    public function transpile($code);
+}

--- a/Neos.Fusion/Configuration/Testing/Settings.yaml
+++ b/Neos.Fusion/Configuration/Testing/Settings.yaml
@@ -7,3 +7,7 @@ Neos:
     defaultContext:
       Testing.String: Neos\Eel\Helper\StringHelper
       Testing.Utility: Neos\Fusion\Tests\Functional\FusionObjects\Fixtures\Helper\UtilityHelper
+    dsl:
+      TestPassthroughDsl: Neos\Fusion\Tests\Functional\Parser\Fixtures\Dsl\PassthroughTestDslImplemenation
+      TestValueObjectDsl: Neos\Fusion\Tests\Functional\Parser\Fixtures\Dsl\ValueObjectExpressionTestDslImplemenation
+

--- a/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
+++ b/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
@@ -1,0 +1,34 @@
+type: dictionary
+properties:
+  Neos:
+    type: dictionary
+    properties:
+      Fusion:
+        type: dictionary
+        additionalProperties: FALSE
+        properties:
+          rendering:
+            type: dictionary
+            additionalProperties: FALSE
+            properties:
+              exceptionHandler:
+                type: string
+                format: class-name
+              innerExceptionHandler:
+                type: string
+                format: class-name
+          debugMode:
+            type: boolean
+          enableContentCache:
+            type: boolean
+          defaultContext:
+            type: dictionary
+            additionalProperties:
+              type: string
+              format: class-name
+          dsl:
+            type: dictionary
+            additionalProperties:
+              type: string
+              format: class-name
+

--- a/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/PassthroughTestDslImplemenation.php
+++ b/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/PassthroughTestDslImplemenation.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\Parser\Fixtures\Dsl;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Core\DslInterface;
+
+class PassthroughTestDslImplemenation implements DslInterface
+{
+    public function transpile($code)
+    {
+        return $code;
+    }
+}

--- a/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/ValueObjectExpressionTestDslImplemenation.php
+++ b/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/ValueObjectExpressionTestDslImplemenation.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\Parser\Fixtures\Dsl;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Core\DslInterface;
+
+class ValueObjectExpressionTestDslImplemenation implements DslInterface
+{
+    public function transpile($code)
+    {
+        return 'Neos.Fusion:Value {
+            value = "' . $code . '"
+        }';
+    }
+}

--- a/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
+++ b/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
@@ -1,0 +1,143 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\Parser;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Fusion\Core\Parser;
+use Neos\Fusion;
+
+/**
+ * Testcase for the Fusion Parser
+ */
+class FusionParserTest extends FunctionalTestCase
+{
+
+    /**
+     * @test
+     */
+    public function parserHandlesExpressionsThatReturnStrings()
+    {
+        $parser = new Parser();
+        $actualAst = $parser->parse('value = TestPassthroughDsl`"StringExpressionValue"`');
+        $expectedAst = [
+            'value' => 'StringExpressionValue'
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserHandlesExpressionsThatReturnMultilineStrings()
+    {
+        $parser = new Parser();
+        $actualAst = $parser->parse('value = TestPassthroughDsl`"String' . chr(10) . 'Expression' . chr(10) . 'Value"`');
+        $expectedAst = [
+            'value' => 'String' . chr(10) . 'Expression' . chr(10) . 'Value'
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserHandlesDslExpressionThatReturnsBooleans()
+    {
+        $parser = new Parser();
+
+        $actualAst = $parser->parse('value = TestPassthroughDsl`true`');
+        $expectedAst = [
+            'value' => true
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+
+        $actualAst = $parser->parse('value = TestPassthroughDsl`false`');
+        $expectedAst = [
+            'value' => false
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserHandlesDslExpressionThatReturnsNumbers()
+    {
+        $parser = new Parser();
+
+        $actualAst = $parser->parse('value = TestPassthroughDsl`1234`');
+        $expectedAst = [
+            'value' => 1234
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+
+        $actualAst = $parser->parse('value = TestPassthroughDsl`12.34`');
+        $expectedAst = [
+            'value' => 12.34
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+
+        $actualAst = $parser->parse('value = TestPassthroughDsl`-12.34`');
+        $expectedAst = [
+            'value' => -12.34
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserHandlesDslExpressionThatReturnsEelExpressions()
+    {
+        $parser = new Parser();
+        $actualAst = $parser->parse('value = TestPassthroughDsl`${1234}`');
+        $expectedAst = [
+            'value' => ["__eelExpression" => "1234","__value" => null, "__objectType" => null]
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserHandlesDslExpressionThatReturnsFusionObjects()
+    {
+        $parser = new Parser();
+        $actualAst = $parser->parse('value = TestValueObjectDsl`foo`');
+        $expectedAst = [
+            'value' => ["__eelExpression" => null,"__value" => null, "__objectType" => 'Neos.Fusion:Value', 'value' => "foo"]
+        ];
+        $this->assertEquals($expectedAst, $actualAst);
+    }
+
+    /**
+     * @test
+     */
+    public function parserThrowsExceptionIfAnUnknownDslIsExecuted()
+    {
+        $parser = new Parser();
+        $this->expectException(Fusion\Exception::class);
+        $this->expectExceptionCode(1490776550);
+        $parser->parse('value = TestUnknownDsl`foobar`');
+    }
+
+    /**
+     * @test
+     */
+    public function parserThrowsExceptionIfAnDslExprssionIsNotClosed()
+    {
+        $parser = new Parser();
+        $this->expectException(Fusion\Exception::class);
+        $this->expectExceptionCode(1490714685);
+        $parser->parse('value = TestPassthroughDsl`foobar');
+    }
+}

--- a/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionFixture23.fusion
+++ b/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionFixture23.fusion
@@ -1,0 +1,10 @@
+//
+// Fusion Fixture 23
+//
+// Checks if path with an dsl is parsed handed over to the respective method
+
+somepath.dslValue1 = dsl1`example value`
+
+somepath.dslValue2 = dsl2`another
+multiline
+value`

--- a/Neos.Fusion/Tests/Unit/Core/Parser/PatternTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/PatternTest.php
@@ -344,6 +344,62 @@ class PatternTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function testSCAN_PATTERN_DSL_EXPRESSION_START()
+    {
+        $pattern = Parser::SCAN_PATTERN_DSL_EXPRESSION_START;
+        $this->assertEquals(preg_match($pattern, 'dsl`value`'), 1, 'The SCAN_PATTERN_DSL_EXPRESSION_START match a single line dsl-expression.');
+        $this->assertEquals(preg_match($pattern, 'dsl`line 1' . chr(10) . 'line 2' .chr(10) . 'line 3`'), 1, 'The SCAN_PATTERN_DSL_EXPRESSION_START match a multiline dsl-expression.');
+        $this->assertEquals(preg_match($pattern, 'true'), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match a boolean assignment.');
+        $this->assertEquals(preg_match($pattern, '1234'), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match a integer assignment.');
+        $this->assertEquals(preg_match($pattern, '\'string\''), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match a string assignment.');
+        $this->assertEquals(preg_match($pattern, '${Math.random()}'), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match an eel assignment.');
+        $this->assertEquals(preg_match($pattern, 'Neos.Fusion:Value'), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match an object assignment.');
+        $this->assertEquals(preg_match($pattern, 'Neos.Fusion:Value {'), 0, 'The SCAN_PATTERN_DSL_EXPRESSION_START does not match an object assignment.');
+    }
+
+    public function SPLIT_PATTERN_DSL_EXPRESSIONdataProvider()
+    {
+        return [
+            'singleLineDsl' => [
+                'expression' => 'testDsl`testDslExpression`',
+                'dslIdentifier' => 'testDsl',
+                '$dslCode' => 'testDslExpression'
+            ],
+            'multilineDsl' => [
+                'expression' => 'testDsl`line 1' . chr(10) . 'line 2' . chr(10) . 'line 3`',
+                'dslIdentifier' => 'testDsl',
+                '$dslCode' => 'line 1' . chr(10) . 'line 2' . chr(10) . 'line 3'
+            ],
+            'dslWithSpecialCharacters' => [
+                'expression' => 'testDsl`${}()[]@<>/123456789abdefg`',
+                'dslIdentifier' => 'testDsl',
+                '$dslCode' => '${}()[]@<>/123456789abdefg'
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider SPLIT_PATTERN_DSL_EXPRESSIONdataProvider
+     * @parameter $markdownMessage
+     * @parameter $renderedMessage
+     */
+    public function testSPLIT_PATTERN_DSL_EXPRESSION($expression, $dslIdentidier, $dslCode)
+    {
+        $pattern = Parser::SPLIT_PATTERN_DSL_EXPRESSION;
+        $expected = array(
+            0 => $expression,
+            'identifier' => $dslIdentidier,
+            1  => $dslIdentidier,
+            'code' => $dslCode,
+            2 => $dslCode
+        );
+        $this->assertRegexMatches($expression, $pattern, $expected, 'It did not match dsl-parts as expected.');
+    }
+
+    /**
      * Custom assertion for matching regexes
      *
      * @param $testString

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -905,6 +905,40 @@ class ParserTest extends UnitTestCase
     }
 
     /**
+     * Checks if dsl value is handed over to the invokeAndParseDsl method
+     *
+     * @test
+     */
+    public function parserInvokesFusionDslParsingIfADslPatternIsDetected()
+    {
+        $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->setMethods(array('invokeAndParseDsl'))->getMock();
+
+        $sourceCode = $this->readFusionFixture('ParserTestFusionFixture23');
+
+        $parser
+            ->expects($this->exactly(2))
+            ->method('invokeAndParseDsl')
+            ->withConsecutive(
+                ['dsl1', 'example value' ],
+                ['dsl2', 'another' . chr(10) . 'multiline' . chr(10) . 'value' ]
+            );
+
+        $parser->parse($sourceCode);
+    }
+
+    /**
+     * Checks unclosed dsl-expressions are
+     *
+     * @test
+     * @expectedException \Neos\Fusion\Exception
+     * @expectedExceptionCode 1490714685
+     */
+    public function parserThrowsFusionExceptionIfUnfinishedDslIsDetected()
+    {
+        $this->parser->parse('dslValue1 = dsl1`unclosed dsl expression');
+    }
+
+    /**
      * @param string $fixtureName File name of the Fusion fixture to be read (without .fusion)
      * @return string The content of the fixture
      */

--- a/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
@@ -524,6 +524,29 @@ To show the result of Fusion Expressions directly you can use the Neos.Fusion:De
 	}
 	# the value of this object is the formatted debug output of all keys given to the object
 
+
+Domain-specific languages in Fusion
+===================================
+
+Fusion allows the implementation of domain-specific sublanguages. Those DSLs can take a piece of code, that
+is optimized to express a specific class of problems, and return the equivalent fusion-code that is cached and executed
+by the Fusion-runtime afterwards.
+
+Fusion-DSLs use the syntax of tagged template literals from ES6 and can be used in all value assignments::
+
+	value = dslIdentifier`... the code that is passed to the dsl ...`
+
+If such a syntax-block is detected fusion will:
+
+* Lookup the key ``dslIdentifier`` in the Setting ``Neos.Fusion.dsl`` to find the matching dsl-implementation.
+* Instantiate the dsl-implementation class that was found registered.
+* Check that the dsl-implementation satisfies the interface ``\Neos\Fusion\Core\DslInterface``
+* Pass the code between the backticks to the dsl-implementation.
+* Finally parse the returned Fusion-code
+
+Fusion DSLs cannot extend the fusion-language and -runtime itself, they are meant to enable a more efficient syntax
+for specific problems.
+
 .. Important Fusion objects and patterns
 .. =========================================
 .. - page, template, content collection, menu, value (TODO ChristianM)

--- a/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -39,7 +39,7 @@ class ConfigurationValidationTest extends FlowConfigurationValidationTest
      *
      * @var array<string>
      */
-    protected $schemaPackageKeys = ['Neos.Flow', 'Neos.Neos', 'Neos.ContentRepository'];
+    protected $schemaPackageKeys = ['Neos.Flow', 'Neos.Neos', 'Neos.ContentRepository', 'Neos.Fusion'];
 
     /**
      * The packages that contain the configuration that is validated


### PR DESCRIPTION
DSLs are implemented for fusion-assignments using the tagged-template-string syntax of es6.
DSL-identifiers are configured in the configuration key `Neos.Fusion.dsl`. The configured objects must satisfy the `DslInterface` and return fusion code that is parsed by the fusion-parser afterwards.

```
value = dslExample`... the code that is passed to the dsl ...`
```
In addition this pr adds a schema for the fusion part of the Settings and integrates it into the automatic schema-validation.

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
