### PR TITLE
BUGFIX: Allow cached content segments to be nested within dynamic ones

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -177,7 +177,7 @@ class ContentCache
             'context' => $this->serializeContext($contextVariables),
         ];
 
-        return self::CACHE_SEGMENT_START_TOKEN . $this->randomCacheMarker . 'evalCached=' . $identifier . self::CACHE_SEGMENT_SEPARATOR_TOKEN . $this->randomCacheMarker . json_encode($segmentData) . self::CACHE_SEGMENT_SEPARATOR_TOKEN . $this->randomCacheMarker . $content . self::CACHE_SEGMENT_END_TOKEN . $this->randomCacheMarker;
+        return self::CACHE_SEGMENT_START_TOKEN . $this->randomCacheMarker . 'evalCached=' . $identifier . self::CACHE_SEGMENT_SEPARATOR_TOKEN . $this->randomCacheMarker . json_encode($segmentData) . self::CACHE_SEGMENT_SEPARATOR_TOKEN . $this->randomCacheMarker . $this->processCacheSegments($content, false) . self::CACHE_SEGMENT_END_TOKEN . $this->randomCacheMarker;
     }
 
     /**

--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/Core/Cache/ContentCache.php
@@ -227,7 +227,7 @@ class ContentCache
             foreach ($segments as $segment) {
                 $metadata = explode(';', $segment['metadata']);
                 $tagsValue = $metadata[0] === '' ? [] : ($metadata[0] === '*' ? false : explode(',', $metadata[0]));
-                    // FALSE means we do not need to store the cache entry again (because it was previously fetched)
+                // FALSE means we do not need to store the cache entry again (because it was previously fetched)
                 if ($tagsValue !== false) {
                     $lifetime = isset($metadata[1]) ? (integer)$metadata[1] : null;
                     $this->cache->set($segment['identifier'], $segment['content'], $this->sanitizeTags($tagsValue), $lifetime);

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
@@ -53,12 +53,12 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $view->assign('object', $object);
         $view->setTypoScriptPath('contentCache/cachedSegment');
 
-            // This render call should create the cache entry
+        // This render call should create the cache entry
         $firstRenderResult = $view->render();
 
         $object->setValue('Object value 2');
 
-            // And this render call should use the existing cache entry
+        // And this render call should use the existing cache entry
         $secondRenderResult = $view->render();
 
         $this->assertSame('Cached segment|Object value 1', $firstRenderResult);
@@ -83,7 +83,7 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
 
         $this->assertSame('Outer segment|site=site1|Inner segment|object=Object value 1|End inner|End outer', $firstRenderResult);
 
-            // This must not influence the output, since the inner segment should be fetched from cache
+        // This must not influence the output, since the inner segment should be fetched from cache
         $object->setValue('Object value 2');
 
         $view->assign('site', 'site2');
@@ -149,7 +149,7 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $firstRenderResult = $view->render();
         $this->assertSame('Outer segment|object=Object value 1|Uncached segment|counter=1|End uncached|End outer', $firstRenderResult);
 
-            // Update the object value to see that the outer segment is really cached
+        // Update the object value to see that the outer segment is really cached
         $object->setValue('Object value 2');
 
         $secondRenderResult = $view->render();
@@ -172,7 +172,7 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $firstRenderResult = $view->render();
         $this->assertSame('Outer segment|object=Object value 1|Uncached segment|counter=1|End uncached|End outer', $firstRenderResult);
 
-            // Assigning a new object changes the identifier and therefore a new outer cache segment is created
+        // Assigning a new object changes the identifier and therefore a new outer cache segment is created
         $newObject = new TestModel(21, 'New object value');
         $view->assign('object', $newObject);
 
@@ -205,10 +205,10 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $secondRenderResult = $view->render();
         $this->assertSame($firstRenderResult, $secondRenderResult);
 
-            // This should flush "Inner segment 1"
+        // This should flush "Inner segment 1"
         $this->contentCache->flushByTag('Object_' . $object->getId());
 
-            // Since the cache entry for "Inner segment 1" is missing, the outer segment is also evaluated, but not "Inner segment 2"
+        // Since the cache entry for "Inner segment 1" is missing, the outer segment is also evaluated, but not "Inner segment 2"
         $secondRenderResult = $view->render();
         $this->assertSame('Outer segment|counter=2|Inner segment 1|object=Object value 2|End innerInner segment 2|object=Object value 1|End inner|End outer', $secondRenderResult);
     }
@@ -232,17 +232,17 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
 
         $object->setValue('Object value 2');
 
-            // This should flush "Inner segment 1"
+        // This should flush "Inner segment 1"
         $this->contentCache->flushByTag('NodeType_Acme.Demo:SampleNodeType');
 
-            // Since the cache entry for "Inner segment 1" is missing, the outer segment is also evaluated, but not "Inner segment 2"
+        // Since the cache entry for "Inner segment 1" is missing, the outer segment is also evaluated, but not "Inner segment 2"
         $secondRenderResult = $view->render();
         $this->assertSame('Outer segment|counter=2|Inner segment 1|object=Object value 2|End innerInner segment 2|object=Object value 1|End inner|End outer', $secondRenderResult);
 
-            // This should flush "Inner segment 2"
+        // This should flush "Inner segment 2"
         $this->contentCache->flushByTag('Node_47a6ee72-936a-4489-abc1-3666a63cdc4a');
 
-            // Since the cache entry for "Inner segment 2" is missing, the outer segment is also evaluated, but not "Inner segment 1"
+        // Since the cache entry for "Inner segment 2" is missing, the outer segment is also evaluated, but not "Inner segment 1"
         $secondRenderResult = $view->render();
         $this->assertSame('Outer segment|counter=3|Inner segment 1|object=Object value 2|End innerInner segment 2|object=Object value 2|End inner|End outer', $secondRenderResult);
     }

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/ContentCacheTest.php
@@ -673,4 +673,23 @@ class ContentCacheTest extends AbstractTypoScriptObjectTest
         $this->assertSame('Dynamic segment|counter=2', $thirdRenderResult);
         $this->assertSame('Dynamic segment|counter=3', $fourthRenderResult);
     }
+
+    /**
+     * @test
+     */
+    public function cachedSegmentsCanBeNestedWithinDynamicSegments()
+    {
+        $renderObject = new TestModel(42, 'Render object');
+
+        $view = $this->buildView();
+        $view->setOption('enableContentCache', true);
+        $view->assign('renderObject', $renderObject);
+        $view->setTypoScriptPath('contentCache/dynamicSegmentWithNestedCachedSegment');
+
+        $firstRenderResult = $view->render();
+        $secondRenderResult = $view->render();
+
+        $this->assertSame('Cached segment|counter=1|Nested dynamic segment|counter=2|Nested cached segment|counter=3', $firstRenderResult);
+        $this->assertSame($firstRenderResult, $secondRenderResult);
+    }
 }

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -559,3 +559,29 @@ contentCache.dynamicSegmentWithDisabledDiscriminator = TYPO3.TypoScript:Array {
 		entryDiscriminator = ${discriminatorObject.value == 'disable' ? false : discriminatorObject.value}
 	}
 }
