### PR TITLE
TASK: Enable translations for labels of the Site Management module

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
@@ -19,14 +19,14 @@
 						</div>
 					</div>
 					<div class="neos-control-group{f:validation.ifHasErrors(for: 'newSiteNodeName', then: ' neos-error')}">
-						<label class="neos-control-label" for="node-name">{neos:backend.translate(id: 'rootNodeName', value: 'Root node name')}</label>
+						<label class="neos-control-label" for="node-name">{neos:backend.translate(id: 'sites.rootNodeName', value: 'Root node name')}</label>
 						<div class="neos-controls">
 							<f:form.textfield name="newSiteNodeName" id="node-name" value="{site.nodeName}" additionalAttributes="{pattern: '^[a-z0-9\-]+$'}" class="neos-span12" required="true" />
 							<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'newSiteNodeName'}"/>
 						</div>
 					</div>
 					<div class="neos-control-group">
-						<label class="neos-control-label" for="asset-collection">{neos:backend.translate(id: 'state', value: 'Default asset collection')}</label>
+						<label class="neos-control-label" for="asset-collection">{neos:backend.translate(id: 'sites.defaultAssetCollection', value: 'Default asset collection')}</label>
 						<div class="neos-controls">
 							<f:form.select property="assetCollection" id="asset-collection" options="{assetCollections}" optionLabelField="title" prependOptionLabel="None" prependOptionValue="" class="neos-span12" />
 						</div>

--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -285,6 +285,54 @@
 			<trans-unit id="primary" xml:space="preserve">
 				<source>Primary</source>
 			</trans-unit>
+			<trans-unit id="package" xml:space="preserve">
+				<source>Package</source>
+			</trans-unit>
+			<trans-unit id="deactivated" xml:space="preserve">
+				<source>Deactivated</source>
+			</trans-unit>
+			<trans-unit id="unavailable" xml:space="preserve">
+				<source>Unavailable</source>
+			</trans-unit>
+			<trans-unit id="inactive" xml:space="preserve">
+				<source>Inactive</source>
+			</trans-unit>
+			<trans-unit id="clickToEdit" xml:space="preserve">
+				<source>Click to edit</source>
+			</trans-unit>
+			<trans-unit id="clickToDeactivate" xml:space="preserve">
+				<source>Click to deactivate</source>
+			</trans-unit>
+			<trans-unit id="clickToActivate" xml:space="preserve">
+				<source>Click to activate</source>
+			</trans-unit>
+			<trans-unit id="clickToDelete" xml:space="preserve">
+				<source>Click to delete</source>
+			</trans-unit>
+			<trans-unit id="clickToCreate" xml:space="preserve">
+				<source>Click to create new</source>
+			</trans-unit>
+			<trans-unit id="state" xml:space="preserve">
+				<source>Status</source>
+			</trans-unit>
+			<trans-unit id="active" xml:space="preserve">
+				<source>Active</source>
+			</trans-unit>
+			<trans-unit id="domains" xml:space="preserve">
+				<source>Domains</source>
+			</trans-unit>
+			<trans-unit id="domain" xml:space="preserve">
+				<source>Domain</source>
+			</trans-unit>
+			<trans-unit id="deleteConfirm" xml:space="preserve">
+				<source>Yes, delete it!</source>
+			</trans-unit>
+			<trans-unit id="packageKey" xml:space="preserve">
+				<source>Package Key</source>
+			</trans-unit>
+			<trans-unit id="description" xml:space="preserve">
+				<source>Description</source>
+			</trans-unit>
 
 			<!-- node types -->
 			<trans-unit id="nodeTypes.groups.general" xml:space="preserve">

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -2,17 +2,11 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 	<file original="" product-name="Neos.Neos" source-language="en" datatype="plaintext">
 		<body>
-			<trans-unit id="clickToEdit" xml:space="preserve">
-				<source>Click to edit</source>
-			</trans-unit>
-			<trans-unit id="clickToDelete" xml:space="preserve">
-				<source>Click to delete</source>
+			<trans-unit id="back" xml:space="preserve">
+				<source>Back</source>
 			</trans-unit>
 			<trans-unit id="cancel" xml:space="preserve">
 				<source>Cancel</source>
-			</trans-unit>
-			<trans-unit id="back" xml:space="preserve">
-				<source>Back</source>
 			</trans-unit>
 
 			<!-- Management -->
