### PR TITLE
FEATURE: Accept JSON string for validation

### DIFF
--- a/Neos.Neos/Resources/Public/JavaScript/Shared/Validation/CountValidator.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Shared/Validation/CountValidator.js
@@ -5,9 +5,10 @@ define(
 	[
 		'./AbstractValidator',
 		'Library/underscore',
-		'Shared/I18n'
+		'Shared/I18n',
+		'Shared/Utility'
 	],
-	function(AbstractValidator, _, I18n) {
+	function(AbstractValidator, _, I18n, Utility) {
 		return AbstractValidator.extend({
 			/**
 			 * @var {object}
@@ -19,11 +20,15 @@ define(
 
 			/**
 			 * The given value is valid if it is an array or object that contains the specified amount of elements.
+			 * If the value is a valid JSON string then the parsed object is checked.
 			 *
 			 * @param {mixed} value The value that should be validated
 			 * @return {void}
 			 */
 			isValid: function(value) {
+				if (Utility.isValidJsonString(value)) {
+					value = JSON.parse(value);
+				}
 				if (typeof value !== 'array' || typeof value !== 'object') {
 					this.addError(I18n.translate('content.inspector.validators.countValidator.notCountable'));
 					return;

--- a/Neos.Neos/Resources/Public/JavaScript/Shared/Validation/NotEmptyValidator.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Shared/Validation/NotEmptyValidator.js
@@ -5,9 +5,10 @@ define(
 	[
 		'./AbstractValidator',
 		'Library/underscore',
-		'Shared/I18n'
+		'Shared/I18n',
+		'Shared/Utility'
 	],
-	function(AbstractValidator, _, I18n) {
+	function(AbstractValidator, _, I18n, Utility) {
 		return AbstractValidator.extend({
 			/**
 			 * Specifies whether this validator accepts empty values.
@@ -17,12 +18,16 @@ define(
 			acceptsEmptyValues: false,
 
 			/**
-			 * Checks if the given value is not empty (NULL, empty string, empty array.
+			 * Checks if the given value is not empty (NULL, empty string, empty array).
+			 * If the value is a valid JSON string then the parsed object is checked.
 			 *
 			 * @param {mixed} value The value that should be validated
 			 * @return {void}
 			 */
 			isValid: function(value) {
+				if (Utility.isValidJsonString(value)) {
+					value = JSON.parse(value);
+				}
 				if (value === null || value === '' || (_.isArray(value) && _.isEmpty(value))) {
 					this.addError(I18n.translate('content.inspector.validators.notEmptyValidator.isEmpty'));
 				}


### PR DESCRIPTION
Allow JSON strings for validation in `CountValidator` and `NotEmptyValidator`. This also allows us to check asset array properties for emptiness.