### PR TITLE
BUGFIX: Remove control characters from CR content

### DIFF
--- a/TYPO3.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
+++ b/TYPO3.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
@@ -8,10 +8,10 @@
       <language>en_US</language>
      </dimensions>
      <accessRoles __type="array"/>
-     <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</creationDateTime>
-     <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</lastModificationDateTime>
+     <creationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:09:49+01:00]]></creationDateTime>
+     <lastModificationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:09:49+01:00]]></lastModificationDateTime>
      <properties>
-      <title __type="string">example.org</title>
+      <title __type="string"><![CDATA[example.org]]></title>
      </properties>
     </variant>
     <node identifier="b2e1b29c-0b33-455a-862b-88bbd09e5310" nodeName="home">
@@ -20,11 +20,11 @@
        <language>en_US</language>
       </dimensions>
       <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</lastModificationDateTime>
+      <creationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:09:49+01:00]]></creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:09:49+01:00]]></lastModificationDateTime>
       <properties>
-       <title __type="string">&lt;h1&gt;Home&lt;/h1&gt;</title>
-       <uriPathSegment __type="string">home</uriPathSegment>
+       <title __type="string"><![CDATA[&lt;h1&gt;Home&lt;/h1&gt;]]></title>
+       <uriPathSegment __type="string"><![CDATA[home]]></uriPathSegment>
       </properties>
      </variant>
      <node identifier="94165d9e-1c0d-43ca-b172-7b867524f349" nodeName="protected">
@@ -33,14 +33,14 @@
         <language>en_US</language>
        </dimensions>
        <accessRoles __type="array">
-        <entry0 __type="string">TYPO3.Neos:Editor</entry0>
-        <entry1 __type="string">TYPO3.Neos:Administrator</entry1>
+        <entry0 __type="string"><![CDATA[TYPO3.Neos:Editor]]></entry0>
+        <entry1 __type="string"><![CDATA[TYPO3.Neos:Administrator]]></entry1>
        </accessRoles>
-       <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+01:00</creationDateTime>
-       <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+01:00</lastModificationDateTime>
+       <creationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:13:11+01:00]]></creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime"><![CDATA[2015-02-23T14:13:11+01:00]]></lastModificationDateTime>
        <properties>
-        <title __type="string">&lt;h1&gt;This node is protected&lt;/h1&gt;</title>
-        <uriPathSegment __type="string">protected</uriPathSegment>
+        <title __type="string"><![CDATA[&lt;h1&gt;This node is protected&lt;/h1&gt;]]></title>
+        <uriPathSegment __type="string"><![CDATA[protected]]></uriPathSegment>
        </properties>
       </variant>
      </node>

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
@@ -21,6 +21,7 @@ use TYPO3\TYPO3CR\Domain\Model\ContentObjectProxy;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Exception\NodeException;
+use TYPO3\TYPO3CR\Utility;
 
 /**
  * Some NodeData (persisted or transient)
@@ -177,7 +178,7 @@ abstract class AbstractNodeData
                 return;
             }
 
-            $this->properties[$propertyName] = $value;
+            $this->properties[$propertyName] = is_string($value) ? Utility::removeControlCharactersFrom($value) : $value;
 
             $this->addOrUpdate();
         } elseif (ObjectAccess::isPropertySettable($this->contentObjectProxy->getObject(), $propertyName)) {

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeExportService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/ImportExport/NodeExportService.php
@@ -22,6 +22,7 @@ use TYPO3\TYPO3CR\Domain\Model\NodeData;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Exception\ExportException;
+use TYPO3\TYPO3CR\Utility;
 
 /**
  * Service for exporting content repository nodes as an XML structure
@@ -394,7 +395,8 @@ class NodeExportService
                     if ($propertyValue instanceof \DateTimeInterface) {
                         $this->xmlWriter->writeAttribute('__classname', 'DateTime');
                     }
-                    $this->xmlWriter->text($this->propertyMapper->convert($propertyValue, 'string', $this->propertyMappingConfiguration));
+                    $text = $this->propertyMapper->convert($propertyValue, 'string', $this->propertyMappingConfiguration);
+                    $this->xmlWriter->writeCData(Utility::removeControlCharactersFrom($text));
                 }
             } catch (\Exception $exception) {
                 $this->xmlWriter->writeComment(sprintf('Could not convert property "%s" to string.', $propertyName));

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Utility.php
@@ -82,4 +82,16 @@ class Utility
 
         return substr($hex, 0, 8) . '-' . substr($hex, 8, 4) . '-' . substr($hex, 12, 4) . '-' . substr($hex, 16, 4) . '-' . substr($hex, 20, 12);
     }
+
+    /**
+     * Removes control characters from a string.
+     * Multibyte safe.
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function removeControlCharactersFrom($string)
+    {
+        return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $string);
+    }
 }

--- a/TYPO3.TYPO3CR/Tests/Unit/UtilityTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/UtilityTest.php
@@ -51,4 +51,16 @@ class UtilityTest extends UnitTestCase
     {
         $this->assertEquals($expectedNodeName, Utility::renderValidNodeName($source));
     }
+
+    /**
+     * @test
+     */
+    public function removeControlCharactersCleansStringButLeavesItIntact()
+    {
+        $simpleStringContent = 'Soemthing with control characters and other stuff #ä#+´´)(=?:_;ÄÖ*+ü ';
+        $originalString = chr(9) . $simpleStringContent . chr(4) . chr(30) . chr(10);
+
+        $result = Utility::removeControlCharactersFrom($originalString);
+        $this->assertEquals(chr(9) . $simpleStringContent  . chr(10), $result);
+    }
 }


### PR DESCRIPTION
To prevent various bugs with content caches and import/export of content
we clean string properties of control characters and do the same on any
exported text as well.

Note that "printable" control characters like newlines and tabs are
preserved.

The drawback would be that you cannot store control characters in the
content repository anymore, but that should be fine.

Fixes: #846
