### PR TITLE
BUGFIX: Asset list should be correctly converted for UI

### DIFF
--- a/Neos.Neos/Classes/Service/Mapping/NodePropertyConverterService.php
+++ b/Neos.Neos/Classes/Service/Mapping/NodePropertyConverterService.php
@@ -123,6 +123,8 @@ class NodePropertyConverterService
     }
 
     /**
+     * Convert the given value to a simple type or an array of simple types.
+     *
      * @param mixed $propertyValue
      * @param string $dataType
      * @return mixed
@@ -141,13 +143,14 @@ class NodePropertyConverterService
         if (!TypeHandling::isSimpleType($parsedType['type'])) {
             $conversionTargetType = 'array';
         }
+        // Technically the "string" hardcoded here is irrelevant as the configured type converter wins, but it cannot be the "elementType"
+        // because if the source is of the type $elementType then the PropertyMapper skips the type converter.
         if ($parsedType['type'] === 'array' && $parsedType['elementType'] !== null) {
-            $conversionTargetType .= '<' . $parsedType['elementType'] . '>';
+            $conversionTargetType .= '<' . (TypeHandling::isSimpleType($parsedType['elementType']) ? $parsedType['elementType'] : 'string') . '>';
         }
 
         $propertyMappingConfiguration = $this->createConfiguration($dataType);
         $convertedValue = $this->propertyMapper->convert($propertyValue, $conversionTargetType, $propertyMappingConfiguration);
-
         if ($convertedValue instanceof \Neos\Error\Messages\Error) {
             throw new PropertyException($convertedValue->getMessage(), $convertedValue->getCode());
         }

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -128,6 +128,9 @@ Neos:
           loadingDepth: 4
 
       inspector:
+        # If you use other datatypes you should configure them in the same way. Specifically if
+        # you use arrays of objects make sure to configure a object-to-simpletype converter for the
+        # object type (class, interface) and additionally the TypedArrayConverter for the "array<Of\ObjectType>".
         dataTypes:
           string:
             editor: Neos.Neos/Inspector/Editors/TextFieldEditor
@@ -187,6 +190,7 @@ Neos:
             typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
             editor: Neos.Neos/Inspector/Editors/AssetEditor
           array<Neos\Media\Domain\Model\Asset>:
+            typeConverter: Neos\Flow\Property\TypeConverter\TypedArrayConverter
             editor: Neos.Neos/Inspector/Editors/AssetEditor
             editorOptions:
               multiple: true


### PR DESCRIPTION
Since PR #1472 was merged the asset list was not correctly converted anymore,
this had two reasons, first the wrong converter was used for the array
itself (``ArrayTypeConverter`` vs. ``TypedArrayConverter``). This is
corrected by setting the correct converter for the respective node property
data type in the settings.

Note that user code should follow the added comment in settings on how to
configure custom types, especially array of objects. It is important to define
the ``TypedArrayConverter`` for the array data type.

Additionally the ``PropertyMapper`` prevent conversion of the inner objects
as with the change the targetType suddenly matched the expected type and so
the PropertyMapper just skipped those objects. That was an unexpected side
effect as the expectation was, that the configured type converter is used no
matter what. By setting the inner target type to the dummy value "string" the
``PropertyMapper`` will proceed with the configured ``TypeConverter``.

Fixes: #1568
Fixes: #1565
