### PR TITLE
BUGFIX: Set empty array for overrideConfiguration as default

### DIFF
--- a/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
@@ -94,6 +94,7 @@ prototype(Neos.NodeTypes:FourColumn) < prototype(Neos.NodeTypes:MultiColumn)
 # Form TS Object
 prototype(Neos.NodeTypes:Form) {
 	presetName = 'default'
+	overrideConfiguration = Neos.Fusion:RawArray
 	@cache {
 		mode = 'uncached'
 		context {


### PR DESCRIPTION
To prevent errors within the form view helper it's necessary to set `overrideConfiguration` as array per default instead of null. The change of the signature of the form view helper has made this change necessary:
https://github.com/neos/form/commit/0cac9ef02043c9ae5e25eb41a7f746ba75e80f2d

The default tempate just by-pass the `overrideConfiguration`:
https://github.com/neos/neos-development-collection/blob/3.0/Neos.NodeTypes/Resources/Private/Templates/NodeTypes/Form.html
