### PR TITLE
TASK: use new fontawesome declaration for contentcollection icon in n…

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -327,7 +327,7 @@
     'Neos.Neos:Node': TRUE
   ui:
     label: i18n
-    icon: 'icon-folder-open-alt'
+    icon: 'icon-folder-open'
   constraints:
     nodeTypes:
       'Neos.Neos:Document': FALSE


### PR DESCRIPTION
…ew neos ui

Related: #


**What I did**

With the new fontawesome the contentcollection icon is obsolete.

**How I did it**
 I only updated the classname in the nodetypes.yaml

This request has to merge when new neos ui is used  

(https://www.neos.io/features/release-roadmap.html)
