### PR TITLE
FEATURE: Introduce command to remove unused assets

### DIFF
--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\ThumbnailRepository;
@@ -124,6 +125,54 @@ class MediaCommandController extends CommandController
                 }
             }
         }
+    }
+
+    /**
+     * Remove unused assets
+     *
+     * This command iterates over all existing assets, checks their usage count
+     * and lists the assets which are not reported as used by any AssetUsageStrategies.
+     * The unused assets can than be removed.
+     */
+    public function removeUnusedCommand()
+    {
+        $iterator = $this->assetRepository->findAllIterator();
+        $assetCount = $this->assetRepository->countAll();
+        $unusedAssets = [];
+        $unusedAssetInfo = [];
+        $unusedAssetCount = 0;
+
+        $this->outputLine('<b>Searching for unused assets:</b>');
+
+        $this->output->progressStart($assetCount);
+        /** @var AssetInterface $asset */
+        foreach ($this->assetRepository->iterate($iterator) as $asset) {
+            if ($asset->getUsageCount() === 0) {
+                $unusedAssets[] = $asset;
+                $unusedAssetInfo[] = sprintf('- %s (%s)', $asset->getIdentifier(), $asset->getResource()->getFilename());
+                $unusedAssetCount++;
+            }
+            $this->output->progressAdvance(1);
+        }
+
+        if ($unusedAssetCount === 0) {
+            $this->output->outputLine(PHP_EOL . sprintf('No unused assets found.', $unusedAssetCount));
+            $this->quit(0);
+        }
+
+        $this->outputLine(PHP_EOL . 'Found the following unused assets: ' . PHP_EOL . implode(PHP_EOL, $unusedAssetInfo));
+
+        $continue = $this->output->askConfirmation(sprintf('Do you want to remove <b>%s</b> unused assets?', $unusedAssetCount));
+        if ($continue !== true) {
+            $this->quit(0);
+        }
+
+        $this->output->progressStart($unusedAssetCount);
+        foreach ($unusedAssets as $asset) {
+            $this->output->progressAdvance(1);
+            $this->assetRepository->remove($asset);
+        }
+        $this->outputLine('');
     }
 
     /**

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -133,6 +133,8 @@ class MediaCommandController extends CommandController
      * This command iterates over all existing assets, checks their usage count
      * and lists the assets which are not reported as used by any AssetUsageStrategies.
      * The unused assets can than be removed.
+     *
+     * @return void
      */
     public function removeUnusedCommand()
     {


### PR DESCRIPTION
This command iterates over all existing assets, checks their usage count
and lists the assets which are not reported as used by any AssetUsageStrategies.
The unused assets can than be removed.

### Example command output (with unused assets): 
```
Searching for unused assets:
 12/12 [============================] 100%
Found the following unused assets:
- 2a2952ce-ba38-45bc-9b88-03d013831fd6 (Bildschirmfoto 2016-11-01 um 14.14.15.png)
- 5279fcc0-4557-4033-be66-5fbe766aa2e2 (Bildschirmfoto 2016-11-01 um 14.11.43.png)
- 5890c270-9f35-4327-8876-46388403bacf (Bildschirmfoto 2016-11-01 um 14.14.57.png)
Do you want to remove 3 unused assets?y
 3/3 [============================] 100%
```

### Example command output (without unused assets):
```
./flow media:removeunused
Searching for unused assets:
 9/9 [============================] 100%
No unused assets found.
```