### PR TITLE
BUGFIX: Use strict comparison to avoid nesting level error

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -6,9 +6,9 @@
 			<tr>
 				<th></th>
 				<th>
-					<f:if condition="{sortBy} == 'Name'">
+					<f:if condition="{sortBy} === 'Name'">
 						<f:then>
-							<f:if condition="{sortDirection} == 'ASC'">
+							<f:if condition="{sortDirection} === 'ASC'">
 								<f:then>
 									<f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE">
 										{neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
@@ -31,9 +31,9 @@
 					</f:if>
 				</th>
 				<th>
-					<f:if condition="{sortBy} == 'Modified'">
+					<f:if condition="{sortBy} === 'Modified'">
 						<f:then>
-							<f:if condition="{sortDirection} == 'ASC'">
+							<f:if condition="{sortDirection} === 'ASC'">
 								<f:then>
 									<f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE">
 										{neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
@@ -71,7 +71,7 @@
 			'deleteAssetLabel': '{neos:backend.translate(id: \'deleteAsset\', package: \'Neos.Media.Browser\')}'
 		}">
 			<f:for each="{paginatedAssets}" as="asset" iteration="iterator">
-				<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
+				<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
 					<td>
 						<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{f:if(condition: asset.width, then: '{asset.width} x {asset.height}')}" data-html="true" data-content="{m:thumbnail(asset: asset, preset: 'Neos.Media.Browser:Thumbnail', alt: asset.label, async: settings.asyncThumbnails) -> f:format.htmlentities()}">
 							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />

--- a/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
@@ -13,7 +13,7 @@
 			<f:for each="{paginatedAssets}" as="asset">
 				<li class="asset">
 					<f:link.action action="edit" class="neos-thumbnail" arguments="{asset: asset}" data="{asset-identifier: '{asset -> f:format.identifier()}'}">
-						<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} == 0', then: ' neos-media-untagged')}">
+						<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}">
 							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
 						</div>
 					</f:link.action>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -20,31 +20,31 @@
 			</span>
 			<ul class="neos-dropdown-menu neos-pull-right" role="menu">
 				<li>
-					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} == \'All\'', then: 'neos-active')}"><i class="icon-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
+					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="icon-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
 				</li>
 				<li>
-					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} == \'Image\'', then: 'neos-active')}"><i class="icon-picture"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
+					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="icon-picture"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
 				</li>
 				<li>
-					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} == \'Document\'', then: 'neos-active')}"><i class="icon-file-text"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
+					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="icon-file-text"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
 				</li>
 				<li>
-					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} == \'Video\'', then: 'neos-active')}"><i class="icon-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
+					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="icon-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
 				</li>
 				<li>
-					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} == \'Audio\'', then: 'neos-active')}"><i class="icon-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
+					<f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="icon-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
 				</li>
 			</ul>
 		</div>
 		<div class="neos-dropdown" id="neos-sort-menu">
 			<span title="{neos:backend.translate(id: 'tooltip.sortOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
 				<a class="dropdown-toggle" href="#" data-neos-toggle="dropdown" data-target="#neos-sort-menu">
-					<f:if condition="{sortDirection} == 'ASC'">
+					<f:if condition="{sortDirection} === 'ASC'">
 						<f:then>
-							<i class="icon-{f:if(condition: '{sortBy} == \'Modified\'', then: 'sort-by-order', else: 'sort-by-alphabet')}"></i>
+							<i class="icon-{f:if(condition: '{sortBy} === \'Modified\'', then: 'sort-by-order', else: 'sort-by-alphabet')}"></i>
 						</f:then>
 						<f:else>
-							<i class="icon-{f:if(condition: '{sortBy} == \'Modified\'', then: 'sort-by-order-alt', else: 'sort-by-alphabet-alt')}"></i>
+							<i class="icon-{f:if(condition: '{sortBy} === \'Modified\'', then: 'sort-by-order-alt', else: 'sort-by-alphabet-alt')}"></i>
 						</f:else>
 					</f:if>
 				</a>
@@ -53,24 +53,24 @@
 				<span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
 				<ul>
 					<li>
