### PR TITLE
FEATURE: Allow modification of uploaded assets based on node

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -127,10 +127,11 @@ class ContentController extends ActionController
      * @param Asset $asset
      * @param string $metadata Type of metadata to return ("Asset" or "Image")
      * @param NodeInterface $node The node the new asset should be assigned to
+     * @param string $propertyName The node property name the new asset should be assigned to
      * @param string $siteNodeName The node name of the site the asset belongs to
      * @return string
      */
-    public function uploadAssetAction(Asset $asset, string $metadata, NodeInterface $node, string $siteNodeName)
+    public function uploadAssetAction(Asset $asset, string $metadata, NodeInterface $node, string $propertyName, string $siteNodeName)
     {
         $this->response->setHeader('Content-Type', 'application/json');
 
@@ -146,7 +147,7 @@ class ContentController extends ActionController
             if ($this->persistenceManager->isNewObject($asset)) {
                 $this->assetRepository->add($asset);
             }
-            $this->emitAssetUploaded($asset, $node, $siteNodeName);
+            $this->emitAssetUploaded($asset, $node, $propertyName, $siteNodeName);
         }
         return json_encode($result);
     }
@@ -398,11 +399,12 @@ class ContentController extends ActionController
      *
      * @param Asset $asset The uploaded asset
      * @param NodeInterface $node The node the asset belongs to
+     * @param string $propertyName The node property name the asset is assigned to
      * @param string $siteNodeName Name of the Site Node in which the asset was uploaded
      * @return void
      * @Flow\Signal
      */
-    protected function emitAssetUploaded(Asset $asset, NodeInterface $node, string $siteNodeName)
+    protected function emitAssetUploaded(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
     {
     }
 }

--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -128,10 +128,9 @@ class ContentController extends ActionController
      * @param string $metadata Type of metadata to return ("Asset" or "Image")
      * @param NodeInterface $node The node the new asset should be assigned to
      * @param string $propertyName The node property name the new asset should be assigned to
-     * @param string $siteNodeName The node name of the site the asset belongs to
      * @return string
      */
-    public function uploadAssetAction(Asset $asset, string $metadata, NodeInterface $node, string $propertyName, string $siteNodeName)
+    public function uploadAssetAction(Asset $asset, string $metadata, NodeInterface $node, string $propertyName)
     {
         $this->response->setHeader('Content-Type', 'application/json');
 
@@ -147,7 +146,7 @@ class ContentController extends ActionController
             if ($this->persistenceManager->isNewObject($asset)) {
                 $this->assetRepository->add($asset);
             }
-            $this->emitAssetUploaded($asset, $node, $propertyName, $siteNodeName);
+            $this->emitAssetUploaded($asset, $node, $propertyName);
         }
         return json_encode($result);
     }
@@ -400,11 +399,10 @@ class ContentController extends ActionController
      * @param Asset $asset The uploaded asset
      * @param NodeInterface $node The node the asset belongs to
      * @param string $propertyName The node property name the asset is assigned to
-     * @param string $siteNodeName Name of the Site Node in which the asset was uploaded
      * @return void
      * @Flow\Signal
      */
-    protected function emitAssetUploaded(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
+    protected function emitAssetUploaded(Asset $asset, NodeInterface $node, string $propertyName)
     {
     }
 }

--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -11,15 +11,17 @@ namespace Neos\Neos\Controller\Backend;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\EelHelper\TranslationHelper;
+use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;
-use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Media\Domain\Model\Asset;
-use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\ImageVariant;
@@ -27,17 +29,13 @@ use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\ImageRepository;
 use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Media\TypeConverter\AssetInterfaceConverter;
-use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\TypeConverter\ImageInterfaceArrayPresenter;
 use Neos\Neos\Controller\BackendUserTranslationTrait;
+use Neos\Neos\Controller\CreateContentContextTrait;
 use Neos\Neos\Domain\Model\PluginViewDefinition;
 use Neos\Neos\Domain\Model\Site;
-use Neos\Neos\Domain\Repository\SiteRepository;
-use Neos\Neos\Controller\CreateContentContextTrait;
 use Neos\Neos\Service\PluginService;
 use Neos\Neos\TypeConverter\EntityToIdentityConverter;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Eel\FlowQuery\FlowQuery;
 
 /**
  * The Neos ContentModule controller; providing backend functionality for the Content Module.
@@ -60,18 +58,6 @@ class ContentController extends ActionController
      * @var ImageRepository
      */
     protected $imageRepository;
