### PR TITLE
Absolute uri generation

### DIFF
--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -288,18 +288,18 @@ class LinkingService
             ->setFormat($format ?: $request->getFormat())
             ->uriFor('show', array('node' => $resolvedNode), 'Frontend\Node', 'Neos.Neos');
 
-        $siteNode = $resolvedNode->getContext()->getCurrentSiteNode();
-        if (NodePaths::isSubPathOf($siteNode->getPath(), $resolvedNode->getPath())) {
-            /** @var Site $site */
-            $site = $resolvedNode->getContext()->getCurrentSite();
-        } else {
-            $nodePath = NodePaths::getRelativePathBetween(SiteService::SITES_ROOT_PATH, $resolvedNode->getPath());
-            list($siteNodeName) = explode('/', $nodePath);
-            $site = $this->siteRepository->findOneByNodeName($siteNodeName);
-        }
-
         $uriObject = new Uri($uri);
         if (!$uriObject->getHost()) {
+            $siteNode = $resolvedNode->getContext()->getCurrentSiteNode();
+            if (NodePaths::isSubPathOf($siteNode->getPath(), $resolvedNode->getPath())) {
+                /** @var Site $site */
+                $site = $resolvedNode->getContext()->getCurrentSite();
+            } else {
+                $nodePath = NodePaths::getRelativePathBetween(SiteService::SITES_ROOT_PATH, $resolvedNode->getPath());
+                list($siteNodeName) = explode('/', $nodePath);
+                $site = $this->siteRepository->findOneByNodeName($siteNodeName);
+            }
+
             if ($site->hasActiveDomains()) {
                 $requestUriHost = $request->getHttpRequest()->getBaseUri()->getHost();
                 $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -298,18 +298,21 @@ class LinkingService
             $site = $this->siteRepository->findOneByNodeName($siteNodeName);
         }
 
-        if ($site->hasActiveDomains()) {
-            $requestUriHost = $request->getHttpRequest()->getBaseUri()->getHost();
-            $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {
-                return $domain->getHostname();
-            })->toArray();
-            if (!in_array($requestUriHost, $activeHostPatterns, true)) {
-                $uri = $this->createSiteUri($controllerContext, $site) . '/' . ltrim($uri, '/');
+        $uriObject = new Uri($uri);
+        if (!$uriObject->getHost()) {
+            if ($site->hasActiveDomains()) {
+                $requestUriHost = $request->getHttpRequest()->getBaseUri()->getHost();
+                $activeHostPatterns = $site->getActiveDomains()->map(function ($domain) {
+                    return $domain->getHostname();
+                })->toArray();
+                if (!in_array($requestUriHost, $activeHostPatterns, true)) {
+                    $uri = $this->createSiteUri($controllerContext, $site) . '/' . ltrim($uri, '/');
+                } elseif ($absolute === true) {
+                    $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
+                }
             } elseif ($absolute === true) {
                 $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
             }
-        } elseif ($absolute === true) {
-            $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
         }
 
         return $uri;


### PR DESCRIPTION
Previously the LinkingService took care of enforcing absolute URIs if requested or necessary.
Now that Flow routing components can already provide absolute URIs, the LinkingService should no longer always have the final say in this.

The LinkingService now simply only post processes relative URIs.

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against 3.3, which is the first version to be able to make use of this
