### PR TITLE
BUGFIX: Don't search for closest document if node is null

### DIFF
--- a/Neos.Neos/Classes/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/Neos.Neos/Classes/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -101,11 +101,13 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
             }
             $site = $context->getCurrentSite();
             $node = $this->nodeFactory->createFromNodeData($relatedNodeData, $context);
-            $flowQuery = new FlowQuery([$node]);
-            /** @var \Neos\ContentRepository\Domain\Model\NodeInterface $documentNode */
-            $documentNode = $flowQuery->closest('[instanceof Neos.Neos:Document]')->get(0);
+            if ($node !== null) {
+                $flowQuery = new FlowQuery([$node]);
+                /** @var \Neos\ContentRepository\Domain\Model\NodeInterface $documentNode */
+                $documentNode = $flowQuery->closest('[instanceof Neos.Neos:Document]')->get(0);
 
-            $relatedNodes[] = new AssetUsageInNodeProperties($asset, $site, $documentNode, $node, $accessible);
+                $relatedNodes[] = new AssetUsageInNodeProperties($asset, $site, $documentNode, $node, $accessible);
+            }
         }
 
         $this->firstlevelCache[$assetIdentifier] = $relatedNodes;


### PR DESCRIPTION
**What I did**
In some cases the editing of a media package asset breaks because the "find usage" feature can't find the corresponding node. 

**How I did it**
I added an if condition to determine if the corresponding node is accessible