### PR TITLE
BUGFIX: Behat tests fail with fresh checkout

### DIFF
--- a/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
@@ -10,6 +10,7 @@ Feature: Publish user workspace
       | Identifier                           | Path                 | Node Type                 | Properties        | Workspace |
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites               | unstructured              |                   | live      |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/example       | TYPO3.Neos.NodeTypes:Page | {"title": "Home"} | live      |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Publish a new ContentCollection with Content

--- a/TYPO3.Neos/Tests/Behavior/Features/EventLog/TYPO3CR/AddingNodes.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/EventLog/TYPO3CR/AddingNodes.feature
@@ -8,6 +8,7 @@ Feature: Adding Nodes
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites         | unstructured               |                   | live      |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | live      |
     And I have an empty history
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Add a new document node to live workspace

--- a/TYPO3.Neos/Tests/Behavior/Features/EventLog/TYPO3CR/EditingNodes.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/EventLog/TYPO3CR/EditingNodes.feature
@@ -10,6 +10,7 @@ Feature: Editing Nodes
       | 49f324f2-6a65-11e4-a901-7831c1d118bc | /sites/typo3cr/main/headline | TYPO3.TYPO3CR.Testing:Headline | {"title": "Welcome"}            | live      |
       | be87d1dc-6a65-11e4-884b-7831c1d118bc | /sites/typo3cr/main/text     | TYPO3.TYPO3CR.Testing:Text     | {"text": "... to this website"} | live      |
     And I have an empty history
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Change a Document node property in the live workspace (e.g. like an API)

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/PublishUserWorkspace.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/PublishUserWorkspace.feature
@@ -8,6 +8,7 @@ Feature: Publish user workspace
       | Identifier                           | Path                 | Node Type                  | Properties        | Workspace |
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites               | unstructured               |                   | live      |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/typo3cr       | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | live      |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Publish a new ContentCollection with Content

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/RemoveNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/RemoveNode.feature
@@ -10,6 +10,7 @@ Feature: Remove node
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/typo3cr               | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"}    |
       | 68ca0dcd-2afb-ef0e-1106-a5301e65b8a0 | /sites/typo3cr/company       | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"} |
       | 52540602-b417-11e3-9358-14109fd7a2dd | /sites/typo3cr/company/about | TYPO3.TYPO3CR.Testing:Page | {"title": "About"}   |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Remove a node in user workspace and publish removes the node itself

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Constraints/ChildNodeConstraints.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Constraints/ChildNodeConstraints.feature
@@ -69,6 +69,7 @@ Feature: ChildNode Constraints
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites              | unstructured                            |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/typo3cr      | TYPO3.TYPO3CR.Testing:Page              |
       | 52540602-b417-11e3-9358-14109fd7a2dd | /sites/typo3cr/main | TYPO3.TYPO3CR.Testing:ContentCollection |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Allow node types for direct child nodes

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/CopyNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/CopyNodeWithDimensions.feature
@@ -15,7 +15,7 @@ Feature: Copy node with dimension support
       | 864b6a8c-6442-11e4-8791-14109fd7a2dd | /sites/typo3cr/company/main/two-col/column0/text0 | TYPO3.TYPO3CR.Testing:Text      | {"text": "The Company"}    | live      | en       |
       | 0c1a50e9-3db5-4c57-a5c7-6cc0b7649ee7 | /sites/typo3cr/about-us                           | TYPO3.TYPO3CR.Testing:Page      | {"title": "About Us"}      | live      | en       |
       | 1c063cf4-65ca-11e4-b79a-14109fd7a2dd | /sites/typo3cr/about-us/main/text0                | TYPO3.TYPO3CR.Testing:Text      | {"text": "Infos about us"} | live      | en       |
