### PR TITLE
DOCS: Document prototypes ContentElementEditable and ContentElementWrapping

### DIFF
--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -862,8 +862,7 @@ Example::
 
 		# The following line must not be removed as it adds required meta data
 		# to edit content elements in the backend
-		@process.contentElementWrapping {
-			expression = TYPO3.Neos:ContentElementWrapping
+		@process.contentElementWrapping = TYPO3.Neos:ContentElementWrapping {
 			@position = 'end'
 		}
 	}

--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -848,12 +848,12 @@ Example::
 ContentElementWrapping
 ----------------------
 
-Processor to augment the rendered html-code with node-metadata that allows the backend to select the node and to show the
-node properties in the inspector. This is especially useful if your content-prototype is not derived from ``TYPO3.Neos:Content``.
+Processor to augment rendered HTML code with node metadata that allows the Neos UI to select the node and show
+node properties in the inspector. This is especially useful if your renderer prototype is not derived from ``TYPO3.Neos:Content``.
 
-The processor expects beeing applied on html-code with a single container tag that is augmented.
+The processor expects being applied on HTML code with a single container tag that is augmented.
 
-:node: (Node) The node of the content element. Optional, will be resolved from the Fusion context by default.
+:node: (Node) The node of the content element. Optional, will use the Fusion context variable ``node`` by default.
 
 Example::
 
@@ -873,16 +873,16 @@ Example::
 ContentElementEditable
 ----------------------
 
-Processor to augment an html-tag with inline editing-metadata to make a rendered representation of a property editable.
+Processor to augment an HTML tag with metadata for inline editing to make a rendered representation of a property editable.
 
-The processor expects beeing applied to an html-tag with the content of the edited property.
+The processor expects beeing applied to an HTML tag with the content of the edited property.
 
-:node: (Node) The node of the content element. Optional, will be resolved from the Fusion context by default.
-:property: (string) The name of the property that shall be changed
+:node: (Node) The node of the content element. Optional, will use the Fusion context variable ``node`` by default.
+:property: (string) Node property that should be editable
 
 Example::
 
-	renderer = Neos.Fusion:Tag {
+	renderer = TYPO3.TypoScript:Tag {
 		tagName = 'h1'
 		content = ${q(node).property('title')}
 		@process.contentElementEditableWrapping = TYPO3.Neos:ContentElementEditable {

--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -842,3 +842,51 @@ Example::
 	prototype(My.Site:Special.Type) {
 		title.@process.convertUris = TYPO3.Neos:ConvertUris
 	}
+
+.. _TYPO3_Neos__ContentElementWrapping:
+
+ContentElementWrapping
+----------------------
+
+Processor to augment the rendered html-code with node-metadata that allows the backend to select the node and to show the
+node properties in the inspector. This is especially useful if your content-prototype is not derived from ``TYPO3.Neos:Content``.
+
+The processor expects beeing applied on html-code with a single container tag that is augmented.
+
+:node: (Node) The node of the content element. Optional, will be resolved from the Fusion context by default.
+
+Example::
+
+	prototype(Vendor.Site:ExampleContent) {
+		value = '<div>Example</div>'
+
+		# The following line must not be removed as it adds required meta data
+		# to edit content elements in the backend
+		@process.contentElementWrapping {
+			expression = TYPO3.Neos:ContentElementWrapping
+			@position = 'end'
+		}
+	}
+
+
+.. _TYPO3_Neos__ContentElementEditable:
+
+ContentElementEditable
+----------------------
+
+Processor to augment an html-tag with inline editing-metadata to make a rendered representation of a property editable.
+
+The processor expects beeing applied to an html-tag with the content of the edited property.
+
+:node: (Node) The node of the content element. Optional, will be resolved from the Fusion context by default.
+:property: (string) The name of the property that shall be changed
+
+Example::
+
+	renderer = Neos.Fusion:Tag {
+		tagName = 'h1'
+		content = ${q(node).property('title')}
+		@process.contentElementEditableWrapping = TYPO3.Neos:ContentElementEditable {
+			property = 'title'
+		}
+	}


### PR DESCRIPTION
The fusion-prototypes `TYPO3.Neos:ContentElementEditable` and  `TYPO3.Neos:ContentElementWrapping`
are not documented.