### PR TITLE
BUGFIX: Fix typo in HowTo code snippet

### DIFF
--- a/TYPO3.Neos/Documentation/HowTos/ExtendingPages.rst
+++ b/TYPO3.Neos/Documentation/HowTos/ExtendingPages.rst
@@ -31,7 +31,7 @@ in the below example:
 
 TypoScript (Sites/Vendor.Site/Resources/Private/TypoScripts/Library/Root.ts2) ::
 
-	prototype(TYPO3.Neos:Page) {
+	prototype(TYPO3.Neos.NodeTypes:Page) {
 		backgroundImage = ${q(node).property('backgroundImage')}
 	}
 


### PR DESCRIPTION
Fixes the example prototype definition in the `ExtendingPages` HowTo