### PR TITLE
BUGFIX: Correct typo in plugin's Settings.yaml

### DIFF
--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -176,7 +176,7 @@ To automatically include the Root.fusion in Neos you have to add the following l
 
   Neos:
     Neos:
-      Fusion:
+      fusion:
         autoInclude:
           'Sarkosh.CdCollection': TRUE
 


### PR DESCRIPTION
**What I did**
- Changed  to  in Settings.yaml. It needs to be lower-case in order to work properly.