### PR TITLE
FEATURE: Add `async` flag to the `Neos.Neos:ImageUri` and `Neos.Neos:ImageTag` fusion-objects

### DIFF
--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -110,6 +110,16 @@ class ImageUriImplementation extends AbstractFusionObject
     }
 
     /**
+     * Async
+     *
+     * @return boolean
+     */
+    public function getAsync()
+    {
+        return $this->fusionValue('async');
+    }
+
+    /**
      * Preset
      *
      * @return string
@@ -136,9 +146,10 @@ class ImageUriImplementation extends AbstractFusionObject
         if ($preset !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling());
+            $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getAsync());
         }
-        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration);
+        $request = $this->getRuntime()->getControllerContext()->getRequest();
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $request);
         if ($thumbnailData === null) {
             return '';
         }

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -827,6 +827,7 @@ Get a URI to a (thumbnail) image for an asset.
 :maximumHeight: (integer) Desired maximum width of the image
 :allowCropping: (boolean) Whether the image should be cropped if the given sizes would hurt the aspect ratio, defaults to ``FALSE``
 :allowUpScaling: (boolean) Whether the resulting image size might exceed the size of the original image, defaults to ``FALSE``
+:async (boolean): Return asynchronous image URI in case the requested image does not exist already, defaults to ``FALSE``
 :preset: (string) Preset used to determine image configuration, if set all other resize attributes will be ignored
 
 Example::

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
@@ -7,6 +7,7 @@ prototype(Neos.Neos:ImageUri) {
 	height = NULL
 	allowCropping = FALSE
 	allowUpScaling = FALSE
+	async = FALSE
 	preset = NULL
 	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
@@ -20,6 +21,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 	height = NULL
 	allowCropping = FALSE
 	allowUpScaling = FALSE
+	async = FALSE
 	preset = NULL
 	@context.asset = ${this.asset}
 	@context.width = ${this.width}
@@ -28,6 +30,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 	@context.maximumHeight = ${this.maximumHeight}
 	@context.allowCropping = ${this.allowCropping}
 	@context.allowUpScaling = ${this.allowUpScaling}
+	@context.async = ${this.async}
 	@context.preset = ${this.preset}
 
 	tagName = 'img'
@@ -40,6 +43,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 			maximumHeight = ${maximumHeight}
 			allowCropping = ${allowCropping}
 			allowUpScaling = ${allowUpScaling}
+			async = ${async}
 			preset = ${preset}
 		}
 	}


### PR DESCRIPTION
Adds support for generating asynchronous image URIs in case the requested image does
not exist already. The feature is already supported in the `ImageViewHelper` but was missing
in the fusion objects.

This works as follows:

- If a resource still has to be processed a /media/thumbnail-uri is rendered that will do the
  actual processing and return the image.
- Later if the resource is already processed the _Resource-uri is rendered as previously.