### PR TITLE
TASK: Removed `typo3` in class naming for alignment in Neos.NodeTypes:Image

### DIFF
--- a/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
@@ -44,6 +44,7 @@ prototype(Neos.NodeTypes:Image) {
 	width = null
 	maximumHeight = 2560
 	height = null
+  # "typo3-alignment-" deprecated since 3.3, removed in 4.0
 	imageClassName = ${q(node).property('alignment') ? ('typo3-neos-alignment-' + q(node).property('alignment') + ' neos-alignment-' + q(node).property('alignment')) : ''}
 	allowCropping = false
 	allowUpScaling = false

--- a/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
@@ -44,7 +44,7 @@ prototype(Neos.NodeTypes:Image) {
 	width = null
 	maximumHeight = 2560
 	height = null
-	imageClassName = ${q(node).property('alignment') ? ('typo3-neos-alignment-' + q(node).property('alignment')) : ''}
+	imageClassName = ${q(node).property('alignment') ? ('neos-alignment-' + q(node).property('alignment')) : ''}
 	allowCropping = false
 	allowUpScaling = false
 	link.@process.convertUris = Neos.Neos:ConvertUris {

--- a/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
@@ -44,7 +44,7 @@ prototype(Neos.NodeTypes:Image) {
 	width = null
 	maximumHeight = 2560
 	height = null
-	imageClassName = ${q(node).property('alignment') ? ('neos-alignment-' + q(node).property('alignment')) : ''}
+	imageClassName = ${q(node).property('alignment') ? ('typo3-neos-alignment-' + q(node).property('alignment') + ' neos-alignment-' + q(node).property('alignment')) : ''}
 	allowCropping = false
 	allowUpScaling = false
 	link.@process.convertUris = Neos.Neos:ConvertUris {


### PR DESCRIPTION
Just a "beauty correction".

- Removed "typo3" in class naming for alignment in Neos.NodeTypes:Image