### PR TITLE
DOCS: Fix misleading comment in Neos.Fusion:Component implementation

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -27,7 +27,7 @@ use Neos\Fusion\FusionObjects\ArrayImplementation;
 class ComponentImplementation extends ArrayImplementation
 {
     /**
-     * Properties that are ignored and added to the props
+     * Properties that are ignored and not included into the ``props`` context
      *
      * @var array
      */


### PR DESCRIPTION
The comment for the `ignoreProperties`-variable missed a "not" and thus was misleading.