### PR TITLE
BUGFIX: Shortcut nodes result in 404 if target is unavailable

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Frontend/NodeController.php
@@ -157,6 +157,8 @@ class NodeController extends ActionController
             throw new NodeNotFoundException(sprintf('The shortcut node target of node "%s" could not be resolved', $node->getPath()), 1430218730);
         } elseif (is_string($resolvedNode)) {
             $this->redirectToUri($resolvedNode);
+        } elseif ($resolvedNode instanceof NodeInterface && $resolvedNode === $node) {
+            throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1502793585229);
         } elseif ($resolvedNode instanceof NodeInterface) {
             $this->redirect('show', null, null, ['node' => $resolvedNode]);
         } else {


### PR DESCRIPTION
A non existing (or hidden) target node would result in an infinite
redirect chain but should actually result in a 404 error delivered.

Fixes: #1668
