### PR TITLE
BUGFIX: Asset should return same extension as attached resource

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Model/Asset.php
@@ -215,7 +215,7 @@ class Asset implements AssetInterface
      */
     public function getFileExtension()
     {
-        return MediaTypes::getFilenameExtensionFromMediaType($this->resource->getMediaType());
+        return $this->resource->getFileExtension();
     }
 
     /**


### PR DESCRIPTION
Using the resource media type to find an extension for an asset
is suboptimal because the asset knows the extension directly and
the media type -> extension conversion is ambiguous so you might
end up with a different extension than the resource has afterwards.