-						<f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} == \'Modified\'', then: 'neos-active')}"><i class="icon-sort-by-order"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
+						<f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="icon-sort-by-order"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
 					</li>
 					<li>
-						<f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} == \'Name\'', then: 'neos-active')}"><i class="icon-sort-by-alphabet"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
+						<f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="icon-sort-by-alphabet"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
 					</li>
 				</ul>
 				<span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
 				<ul>
 					<li>
-						<f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} == \'ASC\'', then: 'neos-active')}"><i class="icon-{f:if(condition: '{sortBy} == \'Name\'', then: 'sort-by-alphabet', else: 'sort-by-order')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
+						<f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="icon-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-by-alphabet', else: 'sort-by-order')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
 					</li>
 					<li>
-						<f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} == \'DESC\'', then: 'neos-active')}"><i class="icon-{f:if(condition: '{sortBy} == \'Name\'', then: 'sort-by-alphabet-alt', else: 'sort-by-order-alt')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
+						<f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="icon-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-by-alphabet-alt', else: 'sort-by-order-alt')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
 					</li>
 				</ul>
 			</div>
 		</div>
-		<f:if condition="{view} == 'Thumbnail'">
+		<f:if condition="{view} === 'Thumbnail'">
 			<f:then>
 				<f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="icon-th-list"></i></f:link.action>
 			</f:then>
@@ -112,7 +112,7 @@
 				</li>
 				<f:for each="{assetCollections}" as="assetCollection">
 					<li>
-						<f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} == {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+						<f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
 							{assetCollection.object.title}
 							<span class="count">{assetCollection.count}</span>
 						</f:link.action>
@@ -167,20 +167,20 @@
 		</h2>
 		<ul class="neos-media-aside-list">
 			<li class="neos-media-list-all">
-				<f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} == 1', then: 'neos-active')}" arguments="{tagMode: 1}">
+				<f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}">
 					{neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
 					<span class="count">{allCount}</span>
 				</f:link.action>
 			</li>
 			<li class="neos-media-list-untagged">
-				<f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} == 2', then: 'neos-active')}" arguments="{tagMode: 2}">
+				<f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}">
 					{neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
 					<span class="count">{untaggedCount}</span>
 				</f:link.action>
 			</li>
 			<f:for each="{tags}" as="tag">
 				<li>
-					<f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} == {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+					<f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
 						{tag.object.label}
 						<span class="count">{tag.count}</span>
 					</f:link.action>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -21,7 +21,7 @@
 					<label>{neos:backend.translate(id: 'field.tags', package: 'Neos.Media.Browser')}</label>
 					<f:for each="{tags}" as="tag">
 						<label class="neos-checkbox neos-inline">
-							<f:form.checkbox name="asset[tags][]" value="{tag -> f:format.identifier()}" checked="{f:if(condition: '{tag} == {activeTag}', then: 'checked')}" /><span></span> {tag.label}
+							<f:form.checkbox name="asset[tags][]" value="{tag -> f:format.identifier()}" checked="{f:if(condition: '{tag} === {activeTag}', then: 'checked')}" /><span></span> {tag.label}
 						</label>
 					</f:for>
 				</f:if>
@@ -29,7 +29,7 @@
 					<label>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</label>
 					<f:for each="{assetCollections}" as="assetCollection">
 						<label class="neos-checkbox neos-inline">
-							<f:form.checkbox name="asset[assetCollections][]" value="{assetCollection -> f:format.identifier()}" checked="{f:if(condition: '{assetCollection} == {activeAssetCollection}', then: 'checked')}" /><span></span> {assetCollection.title}
+							<f:form.checkbox name="asset[assetCollections][]" value="{assetCollection -> f:format.identifier()}" checked="{f:if(condition: '{assetCollection} === {activeAssetCollection}', then: 'checked')}" /><span></span> {assetCollection.title}
 						</label>
 					</f:for>
 				</f:if>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
@@ -88,7 +88,7 @@
 							<ul>
 								<f:for each="{documentNode.nodes}" as="relatedNode">
 									<li>
-										<f:if condition="{userWorkspace} == {relatedNode.nodeData.workspace}">
+										<f:if condition="{userWorkspace} === {relatedNode.nodeData.workspace}">
 											<f:then>
 												<i class="icon-user" title="{neos:backend.translate(id: 'workspaces.personalWorkspace', package: 'Neos.Neos')}" data-neos-toggle="tooltip"></i>
 											</f:then>

--- a/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
+++ b/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
@@ -17,7 +17,7 @@
 										</a>
 									</f:then>
 									<f:else>
-										<a href="{site.uri}" title="{site.nodeName}" class="{f:if(condition: site.active, then: 'neos-active')}{f:if(condition: '{sites -> f:count()} == 1', then: ' neos-active')}">
+										<a href="{site.uri}" title="{site.nodeName}" class="{f:if(condition: site.active, then: 'neos-active')}{f:if(condition: '{sites -> f:count()} === 1', then: ' neos-active')}">
 											<i class="icon-globe"></i> {site.name}
 										</a>
 									</f:else>
@@ -45,7 +45,7 @@
 
 <f:section name="moduleMenu">
 	<div class="neos-menu-section">
-		<neos:link.module path="{module.modulePath}" class="neos-menu-headline{f:if(condition: '{module.modulePath} == {modulePath}', then: ' neos-active')}">
+		<neos:link.module path="{module.modulePath}" class="neos-menu-headline{f:if(condition: '{module.modulePath} === {modulePath}', then: ' neos-active')}">
 			<i class="{f:if(condition: module.icon, then: module.icon, else: 'icon-puzzle-piece')}"></i>
 			{neos:backend.translate(id: module.label, source: 'Modules', value: module.label)}
 		</neos:link.module>
@@ -64,7 +64,7 @@
 </f:section>
 
 <f:section name="submoduleMenu">
-	<neos:link.module path="{submodule.modulePath}" class="{f:if(condition: '{submodule.modulePath} == {modulePath}', then: ' neos-active')}">
+	<neos:link.module path="{submodule.modulePath}" class="{f:if(condition: '{submodule.modulePath} === {modulePath}', then: ' neos-active')}">
 		<i class="{f:if(condition: submodule.icon, then: submodule.icon, else: 'icon-puzzle-piece')}"></i>
 		{neos:backend.translate(id: submodule.label, source: 'Modules', value: submodule.label)}
 	</neos:link.module>

--- a/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -24,7 +24,7 @@
             </tr>
             <tr>
                 <td colspan="3">
-                    <f:if condition="{contentChanges.type} == 'text'">
+                    <f:if condition="{contentChanges.type} === 'text'">
                         <table>
                             <f:for each="{contentChanges.diff}" key="index" as="blocks">
                                 <f:for each="{blocks}" as="block">
@@ -44,7 +44,7 @@
                             </f:for>
                         </table>
                     </f:if>
-                    <f:if condition="{contentChanges.type} == 'image'">
+                    <f:if condition="{contentChanges.type} === 'image'">
                         <table>
                             <tr>
                                 <td>
@@ -60,7 +60,7 @@
                             </tr>
                         </table>
                     </f:if>
-                    <f:if condition="{contentChanges.type} == 'asset'">
+                    <f:if condition="{contentChanges.type} === 'asset'">
                         <table>
                             <tr>
                                 <td>
@@ -76,7 +76,7 @@
                           </tr>
                        </table>
                     </f:if>
-                    <f:if condition="{contentChanges.type} == 'datetime'">
+                    <f:if condition="{contentChanges.type} === 'datetime'">
                         <table>
                             <tr>
                                 <td>

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/EditUser.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/EditUser.html
@@ -116,7 +116,7 @@
 						</td>
 						<td class="neos-aCenter check">
 							<label class="neos-radio">
-								<f:form.radio property="primaryElectronicAddress" value="{electronicAddress}" checked="{f:if(condition: '{user.primaryElectronicAddress} == {electronicAddress}', then: 'checked')}" /><span></span>
+								<f:form.radio property="primaryElectronicAddress" value="{electronicAddress}" checked="{f:if(condition: '{user.primaryElectronicAddress} === {electronicAddress}', then: 'checked')}" /><span></span>
 							</label>
 						</td>
 						<td class="neos-action">

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/NewElectronicAddress.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/NewElectronicAddress.html
@@ -24,7 +24,7 @@
 					<f:for each="{electronicAddressUsageTypes}" as="electronicAddressUsageType" iteration="iterator">
 						<f:if condition="{electronicAddressUsageType}">
 							<label class="neos-radio neos-inline">
-								<f:form.radio property="usage" value="{electronicAddressUsageType}" checked="{f:if(condition: '{iterator.index} == 1', then: 'checked')}" /><span></span>
+								<f:form.radio property="usage" value="{electronicAddressUsageType}" checked="{f:if(condition: '{iterator.index} === 1', then: 'checked')}" /><span></span>
 								{neos:backend.translate(id: 'users.electronicAddress.usage.type.{electronicAddressUsageType}', package: 'Neos.Neos', value: '{electronicAddressUsageType}')}
 							</label>
 						</f:if>

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/NodeContentDimensionsInformation.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/NodeContentDimensionsInformation.html
@@ -1,9 +1,9 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <f:for each="{node.dimensions}" as="dimension">
 	<f:for each="{contentDimensions}" key="contentDimensionKey" as="contentDimension">
-		<f:if condition="{dimension.name} == {contentDimensionKey}">
+		<f:if condition="{dimension.name} === {contentDimensionKey}">
 			<f:for each="{contentDimension.presets}" key="presetKey" as="preset">
-				<f:if condition="{presetKey} == {dimension.value}">
+				<f:if condition="{presetKey} === {dimension.value}">
 					<span class="neos-label" title="<i class='{contentDimension.icon}'></i> {neos:backend.translate(id: contentDimension.label)}: {presetKey}" data-neos-toggle="tooltip" data-html="1">{neos:backend.translate(id: preset.label)}</span>
 				</f:if>
 			</f:for>

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/BreadcrumbMenu.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/BreadcrumbMenu.html
@@ -4,7 +4,7 @@
 	<ul{attributes -> f:format.raw()}>
 	<f:for each="{items}" as="item" reverse="TRUE">
 		<li{ts:render(path: '{item.state}.attributes', context: {item: item}) -> f:format.raw()}>
-			<f:if condition="{item.state} == 'current'">
+			<f:if condition="{item.state} === 'current'">
 				<f:then>
 					{item.label}
 				</f:then>

--- a/Neos.Neos/Resources/Private/Templates/Login/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Login/Index.html
@@ -86,16 +86,16 @@
 									</button>
 									<f:flashMessages as="flashMessages">
 										<f:for each="{flashMessages}" as="flashMessage">
-											<f:if condition="{flashMessage.severity} == 'OK'">
+											<f:if condition="{flashMessage.severity} === 'OK'">
 												<div class="neos-tooltip neos-bottom neos-in neos-tooltip-success">
 											</f:if>
-											<f:if condition="{flashMessage.severity} == 'Notice'">
+											<f:if condition="{flashMessage.severity} === 'Notice'">
 												<div class="neos-tooltip neos-bottom neos-in neos-tooltip-notice">
 											</f:if>
-											<f:if condition="{flashMessage.severity} == 'Warning'">
+											<f:if condition="{flashMessage.severity} === 'Warning'">
 												<div class="neos-tooltip neos-bottom neos-in neos-tooltip-warning">
 											</f:if>
-											<f:if condition="{flashMessage.severity} == 'Error'">
+											<f:if condition="{flashMessage.severity} === 'Error'">
 												<script>
 													$(function () {
 														$('fieldset').effect('shake', {times: 1}, 60);

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Configuration/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Configuration/Index.html
@@ -3,7 +3,7 @@
 
 <f:section name="content">
 	<f:for each="{availableConfigurationTypes}" as="availableConfigurationType">
-		<f:link.action action="index" arguments="{type: availableConfigurationType}" class="neos-button{f:if(condition: '{availableConfigurationType} == {type}', then: ' neos-active')}">{availableConfigurationType}</f:link.action>
+		<f:link.action action="index" arguments="{type: availableConfigurationType}" class="neos-button{f:if(condition: '{availableConfigurationType} === {type}', then: ' neos-active')}">{availableConfigurationType}</f:link.action>
 	</f:for>
 	<f:if condition="{validationResult.flattenedErrors -> f:count()} > 0">
 		<ul id="neos-notifications-inline">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
@@ -57,14 +57,14 @@
 							<tr>
 								<td>
 									{f:if(condition: domain.scheme, then: '{domain.scheme}://')}<b>{domain.hostname}</b>{f:if(condition: domain.port, then: ':{domain.port}')}
-									<f:if condition="{domain.active} == 0">
+									<f:if condition="{domain.active} === 0">
 										<span class="neos-badge neos-badge-warning">{neos:backend.translate(id: 'inactive', value: 'Inactive')}</span>
 									</f:if>
 								</td>
 								<td class="neos-aCenter check">
 									<f:if condition="{domain.active}">
 										<label class="neos-radio">
-											<f:form.radio property="primaryDomain" value="{domain}" checked="{f:if(condition: '{site.primaryDomain} == {domain}', then: 'checked')}" /><span></span>
+											<f:form.radio property="primaryDomain" value="{domain}" checked="{f:if(condition: '{site.primaryDomain} === {domain}', then: 'checked')}" /><span></span>
 										</label>
 									</f:if>
 								</td>
@@ -73,7 +73,7 @@
 										<f:link.action action="editDomain" arguments="{domain: domain}" class="neos-button" title="{neos:backend.translate(id: 'clickToEdit', value: 'Click to edit')}" additionalAttributes="{data-neos-toggle: 'tooltip'}">
 											<i class="icon-pencil icon-white"></i>
 										</f:link.action>
-										<f:if condition="{domain.active} == 1">
+										<f:if condition="{domain.active} === 1">
 											<f:then>
 												<button form="postHelper" formaction="{f:uri.action(action: 'deactivateDomain', arguments: {domain: domain})}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}" data-neos-toggle="tooltip">
 													<i class="icon-minus-sign icon-white"></i>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
@@ -47,7 +47,7 @@
 										<f:link.action action="edit" arguments="{site: site}" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToEdit', value: 'Click to edit')}" additionalAttributes="{data-neos-toggle: 'tooltip'}">
 											<i class="icon-pencil icon-white"></i>
 										</f:link.action>
-										<f:if condition="{site.state} == 1">
+										<f:if condition="{site.state} === 1">
 											<f:then>
 												<f:form action="deactivateSite" arguments="{site: site}" class="neos-inline">
 													<button class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}" data-neos-toggle="tooltip">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
@@ -28,7 +28,7 @@
 								<i class="icon-pencil icon-white"></i>
 							</f:link.action>
 
-							<f:if condition="{currentUser} == {user}">
+							<f:if condition="{currentUser} === {user}">
 								<f:then>
 									<button class="neos-button neos-button-danger neos-disabled" title="{neos:backend.translate(id: 'users.tooltip.cannotDeleteYourself', source: 'Modules', package: 'Neos.Neos')}" data-neos-toggle="tooltip"><i class="icon-trash icon-white"></i></button>
 								</f:then>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Show.html
@@ -77,7 +77,7 @@
 						<tbody>
 							<f:for each="{user.electronicAddresses}" as="electronicAddress">
 								<tr>
-									<th>{electronicAddress.type} <f:if condition="{user.primaryElectronicAddress} == {electronicAddress}"><span>({neos:backend.translate(id: 'users.show.electronicAddresses.primary', value: 'Primary', source: 'Modules', package: 'Neos.Neos')})</span></f:if></th>
+									<th>{electronicAddress.type} <f:if condition="{user.primaryElectronicAddress} === {electronicAddress}"><span>({neos:backend.translate(id: 'users.show.electronicAddresses.primary', value: 'Primary', source: 'Modules', package: 'Neos.Neos')})</span></f:if></th>
 									<td>{electronicAddress.identifier}</td>
 								</tr>
 							</f:for>
@@ -93,7 +93,7 @@
 
 	<div class="neos-footer">
 		<f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'back', value: 'Back')}</f:link.action>
