### PR TITLE
BUGFIX: Add missing default value for weight of InterDimension/ContentSubgraph

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/InterDimension/ContentSubgraph.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/InterDimension/ContentSubgraph.php
@@ -42,7 +42,7 @@ class ContentSubgraph
     /**
      * @var array
      */
-    protected $weight;
+    protected $weight = [];
 
 
     /**


### PR DESCRIPTION
Without that accessing getWeight caused a TypeError if no dimensions were configured since the getWeight method enforces the return-type array.