### PR TITLE
BUGFIX: Reset broken properties to array

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/AbstractNodeData.php
@@ -135,6 +135,23 @@ abstract class AbstractNodeData
     }
 
     /**
+     * Make sure the properties are always an array.
+     *
+     * If the JSON in the DB is corrupted, decoding it can fail, leading to
+     * a null value. This may lead to errors later, when the value is used with
+     * functions that expect an array.
+     *
+     * @return void
+     * @ORM\PostLoad
+     */
+    public function ensurePropertiesIsNeverNull()
+    {
+        if (!is_array($this->properties)) {
+            $this->properties = [];
+        }
+    }
+
+    /**
      * Sets the specified property.
      * If the node has a content object attached, the property will be set there
      * if it is settable.


### PR DESCRIPTION
If the content of the `properties` property cannot be decoded from JSON
correctly, it will be `null`. This leads to errors when any operation is done
that expects it to always be an array.

This change adds a PostLoad Doctrine lifecycle method to reset `properties`
to an empty array if it is `null` after reconstitution.

Fixes issue #1580
