### PR TITLE
BUGFIX: Avoid orphaned content nodes when calling publishNode()

### DIFF
--- a/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
+++ b/TYPO3.Neos/Tests/Behavior/Features/Content/PublishUserWorkspace.feature
@@ -7,18 +7,17 @@ Feature: Publish user workspace
 
   Background:
     Given I have the following nodes:
-      | Identifier                           | Path                 | Node Type                 | Properties        | Workspace |
-      | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites               | unstructured              |                   | live      |
-      | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/example       | TYPO3.Neos.NodeTypes:Page | {"title": "Home"} | live      |
+      | Identifier                           | Path           | Node Type                 | Properties        | Workspace |
+      | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites         | unstructured              |                   | live      |
+      | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/example | TYPO3.Neos.NodeTypes:Page | {"title": "Home"} | live      |
     And I am authenticated with role "TYPO3.Neos:Editor"
 
   @fixtures
   Scenario: Publish a new ContentCollection with Content
-    Given I am authenticated with role "TYPO3.Neos:Editor"
-    When I create the following nodes:
-      | Path                                     | Node Type                      | Properties              | Workspace |
-      | /sites/example/main/twocol               | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
-      | /sites/example/main/twocol/column0/text  | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+    Given I create the following nodes:
+      | Path                                    | Node Type                      | Properties              | Workspace |
+      | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     And I publish the workspace "user-demo"
     And I get a node by path "/sites/example/main/twocol/column0/text" with the following context:
       | Workspace |
@@ -27,21 +26,19 @@ Feature: Publish user workspace
 
   @fixtures
   Scenario: Unpublished nodes returns the correct count before publish
-    Given I am authenticated with role "TYPO3.Neos:Editor"
-    And I create the following nodes:
-      | Path                                     | Node Type                      | Properties              | Workspace |
-      | /sites/example/main/twocol               | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
-      | /sites/example/main/twocol/column0/text  | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+    Given I create the following nodes:
+      | Path                                    | Node Type                      | Properties              | Workspace |
+      | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     # We expect 4, the 2 column element with 2 columns (3) and the text element (1)
     Then I expect to have 4 unpublished nodes for the following context:
       | Workspace |
       | user-demo |
 
   @fixtures
-  Scenario: Unpublished nodes returns the correct count after publish
-    Given I am authenticated with role "TYPO3.Neos:Editor"
-    And I create the following nodes:
-      | Path                                     | Node Type                      | Properties              | Workspace |
+  Scenario: Unpublished nodes returns the correct count after publishing the whole workspace
+    Given I create the following nodes:
+      | Path                                    | Node Type                      | Properties              | Workspace |
       | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
       | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
     And I publish the workspace "user-demo"
@@ -50,7 +47,31 @@ Feature: Publish user workspace
       | user-demo |
 
   @fixtures
-  Scenario: Unpublished nodes will return an empty array for the live workspace
+  Scenario: Unpublished nodes returns the correct count after publishing a document node
+    Given I create the following nodes:
+      | Path                                    | Node Type                      | Properties              | Workspace |
+      | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+    And I get a node by path "/sites/example" with the following context:
+      | Workspace |
+      | user-demo |
+    And I set the node property "title" to "Home sweet home"
+    And I publish the node
     Then I expect to have 0 unpublished nodes for the following context:
       | Workspace |
-      | live      |
+      | user-demo |
+
+  @fixtures
+  Scenario: Unpublished nodes returns the correct count after discarding a document node
+    Given I create the following nodes:
+      | Path                                    | Node Type                      | Properties              | Workspace |
+      | /sites/example/main/twocol              | TYPO3.Neos.NodeTypes:TwoColumn | {}                      | user-demo |
+      | /sites/example/main/twocol/column0/text | TYPO3.Neos.NodeTypes:Text      | {"text": "Hello world"} | user-demo |
+    And I get a node by path "/sites/example" with the following context:
+      | Workspace |
+      | user-demo |
+    And I set the node property "title" to "Home sweet home"
+    And I discard the node
+    Then I expect to have 0 unpublished nodes for the following context:
+      | Workspace |
+      | user-demo |

--- a/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/TYPO3.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -14,8 +14,6 @@ namespace TYPO3\Neos\Tests\Unit\Service;
 use TYPO3\Flow\Persistence\QueryResultInterface;
 use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Neos\Domain\Model\Site;
