### PR TITLE
BUGFIX: Corrected ContentReferences translation namespace

### DIFF
--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/af/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/af/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="af">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="af">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ar/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ar/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ar">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ar">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ca/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ca/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ca">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ca">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/cs/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/cs/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="cs">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="cs">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/da/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/da/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="da">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="da">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/de/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/de/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="de">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/el/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/el/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="el">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="el">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/en/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/en/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext">
+    <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext">
 		<body>
 			<trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/es/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/es/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="es-ES">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="es-ES">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/fi/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/fi/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="fi">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="fi">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/fr/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/fr/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/he/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/he/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="he">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="he">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/hu/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/hu/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="hu">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="hu">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/id_ID/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/id_ID/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="id">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="id">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/it/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/it/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="it">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ja/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ja/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/kk_KZ/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/kk_KZ/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="kk">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="kk">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/km/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/km/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="km">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="km">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ko/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ko/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/la/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/la/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="la-LA">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="la-LA">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/lv/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/lv/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="lv">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="lv">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/mr/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/mr/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="mr">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="mr">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/nl/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/nl/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="nl">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="nl">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/no/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/no/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="no">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="no">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pl/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pl/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="pl">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="pl">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ps/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ps/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ps">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ps">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pt/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pt/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="pt-PT">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="pt-PT">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pt_BR/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/pt_BR/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ro/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ro/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ro">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ro">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ru/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/ru/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/sr/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/sr/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="sr">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="sr">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/sv/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/sv/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="sv-SE">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="sv-SE">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/tr/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/tr/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="tr">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="tr">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/uk/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/uk/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="uk">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="uk">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/vi/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/vi/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="vi">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="vi">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/zh/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/zh/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="zh-CN">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="zh-CN">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/zh_TW/NodeTypes/ContentReferences.xlf
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Translations/zh_TW/NodeTypes/ContentReferences.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.NodeTypes.ContentReferences.ContentReferences" source-language="en" datatype="plaintext" target-language="zh-TW">
+  <file original="" product-name="Neos.NodeTypes.ContentReferences" source-language="en" datatype="plaintext" target-language="zh-TW">
     <body>
       <trans-unit id="ui.label" xml:space="preserve">
 				<source>Insert content references</source>


### PR DESCRIPTION
#1659 splits the Neos.NodeTypes package into separate packaged. In the translation
rewrite script I had an error, so the Neos.NodeTypes.ContentReferences was set as
`Neos.NodeTypes.ContentReferences.ContentReferences` instead of
`Neos.NodeTypes.ContentReferences`. This bug makes sure that labels are correctly
available.