### PR TITLE
TASK: Rename folder for Node Migrations

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
+++ b/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
@@ -71,6 +71,7 @@ class NodeCommandController extends CommandController
      * @param boolean $confirmation Confirm application of this migration, only needed if the given migration contains any warnings.
      * @param string $direction The direction to work in, MigrationStatus::DIRECTION_UP or MigrationStatus::DIRECTION_DOWN
      * @return void
+     * @see neos.contentrepository.migration:node:migrationstatus
      */
     public function migrateCommand($version, $confirmation = false, $direction = MigrationStatus::DIRECTION_UP)
     {
@@ -107,7 +108,7 @@ class NodeCommandController extends CommandController
      * List available and applied migrations
      *
      * @return void
-     * @see typo3.typo3cr.migration:node:listavailablemigrations
+     * @see neos.contentrepository.migration:node:migrate
      */
     public function migrationStatusCommand()
     {

--- a/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
@@ -46,7 +46,7 @@ class YamlConfiguration extends Configuration
         $this->availableVersions = array();
         foreach ($this->packageManager->getActivePackages() as $package) {
             $this->registerVersionInDirectory($package, 'TYPO3CR');
-            $this->registerVersionInDirectory($package, 'NeosCR');
+            $this->registerVersionInDirectory($package, 'ContentRepository');
         }
         ksort($this->availableVersions);
     }

--- a/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
@@ -54,6 +54,7 @@ class YamlConfiguration extends Configuration
     /**
      * @param PackageInterface $package
      * @param string $directoryName
+     * @return void
      * @throws MigrationException
      */
     protected function registerVersionInDirectory(PackageInterface $package, string $directoryName)

--- a/Neos.Neos/Documentation/References/NodeMigrations.rst
+++ b/Neos.Neos/Documentation/References/NodeMigrations.rst
@@ -72,7 +72,7 @@ that are marked as removed and applies the ``RemoveNode`` transformation on them
   down:
     comments: 'No down migration available'
 
-Like all migrations the file should be placed in a package inside the ``Migrations/NeosCR`` folder where it will be picked
+Like all migrations the file should be placed in a package inside the ``Migrations/ContentRepository`` folder where it will be picked
 up by the CLI tools provided with the content repository:
 
 - ``./flow node:migrationstatus``

--- a/Neos.Neos/Documentation/References/NodeMigrations.rst
+++ b/Neos.Neos/Documentation/References/NodeMigrations.rst
@@ -72,7 +72,7 @@ that are marked as removed and applies the ``RemoveNode`` transformation on them
   down:
     comments: 'No down migration available'
 
-Like all migrations the file should be placed in a package inside the ``Migrations/TYPO3CR`` folder where it will be picked
+Like all migrations the file should be placed in a package inside the ``Migrations/NeosCR`` folder where it will be picked
 up by the CLI tools provided with the content repository:
 
 - ``./flow node:migrationstatus``
@@ -81,6 +81,7 @@ up by the CLI tools provided with the content repository:
 Use ``./flow help <command>`` to get detailed instructions. The ``migrationstatus`` command also prints a short description
 for each migration.
 
+.. note:: Node migrations in ``Migrations/TYPO3CR`` directories are also supported for historic reasons
 
 
 Transformations Reference


### PR DESCRIPTION
With this change node migrations are expected to be located
in a directory `Migrations/NeosCR`.

For backwards compatibility migrations in `Migrations/TYPO3CR` are
still supported.

Fixes: #1861