### PR TITLE
BUGFIX: Avoid null being used in trimExplode()

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1055,7 +1055,7 @@ class NodeDataRepository extends Repository
      *
      * Both are numeric arrays with the respective node types that are included or excluded.
      *
-     * @param string $nodeTypeFilter
+     * @param string|null $nodeTypeFilter
      * @return array
      */
     protected function getNodeTypeFilterConstraintsForDql($nodeTypeFilter = '')

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -482,7 +482,7 @@ class NodeDataRepository extends Repository
         $foundNodes = $this->getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $removedNodes, $recursive);
 
         $childNodeDepth = NodePaths::getPathDepth($parentPath) + 1;
-        $constraints = $nodeTypeFilter !== '' ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : array();
+        $constraints = ($nodeTypeFilter !== '' && $nodeTypeFilter !== null) ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : [];
         /** @var $addedNode NodeData */
         foreach ($this->addedNodes as $addedNode) {
             if (

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -482,7 +482,7 @@ class NodeDataRepository extends Repository
         $foundNodes = $this->getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $removedNodes, $recursive);
 
         $childNodeDepth = NodePaths::getPathDepth($parentPath) + 1;
-        $constraints = ($nodeTypeFilter !== '' && $nodeTypeFilter !== null) ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : [];
+        $constraints = $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter);
         /** @var $addedNode NodeData */
         foreach ($this->addedNodes as $addedNode) {
             if (
@@ -1058,8 +1058,9 @@ class NodeDataRepository extends Repository
      * @param string $nodeTypeFilter
      * @return array
      */
-    protected function getNodeTypeFilterConstraintsForDql($nodeTypeFilter)
+    protected function getNodeTypeFilterConstraintsForDql($nodeTypeFilter = '')
     {
+        $nodeTypeFilter = empty($nodeTypeFilter) ? '' : $nodeTypeFilter;
         $constraints = [
             'excludeNodeTypes' => [],
             'includeNodeTypes' => []


### PR DESCRIPTION
Fixes #1552
