### PR TITLE
BUGFIX: Publish moved nodes in nested workspaces

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -500,39 +500,10 @@ class Workspace
             }
 
             $shadowNodeData = $this->nodeDataRepository->findOneByMovedTo($nodeDataVariant);
-//            if ($shadowNodeData === null && $this->areWorkspacesOnTheSameWorkspaceBranch($targetWorkspace, $nodeDataVariant->getWorkspace())) {
             if ($shadowNodeData === null) {
                 $nodeDataVariant->setPath($targetPath);
             }
         }
-    }
-
-    /**
-     * @param Workspace $workspaceA
-     * @param Workspace $workspaceB
-     * @return bool
-     */
-    protected function areWorkspacesOnTheSameWorkspaceBranch(Workspace $workspaceA, Workspace $workspaceB)
-    {
-        $workspaceNamesBetweenWorkspaceAAndFirstLevelWorkspace = $this->getBaseWorkspaceNamesUntilFirstLevelWorkspace($workspaceA);
-        $workspaceNamesBetweenWorkspaceBAndFirstLevelWorkspace = $this->getBaseWorkspaceNamesUntilFirstLevelWorkspace($workspaceB);
-        return array_intersect($workspaceNamesBetweenWorkspaceAAndFirstLevelWorkspace, $workspaceNamesBetweenWorkspaceBAndFirstLevelWorkspace) !== [];
-    }
-
-    /**
-     *
-     *
-     * @param Workspace $workspace
-     * @return array
-     */
-    protected function getBaseWorkspaceNamesUntilFirstLevelWorkspace(Workspace $workspace)
-    {
-        $workspaceNames = [];
-        while ($workspace->getBaseWorkspace() !== null ) {
-            $workspaceNames[] = $workspace->getName();
-            $workspace = $workspace->getBaseWorkspace();
-        }
-        return $workspaceNames;
     }
 
     /**

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -617,6 +617,7 @@ class Workspace
             return;
         }
 
+        // From now on $sourceShadowNodeData is published to the target workspace:
         $sourceShadowNodeData->setMovedTo($targetNodeData);
         $sourceShadowNodeData->setWorkspace($targetWorkspace);
 
@@ -632,8 +633,10 @@ class Workspace
 
         // Check if a shadow node which has the same path, workspace and dimension values like the shadow node data we just created already exists (in the target workspace).
         // If it does, we re-use the existing node and make sure that all properties etc. are taken from the node which is being published.
-        $existingShadowNodeDataInTargetWorkspace = $this->nodeDataRepository->findOneByPath($sourceShadowNodeData->getPath(), $sourceShadowNodeData->getWorkspace(), $sourceShadowNodeData->getDimensionValues(), true);
-        if ($existingShadowNodeDataInTargetWorkspace !== null) {
+        $existingShadowNodeDataInTargetWorkspace = $this->nodeDataRepository->findOneByPath($sourceShadowNodeData->getPath(), $targetWorkspace, $sourceShadowNodeData->getDimensionValues(), true);
+
+        // findOneByPath() might return a node from a different workspace then the $targetWorkspace we specified, so we need to check that, too:
+        if ($existingShadowNodeDataInTargetWorkspace !== null && $existingShadowNodeDataInTargetWorkspace->getWorkspace() === $targetWorkspace) {
             $existingShadowNodeDataInTargetWorkspace->similarize($sourceShadowNodeData);
             $existingShadowNodeDataInTargetWorkspace->setMovedTo($sourceShadowNodeData->getMovedTo());
             $existingShadowNodeDataInTargetWorkspace->setRemoved($sourceShadowNodeData->isRemoved());

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -473,7 +473,9 @@ class Workspace
     {
         $sourceNodeData = $sourceNode->getNodeData();
         if ($sourceNodeData->getParentPath() !== $targetNodeData->getParentPath()) {
-            $this->moveTargetNodeDataToNewPosition($targetNodeData, $sourceNode->getPath());
+            // When $targetNodeData is moved, the NodeData::move() operation may transform it to a shadow node.
+            // moveTargetNodeDataToNewPosition() will return the correct (non-shadow) node in any case.
+            $targetNodeData = $this->moveTargetNodeDataToNewPosition($targetNodeData, $sourceNode->getPath());
         }
 
         $this->adjustShadowNodeDataForNodePublishing($sourceNodeData, $targetNodeData->getWorkspace(), $targetNodeData);
@@ -532,15 +534,16 @@ class Workspace
      *
      * @param NodeData $targetNodeData The (publish-) target node data to be moved
      * @param string $destinationPath The destination path of the move
+     * @return NodeData Either the same object like $targetNodeData, or, if $targetNodeData was transformed into a shadow node, the new target node (see move())
      */
     protected function moveTargetNodeDataToNewPosition(NodeData $targetNodeData, $destinationPath)
     {
         if ($targetNodeData->getWorkspace()->getBaseWorkspace() === null) {
             $targetNodeData->setPath($destinationPath);
-            return;
+            return $targetNodeData;
         }
 
-        $targetNodeData->move($destinationPath, $targetNodeData->getWorkspace());
+        return $targetNodeData->move($destinationPath, $targetNodeData->getWorkspace());
     }
 
     /**

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -635,7 +635,7 @@ class Workspace
         // If it does, we re-use the existing node and make sure that all properties etc. are taken from the node which is being published.
         $existingShadowNodeDataInTargetWorkspace = $this->nodeDataRepository->findOneByPath($sourceShadowNodeData->getPath(), $targetWorkspace, $sourceShadowNodeData->getDimensionValues(), true);
 
-        // findOneByPath() might return a node from a different workspace then the $targetWorkspace we specified, so we need to check that, too:
+        // findOneByPath() might return a node from a different workspace than the $targetWorkspace we specified, so we need to check that, too:
         if ($existingShadowNodeDataInTargetWorkspace !== null && $existingShadowNodeDataInTargetWorkspace->getWorkspace() === $targetWorkspace) {
             $existingShadowNodeDataInTargetWorkspace->similarize($sourceShadowNodeData);
             $existingShadowNodeDataInTargetWorkspace->setMovedTo($sourceShadowNodeData->getMovedTo());

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -1238,7 +1238,7 @@ class NodeDataRepository extends Repository
      */
     protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes, array $workspaces, array $dimensions)
     {
-        $foundNodes = [];
+        $reducedNodes = [];
 
         $minimalDimensionPositionsByIdentifier = [];
         foreach ($nodes as $node) {
@@ -1283,12 +1283,12 @@ class NodeDataRepository extends Repository
             $identifier = $node->getIdentifier();
             // Yes, it seems to work comparing arrays that way!
             if (!isset($minimalDimensionPositionsByIdentifier[$identifier]) || $dimensionPositions < $minimalDimensionPositionsByIdentifier[$identifier]) {
-                $foundNodes[$identifier] = $node;
+                $reducedNodes[$identifier] = $node;
                 $minimalDimensionPositionsByIdentifier[$identifier] = $dimensionPositions;
             }
         }
 
-        return $foundNodes;
+        return $reducedNodes;
     }
 
     /**

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -126,6 +126,28 @@ trait NodeOperationsTrait
     }
 
     /**
+     * @Given /^I have the following workspaces:$/
+     */
+    public function iHaveTheFollowingWorkspaces($table)
+    {
+        if ($this->isolated === true) {
+            $this->callStepInSubProcess(__METHOD__, sprintf(' %s %s', escapeshellarg('TYPO3\Flow\Tests\Functional\Command\TableNode'), escapeshellarg(json_encode($table->getHash()))), true);
+        } else {
+            $rows = $table->getHash();
+            $workspaceRepository = $this->getObjectManager()->get('TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository');
+            foreach ($rows as $row) {
+                $name = $row['Name'];
+                $baseWorkspaceName = $row['Base Workspace'];
+
+                $baseWorkspace = $workspaceRepository->findOneByName($baseWorkspaceName);
+                $workspace = new Workspace($name, $baseWorkspace);
+                $workspaceRepository->add($workspace);
+                $this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->persistAll();
+            }
+        }
+    }
+
+    /**
      * @Given /^I have the following content dimensions:$/
      */
     public function iHaveTheFollowingContentDimensions($table)

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
@@ -17,10 +17,14 @@ Feature: Multi layered workspaces
       | staging    | live           |
       | campaign   | staging        |
       | user-admin | campaign       |
