### PR TITLE
BUGFIX: Fix code migrations to prevent unnecessary changes

### DIFF
--- a/TYPO3.Neos.NodeTypes/Migrations/Code/Version20130911165500.php
+++ b/TYPO3.Neos.NodeTypes/Migrations/Code/Version20130911165500.php
@@ -45,18 +45,47 @@ class Version20130911165500 extends AbstractMigration
             function (&$configuration) {
                 foreach ($configuration as &$nodeType) {
                     if (isset($nodeType['superTypes'])) {
-                        foreach ($nodeType['superTypes'] as &$superType) {
-                            $superType = str_replace('TYPO3.Neos:Page', 'TYPO3.Neos.NodeTypes:Page', $superType);
-                        }
+                        $this->replaceArrayKeysOrValues($nodeType['superTypes'], 'TYPO3.Neos:Page', 'TYPO3.Neos.NodeTypes:Page');
                     }
                     if (isset($nodeType['childNodes'])) {
-                        foreach ($nodeType['childNodes'] as &$type) {
-                            $type = str_replace('TYPO3.Neos:Page', 'TYPO3.Neos.NodeTypes:Page', $type);
-                        }
+                        $this->replaceArrayKeysOrValues($nodeType['childNodes'], 'TYPO3.Neos:Page', 'TYPO3.Neos.NodeTypes:Page');
                     }
                 }
             },
             true
         );
+    }
+
+    /**
+     * Iterates through the given $array and replaces $oldValue by $newValue
+     * If the array is associative it will replace the keys, otherwise the values
+     *
+     * Example:
+     * ['some', '<oldValue>'] => ['some', '<newValue>']
+     * ['some' => 'foo', '<oldValue>' => 'bar'] => ['some' => 'foo', '<newValue>' => 'bar']
+     *
+     * @param array $array
+     * @param string $oldValue
+     * @param string $newValue
+     * @return void
+     */
+    private function replaceArrayKeysOrValues(array &$array, $oldValue, $newValue)
+    {
+        if ($array === []) {
+            return;
+        }
+        $isAssoc = array_keys($array) !== range(0, count($array) - 1);
+
+        if ($isAssoc) {
+            $keys = array_keys($array);
+            $index = array_search($oldValue, $keys, true);
+            if ($index === false) {
+                return;
+            }
+            $keys[$index] = $newValue;
+            $array = array_combine($keys, $array);
+        } else {
+            $array = str_replace($oldValue, $newValue, $array);
+        }
     }
 }

--- a/TYPO3.TYPO3CR/Migrations/Code/Version20130523180140.php
+++ b/TYPO3.TYPO3CR/Migrations/Code/Version20130523180140.php
@@ -42,18 +42,47 @@ class Version20130523180140 extends AbstractMigration
             function (&$configuration) {
                 foreach ($configuration as &$nodeType) {
                     if (isset($nodeType['superTypes'])) {
-                        foreach ($nodeType['superTypes'] as &$superType) {
-                            $superType = str_replace('TYPO3.TYPO3CR:Folder', 'unstructured', $superType);
-                        }
+                        $this->replaceArrayKeysOrValues($nodeType['superTypes'], 'TYPO3.TYPO3CR:Folder', 'unstructured');
                     }
                     if (isset($nodeType['childNodes'])) {
-                        foreach ($nodeType['childNodes'] as &$type) {
-                            $type = str_replace('TYPO3.TYPO3CR:Folder', 'unstructured', $type);
-                        }
+                        $this->replaceArrayKeysOrValues($nodeType['childNodes'], 'TYPO3.TYPO3CR:Folder', 'unstructured');
                     }
                 }
             },
             true
         );
+    }
+
+    /**
+     * Iterates through the given $array and replaces $oldValue by $newValue
+     * If the array is associative it will replace the keys, otherwise the values
+     *
+     * Example:
+     * ['some', '<oldValue>'] => ['some', '<newValue>']
+     * ['some' => 'foo', '<oldValue>' => 'bar'] => ['some' => 'foo', '<newValue>' => 'bar']
+     *
+     * @param array $array
+     * @param string $oldValue
+     * @param string $newValue
+     * @return void
+     */
+    private function replaceArrayKeysOrValues(array &$array, $oldValue, $newValue)
+    {
+        if ($array === []) {
+            return;
+        }
+        $isAssoc = array_keys($array) !== range(0, count($array) - 1);
+
+        if ($isAssoc) {
+            $keys = array_keys($array);
+            $index = array_search($oldValue, $keys, true);
+            if ($index === false) {
+                return;
+            }
+            $keys[$index] = $newValue;
+            $array = array_combine($keys, $array);
+        } else {
+            $array = str_replace($oldValue, $newValue, $array);
+        }
     }
 }


### PR DESCRIPTION
This change adjusts two code migrations (in a backwards compatible manner)
so that they don't produce invalid YAML files.

Background:

The two migrations `TYPO3.TYPO3CR-130523180140` and `TYPO3.Neos.NodeTypes-201309111655`
both replace some "superType"/"childNode" NodeType settings.
In cases where those already use the suggested format `['<value>' => true]` this leads
to invalid results (`['<value>' => '1']`).
With `TYPO3.TYPO3CR-20150510103823` these invalid values are fixed again, but applying
all migrations lead to three unnecessary commits, possibly corrupting the configuration
and/or removing important comments.

Fixes: #1351