-use TYPO3\Neos\Domain\Repository\DomainRepository;
-use TYPO3\Neos\Domain\Repository\SiteRepository;
 use TYPO3\Neos\Service\PublishingService;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
 use TYPO3\TYPO3CR\Domain\Model\NodeData;
@@ -98,7 +96,7 @@ class PublishingServiceTest extends UnitTestCase
 
         $this->mockContextFactory = $this->getMockBuilder(ContextFactoryInterface::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->publishingService, 'contextFactory', $this->mockContextFactory);
-        
+
         $this->mockBaseWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $this->mockBaseWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
         $this->mockBaseWorkspace->expects($this->any())->method('getBaseWorkspace')->will($this->returnValue(null));
@@ -250,13 +248,14 @@ class PublishingServiceTest extends UnitTestCase
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
+        $mockChildNode->expects($this->any())->method('getChildNodes')->with('!TYPO3.Neos:Document')->will($this->returnValue(array()));
 
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNodeType->expects($this->atLeastOnce())->method('isOfType')->with('TYPO3.Neos:Document')->will($this->returnValue(true));
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
-        $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('TYPO3.Neos:ContentCollection')->will($this->returnValue(array($mockChildNode)));
+        $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('!TYPO3.Neos:Document')->will($this->returnValue(array($mockChildNode)));
 
         $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
@@ -272,13 +271,14 @@ class PublishingServiceTest extends UnitTestCase
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
+        $mockChildNode->expects($this->any())->method('getChildNodes')->with('!TYPO3.Neos:Document')->will($this->returnValue(array()));
 
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(array('hasConfiguration', 'isOfType'))->getMock();
         $mockNodeType->expects($this->atLeastOnce())->method('hasConfiguration')->with('childNodes')->will($this->returnValue(true));
         $mockNode->expects($this->atLeastOnce())->method('getNodeType')->will($this->returnValue($mockNodeType));
 
         $mockNode->expects($this->atLeastOnce())->method('getWorkspace')->will($this->returnValue($this->mockWorkspace));
-        $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('TYPO3.Neos:ContentCollection')->will($this->returnValue(array($mockChildNode)));
+        $mockNode->expects($this->atLeastOnce())->method('getChildNodes')->with('!TYPO3.Neos:Document')->will($this->returnValue(array($mockChildNode)));
 
         $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -350,7 +350,7 @@ trait NodeOperationsTrait
     /**
      * @When /^I publish the node$/
      */
-    public function iPublishNodeToWorkspaceWithTheFollowingContext()
+    public function iPublishTheNode()
     {
         if ($this->isolated === true) {
             $this->callStepInSubProcess(__METHOD__);
@@ -376,10 +376,7 @@ trait NodeOperationsTrait
             $sourceContext = $this->getContextForProperties(array('Workspace' => $sourceWorkspaceName));
             $sourceWorkspace = $sourceContext->getWorkspace();
 
-            $liveContext = $this->getContextForProperties(array('Workspace' => 'live'));
-            $liveWorkspace = $liveContext->getWorkspace();
-
-            $sourceWorkspace->publish($liveWorkspace);
+            $sourceWorkspace->publish($sourceWorkspace->getBaseWorkspace());
 
             $this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->persistAll();
             $this->resetNodeInstances();
@@ -402,6 +399,24 @@ trait NodeOperationsTrait
             $publishingService->discardNodes($publishingService->getUnpublishedNodes($workspace));
 
             $this->getSubcontext('flow')->persistAll();
+            $this->resetNodeInstances();
+        }
+    }
+
+    /**
+     * @When /^I discard the node$/
+     */
+    public function iDiscardTheNode()
+    {
+        if ($this->isolated === true) {
+            $this->callStepInSubProcess(__METHOD__);
+        } else {
+            $node = $this->iShouldHaveOneNode();
+
+            $publishingService = $this->getPublishingService();
+            $publishingService->discardNode($node);
+
+            $this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->persistAll();
             $this->resetNodeInstances();
         }
     }


### PR DESCRIPTION
This changes an issue with using the `PublishingService::publishNode()`
which can result in an inconsistent structure in a user's workspace.

This change also changes the behavior of `PublishingService::discardNode()`
which now will also discard content of a given document node to protect
consistency.

Document nodes and their content must be published or discarded together
in order to protect against inconsistencies when the document node is
moved or removed in one of the base workspaces.

Fixes #1617