### PR TITLE
FEATURE: Make resize filter configurable to save resources

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -82,6 +82,12 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
     protected $allowUpScaling;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Media", path="image.defaultOptions.resizeFilter")
+     * @var string
+     */
+    protected $filter = ImagineImageInterface::FILTER_UNDEFINED;
+
+    /**
      * Sets maximumHeight
      *
      * @param integer $maximumHeight
@@ -286,7 +292,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
     public function applyToImage(ImagineImageInterface $image)
     {
         $ratioMode = $this->ratioMode ?: ImageInterface::RATIOMODE_INSET;
-        return $this->resize($image, $ratioMode);
+        return $this->resize($image, $ratioMode, $this->filter);
     }
 
     /**
@@ -445,25 +451,23 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
         $imageSize = $image->getSize();
         $requestedDimensions = $this->calculateDimensions($imageSize);
 
-        $resizedImage = $image->copy();
-        $resizedImage->usePalette($image->palette());
-        $resizedImage->strip();
+        $image->strip();
 
         $resizeDimensions = $requestedDimensions;
         if ($mode === ImageInterface::RATIOMODE_OUTBOUND) {
             $resizeDimensions = $this->calculateOutboundScalingDimensions($imageSize, $requestedDimensions);
         }
 
-        $resizedImage->resize($resizeDimensions, $filter);
+        $image->resize($resizeDimensions, $filter);
 
         if ($mode === ImageInterface::RATIOMODE_OUTBOUND) {
-            $resizedImage->crop(new Point(
+            $image->crop(new Point(
                 max(0, round(($resizeDimensions->getWidth() - $requestedDimensions->getWidth()) / 2)),
                 max(0, round(($resizeDimensions->getHeight() - $requestedDimensions->getHeight()) / 2))
             ), $requestedDimensions);
         }
 
-        return $resizedImage;
+        return $image;
     }
 
     /**

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -72,6 +72,7 @@ Neos:
         # Image quality, from 0 to 100
         quality: 90
         convertCMYKToRGB: true
+        resizeFilter: '%\Imagine\Image\ImageInterface::FILTER_UNDEFINED%'
 
     thumbnailGenerators:
 


### PR DESCRIPTION
The resize filter can have considerable impact on file size and
processing power needed to do the resize, it's therefore sensible
to give the user a choice in this.

Additionally removes copying the image as that is entirely unnecessary.