### PR TITLE
BUGFIX: Allow choice of filter for resizing images

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -82,6 +82,12 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
     protected $allowUpScaling;
 
     /**
+     * @Flow\InjectConfiguration(package="TYPO3.Media", path="image.defaultOptions.resizeFilter")
+     * @var string
+     */
+    protected $filter;
+
+    /**
      * Sets maximumHeight
      *
      * @param integer $maximumHeight
@@ -286,7 +292,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
     public function applyToImage(ImagineImageInterface $image)
     {
         $ratioMode = $this->ratioMode ?: ImageInterface::RATIOMODE_INSET;
-        return $this->resize($image, $ratioMode);
+        return $this->resize($image, $ratioMode, $this->filter);
     }
 
     /**
@@ -445,25 +451,23 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
         $imageSize = $image->getSize();
         $requestedDimensions = $this->calculateDimensions($imageSize);
 
-        $resizedImage = $image->copy();
-        $resizedImage->usePalette($image->palette());
-        $resizedImage->strip();
+        $image->strip();
 
         $resizeDimensions = $requestedDimensions;
         if ($mode === ImageInterface::RATIOMODE_OUTBOUND) {
             $resizeDimensions = $this->calculateOutboundScalingDimensions($imageSize, $requestedDimensions);
         }
 
-        $resizedImage->resize($resizeDimensions, $filter);
+        $image->resize($resizeDimensions, $filter);
 
         if ($mode === ImageInterface::RATIOMODE_OUTBOUND) {
-            $resizedImage->crop(new Point(
+            $image->crop(new Point(
                 max(0, round(($resizeDimensions->getWidth() - $requestedDimensions->getWidth()) / 2)),
                 max(0, round(($resizeDimensions->getHeight() - $requestedDimensions->getHeight()) / 2))
             ), $requestedDimensions);
         }
 
-        return $resizedImage;
+        return $image;
     }
 
     /**

--- a/TYPO3.Media/Configuration/Settings.yaml
+++ b/TYPO3.Media/Configuration/Settings.yaml
@@ -40,6 +40,12 @@ TYPO3:
         # Image quality, from 0 to 100
         'quality': 90
         convertCMYKToRGB: true
+        # defines the filter to use for resize operations.
+        # Note that the default GD driver only supports the FILTER_UNDEFINED.
+        # Check the \Imagine\Image\ImageInterface class for a reference of all filters.
+        # They roughly line up with ImageMagick filters, so read up on those to see differences.
+        # A very cheap filter with reasonable quality would be "FILTER_BOX", alternative is "FILTER_CATROM".
+        resizeFilter: '%\Imagine\Image\ImageInterface::FILTER_UNDEFINED%'
 
     thumbnailGenerators:
 


### PR DESCRIPTION
The resize filter can have considerable impact on file size and
processing power needed to do the resize, it's therefore sensible
to give the user a choice in this.

Additionally removes copying the image as that is entirely unnecessary
and impacts memory usage profoundly.