-
-    /**
-     * @Flow\Inject
-     * @var AssetCollectionRepository
-     */
-    protected $assetCollectionRepository;
-
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
 
     /**
      * @Flow\Inject
@@ -112,6 +98,12 @@ class ContentController extends ActionController
     protected $thumbnailService;
 
     /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
      * Initialize property mapping as the upload usually comes from the Inspector JavaScript
      */
     public function initializeUploadAssetAction()
@@ -129,6 +121,9 @@ class ContentController extends ActionController
      * Depending on the $metadata argument it will return asset metadata for the AssetEditor
      * or image metadata for the ImageEditor
      *
+     * Note: This action triggers the AssetUploaded signal that can be used to adjust the asset based on the
+     * (site) node it was attached to.
+     *
      * @param Asset $asset
      * @param string $metadata Type of metadata to return ("Asset" or "Image")
      * @return string
@@ -137,29 +132,21 @@ class ContentController extends ActionController
     {
         $this->response->setHeader('Content-Type', 'application/json');
 
-        /** @var Site $currentSite */
-        $currentSite = $this->siteRepository->findOneByNodeName($this->request->getInternalArgument('__siteNodeName'));
-        if ($currentSite !== null && $currentSite->getAssetCollection() !== null) {
-            $currentSite->getAssetCollection()->addAsset($asset);
-            $this->assetCollectionRepository->update($currentSite->getAssetCollection());
-        }
-
-        switch ($metadata) {
-            case 'Asset':
-                $result = $this->getAssetProperties($asset);
-                if ($this->persistenceManager->isNewObject($asset)) {
-                    $this->assetRepository->add($asset);
-                }
-                break;
-            case 'Image':
+        if ($metadata !== 'Asset' && $metadata !== 'Image') {
+            $this->response->setStatus(400);
+            $result = ['error' => 'Invalid "metadata" type: ' . $metadata];
+        } else {
+            if ($asset instanceof ImageInterface && $metadata === 'Image') {
                 $result = $this->getImageInterfacePreviewData($asset);
-                if ($this->persistenceManager->isNewObject($asset)) {
-                    $this->imageRepository->add($asset);
-                }
-                break;
-            default:
-                $this->response->setStatus(400);
-                $result = array('error' => 'Invalid "metadata" type: ' . $metadata);
+            } else {
+                $result = $this->getAssetProperties($asset);
+            }
+            $nodePath = $this->request->getInternalArgument('__nodePath');
+            $node = $this->propertyMapper->convert($nodePath, NodeInterface::class);
+            if ($this->persistenceManager->isNewObject($asset)) {
+                $this->assetRepository->add($asset);
+            }
+            $this->emitAssetUploaded($asset, $node, $this->request->getInternalArgument('__siteNodeName'));
         }
         return json_encode($result);
     }
@@ -404,5 +391,18 @@ class ContentController extends ActionController
             }
         }
         return json_encode((object) $masterPlugins);
+    }
+
+    /**
+     * Signals that a new asset has been uploaded through the Neos Backend
+     *
+     * @param Asset $asset The uploaded asset
+     * @param NodeInterface $node The node the asset belongs to
+     * @param string $siteNodeName Name of the Site Node in which the asset was uploaded
+     * @return void
+     * @Flow\Signal
+     */
+    protected function emitAssetUploaded(Asset $asset, NodeInterface $node, string $siteNodeName)
+    {
     }
 }

--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -126,9 +126,11 @@ class ContentController extends ActionController
      *
      * @param Asset $asset
      * @param string $metadata Type of metadata to return ("Asset" or "Image")
+     * @param NodeInterface $node The node the new asset should be assigned to
+     * @param string $siteNodeName The node name of the site the asset belongs to
      * @return string
      */
-    public function uploadAssetAction(Asset $asset, $metadata)
+    public function uploadAssetAction(Asset $asset, string $metadata, NodeInterface $node, string $siteNodeName)
     {
         $this->response->setHeader('Content-Type', 'application/json');
 
@@ -141,12 +143,10 @@ class ContentController extends ActionController
             } else {
                 $result = $this->getAssetProperties($asset);
             }
