### PR TITLE
BUGFIX: Context variable `site` is available in Plugin prototype

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Plugin.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Plugin.ts2
@@ -10,6 +10,7 @@ prototype(TYPO3.Neos:Plugin) < prototype(TYPO3.Neos:Content) {
 		context {
 			1 = 'node'
 			2 = 'documentNode'
+			3 = 'site'
 		}
 	}
 }


### PR DESCRIPTION
As plugins are uncached the prototype defines which context variables
will be available inside. As ``node``, ``documentNode`` and ``site`` are
defaults that apply everywhere else, the missing ``site`` variable
was added to the context for consistency.

Fixes: #841
