### PR TITLE
BUGFIX: Avoid ``InvalidArgumentException`` if ``$nodeTypeFilter`` is ``null``

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -482,7 +482,7 @@ class NodeDataRepository extends Repository
         $foundNodes = $this->getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $removedNodes, $recursive);
 
         $childNodeDepth = NodePaths::getPathDepth($parentPath) + 1;
-        $constraints = $nodeTypeFilter !== '' ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : array();
+        $constraints = ($nodeTypeFilter !== '' && $nodeTypeFilter !== null) ? $this->getNodeTypeFilterConstraintsForDql($nodeTypeFilter) : array();
         /** @var $addedNode NodeData */
         foreach ($this->addedNodes as $addedNode) {
             if (


### PR DESCRIPTION
Since https://github.com/neos/flow-development-collection/pull/946 got merged, an exception is thrown, if the ``nodeTypeFilter`` is not an (empty) string, but ``null``. Before the scalar type hints, the ``trimExplode`` method (incorrectly) accepted ``null`` instead of a string to perform the ``explode`` function (which seemed to have failed silently) see: https://github.com/neos/flow-development-collection/blob/119d21b7deb7684b322f5cf3e00565ea35d243a1/Neos.Utility.Arrays/Classes/Arrays.php#L47. This happens for example when finding nodes by its parent and (optionally) by its node type. A simple 
```
  teaser = ContentCollection {
    nodePath = 'teaser'
  }
```
would cause the exception to be thrown.
