### PR TITLE
BUGFIX: Update publish button when copying page in node tree

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/NodeTree.js
@@ -462,6 +462,10 @@ define(
 				ContentModule.loadPage(node.data.href);
 			},
 
+			afterPaste: function(node) {
+				this.afterPersistNode(node);
+			},
+
 			refresh: function() {
 				this._updateMetaInformation();
 				this.filterTree();


### PR DESCRIPTION
Make sure the publish button is updated so the new changes can be published.
Additionally selects the newly copied page similar to when inserting a new document.

Resolves #914