### PR TITLE
BUGFIX: Register pending change must be called during editor init

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/PropertyEditor.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/PropertyEditor.js
@@ -56,6 +56,7 @@ define(
 			this._super();
 			this._loadView();
 			this.get('inspector').registerPropertyEditor(this.get('propertyDefinition.key'), this);
+			this.get('inspector').registerPendingChange(this.get('propertyDefinition').key, this.get('value'));
 		},
 
 		_loadView: function() {


### PR DESCRIPTION
This change makes sure editor listeners are called in the init of the editor. This can help in situations like hiding an editor based on depending properties on the first page load or inspector initialization.