### PR TITLE
TASK: Document canvas width and height in editPreviewMode

### DIFF
--- a/Neos.Neos/Documentation/ExtendingNeos/CustomEditPreviewMode.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CustomEditPreviewMode.rst
@@ -30,6 +30,10 @@ Edit/preview modes are added to the Neos-Backend via *Settings.yaml*.
             fusionRenderingPath: 'print'
             # show after the existing modes
             position: 200
+            # sets the width of the iframe (React UI only)
+            width: 800
+            # sets the height of the iframe (React UI only)
+            height: 600
 
 The settings ``isEditingMode`` and ``isPreviewMode`` are controlling whether the mode will show up in the section "Edit"
 or "Preview" of the Neos-Backend. The major difference between both sections is that inside "Preview" section the inline


### PR DESCRIPTION
**What I did**
I added missing components in documentation for custom preview modes

**How I did it**
I analysed the react frontend and found some editable variables for height and width. After searching the code for it, I found some optional variables, which were missing in the documentation. These variables are new and came with the new UI.

- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
