### PR TITLE
BUGFIX: Fix missing translation for inspector file uploads

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -212,11 +212,11 @@ Neos:
 
           Neos.Neos/Inspector/Editors/AssetEditor:
             editorOptions:
-              fileUploadLabel: 'Neos.Neos:Main:upload'
+              fileUploadLabel: 'Neos.Neos:Main:choose'
 
           Neos.Neos/Inspector/Editors/ImageEditor:
             editorOptions:
-              fileUploadLabel: 'Neos.Neos:Main:upload'
+              fileUploadLabel: 'Neos.Neos:Main:choose'
 
           Neos.Neos/Inspector/Editors/LinkEditor:
             editorOptions:


### PR DESCRIPTION
This changes the occurrences of `Neos.Neos:Main:upload` to `Neos.Neos:Main:choose` in Settings.yaml, as this has been the label formerly used for upload-related Inspector editors.

The label `Neos.Neos:Main:upload` does not seem to exist currently, so the tooltips above upload buttons in the Inspector haven't been translated.

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Fix the missing translation for the upload buttons in the image and asset inspector editors.

**How I did it**
Change all occurrences of `Neos.Neos:Main:upload` to `Neos.Neos:Main:choose` in Settings.yaml.

**How to verify it**

Hover above the upload Button of the image editor. Without this change, the tooltip contains the fallback label "Upload file" in every language. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) **PR is against 3.0, since the problem doesn't seem to occur prior to that**
