### PR TITLE
BUGFIX: Allow childNode definitions to be reset

### DIFF
--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -35,7 +35,7 @@ additionalProperties:
     'childNodes':
       type: dictionary
       additionalProperties:
-        type: dictionary
+        type: [dictionary, 'null']
         additionalProperties: FALSE
         properties:
           'type': { type: string, description: "Node Type of this child node." }


### PR DESCRIPTION
A NodeType can reset the `childNode` definitions of a
superType by setting it to `null`:

```yaml
'Some:NodeType':
  superTypes:
    'Some:Other.NodeType': true
  childNodes:
    'someChildNodes': ~
```

But doing so lead to a schema error.
This patch adjusts the schema accordingly.