### PR TITLE
BUGFIX: Avoid error if no dimension is set in DimensionsMenuImplementation

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/DimensionsMenuImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/DimensionsMenuImplementation.php
@@ -115,7 +115,13 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
                 ];
             }, $allDimensionPresets);
 
-            if ($pinnedDimensionName === null) {
+            if ($nodeInDimensions === null) {
+                $itemLabel = '';
+                foreach ($targetDimensions as $item) {
+                    $itemLabel .= $item['label'] . ' - ';
+                }
+                $itemLabel = trim($itemLabel, ' -');
+            } elseif ($pinnedDimensionName === null) {
                 $itemLabel = $nodeInDimensions->getLabel();
             } else {
                 $itemLabel = $targetDimensions[$pinnedDimensionName]['label'];

--- a/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/DimensionsMenuImplementation.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/TypoScript/DimensionsMenuImplementation.php
@@ -115,13 +115,13 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
                 ];
             }, $allDimensionPresets);
 
-            if ($nodeInDimensions === null) {
+            if ($nodeInDimensions === null && $pinnedDimensionName === null) {
                 $itemLabel = '';
                 foreach ($targetDimensions as $item) {
                     $itemLabel .= $item['label'] . ' - ';
                 }
                 $itemLabel = trim($itemLabel, ' -');
-            } elseif ($pinnedDimensionName === null) {
+            } elseif ($nodeInDimensions instanceof NodeInterface && $pinnedDimensionName === null) {
                 $itemLabel = $nodeInDimensions->getLabel();
             } else {
                 $itemLabel = $targetDimensions[$pinnedDimensionName]['label'];


### PR DESCRIPTION
When using the DimensionsMenuImplementation without a set `dimension`
(yes, there are use cases for that, e.g. hreflang tags for language _and_
country), the following could happen:

    Call to a member function getLabel() on null

This change avoids that.