+      | hotfix     | live           |
+      | user-john  | hotfix         |
 
   # See https://github.com/neos/neos-development-collection/issues/1608
   @fixtures
   Scenario: Move node in nested workspace which has been modified earlier
+
+    # First change the title of a page and publish it to "campaign":
 
     When I get a node by path "/sites/neos/foundation" with the following context:
       | Workspace  |
@@ -33,16 +37,162 @@ Feature: Multi layered workspaces
     Then I should have one node
     And the node property "title" should be "Foundation (changed)"
 
+    # Then move that same page and also publish that to "campaign":
+
     When I get a node by path "/sites/neos/foundation" with the following context:
       | Workspace  |
       | user-admin |
     And I move the node into the node with path "/sites/neos/about"
     And I publish the workspace "user-admin"
     And I get a node by path "/sites/neos/about/foundation" with the following context:
-      | Workspace  |
-      | campaign |
+      | Workspace |
+      | campaign  |
     Then the node property "title" should be "Foundation (changed)"
     When I get a node by path "/sites/neos/foundation" with the following context:
-      | Workspace  |
-      | campaign |
+      | Workspace |
+      | campaign  |
     Then I should have 0 nodes
+
+    # Then publish the changes (move + title change) from "campaign" to "staging"
+    # and check that shadow nodes are cleaned up correctly in "campaign":
+
+    When I publish the workspace "campaign"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | staging   |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | staging   |
+    Then I should have 0 nodes
+    And the unpublished node count in workspace "campaign" should be 0
+
+    When I publish the workspace "staging"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | live      |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | live      |
+    Then I should have 0 nodes
+    And the unpublished node count in workspace "staging" should be 0
+
+  @fixtures
+  Scenario: Move node in nested workspace which has been modified earlier and has a corresponding change in a separate workspace branch
+
+    # Explanation:
+    #
+    # One user moves and modifies a page and publishes that to "hotfix", which is based on "live". Another user moves
+    # and modifies the same page, but moves it to a different position, and publishes that to "campaign".
+    #
+    # Test then makes sure that publishing the changes subsequently from campaign to staging and then to live does
+    # not affect the node or shadow node in "hotfix".
+
+    # First change the title of a page and publish it to "hotfix":
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | user-john |
+    And I set the node property "title" to "Foundation (hotfix)"
+    And I publish the workspace "user-john"
+    And I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | hotfix    |
+    Then I should have one node
+    And the node property "title" should be "Foundation (hotfix)"
+
+    # Then move that same page and also publish that to "hotfix":
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | user-john |
+    And I move the node into the node with path "/sites/neos/service"
+    And I publish the workspace "user-john"
+    And I get a node by path "/sites/neos/service/foundation" with the following context:
+      | Workspace |
+      | hotfix    |
+    Then the node property "title" should be "Foundation (hotfix)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | hotfix    |
+    Then I should have 0 nodes
+
+    # Now the same in "campaign": First change the title of a page and publish it to "campaign":
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I set the node property "title" to "Foundation (changed)"
+    And I publish the workspace "user-admin"
+    And I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | campaign  |
+    Then I should have one node
+    And the node property "title" should be "Foundation (changed)"
+
+    # Then move that same page and also publish that to "campaign":
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I move the node into the node with path "/sites/neos/about"
+    And I publish the workspace "user-admin"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | campaign  |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | campaign  |
+    Then I should have 0 nodes
+
+    # Then publish the changes (move + title change) from "campaign" to "staging" and check that shadow nodes
+    # are cleaned up correctly in "campaign" and nodes are untouched in "hotfix":
+
+    When I publish the workspace "campaign"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | staging   |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | staging   |
+    Then I should have 0 nodes
+    And the unpublished node count in workspace "campaign" should be 0
+
+    When I get a node by path "/sites/neos/service/foundation" with the following context:
+      | Workspace |
+      | hotfix    |
+    Then the node property "title" should be "Foundation (hotfix)"
+
+    # Now publish "staging" to "live" and check again if "hotfix" is unchanged:
+
+    When I publish the workspace "staging"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | live   |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | live   |
+    Then I should have 0 nodes
+    And the unpublished node count in workspace "staging" should be 0
+
+    When I get a node by path "/sites/neos/service/foundation" with the following context:
+      | Workspace |
+      | hotfix    |
+    Then the node property "title" should be "Foundation (hotfix)"
+
+    # Finally publish "hotifx" to "live"! The page should now be moved again and show the right title:
+
+    When I publish the workspace "hotfix"
+    And I get a node by path "/sites/neos/service/foundation" with the following context:
+      | Workspace |
+      | live   |
+    Then the node property "title" should be "Foundation (hotfix)"
+    When I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | live   |
+    Then I should have 0 nodes
+    And the unpublished node count in workspace "hotfix" should be 0

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
@@ -1,0 +1,48 @@
+Feature: Multi layered workspaces
+  In order to publish nodes across nested workspaces
+  As an API user of the content repository
+  I need support to publish and move nodes and child nodes considering nested workspaces
+
+  Background:
+    Given I am authenticated with role "TYPO3.Neos:Administrator"
+    And I have the following nodes:
+      | Identifier                           | Path                   | Node Type                  | Properties              | Workspace |
+      | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites                 | unstructured               |                         | live      |
+      | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/neos            | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"}       | live      |
+      | 68ca0dcd-2afb-ef0e-1106-a5301e65b8a0 | /sites/neos/foundation | TYPO3.TYPO3CR.Testing:Page | {"title": "Foundation"} | live      |
+      | 52540602-b417-11e3-9358-14109fd7a2dd | /sites/neos/service    | TYPO3.TYPO3CR.Testing:Page | {"title": "Service"}    | live      |
+      | dc48851c-f653-ebd5-4d35-3feac69a3e09 | /sites/neos/about      | TYPO3.TYPO3CR.Testing:Page | {"title": "About"}      | live      |
+    And I have the following workspaces:
+      | Name       | Base Workspace |
+      | staging    | live           |
+      | campaign   | staging        |
+      | user-admin | campaign       |
+
+  # See https://github.com/neos/neos-development-collection/issues/1608
+  @fixtures
+  Scenario: Move node in nested workspace which has been modified earlier
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I set the node property "title" to "Foundation (changed)"
+    And I publish the workspace "user-admin"
+    And I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | campaign  |
+    Then I should have one node
+    And the node property "title" should be "Foundation (changed)"
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I move the node into the node with path "/sites/neos/about"
+    And I publish the workspace "user-admin"
+    And I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace  |
+      | campaign |
+    Then the node property "title" should be "Foundation (changed)"
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace  |
+      | campaign |
+    Then I should have 0 nodes


### PR DESCRIPTION
This change contains a fix and additional Behat tests which solves an issue with moving and publishing nodes in a nested workspace scenario which can lead to data corruption in the content repository.

Resolves #1608 