-            $nodePath = $this->request->getInternalArgument('__nodePath');
-            $node = $this->propertyMapper->convert($nodePath, NodeInterface::class);
             if ($this->persistenceManager->isNewObject($asset)) {
                 $this->assetRepository->add($asset);
             }
-            $this->emitAssetUploaded($asset, $node, $this->request->getInternalArgument('__siteNodeName'));
+            $this->emitAssetUploaded($asset, $node, $siteNodeName);
         }
         return json_encode($result);
     }

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -118,10 +118,11 @@ class SiteService
      *
      * @param Asset $asset
      * @param NodeInterface $node
+     * @param string $propertyName
      * @param string $siteNodeName
      * @return void
      */
-    public function assignUploadedAssetToSiteAssetCollection(Asset $asset, NodeInterface $node, string $siteNodeName)
+    public function assignUploadedAssetToSiteAssetCollection(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
     {
         /** @var Site $site */
         $site = $this->siteRepository->findOneByNodeName($siteNodeName);

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -11,8 +11,11 @@ namespace Neos\Neos\Domain\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
@@ -63,6 +66,12 @@ class SiteService
     protected $persistenceManager;
 
     /**
+     * @Flow\Inject
+     * @var AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+    /**
      * Remove given site all nodes for that site and all domains associated.
      *
      * @param Site $site
@@ -101,6 +110,30 @@ class SiteService
         foreach ($this->siteRepository->findAll() as $site) {
             $this->pruneSite($site);
         }
+    }
+
+    /**
+     * Adds an asset to the asset collection of the site it has been uploaded to
+     * Note: This is usually triggered by the ContentController::assetUploaded signal
+     *
+     * @param Asset $asset
+     * @param NodeInterface $node
+     * @param string $siteNodeName
+     * @return void
+     */
+    public function assignUploadedAssetToSiteAssetCollection(Asset $asset, NodeInterface $node, string $siteNodeName)
+    {
+        /** @var Site $site */
+        $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+        if ($site === null) {
+            return;
+        }
+        $assetCollection = $site->getAssetCollection();
+        if ($assetCollection === null) {
+            return;
+        }
+        $assetCollection->addAsset($asset);
+        $this->assetCollectionRepository->update($assetCollection);
     }
 
     /**

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -119,13 +119,15 @@ class SiteService
      * @param Asset $asset
      * @param NodeInterface $node
      * @param string $propertyName
-     * @param string $siteNodeName
      * @return void
      */
-    public function assignUploadedAssetToSiteAssetCollection(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
+    public function assignUploadedAssetToSiteAssetCollection(Asset $asset, NodeInterface $node, string $propertyName)
     {
-        /** @var Site $site */
-        $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+        $contentContext = $node->getContext();
+        if (!$contentContext instanceof ContentContext) {
+            return;
+        }
+        $site = $contentContext->getCurrentSite();
         if ($site === null) {
             return;
         }

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -18,6 +18,7 @@ use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Service\AssetService;
+use Neos\Neos\Controller\Backend\ContentController;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\Neos\Domain\Service\SiteService;
@@ -78,6 +79,8 @@ class Package extends BasePackage
 
         $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetChange');
         $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetChange');
+
+        $dispatcher->connect(ContentController::class, 'assetUploaded', SiteService::class, 'assignUploadedAssetToSiteAssetCollection');
 
         $dispatcher->connect(Node::class, 'nodeAdded', NodeUriPathSegmentGenerator::class, '::setUniqueUriPathSegment');
         $dispatcher->connect(Node::class, 'nodePropertyChanged', Service\ImageVariantGarbageCollector::class, 'removeUnusedImageVariant');

--- a/Neos.Neos/Documentation/HowTos/TaggingAssetsAutomatically.rst
+++ b/Neos.Neos/Documentation/HowTos/TaggingAssetsAutomatically.rst
@@ -52,11 +52,10 @@ The slot gets called with the following arguments:
 * The ``Asset`` instance that is about to be persisted
 * The ``NodeInterface`` instance the asset has been attached to
 * The node property name (``string``) the asset has been assigned to
-* The node name (``string``) of the site the node belongs to
 
 So the signature of the slot method could look like this::
 
-	function theSlot(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
+	function theSlot(Asset $asset, NodeInterface $node, string $propertyName)
 
 This allows for manipulation of the asset based on the node property it has been assigned to.
 

--- a/Neos.Neos/Documentation/HowTos/TaggingAssetsAutomatically.rst
+++ b/Neos.Neos/Documentation/HowTos/TaggingAssetsAutomatically.rst
@@ -1,0 +1,125 @@
+.. _cookbook-tagging-assets-automatically:
+
+============================
+Tagging assets automatically
+============================
+
+Uploaded assets like images, documents or media files can be assigned to `Tags` and `AssetCollections` manually
+in the `Media` module.
+Especially for sites with many assets it is useful to automate this in order to keep files organized.
+
+Asset Collection based on site
+==============================
+
+Sites can already be assigned to an `AssetCollection` in the `Sites Management` module.
+If that is the case, any asset uploaded to a node within that site will automatically be added
+to the corresponding `AssetCollection`.
+This is especially useful in order to keep files of multi-site installations separated.
+
+For more fine-granular manipulation the ``ContentController::assetUploaded`` signal can be used to
+alter assets based on the node they were attached to:
+
+Hooking into the asset creation
+===============================
+
+In order to hook into the asset creation, a new signal/slot connection has to be established.
+For this a new `Package.php` (usually in `Packages/Site/The.Site/Classes/`) has to be added:
+
+*Example: Package.php* ::
+
+	<?php
+	namespace Some\Package;
+
+	use Neos\Flow\Core\Bootstrap;
+	use Neos\Flow\Package\Package as BasePackage;
+	use Neos\Neos\Controller\Backend\ContentController;
+
+	class Package extends BasePackage
+	{
+	    public function boot(Bootstrap $bootstrap)
+	    {
+	        $dispatcher = $bootstrap->getSignalSlotDispatcher();
+	        $dispatcher->connect(ContentController::class, 'assetUploaded', AssetManipulator::class, 'manipulateAsset');
+	    }
+	}
+
+.. note::
+
+    If you created a new ``Package.php`` file you need to run `./flow flow:package:rescan` in order for Flow to pick it up!
+
+The slot gets called with the following arguments:
+
+* The ``Asset`` instance that is about to be persisted
+* The ``NodeInterface`` instance the asset has been attached to
+* The node property name (``string``) the asset has been assigned to
+* The node name (``string``) of the site the node belongs to
+
+So the signature of the slot method could look like this::
+
+	function theSlot(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
+
+This allows for manipulation of the asset based on the node property it has been assigned to.
+
+Example: Tagging employee images
+================================
+
+Imagine you have a node type `Employee` with the following setup::
+
+	'Some.Package:Employee':
+	  superTypes:
+	    'Neos.Neos:Content': true
+	  ui:
+	    label: 'Employee'
+	    inspector:
+	      groups:
+	        'employee':
+	          label: 'Employee'
+	  properties:
+	    'image':
+	      type: 'Neos\Media\Domain\Model\ImageInterface'
+	      ui:
+	        label: 'Employee profile picture'
+	        reloadIfChanged: true
+	        inspector:
+	          group: 'employee'
+	          editorOptions:
+	            features:
+	              mediaBrowser: false
+
+The following code would automatically tag this with the `employee` tag (if it exists):
+
+*Example: AssetManipulator.php* ::
+
+	<?php
+	namespace Some\Package;
+
+	use Neos\ContentRepository\Domain\Model\NodeInterface;
+	use Neos\Flow\Annotations as Flow;
+	use Neos\Media\Domain\Model\Asset;
+	use Neos\Media\Domain\Repository\TagRepository;
+
+	/**
+	 * @Flow\Scope("singleton")
+	 */
+	class AssetManipulator
+	{
+	    /**
+	     * @Flow\Inject
+	     * @var TagRepository
+	     */
+	    protected $tagRepository;
+
+	    public function assignTag(Asset $asset, NodeInterface $node, string $propertyName)
+	    {
+	        if (!$node->getNodeType()->isOfType('Some.Package:Employee') || $propertyName !== 'image') {
+	            return;
+	        }
+	        $employeeTag = $this->tagRepository->findOneByLabel('employee');
+	        if ($employeeTag === null) {
+	            return;
+	        }
+	        $asset->addTag($employeeTag);
+	    }
+	}
+
+Alternatively, the slot could also assign the asset to `AssetCollections` or alter the asset's `title` or `caption`.

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
@@ -97,10 +97,11 @@ function(Ember, $, template, plupload, Notification, Configuration, I18n, Inspec
 				uploader.splice();
 			});
 
-			this._uploader.bind('BeforeUpload', function(uploader, file) {
+			this._uploader.bind('BeforeUpload', function(uploader) {
 				uploader.settings.multipart_params['__csrfToken'] = Configuration.get('CsrfToken');
-				uploader.settings.multipart_params['siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
 				uploader.settings.multipart_params['node'] = InspectorController.nodeSelection.get('selectedNode.nodePath');
+				uploader.settings.multipart_params['propertyName'] = that.get('property');
+				uploader.settings.multipart_params['siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
 			});
 
 			this._uploader.bind('FileUploaded', function(uploader, file, response) {

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
@@ -6,9 +6,10 @@ define(
 	'Library/plupload',
 	'Shared/Notification',
 	'Shared/Configuration',
-	'Shared/I18n'
+	'Shared/I18n',
+	'Content/Inspector/InspectorController'
 ],
-function(Ember, $, template, plupload, Notification, Configuration, I18n) {
+function(Ember, $, template, plupload, Notification, Configuration, I18n, InspectorController) {
 	return Ember.View.extend({
 		value: '',
 
@@ -99,6 +100,7 @@ function(Ember, $, template, plupload, Notification, Configuration, I18n) {
 			this._uploader.bind('BeforeUpload', function(uploader, file) {
 				uploader.settings.multipart_params['__csrfToken'] = Configuration.get('CsrfToken');
 				uploader.settings.multipart_params['__siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
+				uploader.settings.multipart_params['__nodePath'] = InspectorController.nodeSelection.get('selectedNode.nodePath');
 			});
 
 			this._uploader.bind('FileUploaded', function(uploader, file, response) {

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
@@ -101,7 +101,6 @@ function(Ember, $, template, plupload, Notification, Configuration, I18n, Inspec
 				uploader.settings.multipart_params['__csrfToken'] = Configuration.get('CsrfToken');
 				uploader.settings.multipart_params['node'] = InspectorController.nodeSelection.get('selectedNode.nodePath');
 				uploader.settings.multipart_params['propertyName'] = that.get('property');
-				uploader.settings.multipart_params['siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
 			});
 
 			this._uploader.bind('FileUploaded', function(uploader, file, response) {

--- a/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Content/Inspector/Editors/FileUpload.js
@@ -99,8 +99,8 @@ function(Ember, $, template, plupload, Notification, Configuration, I18n, Inspec
 
 			this._uploader.bind('BeforeUpload', function(uploader, file) {
 				uploader.settings.multipart_params['__csrfToken'] = Configuration.get('CsrfToken');
-				uploader.settings.multipart_params['__siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
-				uploader.settings.multipart_params['__nodePath'] = InspectorController.nodeSelection.get('selectedNode.nodePath');
+				uploader.settings.multipart_params['siteNodeName'] = $('link[rel="neos-site"]').data('node-name');
+				uploader.settings.multipart_params['node'] = InspectorController.nodeSelection.get('selectedNode.nodePath');
 			});
 
 			this._uploader.bind('FileUploaded', function(uploader, file, response) {


### PR DESCRIPTION
Introduces a signal `ContentController::assetUploaded` that
sends the currently selected `node` and the `siteNodeName`
along with the asset that's about to be persisted.

This allows the asset to be tagged or added to collections
based on the node type or path etc.

For example, the following slot would assign assets of an
`Employee` node type to the corresponding tag:

```php
public function theSlot(Asset $asset, NodeInterface $node, string $propertyName, string $siteNodeName)
{
    if (!$node->getNodeType()->isOfType('Some.Package:Employee') || $propertyName !== 'image') {
        return;
    }
    $tag = $this->tagRepository->findOneByLabel('Employee');
    if ($tag === null) {
        return;
    }
    $asset->addTag($tag);
}
```

Resolves: #893