### PR TITLE
TASK: Fix documentation of Debug Object

### DIFF
--- a/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
+++ b/TYPO3.Neos/Documentation/References/NeosTypoScriptReference.rst
@@ -183,7 +183,7 @@ Shows the result of TypoScript Expressions directly.
 
 Example::
 
-  debugObject = Debug {
+  debugObject = TYPO3.TypoScript:Debug {
         title = 'Debug of hello world'
 
         # If only the "value"-key is given it is debugged directly,


### PR DESCRIPTION
Example is missing the namespace.