### PR TITLE
TASK: Ignore preset value if ``false``

### DIFF
--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -143,7 +143,7 @@ class ImageUriImplementation extends AbstractFusionObject
         if (!$asset instanceof AssetInterface) {
             throw new \Exception('No asset given for rendering.', 1415184217);
         }
-        if ($preset !== null && $preset !== false) {
+        if (!empty($preset)) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getAsync());

--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -143,7 +143,7 @@ class ImageUriImplementation extends AbstractFusionObject
         if (!$asset instanceof AssetInterface) {
             throw new \Exception('No asset given for rendering.', 1415184217);
         }
-        if ($preset !== null) {
+        if ($preset !== null && $preset !== false) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getAsync());


### PR DESCRIPTION
Until now the ``ImageUri`` prototype would return no image if the preset was set to ``false`` (only accepted fallback until now was ``null``). With this change it's also possible to reset the preset with ``false``.