### PR TITLE
BUGFIX: Clean TypoScript of windows line-breaks

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
@@ -275,6 +275,7 @@ class Parser implements ParserInterface
         $this->initialize();
         $this->objectTree = $objectTreeUntilNow;
         $this->contextPathAndFilename = $contextPathAndFilename;
+        $sourceCode = str_replace("\r\n", "\n", $sourceCode);
         $this->currentSourceCodeLines = explode(chr(10), $sourceCode);
         while (($typoScriptLine = $this->getNextTypoScriptLine()) !== false) {
             $this->parseTypoScriptLine($typoScriptLine);


### PR DESCRIPTION
Multi-line EEL expressions fail if the TypoScript file had
Windows linebreaks as the explode on line feed leaves the
carriage return in every line which then stops the parser
from detecting the end of a multi-line EEL expression.