+
+contentCache.dynamicSegmentWithNestedCachedSegment = TYPO3.TypoScript:Array {
+	5 = 'Cached segment|'
+	10 = ${'counter=' + renderObject.counter + '|'}
+	15 = TYPO3.TypoScript:Array {
+		5 = 'Nested dynamic segment|'
+		10 = ${'counter=' + renderObject.counter + '|'}
+		15 = TYPO3.TypoScript:Array {
+			5 = 'Nested cached segment|'
+			10 = ${'counter=' + renderObject.counter}
+			@cache {
+				mode = 'cached'
+			}
+		}
+		@cache {
+			mode = 'dynamic'
+			context {
+				1 = 'node'
+				2 = 'documentNode'
+			}
+		}
+	}
+	@cache {
+		mode = 'cached'
+	}
+}

--- a/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
+++ b/TYPO3.TypoScript/Tests/Functional/TypoScriptObjects/Fixtures/TypoScript/ContentCache.ts2
@@ -576,8 +576,7 @@ contentCache.dynamicSegmentWithNestedCachedSegment = TYPO3.TypoScript:Array {
 		@cache {
 			mode = 'dynamic'
 			context {
-				1 = 'node'
-				2 = 'documentNode'
+				1 = 'renderObject'
 			}
 		}
 	}


### PR DESCRIPTION
Previously when nesting content with Content Cache mode `cached` within
segments with Content Cache mode `dynamic` the `CONTENT_CACHE` markers
weren't replaced at the second rendering.

Fixes: #1591