### PR TITLE
BUGFIX: Add missing dependency to Neos.NodeTypes.Form to Neos.NodeTypes

### DIFF
--- a/Neos.NodeTypes/composer.json
+++ b/Neos.NodeTypes/composer.json
@@ -16,7 +16,8 @@
         "neos/nodetypes-columnlayouts": "self.version",
         "neos/nodetypes-contentreferences": "self.version",
         "neos/nodetypes-html": "self.version",
-        "neos/nodetypes-navigation": "self.version"
+        "neos/nodetypes-navigation": "self.version",
+        "neos/nodetypes-form": "self.version"
     },
     "replace": {
         "typo3/neos-nodetypes": "self.version"


### PR DESCRIPTION
This dependency was forgotten in the NodeTypes split.