### PR TITLE
BUGFIX: Respect `entryDiscriminator` when using Content Cache mode `dynamic`

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -246,12 +246,16 @@ class ContentCache
      * @param string $typoScriptPath TypoScript path identifying the TypoScript object to retrieve from the content cache
      * @param array $cacheIdentifierValues Further values which play into the cache identifier hash, must be the same as the ones specified while the cache entry was written
      * @param boolean $addCacheSegmentMarkersToPlaceholders If cache segment markers should be added – this makes sense if the cached segment is about to be included in a not-yet-cached segment
+     * @param string $cacheDiscriminator The evaluated cache discriminator value, if any
      * @return string|boolean The segment with replaced cache placeholders, or FALSE if a segment was missing in the cache
      * @throws Exception
      */
-    public function getCachedSegment($uncachedCommandCallback, $typoScriptPath, $cacheIdentifierValues, $addCacheSegmentMarkersToPlaceholders = false)
+    public function getCachedSegment($uncachedCommandCallback, $typoScriptPath, $cacheIdentifierValues, $addCacheSegmentMarkersToPlaceholders = false, $cacheDiscriminator = null)
     {
         $cacheIdentifier = $this->renderContentCacheEntryIdentifier($typoScriptPath, $cacheIdentifierValues);
+        if ($cacheDiscriminator !== null) {
+            $cacheIdentifier .= '_' . md5($cacheDiscriminator);
+        }
         $content = $this->cache->get($cacheIdentifier);
 
         if ($content === false) {

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
@@ -161,8 +161,12 @@ class RuntimeContentCache
     public function preEvaluate(array &$evaluateContext, $tsObject)
     {
         if ($this->enableContentCache) {
+            if ($evaluateContext['cacheForPathEnabled'] && $evaluateContext['cacheForPathDisabled']) {
+                $evaluateContext['cacheDiscriminator'] = $this->runtime->evaluate($evaluateContext['typoScriptPath'] . '/__meta/cache/entryDiscriminator');
+            }
             if ($evaluateContext['cacheForPathEnabled']) {
                 $evaluateContext['cacheIdentifierValues'] = $this->buildCacheIdentifierValues($evaluateContext['configuration'], $evaluateContext['typoScriptPath'], $tsObject);
+                $cacheDiscriminator = isset($evaluateContext['cacheDiscriminator']) ? $evaluateContext['cacheDiscriminator'] : null;
                 $self = $this;
                 $segment = $this->contentCache->getCachedSegment(function ($command, $additionalData, $cache) use ($self, $evaluateContext, $tsObject) {
                     if (strpos($command, 'eval=') === 0) {
@@ -190,7 +194,7 @@ class RuntimeContentCache
                     } else {
                         throw new Exception(sprintf('Unknown uncached command "%s"', $command), 1392837596);
                     }
-                }, $evaluateContext['typoScriptPath'], $evaluateContext['cacheIdentifierValues'], $this->addCacheSegmentMarkersToPlaceholders);
+                }, $evaluateContext['typoScriptPath'], $evaluateContext['cacheIdentifierValues'], $this->addCacheSegmentMarkersToPlaceholders, $cacheDiscriminator);
                 if ($segment !== false) {
                     return [true, $segment];
                 } else {
@@ -200,9 +204,7 @@ class RuntimeContentCache
                 $this->cacheMetadata[] = ['lifetime' => null];
             }
 
-            if ($evaluateContext['cacheForPathEnabled'] && $evaluateContext['cacheForPathDisabled']) {
-                $evaluateContext['cacheDiscriminator'] = $this->runtime->evaluate($evaluateContext['typoScriptPath'] . '/__meta/cache/entryDiscriminator');
-            }
+
 
             if (isset($evaluateContext['configuration']['maximumLifetime'])) {
                 $maximumLifetime = $this->runtime->evaluate($evaluateContext['typoScriptPath'] . '/__meta/cache/maximumLifetime', $tsObject);

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
@@ -597,4 +597,52 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $secondRenderResult = $view->render();
         $this->assertSame('Outer segment|object=Object value 1|Uncached segment|counter=2|End uncached|End outer', $secondRenderResult);
     }
+
+    /**
+     * @test
+     */
+    public function dynamicSegmentIsCachedIfDiscriminatorIsNotChanged()
+    {
+        $renderObject = new TestModel(42, 'Render object');
+        $discriminatorObject = new TestModel(43, 'Discriminator object');
+
+        $view = $this->buildView();
+        $view->setOption('enableContentCache', true);
+        $view->assign('renderObject', $renderObject);
+        $view->assign('discriminatorObject', $discriminatorObject);
+        $view->setTypoScriptPath('contentCache/dynamicSegment');
+
+        $firstRenderResult = $view->render();
+
+        $renderObject->setValue('Should not affect the cache');
+
+        $secondRenderResult = $view->render();
+
+        $this->assertSame('Dynamic segment|counter=1', $secondRenderResult);
+        $this->assertSame($firstRenderResult, $secondRenderResult);
+    }
+
+    /**
+     * @test
+     */
+    public function dynamicSegmentCacheIsFlushedIfDiscriminatorIsChanged()
+    {
+        $renderObject = new TestModel(42, 'Render object');
+        $discriminatorObject = new TestModel(43, 'Discriminator object');
+
+        $view = $this->buildView();
+        $view->setOption('enableContentCache', true);
+        $view->assign('renderObject', $renderObject);
+        $view->assign('discriminatorObject', $discriminatorObject);
+        $view->setTypoScriptPath('contentCache/dynamicSegment');
+
+        $firstRenderResult = $view->render();
+
+        $discriminatorObject->setValue('This should affect the cache');
+
+        $secondRenderResult = $view->render();
+
+        $this->assertSame('Dynamic segment|counter=2', $secondRenderResult);
+        $this->assertNotSame($firstRenderResult, $secondRenderResult);
+    }
 }

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -525,3 +525,41 @@ contentCache.uncachedSegmentInCachedSegmentCanOverrideContextVariables = TYPO3.T
 		}
 	}
 }
