### PR TITLE
TASK: Improve node migration for large data sets

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -12,6 +12,7 @@ namespace Neos\ContentRepository\Domain\Repository;
  */
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Neos\Flow\Annotations as Flow;
@@ -365,6 +366,44 @@ class NodeDataRepository extends Repository
         }
 
         return null;
+    }
+
+    /**
+     * Find all objects and return an IterableResult
+     *
+     * @return IterableResult
+     */
+    public function findAllIterator()
+    {
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('node')
+            ->from($this->getEntityClassName(), 'node')
+            ->getQuery()->iterate();
+    }
+
+    /**
+     * Iterate over an IterableResult and return a Generator
+     *
+     * This method is useful for batch processing a huge result set.
+     *
+     * @param IterableResult $iterator
+     * @param callable $callback
+     * @return \Generator
+     */
+    public function iterate(IterableResult $iterator, callable $callback = null)
+    {
+        $iteration = 0;
+        foreach ($iterator as $object) {
+            $object = current($object);
+            yield $object;
+            if ($callback !== null) {
+                call_user_func($callback, $iteration, $object);
+            }
+
+            $iteration++;
+        }
     }
 
     /**


### PR DESCRIPTION
This adds findAllIterator to the NodeDataRepository
and uses it in the NodeMigration, which makes it
possible to run migrations on large datasets.

Before, a `findAll()` on the NodeDataRepository was used, which does not scale at all
and exceeds even higher memory limits with repositories > 30k nodes.