### PR TITLE
BUGFIX: Trigger ContentCacheFlusher on asset update

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -86,12 +86,24 @@ class ContentCacheFlusher
     }
 
     /**
+     * Deprecated. Please use ContentCacheFlush::registerAssetChange
+     *
+     * @deprecated
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function registerAssetResourceChange(AssetInterface $asset)
+    {
+        $this->registerAssetChange($asset);
+    }
+
+    /**
      * Fetches possible usages of the asset and registers nodes that use the asset as changed.
      *
      * @param AssetInterface $asset
      * @return void
      */
-    public function registerAssetResourceChange(AssetInterface $asset)
+    public function registerAssetChange(AssetInterface $asset)
     {
         if (!$asset->isInUse()) {
             return;

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -76,6 +76,7 @@ class Package extends BasePackage
         $dispatcher->connect(Node::class, 'nodeRemoved', ContentCacheFlusher::class, 'registerNodeChange');
         $dispatcher->connect(Node::class, 'beforeNodeMove', ContentCacheFlusher::class, 'registerNodeChange');
 
+        $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetResourceChange');
         $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetResourceChange');
 
         $dispatcher->connect(Node::class, 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -76,8 +76,8 @@ class Package extends BasePackage
         $dispatcher->connect(Node::class, 'nodeRemoved', ContentCacheFlusher::class, 'registerNodeChange');
         $dispatcher->connect(Node::class, 'beforeNodeMove', ContentCacheFlusher::class, 'registerNodeChange');
 
-        $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetResourceChange');
-        $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetResourceChange');
+        $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetChange');
+        $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetChange');
 
         $dispatcher->connect(Node::class, 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
         $dispatcher->connect(Node::class, 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');


### PR DESCRIPTION
The content cache does not invalidate on changes to an asset. Expected behavior would
be to flush the content cache on changes to an asset (e.g title, caption).