### PR TITLE
TASK: Allow using the context variable in node privileges

### DIFF
--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/Doctrine/ConditionGenerator.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/Doctrine/ConditionGenerator.php
@@ -69,6 +69,9 @@ class ConditionGenerator extends EntityConditionGenerator
      */
     public function isDescendantNodeOf($nodePathOrIdentifier)
     {
+        $propertyConditionGenerator1 = new PropertyConditionGenerator('path');
+        $propertyConditionGenerator2 = new PropertyConditionGenerator('path');
+
         if (preg_match(UuidValidator::PATTERN_MATCH_UUID, $nodePathOrIdentifier) === 1) {
             $node = $this->getNodeByIdentifier($nodePathOrIdentifier);
             if ($node === null) {
@@ -76,10 +79,9 @@ class ConditionGenerator extends EntityConditionGenerator
             }
             $nodePath = $node->getPath();
         } else {
+            $nodePathOrIdentifier = $propertyConditionGenerator1->getValueForOperand($nodePathOrIdentifier);
             $nodePath = rtrim($nodePathOrIdentifier, '/');
         }
-        $propertyConditionGenerator1 = new PropertyConditionGenerator('path');
-        $propertyConditionGenerator2 = new PropertyConditionGenerator('path');
 
         return new DisjunctionGenerator(array($propertyConditionGenerator1->like($nodePath . '/%'), $propertyConditionGenerator2->equals($nodePath)));
     }
@@ -91,6 +93,7 @@ class ConditionGenerator extends EntityConditionGenerator
     public function nodeIsOfType($nodeTypes)
     {
         $propertyConditionGenerator = new PropertyConditionGenerator('nodeType');
+        $nodeTypes = $propertyConditionGenerator->getValueForOperand($nodeTypes);
         if (!is_array($nodeTypes)) {
             $nodeTypes = array($nodeTypes);
         }
@@ -109,6 +112,7 @@ class ConditionGenerator extends EntityConditionGenerator
     public function isInWorkspace($workspaceNames)
     {
         $propertyConditionGenerator = new PropertyConditionGenerator('workspace');
+        $workspaceNames = $propertyConditionGenerator->getValueForOperand($workspaceNames);
         if (!is_array($workspaceNames)) {
             $workspaceNames = array($workspaceNames);
         }

--- a/Neos.Neos/Documentation/CreatingASite/Security.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Security.rst
@@ -267,6 +267,22 @@ Privilege Matchers
 The privileges need to be applied to certain nodes to be useful. For this, matchers are used in the policy, written
 using Eel. Depending on the privilege, various methods to address nodes are available.
 
+.. note::
+    **Global objects in matcher expressions**
+
+    Since the matchers are written using Eel, anything in the Eel context during evaluation is usable for matching.
+    This is done by using the ``context`` keyword, followed by dotted path to the value needed. E.g. to access the
+    personal workspace name of the currently logged in user, this can be used::
+
+      privilegeTargets:
+        'Neos\ContentRepository\Security\Authorization\Privilege\Node\ReadNodePrivilege':
+          'Neos.ContentRepository:Workspace':
+            matcher: 'isInWorkspace("context.userInformation.personalWorkspaceName“))’
+
+    These global objects available under ``context`` (by default the current ``SsecurityContext`` imported as
+    ``securityContext`` and the ``UserService`` imported as ``userInformation``) are registered in the *Settings.yaml*
+    file in section ``aop.globalObjects``. That way you can add your own as well.
+
 Position in the Node Tree
 -------------------------
 


### PR DESCRIPTION
This makes it possible to access global objects via the context variable in node privileges.

For example this can be used to hide nodes based on a node property which needs to
match a username or group. One use case is to have several sites in one Neos and restrict
each user to one site.

How it works: The values given to the `ConditionGenerator` of the node privileges are
first put through `getValueForOperand` instead of treating them just as string.