### PR TITLE
BUGFIX: Allow Prototype names starting with digits

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Parser.php
@@ -784,8 +784,8 @@ class Parser implements ParserInterface
         }
 
         $currentKey = array_shift($objectPathArray);
-        if ((integer)$currentKey > 0) {
-            $currentKey = (integer)$currentKey;
+        if (is_numeric($currentKey)) {
+            $currentKey = (int)$currentKey;
         }
 
         if (empty($objectPathArray)) {
@@ -837,8 +837,8 @@ class Parser implements ParserInterface
 
         if (count($objectPathArray) > 0) {
             $currentKey = array_shift($objectPathArray);
-            if ((integer)$currentKey > 0) {
-                $currentKey = intval($currentKey);
+            if (is_numeric($currentKey)) {
+                $currentKey = (int)$currentKey;
             }
             if (!isset($objectTree[$currentKey])) {
                 $objectTree[$currentKey] = array();

--- a/TYPO3.TypoScript/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture21.ts2
+++ b/TYPO3.TypoScript/Tests/Unit/Core/Fixtures/ParserTestTypoScriptFixture21.ts2
@@ -1,0 +1,10 @@
+//
+// TypoScript Fixture 21
+//
+// Checks if identifiers starting with digits are parsed correctly
+
+prototype(4Testing:Example) {
+	someValue = true
+}
+
+somepath.101Neos = 'A string value'

--- a/TYPO3.TypoScript/Tests/Unit/Core/ParserTest.php
+++ b/TYPO3.TypoScript/Tests/Unit/Core/ParserTest.php
@@ -872,6 +872,30 @@ class ParserTest extends UnitTestCase
     }
 
     /**
+     * Checks if identifiers starting with digits are parsed correctly
+     *
+     * @test
+     */
+    public function parserCorrectlyParsesFixture21()
+    {
+        $sourceCode = $this->readTypoScriptFixture('ParserTestTypoScriptFixture21');
+
+        $expectedParseTree = array(
+            '__prototypes' => array(
+                '4Testing:Example' => array(
+                    'someValue' => true
+                )
+            ),
+            'somepath' => array(
+                '101Neos' => 'A string value',
+            ),
+        );
+
+        $actualParseTree = $this->parser->parse($sourceCode);
+        $this->assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 21.');
+    }
+
+    /**
      * Checks if comments in comments are parsed correctly
      *
      * @test


### PR DESCRIPTION
Prototype declarations starting with digits previously were wrongly
parsed and resulted in broken names, this change fixes it by only
casting numeric strings to integers as object keys.

Fixes: #1114 
