### PR TITLE
BUGFIX: Load thumbs in media browser asynchronous

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -149,6 +149,12 @@ class AssetController extends ActionController
     protected $translator;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Media", path="asyncThumbnails")
+     * @var boolean
+     */
+    protected $asyncThumbnails;
+
+    /**
      * @return void
      */
     public function initializeObject()
@@ -175,7 +181,8 @@ class AssetController extends ActionController
             'sortDirection' => $this->browserState->get('sortDirection'),
             'filter' => $this->browserState->get('filter'),
             'activeTag' => $this->browserState->get('activeTag'),
-            'activeAssetCollection' => $this->browserState->get('activeAssetCollection')
+            'activeAssetCollection' => $this->browserState->get('activeAssetCollection'),
+            'asyncThumbnails' => $this->asyncThumbnails
         ]);
     }
 

--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -73,8 +73,8 @@
 			<f:for each="{paginatedAssets}" as="asset" iteration="iterator">
 				<tr class="asset draggable-asset{f:if(condition: '{asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}" data-asset-identifier="{asset -> f:format.identifier()}">
 					<td>
-						<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{f:if(condition: asset.width, then: '{asset.width} x {asset.height}')}" data-html="true" data-content="{m:thumbnail(asset: asset, preset: 'Neos.Media.Browser:Thumbnail', alt: asset.label, async: settings.asyncThumbnails) -> f:format.htmlentities()}">
-							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
+						<div class="neos-list-thumbnail" data-neos-toggle="popover" data-placement="{f:if(condition: '{iterator.index} > 2', then: 'top', else: 'bottom')}" data-trigger="hover" data-title="{f:if(condition: asset.width, then: '{asset.width} x {asset.height}')}" data-html="true" data-content="{m:thumbnail(asset: asset, preset: 'Neos.Media.Browser:Thumbnail', alt: asset.label, async: asyncThumbnails) -> f:format.htmlentities()}">
+							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{asyncThumbnails}" />
 						</div>
 					</td>
 					<td class="asset-label"><span data-neos-toggle="tooltip" title="{asset.label}"><f:format.crop maxCharacters="50">{asset.label}</f:format.crop></span></td>

--- a/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
@@ -14,7 +14,7 @@
 				<li class="asset">
 					<f:link.action action="edit" class="neos-thumbnail" arguments="{asset: asset}" data="{asset-identifier: '{asset -> f:format.identifier()}'}">
 						<div class="neos-img-container draggable-asset {f:if(condition: '{asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}">
-							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{settings.asyncThumbnails}" />
+							<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Thumbnail" alt="{asset.label}" async="{asyncThumbnails}" />
 						</div>
 					</f:link.action>
 					<div class="neos-img-label">

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -124,7 +124,7 @@
 	<label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
 	<div class="neos-preview-image">
 		<a href="{f:uri.resource(resource: asset.resource)}" target="_blank">
-			<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Preview" alt="{asset.label}" async="{settings.asyncThumbnails}" class="img-polaroid" />
+			<m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Preview" alt="{asset.label}" async="{asyncThumbnails}" class="img-polaroid" />
 		</a>
 	</div>
 </f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -241,7 +241,7 @@
 			<div class="neos-media-content-help">
 				<i class="icon-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package: 'Neos.Media.Browser')}
 			</div>
-			<f:render partial="{view}View" arguments="{assets: assets, sortBy: sortBy, sortDirection: sortDirection}" />
+			<f:render partial="{view}View" arguments="{assets: assets, sortBy: sortBy, sortDirection: sortDirection, asyncThumbnails: asyncThumbnails}" />
 
 			<div class="neos-hide" id="delete-asset-modal">
 				<div class="neos-modal-centered">


### PR DESCRIPTION
When you open the media module with a lot of high-res images while the thumbnails are not already generated and cached, loading can take a long time without noticable feedback.

The templates use a setting not available since the media browser was split into it's own package. Instead the setting needs to be read from the Media package.