### PR TITLE
FEATURE: HtmlAugmenter will augment plaintext with the given fallback-tag

### DIFF
--- a/Neos.Neos/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Neos/Classes/Service/HtmlAugmenter.php
@@ -62,7 +62,8 @@ class HtmlAugmenter
      */
     protected function getHtmlRootElement($html)
     {
-        if (trim($html) === '') {
+        $html = trim($html);
+        if ($html === '') {
             return null;
         }
         $domDocument = new \DOMDocument('1.0', 'UTF-8');
@@ -75,6 +76,10 @@ class HtmlAugmenter
             libxml_use_internal_errors($useInternalErrorsBackup);
         }
         if ($rootElement === false || $rootElement->length !== 1) {
+            return null;
+        }
+        // detect whether loadHTML has wrapped plaintext in a p-tag without asking for permission
+        if ($rootElement instanceof \DOMNodeList && $rootElement->item(0)->tagName === 'p' && substr($html, 0, 2) !== '<p') {
             return null;
         }
         return $rootElement->item(0);

--- a/Neos.Neos/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Neos/Classes/Service/HtmlAugmenter.php
@@ -79,7 +79,7 @@ class HtmlAugmenter
             return null;
         }
         // detect whether loadHTML has wrapped plaintext in a p-tag without asking for permission
-        if ($rootElement instanceof \DOMNodeList && $rootElement->item(0)->tagName === 'p' && substr($html, 0, 2) !== '<p') {
+        if ($rootElement instanceof \DOMNodeList && $rootElement->item(0)->tagName === 'p' && !preg_match('/^<p/ui', $html)) {
             return null;
         }
         return $rootElement->item(0);

--- a/Neos.Neos/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Neos/Classes/Service/HtmlAugmenter.php
@@ -79,7 +79,7 @@ class HtmlAugmenter
             return null;
         }
         // detect whether loadHTML has wrapped plaintext in a p-tag without asking for permission
-        if ($rootElement instanceof \DOMNodeList && $rootElement->item(0)->tagName === 'p' && !preg_match('/^<p/ui', $html)) {
+        if ($rootElement instanceof \DOMNodeList && $rootElement->item(0)->tagName === 'p' && preg_match('/^<p/ui', $html) === 0) {
             return null;
         }
         return $rootElement->item(0);

--- a/Neos.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -77,6 +77,15 @@ class HtmlAugmenterTest extends UnitTestCase
                 'expectedResult' => '<div class="new-class">   	' . chr(10) . '  </div>',
             ),
 
+            // plaintext source
+            array(
+                'html' => 'Plain Text without html',
+                'attributes' => array('class' => 'some-class'),
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<div class="some-class">Plain Text without html</div>',
+            ),
+
             // root element detection
             array(
                 'html' => '<p>Simple HTML with unique root element</p>',
@@ -91,6 +100,20 @@ class HtmlAugmenterTest extends UnitTestCase
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'expectedResult' => '<div class="new-class"><p>Simple HTML without</p><p> unique root element</p></div>',
+            ),
+            array(
+                'html' => 'Plain text and simple HTML without<p> unique root element</p>',
+                'attributes' => array('class' => 'new-class'),
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<div class="new-class">Plain text and simple HTML without<p> unique root element</p></div>',
+            ),
+            array(
+                'html' => '   <p>Simple HTML with unique root element in whitespace</p>   ',
+                'attributes' => array('class' => 'some-class'),
+                'fallbackTagName' => 'fallback-tag',
+                'exclusiveAttributes' => null,
+                'expectedResult' => '   <p class="some-class">Simple HTML with unique root element in whitespace</p>   ',
             ),
             array(
                 'html' => '<p class="some-class">Simple HTML without</p><p> unique root element</p>',


### PR DESCRIPTION
If plaintext is given to the html augmenter now uses the fallback-tag
as it already does if multiple tags are found on the same level.

This fixed the problem of contents not beeing selectable in the backend 
if no tags are found but just some text.