### PR TITLE
BUGFIX: render asset changes correctly in workspaces overview

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -23,6 +23,7 @@ use TYPO3\Flow\Property\PropertyMappingConfigurationBuilder;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Flow\Security\Context;
 use TYPO3\Media\Domain\Model\AssetInterface;
+use TYPO3\Media\Domain\Model\ImageInterface;
 use TYPO3\Neos\Controller\Module\AbstractModuleController;
 use TYPO3\Neos\Domain\Model\User;
 use TYPO3\Neos\Domain\Repository\SiteRepository;
@@ -583,6 +584,13 @@ class WorkspacesController extends AbstractModuleController
                         'diff' => $diffArray
                     ];
                 }
+            } elseif ($originalPropertyValue instanceof ImageInterface || $changedPropertyValue instanceof ImageInterface) {
+                $contentChanges[$propertyName] = [
+                    'type' => 'image',
+                    'propertyLabel' => $this->getPropertyLabel($propertyName, $changedNode),
+                    'original' => $originalPropertyValue,
+                    'changed' => $changedPropertyValue
+                ];
             } elseif ($originalPropertyValue instanceof AssetInterface || $changedPropertyValue instanceof AssetInterface) {
                 $contentChanges[$propertyName] = [
                     'type' => 'asset',

--- a/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/TYPO3.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -44,7 +44,7 @@
                             </f:for>
                         </table>
                     </f:if>
-                    <f:if condition="{contentChanges.type} == 'asset'">
+                    <f:if condition="{contentChanges.type} == 'image'">
                         <table>
                             <tr>
                                 <td>
@@ -59,6 +59,22 @@
                                 </td>
                             </tr>
                         </table>
+                    </f:if>
+                    <f:if condition="{contentChanges.type} == 'asset'">
+                        <table>
+                            <tr>
+                                <td>
+                                    <f:if condition="{contentChanges.original}">
+                                        <del><a href="{f:uri.resource(resource: contentChanges.original.resource)}">{contentChanges.original.resource.filename}</a></del>
+                                    </f:if>
+                                </td>
+                                <td>
+                                    <f:if condition="{contentChanges.changed}">
+                                        <ins><a href="{f:uri.resource(resource: contentChanges.changed.resource)}">{contentChanges.changed.resource.filename}</a></ins>
+                                    </f:if>
+                              </td>
+                          </tr>
+                       </table>
                     </f:if>
                     <f:if condition="{contentChanges.type} == 'datetime'">
                         <table>

--- a/TYPO3.Neos/Resources/Private/Styles/Modules/Management/_Workspaces.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Modules/Management/_Workspaces.scss
@@ -174,12 +174,12 @@
 		}
 	}
 
-	ins {
+	ins, ins a {
 		color: $green;
 		text-decoration: none;
 	}
 
-	del {
+	del, del a {
 		color: $red;
 		text-decoration: none;
 	}


### PR DESCRIPTION
This change fixes asset rendering in the workspace overview.

Fixes #1592.
