### PR TITLE
BUGFIX: Skip apply change handler if the editor is undefined

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/InspectorController.js
@@ -381,7 +381,10 @@ define(
 					for (var listenerName in listenersInProperty) {
 						if (listenersInProperty.hasOwnProperty(listenerName)) {
 							var handlerConfiguration = listenersInProperty[listenerName];
-							this._applyChangeHandler(handlerConfiguration, this.get('registeredEditors.' + observerProperty + '.currentView'), listenerName, propertyName, value);
+							var observerEditor = this.get('registeredEditors.' + observerProperty + '.currentView');
+							if (observerEditor !== undefined) {
+								this._applyChangeHandler(handlerConfiguration, observerEditor, listenerName, propertyName, value);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This change fix a JS console error, when ember try to call _applyChangeHandler
on property like _nodeType, because this property is not really an editor.