### PR TITLE
TASK: Display changes in workspaces module when setting/unsetting a DateTime values

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/WorkspacesController.php
@@ -598,8 +598,14 @@ class WorkspacesController extends AbstractModuleController
                     'original' => $originalPropertyValue,
                     'changed' => $changedPropertyValue
                 ];
-            } elseif ($originalPropertyValue instanceof \DateTime && $changedPropertyValue instanceof \DateTime) {
-                if ($changedPropertyValue->getTimestamp() !== $originalPropertyValue->getTimestamp()) {
+            } elseif ($originalPropertyValue instanceof \DateTime || $changedPropertyValue instanceof \DateTime) {
+                $changed = false;
+                if (!$changedPropertyValue instanceof \DateTime || !$originalPropertyValue instanceof \DateTime) {
+                    $changed = true;
+                } elseif ($changedPropertyValue->getTimestamp() !== $originalPropertyValue->getTimestamp()) {
+                    $changed = true;
+                }
+                if ($changed) {
                     $contentChanges[$propertyName] = [
                         'type' => 'datetime',
                         'propertyLabel' => $this->getPropertyLabel($propertyName, $changedNode),


### PR DESCRIPTION
When a DateTime property value is either set for the first time or unset the workspace module will now show that change. Previously it would only display the change if the time was set changed to a different time.