### PR TITLE
TASK: Adjust Travis CI build matrix to use PHP 7.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,34 +2,26 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      env: DB=mysql
-    - php: 7.0
-      env: DB=pgsql
-      addons:
-        postgresql: "9.4"
-    - php: 7.0
-      env: DB=pgsql
-      sudo: true
-      dist: trusty
-      addons:
-        postgresql: "9.5"
-    - php: 7.0
-      env: DB=mysql BEHAT=true
-    - php: 7.0
-      env: DB=pgsql BEHAT=true
-      addons:
-        postgresql: "9.4"
-    - php: 7.0
-      env: DB=pgsql BEHAT=true
-      sudo: true
-      dist: trusty
-      addons:
-        postgresql: "9.5"
     - php: 7.1
       env: DB=mysql
     - php: 7.1
+      env: DB=pgsql
+      addons:
+        postgresql: "9.4"
+    - php: 7.1
+      env: DB=pgsql
+      addons:
+        postgresql: "9.5"
+    - php: 7.1
       env: DB=mysql BEHAT=true
+    - php: 7.1
+      env: DB=pgsql BEHAT=true
+      addons:
+        postgresql: "9.4"
+    - php: 7.1
+      env: DB=pgsql BEHAT=true
+      addons:
+        postgresql: "9.5"
     - php: 7.2
       env: DB=mysql
     - php: 7.2


### PR DESCRIPTION
As of https://github.com/neos/flow-development-collection/pull/1160
Flow requires PHP 7.1 or higher.

The master of Neos needs to follow, so this adjusts the Travis CI
build matrix to skip PHP 7.0.

Additionally it removes some options no longer needed, since the
required PostgreSQL versions are meanwhile available without any
use of sudo in the default container infrastructure, as shown in

- https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
- https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version
