### PR TITLE
BUGFIX: Context structure tree only shows content

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Navigate/ContextStructureTree.js
@@ -38,7 +38,7 @@ define(
 		template: Ember.Handlebars.compile(template),
 		controller: NavigatePanelController,
 		nodeSelection: NodeSelection,
-		baseNodeType: '!TYPO3.Neos:Document',
+		baseNodeType: 'TYPO3.Neos:ContentCollection,TYPO3.Neos:Content',
 		treeSelector: '#neos-context-structure-tree',
 		desiredNewPosition: 'inside',
 		desiredPastePosition: 'inside',


### PR DESCRIPTION
Changes the base node type filter used in the context structure tree to explicitly include content collections and content elements instead of everything that's not a document node type.

Resolves #1784