### PR TITLE
TASK: Keep asset adjustments if asset size did not change

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -265,7 +265,7 @@ class AssetService
 
                 if (method_exists($variant, 'getAdjustments')) {
                     foreach ($variant->getAdjustments() as $adjustment) {
-                        if (method_exists($adjustment, 'refit')) {
+                        if (method_exists($adjustment, 'refit') && $this->imageService->getImageSize($originalAssetResource) != $this->imageService->getImageSize($resource)) {
                             $adjustment->refit($asset);
                         }
                     }

--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -265,7 +265,7 @@ class AssetService
 
                 if (method_exists($variant, 'getAdjustments')) {
                     foreach ($variant->getAdjustments() as $adjustment) {
-                        if (method_exists($adjustment, 'refit') && $this->imageService->getImageSize($originalAssetResource) != $this->imageService->getImageSize($resource)) {
+                        if (method_exists($adjustment, 'refit') && $this->imageService->getImageSize($originalAssetResource) !== $this->imageService->getImageSize($resource)) {
                             $adjustment->refit($asset);
                         }
                     }


### PR DESCRIPTION
This adds a condition to compare the size of the old and new asset in order to verify
the size did not change. In this case the method `refit()` will not be executed to keep
asset adjustments. This is very handy if you upload/replace a image with enriched
meta data (eg. IPTC or Exif.)