@@ -529,11 +523,87 @@
 			<trans-unit id="sites.description" xml:space="preserve">
 				<source>The Sites Management module provides you with an overview of all sites. You can edit, add and delete information about your sites, such as adding a new domain.</source>
 			</trans-unit>
+			<trans-unit id="sites.add" xml:space="preserve">
+				<source>Add new site</source>
+			</trans-unit>
 			<trans-unit id="sites.actions.newSite.label" xml:space="preserve">
 				<source>Create site</source>
 			</trans-unit>
 			<trans-unit id="sites.actions.newSite.title" xml:space="preserve">
 				<source>Create a new site</source>
+			</trans-unit>
+			<trans-unit id="sites.rootNodeName" xml:space="preserve">
+				<source>Root node name</source>
+			</trans-unit>
+			<trans-unit id="sites.domains" xml:space="preserve">
+				<source>Domains</source>
+			</trans-unit>
+			<trans-unit id="sites" xml:space="preserve">
+				<source>Site</source>
+			</trans-unit>
+			<trans-unit id="site.name" xml:space="preserve">
+				<source>Name</source>
+			</trans-unit>
+			<trans-unit id="sites.defaultAssetCollection" xml:space="preserve">
+				<source>Default asset collection</source>
+			</trans-unit>
+			<trans-unit id="sites.sitePackage" xml:space="preserve">
+				<source>Site package</source>
+			</trans-unit>
+			<trans-unit id="sites.delete" xml:space="preserve">
+				<source>Delete this site</source>
+			</trans-unit>
+			<trans-unit id="sites.deactivate" xml:space="preserve">
+				<source>Deactivate site</source>
+			</trans-unit>
+			<trans-unit id="sites.activate" xml:space="preserve">
+				<source>Activate site</source>
+			</trans-unit>
+			<trans-unit id="sites.confirmDeleteQuestion" xml:space="preserve">
+				<source>Do you really want to delete "{0}"? This action cannot be undone.</source>
+			</trans-unit>
+			<trans-unit id="sites.confirmDelete" xml:space="preserve">
+				<source>Yes, delete the site</source>
+			</trans-unit>
+			<trans-unit id="sites.import" xml:space="preserve">
+				<source>Import a site</source>
+			</trans-unit>
+			<trans-unit id="sites.select" xml:space="preserve">
+				<source>Select a site package</source>
+			</trans-unit>
+			<trans-unit id="sites.noPackackeInfo" xml:space="preserve">
+				<source>No site packages are available. Make sure you have an active site package.</source>
+			</trans-unit>
+			<trans-unit id="sites.createBlank" xml:space="preserve">
+				<source>Create a blank site</source>
+			</trans-unit>
+			<trans-unit id="sites.documentType" xml:space="preserve">
+				<source>Select a document nodeType</source>
+			</trans-unit>
+			<trans-unit id="sites.name" xml:space="preserve">
+				<source>Site name</source>
+			</trans-unit>
+			<trans-unit id="sites.createNode" xml:space="preserve">
+				<source>Create empty site</source>
+			</trans-unit>
+			<trans-unit id="sites.createPackage" xml:space="preserve">
+				<source>Create a new site package</source>
+			</trans-unit>
+			<trans-unit id="sites.validPackageKeyInfo" xml:space="preserve">
+				<source>VendorName.MyPackageKey</source>
+			</trans-unit>
+			<trans-unit id="sites.noNeosKickstarterInfo" xml:space="preserve">
+				<source>The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.</source>
+			</trans-unit>
+
+			<trans-unit id="domain.deleteConfirmQuestion" xml:space="preserve">
+				<source>Do you really want to delete "{0}"? This action cannot be undone.</source>
+			</trans-unit>
+			<trans-unit id="domain.new" xml:space="preserve">
+				<source>New domain</source>
+			</trans-unit>
+			<trans-unit id="domain.edit" xml:space="preserve">
+				<source>Edit domain</source>
 			</trans-unit>
 
 			<trans-unit id="configuration.label" xml:space="preserve">


### PR DESCRIPTION
**What I did**

- Add translation for labels with none in the XLIFF files to enable the translation to other languages
- Eliminated labels with duplicated IDs and different values
- Some simple sorting and cleanup of the XLIFF files

**How I did it**
- I took the labels of the templates and searched the XLIFF files for them
- I put the specific Site Management labels to `Modules.xlf`
- I put the generic labels to `Main.xlf`

**How to verify it**
- Login to the backend and go to the Site Management module
- Click through it and check whether there are corrupted labels
- The labels should look like before
