### PR TITLE
TASK: Allow to configure if processed images must be interlaced

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -145,6 +145,10 @@ class ImageService
         }
 
         if ($adjustmentsApplied === true) {
+            $interlace = Arrays::getValueByPath($this->settings, 'image.defaultOptions.interlace');
+            if ($interlace !== null) {
+                $imagineImage->interlace($interlace);
+            }
             $imagineImage->save($transformedImageTemporaryPathAndFilename, $this->getOptionsMergedWithDefaults($additionalOptions));
             $imageSize = $imagineImage->getSize();
 

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -72,6 +72,7 @@ Neos:
         # Image quality, from 0 to 100
         quality: 90
         convertCMYKToRGB: true
+        interlace: '%\Imagine\Image\ImageInterface::INTERLACE_NONE%'
         # defines the filter to use for resize operations.
         # Note that the default GD driver only supports the FILTER_UNDEFINED.
         # Check the \Imagine\Image\ImageInterface class for a reference of all filters.

--- a/Neos.Media/Documentation/ConfigureImageGeneration.rst
+++ b/Neos.Media/Documentation/ConfigureImageGeneration.rst
@@ -38,7 +38,7 @@ If you have configured a Imagine driver that support alternative filter (this th
 
 .. code-block:: yaml
 
-    TYPO3:
+    Neos:
       Media:
         image:
           defaultOptions:
@@ -54,7 +54,7 @@ To generate progressive images you can configure the driver within your Settings
 
 .. code-block:: yaml
 
-    TYPO3:
+    Neos:
       Media:
         image:
           defaultOptions:

--- a/Neos.Media/Documentation/ConfigureImageGeneration.rst
+++ b/Neos.Media/Documentation/ConfigureImageGeneration.rst
@@ -10,7 +10,7 @@ Set the `quality` to your preferred value (between 0 - very poor and 100 - very 
 
 .. code-block:: yaml
 
-    TYPO3:
+    Neos:
       Media:
         image:
           defaultOptions:
@@ -24,7 +24,7 @@ If you are working with CMYK images and don't like to convert them automatically
 
 .. code-block:: yaml
 
-    TYPO3:
+    Neos:
       Media:
         image:
           defaultOptions:

--- a/Neos.Media/Documentation/ConfigureImageGeneration.rst
+++ b/Neos.Media/Documentation/ConfigureImageGeneration.rst
@@ -29,3 +29,35 @@ If you are working with CMYK images and don't like to convert them automatically
         image:
           defaultOptions:
             convertCMYKToRGB: false #default is true
+
+
+Changed default filter for Image processing
+===========================================
+
+If you have configured a Imagine driver that support alternative filter (this the case is you use Imagick or Gmagick), you can select the filter within your Settings.yaml:
+
+.. code-block:: yaml
+
+    TYPO3:
+      Media:
+        image:
+          defaultOptions:
+            resizeFilter: '%\Imagine\Image\ImageInterface::FILTER_UNDEFINED%'
+
+Unfortunatly Gd does not support other filter than the default one. Good candidate can be FILTER_BOX or FILTER_CATROOM. You can check the documentation of your image driver for
+more informations about each filter. Check the \Imagine\Image\ImageInterface to know with filter are supported by Imagine.
+
+Produce interlaced images
+=========================
+
+To generate progressive images you can configure the driver within your Settings.yaml:
+
+.. code-block:: yaml
+
+    TYPO3:
+      Media:
+        image:
+          defaultOptions:
+            interlace: '%\Imagine\Image\ImageInterface::INTERLACE_LINE%'
+
+ Check the \Imagine\Image\ImageInterface to know with mode are supported by Imagine.


### PR DESCRIPTION
This change adds a new setting in the Media package to enable image interlacing.

It's disabled by default, but you can change the setting to one of the values in
`Neos.Media.image.defaultOptions.interlace`:

- `%\Imagine\Image\ImageInterface::INTERLACE_NONE%` (default)
- `%\Imagine\Image\ImageInterface::INTERLACE_LINE%`
- `%\Imagine\Image\ImageInterface::INTERLACE_PLANE%`
- `%\Imagine\Image\ImageInterface::INTERLACE_PARTITION%`
