### PR TITLE
BUGFIX: Add missing neos/form dependency

### DIFF
--- a/Neos.NodeTypes.Form/composer.json
+++ b/Neos.NodeTypes.Form/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-3.0+",
     "require": {
         "neos/neos": "*",
+        "neos/form": "*",
         "neos/nodetypes-basemixins": "*"
     },
     "autoload": {


### PR DESCRIPTION
This dependency was forgotten in the NodeTypes split.