### PR TITLE
TASK: Fix border-radius on button elements

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Foundation/_buttons.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Foundation/_buttons.scss
@@ -24,6 +24,7 @@ button,
 	background-color: $grayLight;
 	background-image: none;
 	border: none;
+	border-radius: 0;
 	@include text-shadow(none);
 	@include box-shadow(none);
 	@include box-sizing(border-box);

--- a/TYPO3.Neos/Resources/Public/Styles/Includes-built.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Includes-built.css
@@ -5354,6 +5354,7 @@
   background-color: #3f3f3f;
   background-image: none;
   border: none;
+  border-radius: 0;
   text-shadow: none;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -5354,6 +5354,7 @@
   background-color: #3f3f3f;
   background-image: none;
   border: none;
+  border-radius: 0;
   text-shadow: none;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;


### PR DESCRIPTION
On Chrome (macOS), all `<button>` elements had a `border-radius` of `4px`, which is now removed.

