### PR TITLE
BUGFIX: Fix upmerge mistake in ResizeImageAdjustment

### DIFF
--- a/Neos.ContentRepository/Migrations/Postgresql/Version20170328183557.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20170328183557.php
@@ -1,5 +1,5 @@
 <?php
-namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -82,7 +82,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
     protected $allowUpScaling;
 
     /**
-     * @Flow\InjectConfiguration(package="TYPO3.Media", path="image.defaultOptions.resizeFilter")
+     * @Flow\InjectConfiguration(package="Neos.Media", path="image.defaultOptions.resizeFilter")
      * @var string
      */
     protected $filter;


### PR DESCRIPTION
The wrong namespace/vendor name was pulled in from the 2.3 branch
during an upmerge.