### PR TITLE
BUGFIX: Avoid errors on undefined array index

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimension.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimension.php
@@ -93,7 +93,7 @@ class ContentDimension
      */
     public function getValue(string $value)
     {
-        return $this->valueRegistry[$value] ?: null;
+        return $this->valueRegistry[$value] ?? null;
     }
 
     /**


### PR DESCRIPTION
The use of the ternary operator with a potentially undefined array index
leads to errors, this change uses the null-coalesce operator (`??`) instead.

> In particular, this operator does not emit a notice if the left-hand
> side value does not exist, just like isset(). This is especially useful
> on array keys.

(http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.coalesce)