### PR TITLE
BUGFIX: Use XliffService label override for Neos UI

### DIFF
--- a/Neos.Neos/Classes/Service/XliffService.php
+++ b/Neos.Neos/Classes/Service/XliffService.php
@@ -176,7 +176,7 @@ class XliffService
                     }
                     if (is_array($sourcesToBeIncluded)) {
                         $addSource = false;
-                        foreach($sourcesToBeIncluded as $sourcePattern) {
+                        foreach ($sourcesToBeIncluded as $sourcePattern) {
                             if (fnmatch($sourcePattern, $source)) {
                                 $addSource = true;
                                 break;

--- a/Neos.Neos/Classes/Service/XliffService.php
+++ b/Neos.Neos/Classes/Service/XliffService.php
@@ -15,7 +15,9 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Error\Messages\Result;
 use Neos\Flow\I18n\Exception;
-use Neos\Flow\I18n\Xliff\XliffParser;
+use Neos\Flow\I18n\Xliff\Service\XliffFileProvider;
+use Neos\Flow\I18n\Xliff\Service\XliffReader;
+use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Utility\Arrays;
 use Neos\Utility\Files;
@@ -39,9 +41,9 @@ class XliffService
 
     /**
      * @Flow\Inject
-     * @var XliffParser
+     * @var XliffReader
      */
-    protected $xliffParser;
+    protected $xliffReader;
 
     /**
      * @Flow\Inject
@@ -69,6 +71,12 @@ class XliffService
 
     /**
      * @Flow\Inject
+     * @var XliffFileProvider
+     */
+    protected $xliffFileProvider;
+
+    /**
+     * @Flow\Inject
      * @var PackageManagerInterface
      */
     protected $packageManager;
@@ -89,27 +97,36 @@ class XliffService
             $json = $this->xliffToJsonTranslationsCache->get($cacheIdentifier);
         } else {
             $labels = [];
-            $localeChain = $this->localizationService->getLocaleChain($locale);
 
             foreach ($this->packagesRegisteredForAutoInclusion as $packageKey => $sourcesToBeIncluded) {
                 if (!is_array($sourcesToBeIncluded)) {
                     continue;
                 }
 
-                $translationBasePath = Files::concatenatePaths([
-                    $this->packageManager->getPackage($packageKey)->getResourcesPath(),
-                    $this->xliffBasePath
-                ]);
+                $package = $this->packageManager->getPackage($packageKey);
+                $sources = $this->collectPackageSources($package);
 
-                // We merge labels in the chain from the worst choice to best choice
-                foreach (array_reverse($localeChain) as $allowedLocale) {
-                    $localeSourcePath = Files::getNormalizedPath(Files::concatenatePaths([$translationBasePath, $allowedLocale]));
-                    foreach ($sourcesToBeIncluded as $sourceName) {
-                        foreach (glob($localeSourcePath . $sourceName . '.xlf') as $xliffPathAndFilename) {
-                            $xliffPathInfo = pathinfo($xliffPathAndFilename);
-                            $sourceName = str_replace($localeSourcePath, '', $xliffPathInfo['dirname'] . '/' . $xliffPathInfo['filename']);
-                            $labels = Arrays::arrayMergeRecursiveOverrule($labels, $this->parseXliffToArray($xliffPathAndFilename, $packageKey, $sourceName));
+                //filter sources to be included
+                $relevantSources = array_filter($sources, function($source) use ($sourcesToBeIncluded) {
+                    foreach($sourcesToBeIncluded as $sourcePattern) {
+                        if (fnmatch($sourcePattern, $source)) {
+                            return true;
                         }
+                    }
+                    return false;
+                });
+
+                //get the xliff files for those sources
+                foreach ($relevantSources as $sourceName) {
+                    $fileId = $packageKey . ':' . $sourceName;
+                    $file = $this->xliffFileProvider->getFile($fileId, $locale);
+
+                    foreach ($file->getTranslationUnits() as $key => $value) {
+                        $valueToStore = !empty($value[0]['target']) ? $value[0]['target'] : $value[0]['source'];
+                        if ($this->scrambleTranslatedLabels) {
+                            $valueToStore = str_repeat('#', UnicodeFunctions::strlen($valueToStore));
+                        }
+                        $this->setArrayDataValue($labels, str_replace('.', '_', $packageKey) . '.' . str_replace('/', '_', $sourceName) . '.' . str_replace('.', '_', $key), $valueToStore);
                     }
                 }
             }
@@ -119,34 +136,6 @@ class XliffService
         }
 
         return $json;
-    }
-
-    /**
-     * Read the xliff file and create the desired json
-     *
-     * @param string $xliffPathAndFilename The file to read
-     * @param string $packageKey
-     * @param string $sourceName
-     * @return array
-     *
-     * @todo remove the override handling once Flow takes care of that, see FLOW-61
-     */
-    public function parseXliffToArray($xliffPathAndFilename, $packageKey, $sourceName)
-    {
-        /** @var array $parsedData */
-        $parsedData = $this->xliffParser->getParsedData($xliffPathAndFilename);
-        $arrayData = array();
-        foreach ($parsedData['translationUnits'] as $key => $value) {
-            $valueToStore = !empty($value[0]['target']) ? $value[0]['target'] : $value[0]['source'];
-
-            if ($this->scrambleTranslatedLabels) {
-                $valueToStore = str_repeat('#', UnicodeFunctions::strlen($valueToStore));
-            }
-
-            $this->setArrayDataValue($arrayData, str_replace('.', '_', $packageKey) . '.' . str_replace('/', '_', $sourceName) . '.' . str_replace('.', '_', $key), $valueToStore);
-        }
-
-        return $arrayData;
     }
 
     /**
@@ -160,6 +149,39 @@ class XliffService
             $this->xliffToJsonTranslationsCache->set('ConfigurationVersion', (string)$version);
         }
         return $version;
+    }
+
+    /**
+     * @param PackageInterface $package
+     * @return array
+     */
+    protected function collectPackageSources(PackageInterface $package)
+    {
+        $packageKey = $package->getPackageKey();
+        $sources = [];
+        $translationPath = $package->getResourcesPath() . $this->xliffBasePath;
+        foreach (Files::readDirectoryRecursively($translationPath, '.xlf') as $filePath) {
+            $source = trim(str_replace($translationPath, '', $filePath), '/');
+            $source = trim(substr($source, strpos($source, '/')), '/');
+            $source = substr($source, 0, strrpos($source, '.'));
+
+            $this->xliffReader->readFiles($filePath,
+                function (\XMLReader $file, $offset, $version) use ($packageKey, &$sources, $source) {
+                    $packageName = $packageKey;
+                    switch ($version) {
+                        case '1.2':
+                            $packageName = $file->getAttribute('product-name') ?: $packageKey;
+                            $source = $file->getAttribute('original') ?: $source;
+                            break;
+                    }
+                    if ($packageKey !== $packageName) {
+                        return;
+                    }
+                    $sources[$source] = true;
+                }
+            );
+        }
+        return array_keys($sources);
     }
 
     /**

--- a/Neos.Neos/Tests/Functional/Service/Fixtures/de/BasePackage.Included.xlf
+++ b/Neos.Neos/Tests/Functional/Service/Fixtures/de/BasePackage.Included.xlf
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="Included" product-name="Vendor.BasePackage" source-language="en" target-language="de" datatype="plaintext">
+        <body>
+            <trans-unit id="key1" xml:space="preserve">
+                <source>Source string</source>
+                <target>Übersetzte Zeichenkette</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Neos.Neos/Tests/Functional/Service/Fixtures/de/BasePackage.NotIncluded.xlf
+++ b/Neos.Neos/Tests/Functional/Service/Fixtures/de/BasePackage.NotIncluded.xlf
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="NotIncluded" product-name="Vendor.BasePackage" source-language="en" target-language="de" datatype="plaintext">
+        <body>
+            <trans-unit id="key2" xml:space="preserve">
+                <source>Source string</source>
+                <target>Übersetzte Zeichenkette</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Neos.Neos/Tests/Functional/Service/Fixtures/de/DependentPackage.Included.xlf
+++ b/Neos.Neos/Tests/Functional/Service/Fixtures/de/DependentPackage.Included.xlf
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="Included" product-name="Vendor.BasePackage" source-language="en" target-language="de" datatype="plaintext">
+        <body>
+            <trans-unit id="key1" xml:space="preserve">
+                <source>Source string</source>
+                <target>Anders übersetzte Zeichenkette</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Neos.Neos/Tests/Functional/Service/Fixtures/de/DependentPackage.NotIncluded.xlf
+++ b/Neos.Neos/Tests/Functional/Service/Fixtures/de/DependentPackage.NotIncluded.xlf
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="NotIncluded" product-name="Vendor.BasePackage" source-language="en" target-language="de" datatype="plaintext">
+        <body>
+            <trans-unit id="key2" xml:space="preserve">
+                <source>Source string</source>
+                <target>Anders übersetzte Zeichenkette</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Neos\Neos\Tests\Functional\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Composer\ComposerUtility;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Xliff\Service\XliffFileProvider;
+use Neos\Flow\Package;
+use Neos\Flow\Package\PackageManager;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Neos\Service\XliffService;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Test case for the XliffService
+ */
+class XliffServiceTest extends FunctionalTestCase
+{
+    /**
+     * @var XliffService
+     */
+    protected $xliffService;
+
+    /**
+     * @var XliffFileProvider
+     */
+    protected $fileProvider;
+
+    /**
+     * @var array
+     */
+    protected $packages;
+
+
+    /**
+     * Initialize dependencies
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->xliffService = $this->objectManager->get(XliffService::class);
+        $this->fileProvider = $this->objectManager->get(XliffFileProvider::class);
+
+        $this->packages = $this->setUpPackages();
+        ComposerUtility::flushCaches();
+
+        $mockPackageManager = $this->getMockBuilder(PackageManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockPackageManager->expects($this->any())
+            ->method('getActivePackages')
+            ->will($this->returnValue($this->packages));
+        $mockPackageManager->expects($this->any())
+            ->method('getPackage')
+            ->with($this->logicalOr(
+                $this->equalTo('Vendor.BasePackage'),
+                $this->equalTo('Vendor.DependentPackage')
+            ))
+            ->will($this->returnCallback(array($this, 'myCallback')));
+        $this->inject($this->xliffService, 'packageManager', $mockPackageManager);
+        $this->inject($this->fileProvider, 'packageManager', $mockPackageManager);
+
+        $this->inject($this->xliffService, 'packagesRegisteredForAutoInclusion', [
+            'Vendor.BasePackage' => ['Included'],
+            'Vendor.DependentPackage' => ['Included']
+        ]);
+
+        $cacheManager = $this->objectManager->get(CacheManager::class);
+        $cacheManager->getCache('Neos_Neos_XliffToJsonTranslations')->flush();
+        $cacheManager->getCache('Flow_I18n_XmlModelCache')->flush();
+    }
+
+    public function myCallback($foo)
+    {
+        return $this->packages[$foo];
+    }
+
+    /**
+     * @return array|Package[]
+     */
+    protected function setUpPackages()
+    {
+        vfsStream::setup('Packages');
+
+        $basePackage = $this->setUpPackage('BasePackage', [
+            'de/BasePackage.Included.xlf' => 'Resources/Private/Translations/de/Included.xlf',
+            'de/BasePackage.NotIncluded.xlf' => 'Resources/Private/Translations/de/NotIncluded.xlf'
+        ]);
+        $packages[$basePackage->getPackageKey()] = $basePackage;
+
+        $dependentPackage = $this->setUpPackage('DependentPackage', [
+            'de/DependentPackage.Included.xlf' => 'Resources/Private/Translations/de/Included.xlf',
+            'de/DependentPackage.NotIncluded.xlf' => 'Resources/Private/Translations/de/NotIncluded.xlf'
+        ]);
+        $packages[$dependentPackage->getPackageKey()] = $dependentPackage;
+
+        return $packages;
+    }
+
+    /**
+     * @param string $packageName
+     * @param array $filePaths
+     * @return Package
+     */
+    protected function setUpPackage($packageName, array $filePaths)
+    {
+        $vendorName = 'Vendor';
+        $packagePath = 'vfs://Packages/Application/' . $vendorName . '/' . $packageName . '/';
+        $composerName = strtolower($vendorName) . '/' . strtolower($packageName);
+        $packageKey = $vendorName . '.' . $packageName;
+        mkdir($packagePath, 0700, true);
+        mkdir($packagePath . 'Resources/Private/Translations/de/', 0700, true);
+        file_put_contents($packagePath . 'composer.json', '{"name": "' . $composerName . '", "type": "flow-test"}');
+
+        $fixtureBasePath = __DIR__ . '/Fixtures/';
+        foreach ($filePaths as $fixturePath => $targetPath) {
+            copy($fixtureBasePath . $fixturePath, $packagePath . $targetPath);
+        }
+
+        return new Package($packageKey, $composerName, $packagePath);
+    }
+
+    /**
+     * @test
+     */
+    public function getCachedJsonRespectsIncludedFiles()
+    {
+        $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);
+
+        $this->assertArrayHasKey(
+            'Included',
+            $translationResult['Vendor_BasePackage']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getCachedJsonDoesNotRespectNotIncludedFiles()
+    {
+        $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);
+
+        $this->assertArrayNotHasKey(
+            'NotIncluded',
+            $translationResult['Vendor_BasePackage']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getCachedJsonRespectsOverride()
+    {
+        $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);
+
+        $this->assertSame(
+            'Anders übersetzte Zeichenkette',
+            $translationResult['Vendor_BasePackage']['Included']['key1']
+        );
+    }
+}


### PR DESCRIPTION
Recently (Flow 4.2) introduced the feature to override labels from other packages or add own translations for other packages via neos/flow-development-collection#894. This was formerly suggested in JIRA-issue FLOW-61.

This works nicely but the Neos UI is not using `\Neos\Neos\Service\XliffService`. This Service deliveres a xliff-json that contains labels e.g. for the property editor. Currently you cannot override labels from other packages that are used in the property editor. `\Neos\Neos\Service\XliffService::parseXliffToArray` is annotated (todo) to be changed when FLOW-61 is resolved.

This change refactors the class to make use of `\Neos\Flow\I18n\Xliff\Service\XliffFileProvider::getFile` which handles the overrides.