-
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Copying a non-aggregate node creates a node variant in the other dimension if the node does not exist in the target dimension.

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNode.feature
@@ -11,6 +11,7 @@ Feature: Move node
       | 68ca0dcd-2afb-ef0e-1106-a5301e65b8a0 | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"} | live      |
       | 52540602-b417-11e3-9358-14109fd7a2dd | /sites/typo3cr/service | TYPO3.TYPO3CR.Testing:Page | {"title": "Service"} | live      |
       | dc48851c-f653-ebd5-4d35-3feac69a3e09 | /sites/typo3cr/about   | TYPO3.TYPO3CR.Testing:Page | {"title": "About"}   | live      |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Move a node (into) in user workspace and get by path

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/MoveNodeWithDimensions.feature
@@ -13,6 +13,7 @@ Feature: Move node with dimension support
       | 8952d7b2-64d1-11e4-9fe2-14109fd7a2dd | /sites/typo3cr         | TYPO3.TYPO3CR.Testing:Page | {"title": "Startseite"}       | live      | de       |
       | 8ed74376-64d1-11e4-b98b-14109fd7a2dd | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Die Firma"}        | live      | de       |
       | 9315622e-64d1-11e4-a28c-14109fd7a2dd | /sites/typo3cr/service | TYPO3.TYPO3CR.Testing:Page | {"title": "Dienstleistungen"} | live      | de       |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Moving an aggregate node (Document) in user workspace should move across all dimensions; making sure the live workspace is unaffected

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/RenameNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/RenameNode.feature
@@ -12,6 +12,7 @@ Feature: Rename node
       | bdbc9add-800b-6613-8a86-263858cc7964 | /sites/typo3cr/service/request  | TYPO3.TYPO3CR.Testing:Page | {"title": "Service Request"} | live      |
       | c41d35bf-27e5-5645-a290-6a8b35c5935a | /sites/typo3cr/company          | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"}         | live      |
       | 23ebd69e-4e0e-27e6-a41a-42dd14df615f | /sites/typo3cr/company/about-us | TYPO3.TYPO3CR.Testing:Page | {"title": "About us"}        | live      |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Rename a non-materialized node

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/RenameNodeWithDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Crazy/RenameNodeWithDimensions.feature
@@ -13,6 +13,7 @@ Feature: Rename node with dimension support
       | c41d35bf-27e5-5645-a290-6a8b35c5935a | /sites/typo3cr/company          | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"}         | live      | en       |
       | c41d35bf-27e5-5645-a290-6a8b35c5935a | /sites/typo3cr/company          | TYPO3.TYPO3CR.Testing:Page | {"title": "Unternehmen"}     | live      | de       |
       | 4f19cb3c-6148-11e4-a977-14109fd7a2dd | /sites/typo3cr/contact          | TYPO3.TYPO3CR.Testing:Page | {"title": "Kontakt"}         | live      | de       |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Rename a node to a name conflicting with an existing node

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/EmptyDimensionValues.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/EmptyDimensionValues.feature
@@ -13,6 +13,7 @@ Feature: Empty dimension values act as a fallback
       # Intentionally the /sites node should not have any dimension value assigned!
       | 0befa678-79ad-11e5-b465-14109fd7a2dd | /sites         | unstructured               |                   |                     |                            |                     |                            |
       | 17046dc8-79ad-11e5-9fef-14109fd7a2dd | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | en_US               | en_US                      | specialist          | specialist                 |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Node variant with empty dimension values is found

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/FindSiteNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/FindSiteNode.feature
@@ -34,6 +34,7 @@ Feature: Find site node in non-default content dimension context
       | 0d80f01c-1234-4b73-9c0f-d1ec6f4592ed | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine FR FR"}  | fr                  | fr                         | fr                 | fr                        |
       | 46c505c2-fb5f-46f5-aba1-37fe17a1a000 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine ES INT"} | es                  | es                         | int                | int                       |
       | ebd4bef1-5f51-4348-9d31-f221cc8cc1d7 | /sites/wwwexamplecom/shop/coffeemachine | TYPO3.TYPO3CR.Testing:Page | {"title": "Coffee Machine IT INT"} | it                  | it                         | int                | int                       |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Retrieve site node from a node which is connected to the site node through a node with the same dimension values

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LanguageDimension.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LanguageDimension.feature
@@ -8,6 +8,7 @@ Feature: Multiple languages as content dimension
       | Path           | Node Type                  | Properties        |
       | /sites         | unstructured               |                   |
       | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Assign multiple values to language content dimension for a node variant

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LocalizationInWorkspaces.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LocalizationInWorkspaces.feature
@@ -8,6 +8,7 @@ Feature: Localization in workspaces
       | Path           | Node Type                  | Properties        | Language |
       | /sites         | unstructured               |                   | mul_ZZ   |
       | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | mul_ZZ   |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Translate existing node in user workspace, get by path

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LocalizedStructure.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/LocalizedStructure.feature
@@ -12,6 +12,7 @@ Feature: Localized structure
       | /sites/typo3cr         | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"}    | mul_ZZ   |
       | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"} | mul_ZZ   |
       | /sites/typo3cr/service | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"} | mul_ZZ   |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: The same node can be fetched using different node paths in different languages

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/MatchingMostSpecificLocale.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/MatchingMostSpecificLocale.feature
@@ -8,6 +8,7 @@ Feature: Matching most specific language
       | Path           | Node Type                  | Properties        | Language |
       | /sites         | unstructured               |                   | mul_ZZ   |
       | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} | mul_ZZ   |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: One document node and specific languages

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/MultipleDimensions.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/MultipleDimensions.feature
@@ -12,6 +12,7 @@ Feature: Multiple languages as content dimension
       | Path           | Node Type                  | Properties        |
       | /sites         | unstructured               |                   |
       | /sites/typo3cr | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"} |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Get a node from multiple mixed content dimensions

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/TranslateExistingNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/TranslateExistingNode.feature
@@ -9,6 +9,7 @@ Feature: Translate existing node
       | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites                 | unstructured               |                      | mul_ZZ   | live      |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/typo3cr         | TYPO3.TYPO3CR.Testing:Page | {"title": "Home"}    | mul_ZZ   | live      |
       | 68ca0dcd-2afb-ef0e-1106-a5301e65b8a0 | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Company"} | en_ZZ    | live      |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: An existing node can be translated to a new language by adopting it from a different context

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/Variants.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Localization/Variants.feature
@@ -12,6 +12,7 @@ Feature: Node variants
       | 8ed74376-64d1-11e4-b98b-14109fd7a2dd | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Unternehmen"} | live      | de       |
       | 8ed74376-64d1-11e4-b98b-14109fd7a2dd | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Firma"}       | live      | de_CH    |
       | 8ed74376-64d1-11e4-b98b-14109fd7a2dd | /sites/typo3cr/company | TYPO3.TYPO3CR.Testing:Page | {"title": "Entreprise"}  | live      | fr       |
+    And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Get other node variants of an aggregate node


### PR DESCRIPTION
This change fixes an issue with failing Behat tests caused by
missing isolation between tests.

When certain tests were run in a specific order, they might fail
with an access denied error because no user is authenticated.

Fixes #1613