### PR TITLE
TASK: Make FusionRuntime available to Form Renderers

### DIFF
--- a/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Root.fusion
@@ -94,7 +94,12 @@ prototype(Neos.NodeTypes:FourColumn) < prototype(Neos.NodeTypes:MultiColumn)
 # Form TS Object
 prototype(Neos.NodeTypes:Form) {
 	presetName = 'default'
-	overrideConfiguration = Neos.Fusion:RawArray
+	overrideConfiguration = Neos.Fusion:RawArray {
+		renderingOptions = Neos.Fusion:RawArray {
+			# Make the current FusionRuntime available to the Form Renderer
+			_fusionRuntime = ${this.runtime}
+		}
+	}
 	@cache {
 		mode = 'uncached'
 		context {


### PR DESCRIPTION
Adjusts the `Neos.NodeTypes:Form` Fusion prototype to make
the current `Fusion\Runtime` available to the Form renderer
via the forms rendering options.

Background:

This is especially useful for forms that are rendererd with
the `neos/form-fusionrenderer` which, otherwise, can't re-use
Fusion prototypes that are not explicitly loaded.

For forms rendered with the `neos/form-builder`, the runtime
is already set.