### PR TITLE
BUGFIX: After moving newly created nodes, findByIdentifier() should return the correct node

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -355,7 +355,7 @@ class NodeDataRepository extends Repository
         $query = $queryBuilder->getQuery();
         $nodes = $query->getResult();
 
-        $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions);
+        $foundNodes = $this->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $workspaces, $dimensions, true);
         if ($removedNodes === false) {
             $foundNodes = $this->withoutRemovedNodes($foundNodes);
         }
@@ -1238,10 +1238,11 @@ class NodeDataRepository extends Repository
      * @param array $nodes NodeData result with multiple and duplicate identifiers (different nodes and redundant results for node variants with different dimensions)
      * @param array $workspaces
      * @param array $dimensions
+     * @param boolean $preferNonShadowNodes if set to TRUE and we have two nodes with the same dimension positions, we prefer the non-shadow variant of it.
      * @return array Array of unique node results indexed by identifier
      * @throws Exception\NodeException
      */
-    protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes, array $workspaces, array $dimensions)
+    protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes, array $workspaces, array $dimensions, $preferNonShadowNodes = false)
     {
         $reducedNodes = [];
 
@@ -1287,7 +1288,10 @@ class NodeDataRepository extends Repository
 
             $identifier = $node->getIdentifier();
             // Yes, it seems to work comparing arrays that way!
-            if (!isset($minimalDimensionPositionsByIdentifier[$identifier]) || $dimensionPositions < $minimalDimensionPositionsByIdentifier[$identifier]) {
+            if (!isset($minimalDimensionPositionsByIdentifier[$identifier])
+                || ($dimensionPositions < $minimalDimensionPositionsByIdentifier[$identifier])
+                || ($preferNonShadowNodes === true && $dimensionPositions === $minimalDimensionPositionsByIdentifier[$identifier] && $reducedNodes[$identifier]->isInternal() && !$node->isInternal())
+            ) {
                 $reducedNodes[$identifier] = $node;
                 $minimalDimensionPositionsByIdentifier[$identifier] = $dimensionPositions;
             }

--- a/Neos.ContentRepository/Tests/Behavior/Features/Crazy/MoveNode.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/Crazy/MoveNode.feature
@@ -13,6 +13,34 @@ Feature: Move node
       | dc48851c-f653-ebd5-4d35-3feac69a3e09 | /sites/content-repository/about   | Neos.ContentRepository.Testing:Page | {"title": "About"}   | live      |
     And I am authenticated with role "Neos.Neos:Editor"
 
+  # the following behat test initially failed in about 50% of the cases -- see the commit description where this test was introduced
+  # for a full explanation of the bug being fixed (NodeDataRepository::findOneByIdentifier)
+  @fixtures
+  Scenario: Move a newly created node in user workspace and get it by identifier
+    Given I create the following nodes:
+      | Identifier                           | Path                          | Node Type                           | Properties | Workspace  |
+      | 86431a7c-3daf-430a-9a7d-e1eaafd46177 | /sites/content-repository/foo | Neos.ContentRepository.Testing:Page | {}         | user-admin |
+
+    And I get a node by identifier "86431a7c-3daf-430a-9a7d-e1eaafd46177" with the following context:
+      | Workspace  |
+      | user-admin |
+    When I move the node into the node with path "/sites/content-repository/company"
+    And I get a node by identifier "86431a7c-3daf-430a-9a7d-e1eaafd46177" with the following context:
+      | Workspace  |
+      | user-admin |
+    Then I should have one node
+
+  @fixtures
+  Scenario: Delete a node in a user workspace, it should not be found when retrieving it by identifier
+    Given I get a node by identifier "dc48851c-f653-ebd5-4d35-3feac69a3e09" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I remove the node
+    And I get a node by identifier "dc48851c-f653-ebd5-4d35-3feac69a3e09" with the following context:
+      | Workspace  |
+      | user-admin |
+    Then I should have 0 nodes
+
   @fixtures
   Scenario: Move a node (into) in user workspace and get by path
     When I get a node by path "/sites/content-repository/service" with the following context:


### PR DESCRIPTION
This fixes a non-deterministic React UI Error…

## Problem Description

In the new React UI, do the following:
- create node A
- create node B
- move node B underneath node A
- chances are that in at least 20-30% of the cases, you cannot navigate to node B
  because it has an empty URL, but instead, you are redirected to the root page.
- this error is persistent, i.e. you are never able to navigate to node B, *unless you
  clear the routing cache*.

## Problem Drilldown

I initially suspected some race condition of different PHP requests going on concurrently,
but it turned out not to be the case. Instead, I found out the following:

- in the 20-30% of failed requests, the URI Builder returned strange/wrong values for the
  just-moved node: The method FrontendNodeRoutePartHandler::getRequestPathByNode returned
  *an empty string* instead of proper URIs.
- This is because the following code snippet returned NULL (from
  FrontendNodeRoutePartHandler):
  ```
  $contextProperties = $node->getContext()->getProperties();
  $contextAllowingHiddenNodes = $this->contextFactory->create(array_merge($contextProperties, ['invisibleContentShown' => true]));
  $currentNode = $contextAllowingHiddenNodes->getNodeByIdentifier($node->getIdentifier());
  ```

After the node has been moved, we have two entries in the NodeData table, looking roughly as follows:

```
- entry1:
    - persistence_object_identifier uuid_A
    - workspace: <myWorkspace>
    - identifier: <myUUID>
    - removed: true
    - movedto: uuid_B
- entry2
    - persistence_object_identifier uuid_B
    - workspace: <myWorkspace>
    - identifier: <myUUID>
    - removed: true
    - movedto: uuid_B
```

After some digging in `NodeDataRepository::findOneByIdentifier`, I figured out the
following happens in there:

- we build a query where we fetch the node in all base workspaces, regardless of whether
  they are removed or not - so basically a `WHERE workspace IN (myWorkspace, live) AND
  identifier=<myUUID>`.
- after that, we run `reduceNodeVariantsByWorkspacesAndDimensions()`, which implements the
  workspace fallbacks.
  - this method groups nodes by their identifier, i.e. if the identifier is already used,
    it will return only one of the two entries.
  - IN OUR CASE, `reduceNodeVariantsByWorkspacesAndDimensions()` should not do anything as
    we do not have workspace fallbacks or dimension fallbacks used for the node. 
    **However, depending on the ordering of the result of MySQL, we get back entry1 or
    entry2.**
- After that, we filter for removed nodes. (using `withoutRemovedNodes`)
  - in case entry2 is returned from `reduceNodeVariantsByWorkspacesAndDimensions()`,
    we filter it to an empty set, and thus return NULL.

Thus, we build up a wrong URI for the node, which is then cached in the Resolve Cache
(permanently).

In the old UI, I believe we did not hit the bug because there are quite some cases which
mask the bug:
- if you first use findByParentAndNodeType(), e.g. by traversing the tree, then the
  correct NodeData object is cached in the FirstLevelNodeCache.
- if the routing cache is flushed after the move, there is a higher likelyhood the error 
  will be masked; as in the new request, we only again have a 30% chance of hitting the 
  error (depending on the code path used).

## Bugfix

We can **not** first filter for deleted nodes, and then handle the workspace fallback,
as this would lead to un-intended side effects (i.e. if a node in a workspace has been
deleted, it would still be findable using "findOneByIdentifier"). (This case is
tested by the second behat test).

However, we can ensure that when being in findOneByIdentifier, we ensure that non-
shadow nodes get preferred over shadow nodes if they have the same dimension points.

Note: The first added Behat test fails in 50% of the times (depending on result
ordering) without the fix.