### PR TITLE
BUGFIX: Moving node back and forth in nested workspace causes SQL error

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -877,7 +877,7 @@ class NodeData extends AbstractNodeData
             return $this;
         }
 
-        $targetPathShadowNodeData = $this->getExistingShadowNodeData($path, $workspace, $nodeData->getDimensionValues());
+        $targetPathShadowNodeData = $this->getExistingShadowNodeDataInExactWorkspace($path, $workspace, $nodeData->getDimensionValues());
 
         if ($this->workspace->getName() !== $workspace->getName()) {
             if ($targetPathShadowNodeData === null) {
@@ -942,13 +942,17 @@ class NodeData extends AbstractNodeData
      * Find an existing shadow node data on the given path for the current node data of the node (used by setPath)
      *
      * @param string $path The (new) path of the node data
-     * @param Workspace $workspace
-     * @param array $dimensionValues
+     * @param Workspace $workspace The workspace. Only shadow node data object with exactly this workspace will be considered
+     * @param array $dimensionValues Dimension values which must match with an existing node data object
      * @return NodeData|null
      */
-    protected function getExistingShadowNodeData($path, $workspace, $dimensionValues)
+    protected function getExistingShadowNodeDataInExactWorkspace($path, $workspace, $dimensionValues)
     {
-        return $this->nodeDataRepository->findShadowNodeByPath($path, $workspace, $dimensionValues);
+        $shadowNodeData = $this->nodeDataRepository->findShadowNodeByPath($path, $workspace, $dimensionValues);
+        if ($shadowNodeData !== null && $shadowNodeData->getWorkspace()->getName() !== $workspace->getName()) {
+            $shadowNodeData = null;
+        }
+        return $shadowNodeData;
     }
 
     /**

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -865,51 +865,74 @@ class NodeData extends AbstractNodeData
      * Because unique key constraints and Doctrine ORM don't support arbitrary removal and update combinations,
      * existing NodeData instances are re-used and the metadata and content is swapped around.
      *
-     * @param string $path
-     * @param Workspace $workspace
+     * @param string $targetPath
+     * @param Workspace $targetWorkspace
      * @return NodeData If a shadow node was created this is the new NodeData object after the move.
      */
-    public function move($path, $workspace)
+    public function move(string $targetPath, Workspace $targetWorkspace)
     {
-        $nodeData = $this;
+        $sourceNodeData = $this;
         $originalPath = $this->path;
-        if ($originalPath === $path) {
+        if ($originalPath === $targetPath && $this->workspace->getName() === $targetWorkspace) {
             return $this;
         }
 
-        $targetPathShadowNodeData = $this->getExistingShadowNodeDataInExactWorkspace($path, $workspace, $nodeData->getDimensionValues());
+        $targetPathShadowNodeData = $this->getExistingShadowNodeDataInExactWorkspace($targetPath, $targetWorkspace, $sourceNodeData->getDimensionValues());
 
-        if ($this->workspace->getName() !== $workspace->getName()) {
-            if ($targetPathShadowNodeData === null) {
-                // If there is no shadow node at the target path we need to materialize before moving and create a shadow node.
-                $nodeData = $this->materializeToWorkspace($workspace);
-                $nodeData->setPath($path, false);
-                $movedNodeData = $nodeData;
-            } else {
-                // The existing shadow node on the target path will be used as the moved node. We don't need to materialize into the workspace.
+        if ($this->workspace->getName() !== $targetWorkspace->getName()) {
+            if ($targetPath === $originalPath) {
+
+                // The existing shadow node in the target workspace will be used as the actual moved node
+                $movedNodeDataInTargetWorkspace = $targetPathShadowNodeData->getMovedTo();
+                if ($movedNodeDataInTargetWorkspace !== null) {
+                    $this->nodeDataRepository->remove($movedNodeDataInTargetWorkspace);
+                }
+
+                $referencedShadowNode = $this->nodeDataRepository->findOneByMovedTo($sourceNodeData);
+                if ($referencedShadowNode !== null) {
+                    $this->nodeDataRepository->remove($referencedShadowNode);
+                }
+
                 $movedNodeData = $targetPathShadowNodeData;
                 $movedNodeData->setAsShadowOf(null);
-                $movedNodeData->setIdentifier($nodeData->getIdentifier());
-                $movedNodeData->similarize($nodeData);
-                // A new shadow node will be created for the node data that references the recycled, existing shadow node
+                $movedNodeData->setIdentifier($sourceNodeData->getIdentifier());
+                $movedNodeData->similarize($sourceNodeData);
+
+                $this->nodeDataRepository->remove($sourceNodeData);
+            } else {
+                if ($targetPathShadowNodeData === null) {
+                    // If there is no shadow node at the target path we need to materialize before moving and create a shadow node.
+                    $sourceNodeData = $this->materializeToWorkspace($targetWorkspace);
+                    $sourceNodeData->setPath($targetPath, false);
+                    $movedNodeData = $sourceNodeData;
+                } else {
+                    // The existing shadow node on the target path will be used as the moved node. We don't need to materialize into the workspace.
+                    $movedNodeData = $targetPathShadowNodeData;
+                    $movedNodeData->setAsShadowOf(null);
+                    $movedNodeData->setIdentifier($sourceNodeData->getIdentifier());
+                    $movedNodeData->similarize($sourceNodeData);
+                    // A new shadow node will be created for the node data that references the recycled, existing shadow node
+                }
+                $movedNodeData->createShadow($originalPath);
             }
-            $movedNodeData->createShadow($originalPath);
         } else {
-            $referencedShadowNode = $this->nodeDataRepository->findOneByMovedTo($nodeData);
+            $referencedShadowNode = $this->nodeDataRepository->findOneByMovedTo($sourceNodeData);
             if ($targetPathShadowNodeData === null) {
                 if ($referencedShadowNode === null) {
                     // There is no shadow node on the original or target path, so the current node data will be turned to a shadow node and a new node data will be created for the moved node.
                     // We cannot just create a new shadow node, since the order of Doctrine queries would cause unique key conflicts
-                    $movedNodeData = new NodeData($path, $nodeData->getWorkspace(), $nodeData->getIdentifier(), $nodeData->getDimensionValues());
-                    $movedNodeData->similarize($nodeData);
+                    $movedNodeData = new NodeData($targetPath, $sourceNodeData->getWorkspace(), $sourceNodeData->getIdentifier(), $sourceNodeData->getDimensionValues());
+                    $movedNodeData->similarize($sourceNodeData);
                     $this->addOrUpdate($movedNodeData);
 
-                    $shadowNodeData = $nodeData;
-                    $shadowNodeData->setAsShadowOf($movedNodeData);
+                    $shadowNodeData = $sourceNodeData;
+                    $shadowNodeData->setRemoved(true);
+                    $shadowNodeData->setMovedTo($movedNodeData);
+                    $this->addOrUpdate($shadowNodeData);
                 } else {
                     // A shadow node that references this node data already exists, so we just move the current node data
-                    $movedNodeData = $nodeData;
-                    $movedNodeData->setPath($path, false);
+                    $movedNodeData = $sourceNodeData;
+                    $movedNodeData->setPath($targetPath, false);
                 }
             } else {
                 if ($referencedShadowNode === null) {
@@ -918,19 +941,19 @@ class NodeData extends AbstractNodeData
                     $movedNodeData = $targetPathShadowNodeData;
                     // Since the shadow node at the target path does not belong to the current node, we have to adjust the identifier
                     $movedNodeData->setRemoved(false);
-                    $movedNodeData->setIdentifier($nodeData->getIdentifier());
-                    $movedNodeData->similarize($nodeData);
+                    $movedNodeData->setIdentifier($sourceNodeData->getIdentifier());
+                    $movedNodeData->similarize($sourceNodeData);
                     // Create a shadow node from the current node that shadows the recycled node
-                    $shadowNodeData = $nodeData;
+                    $shadowNodeData = $sourceNodeData;
                     $shadowNodeData->setAsShadowOf($movedNodeData);
                 } else {
                     // If there is already shadow node on the target path, we need to make that shadow node the actual moved node and remove the current node data (which cannot be live).
                     // We cannot remove the shadow node and update the current node data, since the order of Doctrine queries would cause unique key conflicts.
                     $movedNodeData = $targetPathShadowNodeData;
                     $movedNodeData->setAsShadowOf(null);
-                    $movedNodeData->similarize($nodeData);
-                    $movedNodeData->setPath($path, false);
-                    $this->nodeDataRepository->remove($nodeData);
+                    $movedNodeData->similarize($sourceNodeData);
+                    $movedNodeData->setPath($targetPath, false);
+                    $this->nodeDataRepository->remove($sourceNodeData);
                 }
             }
         }
@@ -1025,8 +1048,9 @@ class NodeData extends AbstractNodeData
             return;
         }
 
-        // If the node is marked to be removed but didn't exist in a base workspace yet, we can delete it for real, without creating a shadow node:
-        if ($nodeData->isRemoved() && $this->nodeDataRepository->findOneByIdentifier($nodeData->getIdentifier(), $this->workspace->getBaseWorkspace()) === null) {
+        // If the node is marked to be removed but didn't exist in a base workspace yet, we can delete it for real, without creating a shadow node.
+        // This optimization cannot be made for shadow nodes which are moved.
+        if ($nodeData->isRemoved() && $nodeData->getMovedTo() === null && $this->nodeDataRepository->findOneByIdentifier($nodeData->getIdentifier(), $this->workspace->getBaseWorkspace()) === null) {
             if ($this->persistenceManager->isNewObject($nodeData) === false) {
                 $this->nodeDataRepository->remove($nodeData);
             }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/NodeData.php
@@ -869,7 +869,7 @@ class NodeData extends AbstractNodeData
      * @param Workspace $targetWorkspace
      * @return NodeData If a shadow node was created this is the new NodeData object after the move.
      */
-    public function move(string $targetPath, Workspace $targetWorkspace)
+    public function move($targetPath, Workspace $targetWorkspace)
     {
         $sourceNodeData = $this;
         $originalPath = $this->path;

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -691,7 +691,7 @@ class Workspace
      */
     protected function findCorrespondingNodeDataInTargetWorkspace(NodeInterface $node, Workspace $targetWorkspace)
     {
-        $nodeData = $this->nodeDataRepository->findOneByIdentifier($node->getIdentifier(), $targetWorkspace, $node->getDimensions());
+        $nodeData = $this->nodeDataRepository->findOneByIdentifier($node->getIdentifier(), $targetWorkspace, $node->getDimensions(), true);
         if ($nodeData === null || $nodeData->getWorkspace() !== $targetWorkspace) {
             return null;
         }

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Workspace.php
@@ -472,6 +472,13 @@ class Workspace
     protected function replaceNodeData(NodeInterface $sourceNode, NodeData $targetNodeData)
     {
         $sourceNodeData = $sourceNode->getNodeData();
+
+        // The source node is a regular, not moved node and the target node is a moved shadow node
+        if (!$sourceNode->getNodeData()->isRemoved() && $sourceNode->getNodeData()->getMovedTo() === null && $targetNodeData->isRemoved() && $targetNodeData->getMovedTo() !== null) {
+            $sourceNodeData->move($sourceNodeData->getPath(), $targetNodeData->getWorkspace());
+            return;
+        }
+
         if ($sourceNodeData->getParentPath() !== $targetNodeData->getParentPath()) {
             // When $targetNodeData is moved, the NodeData::move() operation may transform it to a shadow node.
             // moveTargetNodeDataToNewPosition() will return the correct (non-shadow) node in any case.
@@ -685,9 +692,9 @@ class Workspace
      * Returns the NodeData instance with the given identifier from the target workspace.
      * If no NodeData instance is found in that target workspace, null is returned.
      *
-     * @param NodeInterface $node
-     * @param Workspace $targetWorkspace
-     * @return NodeData
+     * @param NodeInterface $node The reference node to find a corresponding variant for
+     * @param Workspace $targetWorkspace The target workspace to look in
+     * @return NodeData Either a regular node, a shadow node or null
      */
     protected function findCorrespondingNodeDataInTargetWorkspace(NodeInterface $node, Workspace $targetWorkspace)
     {

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -193,7 +193,12 @@ class NodeDataRepository extends Repository
         $dimensions = $dimensions === null ? [] : $dimensions;
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
         $foundNodes = $this->filterNodeDataByBestMatchInContext($foundNodes, $workspace, $dimensions, $removedNodes);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, $removedNodes);
+
+        if ($removedNodes === true) {
+            $foundNodes = $this->onlyRemovedNodes($foundNodes);
+        } elseif ($removedNodes === false) {
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
+        }
 
         if ($foundNodes !== []) {
             return reset($foundNodes);
@@ -216,7 +221,7 @@ class NodeDataRepository extends Repository
         $nodes = $this->findRawNodesByPath($path, $workspace, $dimensions, true);
         $dimensions = $dimensions === null ? [] : $dimensions;
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, true);
+        $foundNodes = $this->onlyRemovedNodes($foundNodes);
 
         if ($foundNodes !== []) {
             return reset($foundNodes);
@@ -350,7 +355,7 @@ class NodeDataRepository extends Repository
         $nodes = $query->getResult();
 
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, false);
+        $foundNodes = $this->withoutRemovedNodes($foundNodes);
 
         if ($foundNodes !== []) {
             return reset($foundNodes);
@@ -555,7 +560,12 @@ class NodeDataRepository extends Repository
 
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
         $foundNodes = $this->filterNodeDataByBestMatchInContext($foundNodes, $workspaces[0], $dimensions, $removedNodes);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, $removedNodes);
+
+        if ($removedNodes === true) {
+            $foundNodes = $this->onlyRemovedNodes($foundNodes);
+        } elseif ($removedNodes === false) {
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
+        }
 
         return $foundNodes;
     }
@@ -943,7 +953,7 @@ class NodeDataRepository extends Repository
         $foundNodes = $this->filterNodeDataByBestMatchInContext($foundNodes, $workspaces[0], $dimensions, $includeRemovedNodes);
 
         if ($includeRemovedNodes === false) {
-            $foundNodes = $this->filterRemovedNodes($foundNodes, false);
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
         }
 
         $nodesByDepth = [];
@@ -1008,7 +1018,7 @@ class NodeDataRepository extends Repository
         $query = $queryBuilder->getQuery();
         $foundNodes = $query->getResult();
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($foundNodes, $workspaces, $dimensions);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, false);
+        $foundNodes = $this->withoutRemovedNodes($foundNodes);
 
         return $foundNodes;
     }
@@ -1144,25 +1154,29 @@ class NodeDataRepository extends Repository
     }
 
     /**
-     * Removes NodeData with the removed property set from the given array.
+     * Returns a subset of $nodes which are not flagged as removed.
      *
      * @param array $nodes NodeData including removed entries
-     * @param boolean|NULL $removedNodes If TRUE the result has ONLY removed nodes. If FALSE removed nodes are NOT inside the result. If NULL the result contains BOTH removed and non-removed nodes.
-     * @return array NodeData with removed entries removed
+     * @return array Only those NodeData instances which are not flagged as removed
      */
-    protected function filterRemovedNodes($nodes, $removedNodes)
+    protected function withoutRemovedNodes(array $nodes)
     {
-        if ($removedNodes === true) {
-            return array_filter($nodes, function (NodeData $node) use ($removedNodes) {
-                return $node->isRemoved();
-            });
-        } elseif ($removedNodes === false) {
-            return array_filter($nodes, function (NodeData $node) use ($removedNodes) {
-                return !$node->isRemoved();
-            });
-        } else {
-            return $nodes;
-        }
+        return array_filter($nodes, function (NodeData $node) {
+            return !$node->isRemoved();
+        });
+    }
+
+    /**
+     * Returns a subset of $nodes which are flagged as removed.
+     *
+     * @param array $nodes NodeData including removed entries
+     * @return array Only those NodeData instances which are flagged as removed
+     */
+    protected function onlyRemovedNodes(array $nodes)
+    {
+        return array_filter($nodes, function (NodeData $node) {
+            return $node->isRemoved();
+        });
     }
 
     /**
@@ -1406,7 +1420,7 @@ class NodeDataRepository extends Repository
 
         $foundNodes = $this->reduceNodeVariantsByWorkspaces($foundNodes, $workspaces);
         if ($includeRemovedNodes === false) {
-            $foundNodes = $this->filterRemovedNodes($foundNodes, false);
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
         }
 
         return $foundNodes;
@@ -1591,7 +1605,12 @@ class NodeDataRepository extends Repository
         $nodes = $query->getResult();
         $foundNodes = array_merge($nodes, $nonPersistedNodes);
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($foundNodes, $workspaces, $dimensions);
-        $foundNodes = $this->filterRemovedNodes($foundNodes, $includeRemovedNodes);
+
+        if ($includeRemovedNodes === true) {
+            $foundNodes = $this->onlyRemovedNodes($foundNodes);
+        } elseif ($includeRemovedNodes === false) {
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
+        }
 
         /** @var NodeData $nodeData */
         return array_filter($nodeDataObjects, function (NodeData $nodeData) use ($foundNodes) {

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -319,9 +319,10 @@ class NodeDataRepository extends Repository
      * @param string $identifier Identifier of the node
      * @param Workspace $workspace The containing workspace
      * @param array $dimensions An array of dimensions with array of ordered values to use for fallback matching
+     * @param bool $removedNodes If shadow nodes should be considered while finding the specified node
      * @return NodeData The matching node if found, otherwise NULL
      */
-    public function findOneByIdentifier($identifier, Workspace $workspace, array $dimensions = null)
+    public function findOneByIdentifier($identifier, Workspace $workspace, array $dimensions = null, $removedNodes = false)
     {
         $workspaces = [];
         while ($workspace !== null) {
@@ -355,7 +356,9 @@ class NodeDataRepository extends Repository
         $nodes = $query->getResult();
 
         $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
-        $foundNodes = $this->withoutRemovedNodes($foundNodes);
+        if ($removedNodes === false) {
+            $foundNodes = $this->withoutRemovedNodes($foundNodes);
+        }
 
         if ($foundNodes !== []) {
             return reset($foundNodes);

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
@@ -171,11 +171,11 @@ Feature: Multi layered workspaces
     When I publish the workspace "staging"
     And I get a node by path "/sites/neos/about/foundation" with the following context:
       | Workspace |
-      | live   |
+      | live      |
     Then the node property "title" should be "Foundation (changed)"
     When I get a node by path "/sites/neos/foundation" with the following context:
       | Workspace |
-      | live   |
+      | live      |
     Then I should have 0 nodes
     And the unpublished node count in workspace "staging" should be 0
 
@@ -189,30 +189,45 @@ Feature: Multi layered workspaces
     When I publish the workspace "hotfix"
     And I get a node by path "/sites/neos/service/foundation" with the following context:
       | Workspace |
-      | live   |
+      | live      |
     Then the node property "title" should be "Foundation (hotfix)"
     When I get a node by path "/sites/neos/about/foundation" with the following context:
       | Workspace |
-      | live   |
+      | live      |
     Then I should have 0 nodes
     And the unpublished node count in workspace "hotfix" should be 0
 
   @fixtures
   Scenario: Move node back and forth
 
+    # See issue #1639
+
     When I get a node by path "/sites/neos/foundation" with the following context:
-      | Workspace |
+      | Workspace  |
       | user-admin |
     And I move the node into the node with path "/sites/neos/about"
     And I publish the workspace "user-admin"
     Then the unpublished node count in workspace "campaign" should be 4
 
     When I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I set the node property "title" to "Changed"
+    And I move the node after the node with path "/sites/neos/about"
+    And  I get a node by path "/sites/neos/foundation" with the following context:
       | Workspace |
       | user-admin |
-    And I move the node after the node with path "/sites/neos/about"
+    Then I should have one node
+
+
     And I publish the workspace "user-admin"
     And  I get a node by path "/sites/neos/foundation" with the following context:
       | Workspace |
-      | user-campaign |
+      | campaign  |
     Then I should have one node
+    And the unpublished node count in workspace "user-admin" should be 0
+
+    When I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | campaign  |
+    Then I should have 0 nodes

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Workspaces/MultiLayeredWorkspaces.feature
@@ -196,3 +196,23 @@ Feature: Multi layered workspaces
       | live   |
     Then I should have 0 nodes
     And the unpublished node count in workspace "hotfix" should be 0
+
+  @fixtures
+  Scenario: Move node back and forth
+
+    When I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | user-admin |
+    And I move the node into the node with path "/sites/neos/about"
+    And I publish the workspace "user-admin"
+    Then the unpublished node count in workspace "campaign" should be 4
+
+    When I get a node by path "/sites/neos/about/foundation" with the following context:
+      | Workspace |
+      | user-admin |
+    And I move the node after the node with path "/sites/neos/about"
+    And I publish the workspace "user-admin"
+    And  I get a node by path "/sites/neos/foundation" with the following context:
+      | Workspace |
+      | user-campaign |
+    Then I should have one node


### PR DESCRIPTION
This change fixes a problem in the content repository which can lead to a uniqueness constraint error when a node is moved back and forth in a nested workspace.

Fixes #1639 