### PR TITLE
TASK: Correct kickstarter package name in documentation

### DIFF
--- a/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CreatingAPlugin.rst
@@ -25,7 +25,7 @@ If you do not have the Kickstart package installed, you must do this now:
 .. code-block:: bash
 
   cd /your/htdocs/Neos
-  php /path/to/composer.phar require typo3/kickstart \*
+  php /path/to/composer.phar require neos/kickstarter \*
 
 Now create a package with a model, so we have something to show in the plugin:
 


### PR DESCRIPTION
The kickstart package name is outdated in documentation (Creating a plugin: http://neos.readthedocs.io/en/stable/ExtendingNeos/CreatingAPlugin.html). I replaced it with the current and right one (https://packagist.org/packages/neos/kickstarter).