### PR TITLE
BUGFIX: Clarified doc block for LiveViewHelper

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Rendering/LiveViewHelper.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/ViewHelpers/Rendering/LiveViewHelper.php
@@ -16,6 +16,8 @@ use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 
 /**
  * ViewHelper to find out if Neos is rendering the live website.
+ * Make sure you either give a node from the current context to
+ * the ViewHelper or have "node" set as template variable at least.
  *
  * = Examples =
  *


### PR DESCRIPTION
If the ``LiveViewHelper`` doesn't get a node as argument and neither
there is a node in the template variables it will always return true.
The adjusted doc block clarifies that you need either.

Fixes: #1416
