### PR TITLE
TASK: Generate a unique personal workspace per account

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Domain\Repository;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\QueryInterface;
 use Neos\Flow\Persistence\Repository;
@@ -29,4 +30,18 @@ class WorkspaceRepository extends Repository
         'baseWorkspace' => QueryInterface::ORDER_ASCENDING,
         'title' => QueryInterface::ORDER_ASCENDING
     );
+
+    public function getPersonalWorkspaceByOwnerIdentifier($ownerIdentifier)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->like('name', Workspace::PERSONAL_WORKSPACE_PREFIX . '%'),
+                $query->equals('owner', $ownerIdentifier)
+            )
+        );
+
+        return $query->execute()->getFirst();
+    }
+
 }

--- a/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
@@ -31,7 +31,12 @@ class WorkspaceRepository extends Repository
         'title' => QueryInterface::ORDER_ASCENDING
     );
 
-    public function getPersonalWorkspaceByOwnerIdentifier($ownerIdentifier)
+    /**
+     * Returns the personal workspace with the owner matching the given $ownerIdentifier.
+     *
+     * @var string $ownerIdentifier
+     */
+    public function getPersonalWorkspaceByOwnerIdentifier(string $ownerIdentifier)
     {
         $query = $this->createQuery();
         $query->matching(

--- a/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
@@ -43,5 +43,4 @@ class WorkspaceRepository extends Repository
 
         return $query->execute()->getFirst();
     }
-
 }

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -122,10 +122,13 @@ class WorkspacesController extends AbstractModuleController
      */
     public function indexAction()
     {
-        $currentAccount = $this->securityContext->getAccount();
-        $userWorkspace = $this->workspaceRepository->findOneByName(UserUtility::getPersonalWorkspaceNameForUsername($currentAccount->getAccountIdentifier()));
-        /** @var Workspace $userWorkspace */
+        $userWorkspace = $this->workspaceRepository->getPersonalWorkspaceByOwnerIdentifier(
+            $this->persistenceManager->getIdentifierByObject(
+                $this->userService->getCurrentUser()
+            )
+        );
 
+        /** @var Workspace $userWorkspace */
         $workspacesAndCounts = [
             $userWorkspace->getName() => [
                 'workspace' => $userWorkspace,
@@ -313,8 +316,11 @@ class WorkspacesController extends AbstractModuleController
      */
     public function rebaseAndRedirectAction(NodeInterface $targetNode, Workspace $targetWorkspace)
     {
-        $currentAccount = $this->securityContext->getAccount();
-        $personalWorkspace = $this->workspaceRepository->findOneByName(UserUtility::getPersonalWorkspaceNameForUsername($currentAccount->getAccountIdentifier()));
+        $personalWorkspace = $this->workspaceRepository->getPersonalWorkspaceByOwnerIdentifier(
+            $this->persistenceManager->getIdentifierByObject(
+                $this->userService->getCurrentUser()
+            )
+        );
         /** @var Workspace $personalWorkspace */
 
         if ($personalWorkspace !== $targetWorkspace) {

--- a/Neos.Neos/Classes/Utility/User.php
+++ b/Neos.Neos/Classes/Utility/User.php
@@ -1,24 +1,11 @@
 <?php
 namespace Neos\Neos\Utility;
 
-use Neos\ContentRepository\Domain\Model\Workspace;
-
 /**
  * Utility functions for dealing with users in the Content Repository.
  */
 class User
 {
-    /**
-     * Constructs a personal workspace name for the user with the given username.
-     *
-     * @param string $username
-     * @return string
-     */
-    public static function getPersonalWorkspaceNameForUsername($username)
-    {
-        return Workspace::PERSONAL_WORKSPACE_PREFIX . static::slugifyUsername($username);
-    }
-
     /**
      * Will reduce the username to ascii alphabet and numbers.
      *


### PR DESCRIPTION
This change generates a unique workspace per user even though
the account identifiers might match. This can happen if the same
account identifier is used over multiple account providers.

This fixes that effectively one multiple authentication provider
worked as expected.