### PR TITLE
TASK: Adds a hint that `@context` cant access context variables on the same level

### DIFF
--- a/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
@@ -468,6 +468,13 @@ This functionality is especially helpful if there are strong conventions regardi
 context variables. This is often the case in standalone Fusion applications, but for Neos, this
 functionality is hardly ever used.
 
+.. warning:: In order to prevent unwanted side effects, it is not possible to access context variables from within ``@context`` on the same level. This means that the following will never return the string ``Hello World!``
+
+	@context.contextOne = 'World!'
+	@context.contextTwo = ${'Hello ' + contextOne}
+	output = ${contextTwo}
+
+
 Processors
 ==========
 


### PR DESCRIPTION
see https://neos-project.slack.com/archives/C050C8FEK/p1509054474000170
