### PR TITLE
BUGFIX: fix augumentation of possibly invalid HTML

### DIFF
--- a/Neos.Neos/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Neos/Classes/Service/HtmlAugmenter.php
@@ -69,9 +69,16 @@ class HtmlAugmenter
         $domDocument = new \DOMDocument('1.0', 'UTF-8');
         // ignore parsing errors
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
-        $domDocument->loadHTML($html);
-        $xPath = new \DOMXPath($domDocument);
-        $rootElement = $xPath->query('//html/body/*');
+
+        if ($domDocument->loadXML(html_entity_decode($html))) {
+            $xPath = new \DOMXPath($domDocument);
+            $rootElement = $xPath->query('/*');
+        } else {
+            $domDocument->loadHTML($html);
+            $xPath = new \DOMXPath($domDocument);
+            $rootElement = $xPath->query('//html/body/*');
+        }
+
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }

--- a/Neos.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Neos/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -220,6 +220,14 @@ class HtmlAugmenterTest extends UnitTestCase
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'expectedResult' => '<p data-label="Cost $0.00">Simple HTML with unique root element</p>',
+            ),
+            // Real world example
+            array(
+                'html' => '<p><p>Eine m&ouml;g&shy;lichst umfassende&nbsp;<strong>Heizungswartung</strong>&nbsp;ge&shy;h&ouml;rt deshalb auch zu den Ma&szlig;nahmen, deren Umsetzung die Europ&auml;ische Union ihren Mitgliedsstaaten vorgegeben hat. Die regelm&auml;&szlig;ige<strong>Heizungswartung</strong>&nbsp;durch qualifiziertes Personal gew&auml;hr&shy;leistet &bdquo;eine optimale Leistung aus &ouml;kologischer, sicherheits&shy;tech&shy;nischer und energetischer Sicht&ldquo;, hei&szlig;t es in der EU-Richt&shy;linie 2010/31/EU, die eine europaweite Verbesserung der Ge&shy;samt&shy;energieeffizienz von Geb&auml;uden zum Ziel hat.</p></p>',
+                'attributes' => array('class' => 'neos-inline-editable'),
+                'fallbackTagName' => 'span',
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<p class="neos-inline-editable"><p>Eine m&ouml;g&shy;lichst umfassende&nbsp;<strong>Heizungswartung</strong>&nbsp;ge&shy;h&ouml;rt deshalb auch zu den Ma&szlig;nahmen, deren Umsetzung die Europ&auml;ische Union ihren Mitgliedsstaaten vorgegeben hat. Die regelm&auml;&szlig;ige<strong>Heizungswartung</strong>&nbsp;durch qualifiziertes Personal gew&auml;hr&shy;leistet &bdquo;eine optimale Leistung aus &ouml;kologischer, sicherheits&shy;tech&shy;nischer und energetischer Sicht&ldquo;, hei&szlig;t es in der EU-Richt&shy;linie 2010/31/EU, die eine europaweite Verbesserung der Ge&shy;samt&shy;energieeffizienz von Geb&auml;uden zum Ziel hat.</p></p>',
             )
         );
     }


### PR DESCRIPTION
In our example, the markup was:

    <p><p>...</p></p>

while this is invalid HTML (because P is not allowed inside P), it is still
structurally correct - thus, we should correctly wrap it.

This is needed for correct inline editing behavior in the new React
UI in some cases.
