### PR TITLE
TASK: Fix remove a selectbox option from an existing Node Type documentation

### DIFF
--- a/TYPO3.Neos/Documentation/ExtendingNeos/CustomizingInspector.rst
+++ b/TYPO3.Neos/Documentation/ExtendingNeos/CustomizingInspector.rst
@@ -197,6 +197,6 @@ Yaml (Sites/Vendor.Site/Configuration/NodeTypes.yaml):
           inspector:
             editorOptions:
               values:
-                parentNode: [ ]
+                parentNode: ~
 
 It is also possible to add :ref:`custom-editors` and use :ref:`custom-validators`.


### PR DESCRIPTION
Based on this post: https://discuss.neos.io/t/solved-remove-properties-from-nodetype-of-included-package/2751/6