-		<f:if condition="{currentUser} == {user}">
+		<f:if condition="{currentUser} === {user}">
 			<f:then>
 				<button class="neos-button neos-button-danger neos-disabled" title="{neos:backend.translate(id: 'users.show.cannotDeleteYourself', value: 'You are logged in as this user and you cannot delete yourself.', source: 'Modules', package: 'Neos.Neos')}">
 					<i class="icon-trash icon-white"></i> {neos:backend.translate(id: 'users.show.deleteUser', value: 'Delete User', source: 'Modules', package: 'Neos.Neos')}

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
@@ -18,7 +18,7 @@
 				<f:alias map="{workspace: workspaceAndCounts.workspace, changesCounts: workspaceAndCounts.changesCounts, canPublish: workspaceAndCounts.canPublish, canManage: workspaceAndCounts.canManage, dependentWorkspacesCount: workspaceAndCounts.dependentWorkspacesCount}">
 					<tr>
 						<td class="neos-workspace-type">
-							<f:if condition="{userWorkspace} == {workspace}">
+							<f:if condition="{userWorkspace} === {workspace}">
 								<f:then>
 									<i class="icon-user" title="{neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'Neos.Neos')}" data-neos-toggle="tooltip"></i>
 								</f:then>
@@ -94,7 +94,7 @@
 									</f:link.action>
 								</f:if>
 
