### PR TITLE
FEATURE: Upload/MediaBrowser flags in Image and Asset editor

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -158,6 +158,8 @@ Neos:
               maximumFileSize: null
               features:
                 crop: true
+                upload: true
+                mediaBrowser: true
                 resize: false
               crop:
                 aspectRatio:
@@ -189,11 +191,18 @@ Neos:
           Neos\Media\Domain\Model\Asset:
             typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
             editor: Neos.Neos/Inspector/Editors/AssetEditor
+            editorOptions:
+              features:
+                upload: true
+                mediaBrowser: true
           array<Neos\Media\Domain\Model\Asset>:
             typeConverter: Neos\Flow\Property\TypeConverter\TypedArrayConverter
             editor: Neos.Neos/Inspector/Editors/AssetEditor
             editorOptions:
               multiple: true
+              features:
+                upload: true
+                mediaBrowser: true
           DateTime:
             typeConverter: Neos\Neos\Service\Mapping\DateStringConverter
             editor: Neos.Neos/Inspector/Editors/DateTimeEditor

--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -551,6 +551,12 @@ Options Reference:
 	``crop`` (boolean)
 		If ``TRUE``, enable image cropping. Default ``TRUE``.
 
+	``upload`` (boolean)
+		If ``TRUE``, enable Upload button, allowing new files to be uploaded directly in the editor. Default ``TRUE``.
+
+	``mediaBrowser`` (boolean)
+		If ``TRUE``, enable Media Browser button. Default ``TRUE``.
+
 	``resize`` (boolean)
 		If ``TRUE``, enable image resizing. Default ``FALSE``.
 
@@ -617,7 +623,13 @@ Conversely, if multiple assets shall be uploaded, use ``array<Neos\Media\Domain\
 
 Options Reference:
 
-(no options)
+``features``
+
+	``upload`` (boolean)
+		If ``TRUE``, enable Upload button, allowing new files to be uploaded directly in the editor. Default ``TRUE``.
+
+	``mediaBrowser`` (boolean)
+		If ``TRUE``, enable Media Browser button. Default ``TRUE``.
 
 Property Validation
 -------------------

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.html
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.html
@@ -2,10 +2,14 @@
 	<div>{{view view.assetView contentBinding="view.assets"}}</div>
 
 	<div class="neos-inspector-file-upload" id="{{unbound view._containerId}}">
-		{{view view.SecondaryInspectorButton viewClassBinding="view._mediaBrowserView" label="Media" action="_beforeMediaBrowserIsShown" target="view"}}
-		<button id="{{unbound view._browseButtonId}}" class="neos-button neos-inspector-file-upload-files" {{bindAttr disabled="view._uploadInProgress:neos-disabled"}}>
-			{{view._fileUploadLabel}}
-		</button>
+		{{#if view.shouldRenderMediaBrowser}}
+			{{view view.SecondaryInspectorButton viewClassBinding="view._mediaBrowserView" label="Media" action="_beforeMediaBrowserIsShown" target="view"}}
+		{{/if}}
+		{{#if view.shouldRenderUpload}}
+			<button id="{{unbound view._browseButtonId}}" class="neos-button neos-inspector-file-upload-files" {{bindAttr disabled="view._uploadInProgress:neos-disabled"}}>
+				{{view._fileUploadLabel}}
+			</button>
+		{{/if}}
 		{{#if view._uploadButtonShown}}
 			<button class="neos-button neos-inspector-file-upload-button" allowed-file-types="{{unbound view.allowedFileTypes}}" {{bindAttr disabled="view._uploadInProgress"}} {{action "upload" target="view"}}>
 				{{translate fallbackBinding="view.uploaderLabel" idBinding="view.uploaderLabel"}}

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/AssetEditor.js
@@ -25,6 +25,14 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 		 */
 		multiple: false,
 
+		/**
+		 * Feature flags for this editor
+		 */
+		features: {
+			upload: true,
+			mediaBrowser: true
+		},
+
 		_assetMetadataEndpointUri: null,
 
 		_showLoadingIndicator: false,
@@ -172,6 +180,13 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 			};
 		},
 
+		/**
+		 * Computed property to decide if the Media Browser button should be displayed in the editor
+		 */
+		shouldRenderMediaBrowser: function () {
+			return (this.get('features.mediaBrowser'));
+		}.property('features.mediaBrowser'),
+
 		/****************************************
 		 * FILE REMOVE
 		 ***************************************/
@@ -226,6 +241,13 @@ function(Ember, $, FileUpload, template, SecondaryInspectorController, Utility, 
 			this._uploader.bind('BeforeUpload', function(uploader, file) {
 				uploader.settings.multipart_params['metadata'] = 'Asset';
 			});
-		}
+		},
+
+		/**
+		 * Computed property to decide if the Upload button should be displayed in the editor
+		 */
+		shouldRenderUpload: function () {
+			return (this.get('features.upload'));
+		}.property('features.upload')
 	});
 });

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.html
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.html
@@ -14,10 +14,14 @@
 	</div>
 
 	<div class="neos-inspector-image-upload" id="{{unbound view._containerId}}">
