### PR TITLE
BUGFIX: Nodes are inaccessible after base workspace switch

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -132,6 +132,7 @@ class Package extends BasePackage
 
         $dispatcher->connect(Workspace::class, 'beforeNodePublishing', TYPO3CRIntegrationService::class, 'beforeNodePublishing');
         $dispatcher->connect(Workspace::class, 'afterNodePublishing', TYPO3CRIntegrationService::class, 'afterNodePublishing');
+        $dispatcher->connect(Workspace::class, 'baseWorkspaceChanged', 'TYPO3\Neos\Routing\Cache\RouteCacheFlusher', 'registerBaseWorkspaceChange');
 
         $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', TYPO3CRIntegrationService::class, 'updateEventsAfterPublish');
         $dispatcher->connect(NodeDataRepository::class, 'repositoryObjectsPersisted', TYPO3CRIntegrationService::class, 'updateEventsAfterPublish');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
@@ -14,6 +14,7 @@ namespace TYPO3\Neos\Routing\Cache;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Routing\RouterCachingService;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\TYPO3CR\Domain\Model\Workspace;
 
 /**
  * This service flushes Route caches triggered by node changes.
@@ -49,6 +50,23 @@ class RouteCacheFlusher
             return;
         }
         $this->tagsToFlush[] = $node->getIdentifier();
+    }
+
+    /**
+     * Schedules flushing of the all routing cache entries of the workspace whose base workspace has changed.
+     * In most cases $workspace will be a user's personal workspace. Flushing the respective cache entries guards
+     * against mismatches for nodes which exist in the old and the new base workspace but have different node
+     * identifiers and the same URI path (segment).
+     *
+     * @param Workspace $workspace
+     * @param Workspace|null $oldBaseWorkspace
+     * @param Workspace|null $newBaseWorkspace
+     */
+    public function registerBaseWorkspaceChange(Workspace $workspace, Workspace $oldBaseWorkspace = null, Workspace $newBaseWorkspace = null)
+    {
+        if (!in_array($workspace->getName(), $this->tagsToFlush)) {
+            $this->tagsToFlush[] = $workspace->getName();
+        }
     }
 
     /**

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Routing/Cache/RouteCacheFlusher.php
@@ -61,6 +61,7 @@ class RouteCacheFlusher
      * @param Workspace $workspace
      * @param Workspace|null $oldBaseWorkspace
      * @param Workspace|null $newBaseWorkspace
+     * @return void
      */
     public function registerBaseWorkspaceChange(Workspace $workspace, Workspace $oldBaseWorkspace = null, Workspace $newBaseWorkspace = null)
     {


### PR DESCRIPTION
This change fixes a problem with the routing cache which results in
inaccessible document nodes for cases where nodes with different
identifiers but the same URI path exist in separate workspaces.

Fixes #1602