### PR TITLE
TASK: Use generateRandomString() instead of uniqid()

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ImageService.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Service/ImageService.php
@@ -11,6 +11,7 @@ namespace TYPO3\Media\Domain\Service;
  * source code.
  */
 
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Media\Imagine\Box;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\Exception\InvalidConfigurationException;
@@ -101,7 +102,7 @@ class ImageService
         $resourceUri = $originalResource->createTemporaryLocalCopy();
 
         $resultingFileExtension = $originalResource->getFileExtension();
-        $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('ProcessedImage-') . '.' . $resultingFileExtension;
+        $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $resultingFileExtension;
 
         if (!file_exists($resourceUri)) {
             throw new ImageFileException(sprintf('An error occurred while transforming an image: the resource data of the original image does not exist (%s, %s).', $originalResource->getSha1(), $resourceUri), 1374848224);

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeNameGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeNameGenerator.php
@@ -12,6 +12,7 @@ namespace TYPO3\Neos\Service;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
@@ -55,7 +56,7 @@ class NodeNameGenerator
         if ($idealNodeName !== null) {
             $possibleNodeName = \TYPO3\TYPO3CR\Utility::renderValidNodeName($idealNodeName);
         } else {
-            $possibleNodeName = uniqid('node-');
+            $possibleNodeName = 'node-' . Algorithms::generateRandomString(13);
         }
 
         return $possibleNodeName;

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeTemplate.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeTemplate.php
@@ -12,6 +12,7 @@ namespace TYPO3\TYPO3CR\Domain\Model;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Flow\Validation\Validator\UuidValidator;
 
 /**
@@ -95,7 +96,7 @@ class NodeTemplate extends AbstractNodeData
             return $this->name;
         }
 
-        return uniqid('node');
+        return 'node-' . Algorithms::generateRandomString(13);
     }
 
     /**

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -14,6 +14,7 @@ namespace TYPO3\TypoScript\Core\Cache;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cache\CacheAwareInterface;
 use TYPO3\Flow\Security\Context;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\TypoScript\Exception;
 use Doctrine\ORM\Proxy\Proxy;
 
@@ -91,7 +92,7 @@ class ContentCache
 
     public function __construct()
     {
-        $this->randomCacheMarker = uniqid();
+        $this->randomCacheMarker = Algorithms::generateRandomString(13);
     }
 
     /**


### PR DESCRIPTION
This reduces the risk of collision on temporary names for nodes and
files, as well as cache markers.
