### PR TITLE
BUGFIX: Assets used in moved nodes don't break media module asset view

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -93,6 +93,9 @@ class AssetUsageInNodePropertiesStrategy extends AbstractAssetUsageStrategy
 
         $relatedNodes = [];
         foreach ($this->getRelatedNodes($asset) as $relatedNodeData) {
+            if ($relatedNodeData->isInternal()) {
+                continue;
+            }
             $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());
             if ($accessible) {
                 $context = $this->createContextMatchingNodeData($relatedNodeData);


### PR DESCRIPTION
Prevent assets referenced in moved nodes from breaking the asset view in the media module.

Fixes #1742