### PR TITLE
BUGFIX: cut off long-form processor syntax in ContentElementWrappingImplementation

### DIFF
--- a/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
@@ -95,8 +95,17 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
             && isset($fusionPathSegments[$numberOfFusionPathSegments - 2])
             && $fusionPathSegments[$numberOfFusionPathSegments - 2] === 'process') {
 
-            // cut of the processing segments "__meta/process/contentElementWrapping<Neos.Neos:ContentElementWrapping>"
+            // cut off the SHORT processing syntax "__meta/process/contentElementWrapping<Neos.Neos:ContentElementWrapping>"
             return implode('/', array_slice($fusionPathSegments, 0, -3));
+        }
+
+        if (isset($fusionPathSegments[$numberOfFusionPathSegments - 4])
+            && $fusionPathSegments[$numberOfFusionPathSegments - 4] === '__meta'
+            && isset($fusionPathSegments[$numberOfFusionPathSegments - 3])
+            && $fusionPathSegments[$numberOfFusionPathSegments - 3] === 'process') {
+
+            // cut off the LONG processing syntax "__meta/process/contentElementWrapping/expression<Neos.Neos:ContentElementWrapping>"
+            return implode('/', array_slice($fusionPathSegments, 0, -4));
         }
         return $this->path;
     }


### PR DESCRIPTION
In the change https://github.com/neos/neos/commit/c4f64615297503b5577e5c863758d2a9b480433d,
the default @process.contentElementWrapping on Neos.Neos:Content was changed from
@process.contentElementWrapping to the long form
"@process.contentElementWrapping.expression" (so it was possible to specify
a position).

However, this meant the Fusion path in Frontend for such an element was calculated wrongly;
It appended __meta/process/contentElementWrapping/expression<Neos.Neos:ContentElementWrapping>
to the fusionPath in the DOM.

For the "old" Neos (ember-based) UI, everything works pretty much as expected (it's
quite hard to construct a scenario where this would trigger an actual bug); but
the new React UI gets confused with rendering the element when the Fusion path is wrong.
And as it is a core bug, let's fix it in the core.
