### PR TITLE
BUGFIX: Fix NodeType schema to pass validation

### DIFF
--- a/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/TYPO3.TYPO3CR/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -35,14 +35,18 @@ additionalProperties:
     'childNodes':
       type: dictionary
       additionalProperties:
-        type: [dictionary, 'null']
-        additionalProperties: FALSE
-        properties:
-          'type': { type: string, description: "Node Type of this child node." }
-          'position':
-            type: ['string', 'null']
-            description: "Position of this child node."
-          'constraints': *constraints
+        type:
+          -
+            type: 'null'
+          -
+            type: dictionary
+            additionalProperties: FALSE
+            properties:
+              'type': { type: string, description: "Node Type of this child node." }
+              'position':
+                type: ['string', 'null']
+                description: "Position of this child node."
+              'constraints': *constraints
 
     'properties':
       type: dictionary


### PR DESCRIPTION
In #1678 childNodes were allowed to be nullable. But the way the schema
was adjusted did not pass validation. This change fixes it.