### PR TITLE
BUGFIX: silently ignore attempts to discard live nodes

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
@@ -169,7 +169,8 @@ class PublishingService implements PublishingServiceInterface
     protected function doDiscardNode(NodeInterface $node, array &$alreadyDiscardedNodeIdentifiers = [])
     {
         if ($node->getWorkspace()->getBaseWorkspace() === null) {
-            throw new WorkspaceException('Nodes in a in a workspace without a base workspace cannot be discarded.', 1395841899);
+            // Nodes in a workspace without a base workspace cannot be discarded, so silently ignore
+            return;
         }
         if ($node->getPath() === '/') {
             return;


### PR DESCRIPTION
**What I did**

Imagine you have two nodes, `/sites/site/A` and `/sites/site/A/B`. When you discard A it would also discard changes to B (at least if it's its a ContentCollection). So when you try to discard B one more time, it will already B in live workspace, thus discarding would break.

**How I did it**

I removed the exception on trying to discard a live node.

**How to verify it**

1. Without applying this PR, edit any direct property of a document node.
2. Discard all.
3. Contemplate a `Nodes in a in a workspace without a base workspace` error message.

With this PR it should just work.

This affects all maintained versions.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
