### PR TITLE
BUGFIX: Include configuration reference in TOC

### DIFF
--- a/TYPO3.Neos/Documentation/References/index.rst
+++ b/TYPO3.Neos/Documentation/References/index.rst
@@ -16,5 +16,5 @@ all Packages that are in a default (Demo Package) setup.
    Validators/index
    Signals/index
    CodingGuideLines/index
-   Configuration/index
+   Configuration/Configuration.rst
    NodeMigrations


### PR DESCRIPTION
The configuration reference was no longer included in the documentation TOC
at all, after a recent fix aimed at no longer including it twice.