### PR TITLE
BUGFIX: Hide disabled modules in submodule overviews

### DIFF
--- a/Neos.Neos/Resources/Private/Partials/Module/SubmoduleOverview.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/SubmoduleOverview.html
@@ -2,15 +2,17 @@
 <f:if condition="{moduleConfiguration.submodules}">
 	<div class="neos-row-fluid">
 		<f:for each="{moduleConfiguration.submodules}" key="submoduleIdentifier" as="submoduleConfiguration" iteration="iterator">
-			<f:if condition="{submoduleConfiguration.privilegeTarget}">
-				<f:then>
-					<f:security.ifAccess privilegeTarget="{submoduleConfiguration.privilegeTarget}">
+			<f:if condition="{submoduleConfiguration.enabled} !== false">
+				<f:if condition="{submoduleConfiguration.privilegeTarget}">
+					<f:then>
+						<f:security.ifAccess privilegeTarget="{submoduleConfiguration.privilegeTarget}">
+							<f:render section="submodule" arguments="{_all}" />
+						</f:security.ifAccess>
+					</f:then>
+					<f:else>
 						<f:render section="submodule" arguments="{_all}" />
-					</f:security.ifAccess>
-				</f:then>
-				<f:else>
-					<f:render section="submodule" arguments="{_all}" />
-				</f:else>
+					</f:else>
+				</f:if>
 			</f:if>
 		</f:for>
 	</div>


### PR DESCRIPTION
When a module has been disabled using the `disabled` flag, the module is hidden from the main menu and cannot be accessed, however it was still being displayed in submodule overviews.