### PR TITLE
BUGFIX: Allow node transformations without setting

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Service/NodeTransformation.php
+++ b/Neos.ContentRepository/Classes/Migration/Service/NodeTransformation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\ContentRepository\Migration\Service;
 
 /*
@@ -85,9 +86,11 @@ class NodeTransformation
         $transformationClassName = $this->resolveTransformationClassName($transformationConfiguration['type']);
         $transformation = new $transformationClassName();
 
-        foreach ($transformationConfiguration['settings'] as $settingName => $settingValue) {
-            if (!ObjectAccess::setProperty($transformation, $settingName, $settingValue)) {
-                throw new MigrationException('Cannot set setting "' . $settingName . '" on transformation "' . $transformationClassName . '" , check your configuration.', 1343293094);
+        if (isset($transformationConfiguration['settings']) && is_array($transformationConfiguration['settings'])) {
+            foreach ($transformationConfiguration['settings'] as $settingName => $settingValue) {
+                if (!ObjectAccess::setProperty($transformation, $settingName, $settingValue)) {
+                    throw new MigrationException('Cannot set setting "' . $settingName . '" on transformation "' . $transformationClassName . '" , check your configuration.', 1343293094);
+                }
             }
         }
 


### PR DESCRIPTION
This change allows to create/use node transformations that do not use settings.

Without this change, one always had to provide dummy settings.