### PR TITLE
TASK: Check node migration filename before use

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
@@ -56,11 +56,14 @@ class YamlConfiguration extends Configuration
             foreach ($directoryIterator as $fileInfo) {
                 $filename = $fileInfo->getFilename();
                 if ($fileInfo->isFile() && $filename[0] !== '.' && (substr($filename, -5) === '.yaml')) {
-                    $versionFile = Files::getUnixStylePath($fileInfo->getPathname());
+                    if (preg_match('/^Version[0-9]{14}.yaml$/', $filename) !== 1) {
+                        throw new MigrationException('The migration file ' . $filename . ' is named wrong, expected format is "VersionYYYYMMDDHHmmss.yaml".', 1515752616793);
+                    }
                     $versionNumber = substr(substr($filename, 7), 0, -5);
                     if (array_key_exists($versionNumber, $this->availableVersions)) {
                         throw new MigrationException('The migration version ' . $versionNumber . ' exists twice, that is not supported.', 1345823182);
                     }
+                    $versionFile = Files::getUnixStylePath($fileInfo->getPathname());
                     $this->availableVersions[$versionNumber] = array(
                         'filePathAndName' => $versionFile,
                         'package' => $package,


### PR DESCRIPTION
This makes sure node migrations not named as expected are detected
and rejected properly.