### PR TITLE
BUGFIX: Trigger ContentCacheFlusher on asset update

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Package.php
@@ -17,12 +17,14 @@ use TYPO3\Flow\Monitor\FileMonitor;
 use TYPO3\Flow\Mvc\Routing\RouterCachingService;
 use TYPO3\Flow\Package\Package as BasePackage;
 use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
+use TYPO3\Media\Domain\Service\AssetService;
 use TYPO3\Neos\Domain\Model\Site;
 use TYPO3\Neos\Domain\Service\SiteImportService;
 use TYPO3\Neos\Domain\Service\SiteService;
 use TYPO3\Neos\EventLog\Integrations\TYPO3CRIntegrationService;
 use TYPO3\Neos\Routing\Cache\RouteCacheFlusher;
 use TYPO3\Neos\Service\PublishingService;
+use TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher;
 use TYPO3\Neos\Utility\NodeUriPathSegmentGenerator;
 use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
@@ -74,7 +76,8 @@ class Package extends BasePackage
         $dispatcher->connect(Node::class, 'nodeRemoved', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
         $dispatcher->connect(Node::class, 'beforeNodeMove', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerNodeChange');
 
-        $dispatcher->connect('TYPO3\Media\Domain\Service\AssetService', 'assetResourceReplaced', 'TYPO3\Neos\TypoScript\Cache\ContentCacheFlusher', 'registerAssetResourceChange');
+        $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetChange');
+        $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetChange');
 
         $dispatcher->connect(Node::class, 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
         $dispatcher->connect(Node::class, 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/Cache/ContentCacheFlusher.php
@@ -86,12 +86,24 @@ class ContentCacheFlusher
     }
 
     /**
+     * Deprecated. Please use ContentCacheFlush::registerAssetChange
+     *
+     * @deprecated
+     * @param AssetInterface $asset
+     * @return void
+     */
+    public function registerAssetResourceChange(AssetInterface $asset)
+    {
+        $this->registerAssetChange($asset);
+    }
+
+    /**
      * Fetches possible usages of the asset and registers nodes that use the asset as changed.
      *
      * @param AssetInterface $asset
      * @return void
      */
-    public function registerAssetResourceChange(AssetInterface $asset)
+    public function registerAssetChange(AssetInterface $asset)
     {
         if (!$asset->isInUse()) {
             return;


### PR DESCRIPTION
The content cache does not invalidate on changes to an asset. Expected behavior would be to flush the content cache on changes to an asset (e.g title, caption).

Neos 2.3 PR of: https://github.com/neos/neos-development-collection/pull/1636