### PR TITLE
TASK: Tweak Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
         postgresql: "9.4"
     - php: 7.0
       env: DB=pgsql
-      sudo: true
-      dist: trusty
       addons:
         postgresql: "9.5"
     - php: 7.0
@@ -22,8 +20,6 @@ matrix:
         postgresql: "9.4"
     - php: 7.0
       env: DB=pgsql BEHAT=true
-      sudo: true
-      dist: trusty
       addons:
         postgresql: "9.5"
     - php: 7.1


### PR DESCRIPTION
This removes some options no longer needed, since the required PostgreSQL
versions are meanwhile available without any use of sudo in the default
container infrastructure, as shown in

- https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
- https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version
