### PR TITLE
BUGFIX: No uppercase characters allowed in node names

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeNameGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/NodeNameGenerator.php
@@ -56,7 +56,7 @@ class NodeNameGenerator
         if ($idealNodeName !== null) {
             $possibleNodeName = \TYPO3\TYPO3CR\Utility::renderValidNodeName($idealNodeName);
         } else {
-            $possibleNodeName = 'node-' . Algorithms::generateRandomString(13);
+            $possibleNodeName = 'node-' . Algorithms::generateRandomString(13, 'abcdefghijklmnopqrstuvwxyz0123456789');
         }
 
         return $possibleNodeName;

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeTemplate.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeTemplate.php
@@ -96,7 +96,7 @@ class NodeTemplate extends AbstractNodeData
             return $this->name;
         }
 
-        return 'node-' . Algorithms::generateRandomString(13);
+        return 'node-' . Algorithms::generateRandomString(13, 'abcdefghijklmnopqrstuvwxyz0123456789');
     }
 
     /**


### PR DESCRIPTION
The changed generation of node names must avoid uppercase characters.

This is a followup to neos/neos-development-collection#1523