### PR TITLE
BUGFIX: Prevent space if no css class is given

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Content.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Content.ts2
@@ -23,7 +23,7 @@ prototype(TYPO3.Neos:Content) < prototype(TYPO3.TypoScript:Template) {
 
 		classIsString {
 			condition = ${Type.isString(value)}
-			renderer = ${String.trim(value) + ' ' + nodeTypeClassName}
+			renderer = ${String.trim(String.trim(value) + ' ' + nodeTypeClassName)}
 		}
 
 		classIsArray {


### PR DESCRIPTION
If no `attributes.class` is given the attribute always starts with space. Like that the attributes get trimmed.

### Output before:
`class=" foo-bar-content"`

### Output after:
`class="foo-bar-content"`
