### PR TITLE
BUGFIX: Fix wrong TS path in extending pages example

### DIFF
--- a/TYPO3.Neos/Documentation/HowTos/ExtendingPages.rst
+++ b/TYPO3.Neos/Documentation/HowTos/ExtendingPages.rst
@@ -32,7 +32,7 @@ in the below example:
 TypoScript (Sites/Vendor.Site/Resources/Private/TypoScripts/Library/Root.ts2) ::
 
 	prototype(TYPO3.Neos:Page) {
-		backgroundImage = ${q(node).property('backgroundImage')}
+		body.backgroundImage = ${q(node).property('backgroundImage')}
 	}
 
 With TYPO3.Media ViewHelper you can display the Image with the follwing HTML snippet:


### PR DESCRIPTION
Fix exception when following documentation about extending pages.

See detailed description and discussion on https://discuss.neos.io/t/1952
