### PR TITLE
BUGFIX: Fixing wrong path in documentation to translations folder

### DIFF
--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/TranslateNodeTypes.rst
@@ -103,7 +103,7 @@ contain a path of the format ``Vendor.Package:Xliff.Path.And.Filename:labelType.
 The string consists of three parts delimited by ``:``:
 
 * First, the *Package Key*
-* Second, the path towards the xliff file, replacing slashes by dots (relative to ``Resources/Private/Translation/<language>``).
+* Second, the path towards the xliff file, replacing slashes by dots (relative to ``Resources/Private/Translations/<language>``).
 * Third, the key inside the xliff file.
 
 For the example above that would be ``Vendor.Site:NodeTypes.YourContentElementName:properties.title``:


### PR DESCRIPTION
Like https://github.com/neos/neos-development-collection/pull/1566 but for older branch.