### PR TITLE
BUGFIX: Show object in "missing template" message

### DIFF
--- a/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/TemplateImplementation.php
+++ b/TYPO3.TypoScript/Classes/TYPO3/TypoScript/TypoScriptObjects/TemplateImplementation.php
@@ -93,7 +93,7 @@ class TemplateImplementation extends AbstractArrayTypoScriptObject
 				`prototype(%s) < prototype(TYPO3.TypoScript:Template) {
 					templatePath = 'resource://Vendor.Package/Private/Templates/MyObject.html'
 				}`
-			", $templatePath, $this->typoScriptObjectName));
+			", $this->typoScriptObjectName));
         }
         $fluidTemplate->setTemplatePathAndFilename($templatePath);
 


### PR DESCRIPTION
The sprintf() call should only get one parameter, usage of the first
one was dropped inside the message text previously.