### PR TITLE
BUGFIX: Initialize overrideConfiguration in Fusion

### DIFF
--- a/Neos.NodeTypes.Form/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Form/Resources/Private/Fusion/Root.fusion
@@ -3,6 +3,7 @@ prototype(Neos.NodeTypes.Form:Form) < prototype(Neos.Neos:Content) {
   templatePath = 'resource://Neos.NodeTypes.Form/Private/Templates/NodeTypes/Form.html'
   presetName = 'default'
   formIdentifier = ${q(node).property('formIdentifier')}
+  overrideConfiguration = Neos.Fusion:RawArray
   @cache {
     mode = 'uncached'
     context {


### PR DESCRIPTION
Initialize ``overrideConfiguration`` as empty ``array`` so it's not ``null`` when passed to the form template.