### PR TITLE
BUGFIX: Detect asset://so-me-uu-id links in node properties

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -1641,8 +1641,13 @@ class NodeDataRepository extends Repository
 
         foreach ($relationMap as $relatedObjectType => $relatedIdentifiers) {
             foreach ($relatedIdentifiers as $relatedIdentifier) {
+                // entity references like "__identifier": "so-me-uu-id"
                 $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :entity' . md5($relatedIdentifier) . ' )';
                 $parameters['entity' . md5($relatedIdentifier)] = '%"__identifier": "' . strtolower($relatedIdentifier) . '"%';
+
+                // asset references in text like "asset://so-me-uu-id"
+                $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :asset' . md5($relatedIdentifier) . ' )';
+                $parameters['asset' . md5($relatedIdentifier)] = '%asset:\\\\\\/\\\\\\/' . strtolower($relatedIdentifier) . '%';
             }
         }
 

--- a/TYPO3.TYPO3CR/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
+++ b/TYPO3.TYPO3CR/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
@@ -110,6 +110,31 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         $this->assertCount(1, $result);
     }
 
+    /**
+     * @test
+     */
+    public function findNodesByRelatedEntitiesFindsExistingNodeWithMatchingAssetLink()
+    {
+        $rootNode = $this->context->getRootNode();
+        $newNode = $rootNode->createNode('test', $this->nodeTypeManager->getNodeType('TYPO3.TYPO3CR.Testing:Text'));
+
+        $testImage = new Image();
+        $this->persistenceManager->add($testImage);
+        $testImageIdentifier = $this->persistenceManager->getIdentifierByObject($testImage);
+
+        $newNode->setProperty('text', sprintf('a linked <a href="asset://%s">image</a>', $testImageIdentifier));
+
+        $this->persistenceManager->persistAll();
+
+        $relationMap = [
+            Fixtures\Image::class => [$testImageIdentifier]
+        ];
+
+        $result = $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);
+
+        $this->assertCount(1, $result);
+    }
+
     protected function setUpNodes()
     {
         $rootNode = $this->context->getRootNode();


### PR DESCRIPTION
To detect links to assets as "usage" in the media management, the
search in the NodeDataRepository is amended as needed.

Fixes #1575
