### PR TITLE
TASK: Don't cache dynamic segments with disabled `entryDiscriminator`

### DIFF
--- a/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -167,22 +167,22 @@ In the ``@cache`` meta property the following subproperties are allowed:
 When using ``dynamic`` as the cache mode, the cache can be *disabled* by setting the ``entryDiscriminator`` to ``false``.
 This can be used to make the cache behavior dependable on some context, i.e. the current request method::
 
-	prototype(TYPO3.Neos:Plugin) {
+	prototype(TYPO3.Neos.NodeTypes:Form) {
 		@cache {
 			mode = 'dynamic'
 			entryIdentifier {
 			  node = ${node}
 			}
-			entryDiscriminator = ${request.arguments.pagination ? request.arguments.pagination : false}
+			entryDiscriminator = ${request.httpRequest.methodSafe ? 'static' : false}
 			context {
 				1 = 'node'
 				2 = 'documentNode'
 			}
-			entryTags {
-				1 = ${'Node_' + node.identifier}
-			}
 		}
 	}
+
+In this example the Form will be ``cached`` unless the request method is unsafe (for example ``POST``) in which case it is
+switched to ``uncached``.
 
 .. _Cache Entry Tags:
 

--- a/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -173,7 +173,7 @@ This can be used to make the cache behavior dependable on some context, i.e. the
 			entryIdentifier {
 			  node = ${node}
 			}
-			entryDiscriminator = ${request.arguments.pagination}
+			entryDiscriminator = ${request.arguments.pagination ? request.arguments.pagination : false}
 			context {
 				1 = 'node'
 				2 = 'documentNode'

--- a/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/TYPO3.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -164,6 +164,26 @@ In the ``@cache`` meta property the following subproperties are allowed:
 	}
 
 
+When using ``dynamic`` as the cache mode, the cache can be *disabled* by setting the ``entryDiscriminator`` to ``false``.
+This can be used to make the cache behavior dependable on some context, i.e. the current request method::
+
+	prototype(TYPO3.Neos:Plugin) {
+		@cache {
+			mode = 'dynamic'
+			entryIdentifier {
+			  node = ${node}
+			}
+			entryDiscriminator = ${request.arguments.pagination}
+			context {
+				1 = 'node'
+				2 = 'documentNode'
+			}
+			entryTags {
+				1 = ${'Node_' + node.identifier}
+			}
+		}
+	}
+
 .. _Cache Entry Tags:
 
 Cache Entry Tags

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -246,12 +246,15 @@ class ContentCache
      * @param string $typoScriptPath TypoScript path identifying the TypoScript object to retrieve from the content cache
      * @param array $cacheIdentifierValues Further values which play into the cache identifier hash, must be the same as the ones specified while the cache entry was written
      * @param boolean $addCacheSegmentMarkersToPlaceholders If cache segment markers should be added – this makes sense if the cached segment is about to be included in a not-yet-cached segment
-     * @param string $cacheDiscriminator The evaluated cache discriminator value, if any
+     * @param string|bool $cacheDiscriminator The evaluated cache discriminator value, if any and FALSE if the cache discriminator is disabled for the current context
      * @return string|boolean The segment with replaced cache placeholders, or FALSE if a segment was missing in the cache
      * @throws Exception
      */
     public function getCachedSegment($uncachedCommandCallback, $typoScriptPath, $cacheIdentifierValues, $addCacheSegmentMarkersToPlaceholders = false, $cacheDiscriminator = null)
     {
+        if ($cacheDiscriminator === false) {
+            return false;
+        }
         $cacheIdentifier = $this->renderContentCacheEntryIdentifier($typoScriptPath, $cacheIdentifierValues);
         if ($cacheDiscriminator !== null) {
             $cacheIdentifier .= '_' . md5($cacheDiscriminator);

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/RuntimeContentCache.php
@@ -177,6 +177,10 @@ class RuntimeContentCache
                     } elseif (strpos($command, 'evalCached=') === 0) {
                         $identifier = substr($command, 11);
                         $cacheDiscriminator = $this->runtime->evaluate($additionalData['path'] . '/__meta/cache/entryDiscriminator');
+                        if ($cacheDiscriminator === false) {
+                            $unserializedContext = $self->unserializeContext($additionalData['context']);
+                            return $self->evaluateUncached($additionalData['path'], $unserializedContext);
+                        }
                         $cacheIdentifier = substr($identifier, 0, strpos($identifier, '_')) . '_' . md5($cacheDiscriminator);
                         $result = $cache->get($cacheIdentifier);
                         if ($result === false) {

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
@@ -645,4 +645,32 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $this->assertSame('Dynamic segment|counter=2', $secondRenderResult);
         $this->assertNotSame($firstRenderResult, $secondRenderResult);
     }
+
+    /**
+     * @test
+     */
+    public function dynamicSegmentCacheBehavesLikeUncachedIfDiscriminatorIsDisabled()
+    {
+        $renderObject = new TestModel(42, 'Render object');
+        $discriminatorObject = new TestModel(43, 'Discriminator object');
+
+        $view = $this->buildView();
+        $view->setOption('enableContentCache', true);
+        $view->assign('renderObject', $renderObject);
+        $view->assign('discriminatorObject', $discriminatorObject);
+        $view->setTypoScriptPath('contentCache/dynamicSegmentWithDisabledDiscriminator');
+
+        $firstRenderResult = $view->render();
+        $secondRenderResult = $view->render();
+
+        $discriminatorObject->setValue('disable');
+
+        $thirdRenderResult = $view->render();
+        $fourthRenderResult = $view->render();
+
+        $this->assertSame('Dynamic segment|counter=1', $firstRenderResult);
+        $this->assertSame($firstRenderResult, $secondRenderResult);
+        $this->assertSame('Dynamic segment|counter=2', $thirdRenderResult);
+        $this->assertSame('Dynamic segment|counter=3', $fourthRenderResult);
+    }
 }

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -542,3 +542,20 @@ contentCache.dynamicSegment = TYPO3.TypoScript:Array {
 		entryDiscriminator = ${discriminatorObject.value}
 	}
 }
+
+contentCache.dynamicSegmentWithDisabledDiscriminator = TYPO3.TypoScript:Array {
+	5 = 'Dynamic segment|'
+	10 = ${'counter=' + renderObject.counter}
+
+	@cache {
+		mode = 'dynamic'
+		context {
+			1 = 'renderObject'
+			2 = 'discriminatorObject'
+		}
+		entryIdentifier {
+			renderObject = 'static'
+		}
+		entryDiscriminator = ${discriminatorObject.value == 'disable' ? false : discriminatorObject.value}
+	}
+}


### PR DESCRIPTION
With this change the caching can be disabled by setting the `entryDiscriminator`
to `false` when using Content Cache mode `dynamic`.

Previously a cache entry was created anyways with the `entryDiscriminator` casted
to an (in this case empty) string.

Background:
The Content Cache mode `dynamic` was introduced in order to allow for more flexible
caching behaviors depending on the context.
But one important feature did not work yet: Being able to *disable* the cache
for certain requests.
With this change performance can be improved by caching the display of an interactive
element (i.e. cache Forms for GET requests)

Related: #1630