### PR TITLE
Xliffservice label override

### DIFF
--- a/Neos.Neos/Classes/Service/XliffService.php
+++ b/Neos.Neos/Classes/Service/XliffService.php
@@ -176,7 +176,7 @@ class XliffService
                     }
                     if (is_array($sourcesToBeIncluded)) {
                         $addSource = false;
-                        foreach($sourcesToBeIncluded as $sourcePattern) {
+                        foreach ($sourcesToBeIncluded as $sourcePattern) {
                             if (fnmatch($sourcePattern, $source)) {
                                 $addSource = true;
                                 break;

--- a/Neos.Neos/Classes/Service/XliffService.php
+++ b/Neos.Neos/Classes/Service/XliffService.php
@@ -15,7 +15,9 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Error\Messages\Result;
 use Neos\Flow\I18n\Exception;
-use Neos\Flow\I18n\Xliff\XliffParser;
+use Neos\Flow\I18n\Xliff\Service\XliffFileProvider;
+use Neos\Flow\I18n\Xliff\Service\XliffReader;
+use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Utility\Arrays;
 use Neos\Utility\Files;
@@ -39,9 +41,9 @@ class XliffService
 
     /**
      * @Flow\Inject
-     * @var XliffParser
+     * @var XliffReader
      */
-    protected $xliffParser;
+    protected $xliffReader;
 
     /**
      * @Flow\Inject
@@ -69,6 +71,12 @@ class XliffService
 
     /**
      * @Flow\Inject
+     * @var XliffFileProvider
+     */
+    protected $xliffFileProvider;
+
+    /**
+     * @Flow\Inject
      * @var PackageManagerInterface
      */
     protected $packageManager;
@@ -89,27 +97,36 @@ class XliffService
             $json = $this->xliffToJsonTranslationsCache->get($cacheIdentifier);
         } else {
             $labels = [];
-            $localeChain = $this->localizationService->getLocaleChain($locale);
 
             foreach ($this->packagesRegisteredForAutoInclusion as $packageKey => $sourcesToBeIncluded) {
                 if (!is_array($sourcesToBeIncluded)) {
                     continue;
                 }
 
-                $translationBasePath = Files::concatenatePaths([
-                    $this->packageManager->getPackage($packageKey)->getResourcesPath(),
-                    $this->xliffBasePath
-                ]);
+                $package = $this->packageManager->getPackage($packageKey);
+                $sources = $this->collectPackageSources($package);
 
-                // We merge labels in the chain from the worst choice to best choice
-                foreach (array_reverse($localeChain) as $allowedLocale) {
-                    $localeSourcePath = Files::getNormalizedPath(Files::concatenatePaths([$translationBasePath, $allowedLocale]));
-                    foreach ($sourcesToBeIncluded as $sourceName) {
-                        foreach (glob($localeSourcePath . $sourceName . '.xlf') as $xliffPathAndFilename) {
-                            $xliffPathInfo = pathinfo($xliffPathAndFilename);
-                            $sourceName = str_replace($localeSourcePath, '', $xliffPathInfo['dirname'] . '/' . $xliffPathInfo['filename']);
-                            $labels = Arrays::arrayMergeRecursiveOverrule($labels, $this->parseXliffToArray($xliffPathAndFilename, $packageKey, $sourceName));
+                //filter sources to be included
+                $relevantSources = array_filter($sources, function($source) use ($sourcesToBeIncluded) {
+                    foreach($sourcesToBeIncluded as $sourcePattern) {
+                        if (fnmatch($sourcePattern, $source)) {
+                            return true;
                         }
+                    }
+                    return false;
+                });
+
+                //get the xliff files for those sources
+                foreach ($relevantSources as $sourceName) {
+                    $fileId = $packageKey . ':' . $sourceName;
+                    $file = $this->xliffFileProvider->getFile($fileId, $locale);
+
+                    foreach ($file->getTranslationUnits() as $key => $value) {
+                        $valueToStore = !empty($value[0]['target']) ? $value[0]['target'] : $value[0]['source'];
+                        if ($this->scrambleTranslatedLabels) {
+                            $valueToStore = str_repeat('#', UnicodeFunctions::strlen($valueToStore));
+                        }
+                        $this->setArrayDataValue($labels, str_replace('.', '_', $packageKey) . '.' . str_replace('/', '_', $sourceName) . '.' . str_replace('.', '_', $key), $valueToStore);
                     }
                 }
             }
@@ -119,34 +136,6 @@ class XliffService
         }
 
         return $json;
-    }
-
-    /**
-     * Read the xliff file and create the desired json
-     *
-     * @param string $xliffPathAndFilename The file to read
-     * @param string $packageKey
-     * @param string $sourceName
-     * @return array
-     *
-     * @todo remove the override handling once Flow takes care of that, see FLOW-61
-     */
-    public function parseXliffToArray($xliffPathAndFilename, $packageKey, $sourceName)
-    {
-        /** @var array $parsedData */
-        $parsedData = $this->xliffParser->getParsedData($xliffPathAndFilename);
-        $arrayData = array();
-        foreach ($parsedData['translationUnits'] as $key => $value) {
-            $valueToStore = !empty($value[0]['target']) ? $value[0]['target'] : $value[0]['source'];
-
-            if ($this->scrambleTranslatedLabels) {
-                $valueToStore = str_repeat('#', UnicodeFunctions::strlen($valueToStore));
-            }
-
-            $this->setArrayDataValue($arrayData, str_replace('.', '_', $packageKey) . '.' . str_replace('/', '_', $sourceName) . '.' . str_replace('.', '_', $key), $valueToStore);
-        }
-
-        return $arrayData;
     }
 
     /**
@@ -160,6 +149,39 @@ class XliffService
             $this->xliffToJsonTranslationsCache->set('ConfigurationVersion', (string)$version);
         }
         return $version;
+    }
+
+    /**
+     * @param PackageInterface $package
+     * @return array
+     */
+    protected function collectPackageSources(PackageInterface $package)
+    {
+        $packageKey = $package->getPackageKey();
+        $sources = [];
+        $translationPath = $package->getResourcesPath() . $this->xliffBasePath;
+        foreach (Files::readDirectoryRecursively($translationPath, '.xlf') as $filePath) {
+            $source = trim(str_replace($translationPath, '', $filePath), '/');
+            $source = trim(substr($source, strpos($source, '/')), '/');
+            $source = substr($source, 0, strrpos($source, '.'));
+
+            $this->xliffReader->readFiles($filePath,
+                function (\XMLReader $file, $offset, $version) use ($packageKey, &$sources, $source) {
+                    $packageName = $packageKey;
+                    switch ($version) {
+                        case '1.2':
+                            $packageName = $file->getAttribute('product-name') ?: $packageKey;
+                            $source = $file->getAttribute('original') ?: $source;
+                            break;
+                    }
+                    if ($packageKey !== $packageName) {
+                        return;
+                    }
+                    $sources[$source] = true;
+                }
+            );
+        }
+        return array_keys($sources);
     }
 
     /**


### PR DESCRIPTION
**Motivation**
Recently (Flow 4.2) introduced the feature to override labels from other packages or add own translation for other packages via  https://github.com/neos/flow-development-collection/pull/894. This was formerly suggested in JIRA-issue FLOW-61.

This works nicely but the Neos UI is not using in \Neos\Neos\Service\XliffService. This Service deliveres a xliff-json that contains labels e.g. for the property editor. Currently you cannot override labels from other packages that are used in the property editor. You can try this by installing neos/form-builder and switch your backend-language to german. Result is missing labels, e.g. when you insert an input-field into a form and inspect the properties in the editor.

\Neos\Neos\Service\XliffService::parseXliffToArray is annotated (todo) to be changed when FLOW-61 is resolved.

This pull request is my suggestion for this change.

**What I did**
I refactored the class and made use of \Neos\Flow\I18n\Xliff\Service\XliffFileProvider::getFile which handles the overrides.

**How to verify it**
Provided some labels (that are used for node-properties) for another package (e.g. german labels for neos/form-builder) clear all caches (don't forget the LocalStorage in your browser) and see that your labels are not used.
After you applied this pull request (and clear all the caches again) the labels should be in use.