### PR TITLE
BUGFIX: Make sure nodes that are to be discarded are actually publishable

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/PublishingService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/PublishingService.php
@@ -68,7 +68,12 @@ class PublishingService extends \TYPO3\TYPO3CR\Domain\Service\PublishingService
         $nodeType = $node->getNodeType();
 
         if ($nodeType->isOfType('TYPO3.Neos:Document') || $nodeType->hasConfiguration('childNodes')) {
-            $nodes = array_merge($nodes, $this->collectAllContentChildNodes($node));
+            $nodes = array_filter(
+                array_merge($nodes, $this->collectAllContentChildNodes($node)),
+                function ($possiblyPublishableNode) use ($node) {
+                    return $possiblyPublishableNode->getWorkspace()->getName() === $node->getWorkspace()->getName();
+                }
+            );
         }
 
         $this->discardNodes($nodes);


### PR DESCRIPTION
`TYPO3\Neos\Service\PublishingService` traverses all children of a node to discard that node recursively. Not all those nodes are actually publishable though, so the following batch discard operation fails with the Exception `#1395841899: Nodes in a in a workspace without a base workspace cannot be discarded`.

So, I added a filter to `TYPO3\Neos\Service\PublishingService::discardNode` that removes all nodes from the to-be-discarded list, that are in a different workspace than the given node.

Resolves: #1710