-								<f:if condition="{userWorkspace} == {workspace}">
+								<f:if condition="{userWorkspace} === {workspace}">
 									<f:then>
 										<button class="neos-button neos-button-danger neos-disabled" title="{neos:backend.translate(id: 'workspaces.help.cantDeletePersonalWorkspace', source: 'Modules', package: 'Neos.Neos')}" data-neos-toggle="tooltip"><i class="icon-trash icon-white"></i></button>
 									</f:then>

--- a/Neos.Neos/Resources/Private/Templates/Service/ContentDimensions/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/ContentDimensions/Index.html
@@ -13,7 +13,7 @@
 					<span class="contentdimension-icon">{contentDimensionPresetConfiguration.icon}</span>
 					<h2>Presets</h2>
 					<ol class="contentdimension-presets"><f:for each="{contentDimensionPresetConfiguration.presets}" key="presetIdentifier" as="preset">
-						<li class="contentdimension-preset{f:if(condition: '{presetIdentifier} == {contentDimensionPresetConfiguration.defaultPreset}', then: ' contentdimension-defaultpreset')}">
+						<li class="contentdimension-preset{f:if(condition: '{presetIdentifier} === {contentDimensionPresetConfiguration.defaultPreset}', then: ' contentdimension-defaultpreset')}">
 							<label class="contentdimension-preset-label">{neos:backend.translate(id: preset.label)}</label>
 							<span class="contentdimension-preset-identifier">{presetIdentifier}</span>
 							<ol class="contentdimension-preset-values">

--- a/Neos.Neos/Resources/Private/Templates/Service/ContentDimensions/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/ContentDimensions/Show.html
@@ -13,7 +13,7 @@
 			<span class="contentdimension-icon">{contentDimensionPresetConfiguration.icon}</span>
 			<h2>Presets</h2>
 			<ol class="contentdimension-presets"><f:for each="{contentDimensionPresetConfiguration.presets}" key="presetIdentifier" as="preset">
-				<li class="contentdimension-preset{f:if(condition: '{presetIdentifier} == {contentDimensionPresetConfiguration.defaultPreset}', then: ' contentdimension-defaultpreset')}">
+				<li class="contentdimension-preset{f:if(condition: '{presetIdentifier} === {contentDimensionPresetConfiguration.defaultPreset}', then: ' contentdimension-defaultpreset')}">
 					<label class="contentdimension-preset-label">{neos:backend.translate(id: preset.label)}</label>
 					<span class="contentdimension-preset-identifier">{presetIdentifier}</span>
 					<ol class="contentdimension-preset-values">


### PR DESCRIPTION
Comparing objects in Fluid templates using `==` may lead to "nesting
level too deep" errors, depending on the objects being compared.

This change adjusts all non-strict comparisons against strict ones.

Fixes #1626
