### PR TITLE
BUGFIX Inject missing ImageService into AssetService

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -83,6 +83,12 @@ class AssetService
     protected $packageManager;
 
     /**
+     * @Flow\Inject()
+     * @var ImageService
+     */
+    protected $imageService;
+    
+    /**
      * Returns the repository for an asset
      *
      * @param AssetInterface $asset

--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -83,7 +83,7 @@ class AssetService
     protected $packageManager;
 
     /**
-     * @Flow\Inject()
+     * @Flow\Inject
      * @var ImageService
      */
     protected $imageService;


### PR DESCRIPTION
PR #1597 has introduced a missing service injection. 

The ImageService is used but never injected into AssetService.

See: https://github.com/neos/neos-development-collection/blob/master/Neos.Media/Classes/Domain/Service/AssetService.php#L269