-		{{view view.SecondaryInspectorButton viewClassBinding="view._mediaBrowserView" class="neos-button-icon" titleBinding="view.mediaLabel" icon="camera" action="_beforeMediaBrowserIsShown" target="view" data-neos-tooltip=""}}
-		<button id="{{unbound view._browseButtonId}}" class="neos-button neos-button-icon neos-inspector-image-upload-files" {{bindAttr disabled="view._uploadInProgress:neos-disabled" title="view._fileUploadLabel"}} data-neos-tooltip>
-			<i class="icon-upload"></i>
-		</button>
+		{{#if view.shouldRenderMediaBrowser}}
+			{{view view.SecondaryInspectorButton viewClassBinding="view._mediaBrowserView" class="neos-button-icon" titleBinding="view.mediaLabel" icon="camera" action="_beforeMediaBrowserIsShown" target="view" data-neos-tooltip=""}}
+		{{/if}}
+		{{#if view.shouldRenderUpload}}
+			<button id="{{unbound view._browseButtonId}}" class="neos-button neos-button-icon neos-inspector-image-upload-files" {{bindAttr disabled="view._uploadInProgress:neos-disabled" title="view._fileUploadLabel"}} data-neos-tooltip>
+				<i class="icon-upload"></i>
+			</button>
+		{{/if}}
 		{{#if view.value}}
 			<button class="neos-button neos-button-icon neos-inspector-image-remove-button" {{bindAttr disabled="view._uploadInProgress" title="view.removeButtonLabel"}} {{action "remove" target="view"}} data-neos-tooltip>
 				<i class="icon-remove"></i>

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/ImageEditor.js
@@ -49,10 +49,12 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 		allowedFileTypes: 'jpg,jpeg,png,gif,svg',
 
 		/**
-		 * Feature flags for this editor. Currently we have cropping and resize which can be enabled/disabled via NodeTypes editorOptions.
+		 * Feature flags for this editor. Currently we have cropping, media browser and resize which can be enabled/disabled via NodeTypes editorOptions.
 		 */
 		features: {
 			crop: true,
+			upload: true,
+			mediaBrowser: true,
 			resize: false
 		},
 
@@ -389,6 +391,13 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 			};
 		},
 
+		/**
+		 * Computed property to decide if the Media Browser button should be displayed in the editor
+		 */
+		shouldRenderMediaBrowser: function () {
+			return (this.get('features.mediaBrowser'));
+		}.property('features.mediaBrowser'),
+
 		/****************************************
 		 * IMAGE REMOVE
 		 ***************************************/
@@ -428,6 +437,13 @@ function (Ember, $, FileUpload, template, cropTemplate, BooleanEditor, Spinner, 
 				this.upload();
 			}
 		},
+
+		/**
+		 * Computed property to decide if the Upload button should be displayed in the editor
+		 */
+		shouldRenderUpload: function () {
+			return (this.get('features.upload'));
+		}.property('features.upload'),
 
 		/**
 		 * Callback after file upload is complete


### PR DESCRIPTION
Adds two new feature flags, `upload` and `mediaBrowser` that
allow to hide respective buttons in the `Image` and `Asset`
editors.

Usage:

```yaml
'Some.Node:Type':
  properties:
    'someImageProperty':
      type: Neos\Media\Domain\Model\ImageInterface
      ui:
        inspector:
          editorOptions:
            features:
              # disable uploads through the editor directly
              upload: false
    'someAssetProperty':
      type: Neos\Media\Domain\Model\Asset
      ui:
        inspector:
          editorOptions:
            features:
              # allow assets only to be uploaded through the editor
              mediaBrowser: false
```

Background:

When uploading assets through the property editors, that happens
within the context of a selected node (unlike when it's added
through the media module). This allows us to assign the resulting
asset to a collection/tag based on the node type or path for
example.

Related: #893
Related: #1131