### PR TITLE
TASK: Add labels for UI DateInput Component neos/neos-ui#1534

### DIFF
--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -445,6 +445,12 @@
 			<trans-unit id="content.inspector.editors.dateTimeEditor.noDateSet" xml:space="preserve">
 				<source>No date set</source>
 			</trans-unit>
+			<trans-unit id="content.inspector.editors.dateTimeEditor.today" xml:space="preserve">
+				<source>Today</source>
+			</trans-unit>
+			<trans-unit id="content.inspector.editors.dateTimeEditor.apply" xml:space="preserve">
+				<source>Apply</source>
+			</trans-unit>
 			<trans-unit id="content.inspector.editors.codeEditor.editCode" xml:space="preserve">
 				<source>Edit code</source>
 			</trans-unit>


### PR DESCRIPTION
What I did: A pending change at neos/neos-ui#1534 localizes two labels in the DateInput component. Since the Neos UI uses labels from Neos.Neos, they need to be added to this package.