### PR TITLE
TASK: allow to require stable version of `flow-development-collection`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0+",
     "type": "neos-package-collection",
     "require": {
-        "neos/flow-development-collection": "3.3.x-dev",
+        "neos/flow-development-collection": "~3.3.0 || 3.3.x-dev",
         "php": ">=5.5.0",
         "typo3/flow": "~3.3.0",
         "typo3/imagine": "~2.0",


### PR DESCRIPTION
This relaxes the constraints in order to be able to run stable versions of our development collections.

This is useful when you want to say use beard in production, without having to use the -dev versions.