+
+contentCache.dynamicSegment = TYPO3.TypoScript:Array {
+	5 = 'Dynamic segment|'
+	10 = ${'counter=' + renderObject.counter}
+
+	@cache {
+		mode = 'dynamic'
+		context {
+			1 = 'renderObject'
+			2 = 'discriminatorObject'
+		}
+		entryIdentifier {
+			renderObject = 'static'
+		}
+		entryDiscriminator = ${discriminatorObject.value}
+	}
+}
+
+root = Neos.Fusion:Value {
+    value = Neos.Fusion:Value {
+        value = Neos.Fusion:Value {
+            value = 'hi'
+            @cache {
+                mode = 'cached'
+            }
+        }
+        @cache {
+            mode = 'dynamic'
+            context {
+                1 = 'node'
+                2 = 'documentNode'
+            }
+        }
+    }
+    @cache {
+        mode = 'cached'
+    }
+}

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -542,24 +542,3 @@ contentCache.dynamicSegment = TYPO3.TypoScript:Array {
 		entryDiscriminator = ${discriminatorObject.value}
 	}
 }
-
-root = Neos.Fusion:Value {
-    value = Neos.Fusion:Value {
-        value = Neos.Fusion:Value {
-            value = 'hi'
-            @cache {
-                mode = 'cached'
-            }
-        }
-        @cache {
-            mode = 'dynamic'
-            context {
-                1 = 'node'
-                2 = 'documentNode'
-            }
-        }
-    }
-    @cache {
-        mode = 'cached'
-    }
-}


### PR DESCRIPTION
Currently, when using the content cache mode `dynamic` the `entryDiscriminator`
is only considered when _writing_ the Cache entry.
When trying to _retrieve_ the content segment, the discriminator is omitted
from the cache entry identifier.
Thus, the `dynamic` cache mode currently acts like `uncached`.

This change fixes the behavior and adds a functional test.

Fixes: #1630