### PR TITLE
BUGFIX: TypoScriptView should set response headers correctly

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/View/TypoScriptView.php
@@ -123,7 +123,7 @@ class TypoScriptView extends AbstractView
                     $response = $typoScriptRuntime->getControllerContext()->getResponse();
                     $response->setStatus($renderedResponse->getStatusCode());
                     foreach ($renderedResponse->getHeaders()->getAll() as $headerName => $headerValues) {
-                        $response->setHeader($headerName, $headerValues[0]);
+                        $response->setHeader($headerName, $headerValues);
                     }
 
                     $output = substr($output, strlen($header));

--- a/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
+++ b/TYPO3.Neos/Tests/Unit/View/TypoScriptViewTest.php
@@ -161,7 +161,7 @@ class TypoScriptViewTest extends UnitTestCase
 
         $view->_set('variables', array('value' => $mockContextualizedNode));
 
-        $mockResponse->expects($this->atLeastOnce())->method('setHeader')->with('Content-Type', 'application/json');
+        $mockResponse->expects($this->atLeastOnce())->method('setHeader')->with('Content-Type', ['application/json']);
 
         $output = $view->render();
         $this->assertEquals('Message body', $output);

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/Http/ResponseHeadImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/Http/ResponseHeadImplementation.php
@@ -11,7 +11,6 @@ namespace TYPO3\TypoScript\TypoScriptObjects\Http;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Http\Headers;
 use TYPO3\Flow\Http\Response;
 use TYPO3\TypoScript\TypoScriptObjects\AbstractTypoScriptObject;
@@ -71,6 +70,7 @@ class ResponseHeadImplementation extends AbstractTypoScriptObject
     public function evaluate()
     {
         $httpResponse = new Response();
+        $httpResponse->setVersion($this->getHttpVersion());
         $httpResponse->setStatus($this->getStatusCode());
         $httpResponse->setHeaders(new Headers());
 


### PR DESCRIPTION
The httpVersion which could be set in the `ResponseHeadImplementation`
was not used.

Additionally, if a header had multiple values (which can easily be done in
TypoScript via RawArray) only the first header was actually transferred to
the sent HTTP response.
