### PR TITLE
TASK: Add generateUriPathSegments check identifier

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Command/NodeCommandControllerPlugin.php
@@ -111,6 +111,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
             case 'repair':
                 return <<<'HELPTEXT'
 <u>Generate missing URI path segments</u>
+generateUriPathSegments
 
 Generates URI path segment properties for all document nodes which don't have a path
 segment set yet.


### PR DESCRIPTION
This adds the `generateUriPathSegments` identifier to the `node:repair`
help text.
