### PR TITLE
TASK: Raise gedmo/doctrine-extensions requirement to ~2.4.0 

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -1,7 +1,7 @@
 {
   "name": "neos/neos-development-collection",
   "description": "Neos packages in a joined repository for pull requests.",
-  "license": "GPL-3.0+",
+  "license": "GPL-3.0-or-later",
   "type": "neos-package-collection",
   "require": {
     "neos/flow-development-collection": "dev-master"

--- a/Neos.ContentRepository/composer.json
+++ b/Neos.ContentRepository/composer.json
@@ -13,7 +13,7 @@
         "neos/utility-arrays": "*",
 
         "doctrine/orm": "~2.5.0",
-        "gedmo/doctrine-extensions": "~2.3.0",
+        "gedmo/doctrine-extensions": "~2.4.0",
         "behat/transliterator": "~1.0"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "neos/neos-development-collection",
     "description": "Neos packages in a joined repository for pull requests.",
-    "license": "GPL-3.0+",
+    "license": "GPL-3.0-or-later",
     "type": "neos-package-collection",
     "require": {
         "neos/flow-development-collection": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "neos/utility-files": "*",
         "neos/utility-arrays": "*",
         "doctrine/orm": "~2.5.0",
-        "gedmo/doctrine-extensions": "~2.3.0",
+        "gedmo/doctrine-extensions": "~2.4.0",
         "behat/transliterator": "~1.0",
         "php": ">=5.5.0",
         "neos/utility-unicode": "*",


### PR DESCRIPTION
After the required version of some dependencies have been raised in Flow,
Neos cannot be installed as `dev-master`, since no installable set of
dependencies can be computed.

This raises one suspect blocking this.