### PR TITLE
BUGFIX: Let fusion render preview URIs for the Neos backend

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/Page.ts2
@@ -121,6 +121,17 @@ prototype(TYPO3.Neos:Page) < prototype(TYPO3.TypoScript:Http.Message) {
 		@if.onlyRenderWhenNotInLiveWorkspace = ${documentNode.context.inBackend}
 	}
 
+	neosBackendMetaData = TYPO3.TypoScript:Tag {
+		tagName = 'div'
+		@position = 'after neosBackendDocumentNodeData'
+		attributes = TYPO3.TypoScript:Attributes {
+			data-preview-uri = NodeUri {
+				node = ${q(documentNode).context({'workspaceName': documentNode.context.workspace.baseWorkspace.name}).get(0)}
+			}
+		}
+		@if.onlyRenderWhenNotInLiveWorkspace = ${documentNode.context.inBackend}
+	}
+
 	# Content of the body tag. To be defined by the integrator.
 	body = TYPO3.TypoScript:Template {
 		@position = 'after bodyTag'

--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentContextBar.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentContextBar.js
@@ -45,12 +45,7 @@ define(
        * Update the preview uri
        */
       updatePreviewUri: function () {
-        var targetWorkspaceName = this.get('targetWorkspaceController.targetWorkspace.name');
-        if (targetWorkspaceName === 'live') {
-          this.set('previewUri', location.href.replace(/@[A-Za-z0-9;&,\-_=]+/g, ''));
-        } else {
-          this.set('previewUri', location.href.replace(/@[A-Za-z0-9;&,\-_=]+/g, '@' + targetWorkspaceName));
-        }
+        this.set('previewUri', document.querySelector('[data-preview-uri]').getAttribute('data-preview-uri'));
       }.observes('targetWorkspaceController.targetWorkspace', 'contentDimensionController.selectedDimensions'),
 
       /**


### PR DESCRIPTION
Preview links are now generated via Fusion instead of Javascript