### PR TITLE
BUGFIX: Build correct paths to nodes with hidden parents

### DIFF
--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -139,6 +139,10 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return false;
         }
 
+        if ($node->getWorkspace()->getName() === 'live' && $node->isHidden() === true) {
+            return false;
+        }
+
         $this->value = $node->getContextPath();
 
         return true;
@@ -579,7 +583,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     {
         $contextProperties = [
             'workspaceName' => $workspaceName,
-            'invisibleContentShown' => ($workspaceName !== 'live'),
+            'invisibleContentShown' => true,
             'inaccessibleContentShown' => ($workspaceName !== 'live'),
             'dimensions' => $dimensionsAndDimensionValues
         ];

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -494,7 +494,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         }));
 
         $that = $this;
-        $this->mockContextFactory->expects($this->once())->method('create')->will($this->returnCallback(function ($contextProperties) use ($that, $mockContext) {
+        $this->mockContextFactory->expects($this->atLeastOnce())->method('create')->will($this->returnCallback(function ($contextProperties) use ($that, $mockContext) {
             // The important assertion:
             $that->assertSame('live', $contextProperties['workspaceName']);
             return $mockContext;
@@ -522,7 +522,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         }));
 
         $that = $this;
-        $this->mockContextFactory->expects($this->once())->method('create')->will($this->returnCallback(function ($contextProperties) use ($that, $mockContext) {
+        $this->mockContextFactory->expects($this->atLeastOnce())->method('create')->will($this->returnCallback(function ($contextProperties) use ($that, $mockContext) {
             // The important assertion:
             $that->assertSame('user-johndoe', $contextProperties['workspaceName']);
             return $mockContext;

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -14,13 +14,12 @@ namespace Neos\Neos\Tests\Unit\Routing;
 use Neos\Flow\Log\SystemLoggerInterface;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Neos\Domain\Model\Domain;
+use Neos\Flow\Utility\Algorithms;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ConfigurationContentDimensionPresetSource;
 use Neos\Neos\Domain\Service\ContentContext;
-use Neos\Neos\Routing\Exception\NoHomepageException;
 use Neos\Neos\Routing\FrontendNodeRoutePartHandler;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
@@ -913,6 +912,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      *
      * @param NodeInterface $mockParentNode
      * @param string $nodeName
+     * @param string $nodeTypeName
      * @return NodeInterface
      */
     protected function buildSubNode($mockParentNode, $nodeName, $nodeTypeName = 'Neos.Neos:Document')

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -851,6 +851,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockNode->expects($this->any())->method('getIdentifier')->will($this->returnValue('site-node-uuid'));
         $mockNode->expects($this->any())->method('getName')->will($this->returnValue($nodeName));
         $mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue($mockNodeType));
+        $mockNode->expects($this->any())->method('getWorkspace')->will($this->returnValue($mockContext->getWorkspace()));
 
         // Parent node is set by buildSubNode()
         $mockNode->mockParentNode = null;

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -811,6 +811,13 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
             return $mockContext->mockTargetDimensions;
         }));
 
+        $mockContext->expects($this->any())->method('getNodeByIdentifier')->will($this->returnCallback(function ($identifier) use ($mockContext) {
+            if(array_key_exists($identifier, $mockContext->mockNodesByIdentifier)) {
+                    return $mockContext->mockNodesByIdentifier[$identifier];
+            }
+            return null;
+        }));
+
         $mockContext->expects($this->any())->method('getProperties')->will($this->returnCallback(function () use ($mockContext, $contextProperties) {
             return array(
                 'workspaceName' => $contextProperties['workspaceName'],
@@ -848,10 +855,13 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
         $mockNode = $this->createMock(NodeInterface::class);
         $mockNode->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
-        $mockNode->expects($this->any())->method('getIdentifier')->will($this->returnValue('site-node-uuid'));
         $mockNode->expects($this->any())->method('getName')->will($this->returnValue($nodeName));
         $mockNode->expects($this->any())->method('getNodeType')->will($this->returnValue($mockNodeType));
         $mockNode->expects($this->any())->method('getWorkspace')->will($this->returnValue($mockContext->getWorkspace()));
+
+        $mockNodeIdentifier = Algorithms::generateUUID();
+        $mockNode->expects($this->any())->method('getIdentifier')->will($this->returnValue($mockNodeIdentifier));
+        $mockContext->mockNodesByIdentifier[$mockNodeIdentifier] = $mockNode;
 
         // Parent node is set by buildSubNode()
         $mockNode->mockParentNode = null;


### PR DESCRIPTION
If a node is visible but lies beneath a hidden parent, the URI path
generated for that node had "holes" and did not work. This adjusts the
route part handler to return the complete URI including the URI path
segments of hidden nodes in the chain up to the site node.

Additionally this adjusts the route part handler to return the node,
unless it itself is hidden.  This makes it possible to show visible nodes
beneath hidden parents.

