### PR TITLE
BUGFIX: Detect recursive prototype inheritance

### DIFF
--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -864,6 +864,7 @@ class Parser implements ParserInterface
      * Precalculate merged configuration for inherited prototypes.
      *
      * @return void
+     * @throws Fusion\Exception
      */
     protected function buildPrototypeHierarchy()
     {
@@ -877,6 +878,9 @@ class Parser implements ParserInterface
             while (isset($this->objectTree['__prototypes'][$currentPrototypeName]['__prototypeObjectName'])) {
                 $currentPrototypeName = $this->objectTree['__prototypes'][$currentPrototypeName]['__prototypeObjectName'];
                 array_unshift($prototypeInheritanceHierarchy, $currentPrototypeName);
+                if ($prototypeName === $currentPrototypeName) {
+                    throw new Fusion\Exception(sprintf('Recursive inheritance found for prototype "%s". Prototype chain: %s', $prototypeName, implode(' < ', array_reverse($prototypeInheritanceHierarchy))), 1492801503);
+                }
             }
 
             if (count($prototypeInheritanceHierarchy)) {

--- a/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture21.fusion
+++ b/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture21.fusion
@@ -1,0 +1,7 @@
+//
+// Fusion Fixture 21
+//
+// Checks if parser detects direct recursions
+
+prototype(Neos.Foo:Bar) < prototype(Neos.Foo:Bar) {
+}

--- a/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture22.fusion
+++ b/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture22.fusion
@@ -1,0 +1,10 @@
+//
+// Fusion Fixture 22
+//
+// Checks if parser detects indirect recursions
+
+prototype(Neos.Foo:Bar) < prototype(Neos.Foo:Baz) {
+}
+
+prototype(Neos.Foo:Baz) < prototype(Neos.Foo:Bar) {
+}

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -882,6 +882,16 @@ class ParserTest extends UnitTestCase
     }
 
     /**
+     * @test
+     * @expectedException \Neos\Fusion\Exception
+     */
+    public function parserDetectsIndirectRecursions()
+    {
+        $sourceCode = $this->readTypoScriptFixture('ParserTestTypoScriptFixture22');
+        $this->parser->parse($sourceCode);
+    }
+
+    /**
      * Checks if comments in comments are parsed correctly
      *
      * @test

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -872,6 +872,16 @@ class ParserTest extends UnitTestCase
     }
 
     /**
+     * @test
+     * @expectedException \Neos\Fusion\Exception
+     */
+    public function parserDetectsDirectRecursions()
+    {
+        $sourceCode = $this->readTypoScriptFixture('ParserTestTypoScriptFixture21');
+        $this->parser->parse($sourceCode);
+    }
+
+    /**
      * Checks if comments in comments are parsed correctly
      *
      * @test


### PR DESCRIPTION
This throws an exception if there is a direct or indirect prototype inheritance recursion.

Fix #1115