### PR TITLE
BUGFIX: Enforce NodeTreePrivilege when filtering node tree

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Service/View/NodeView.php
@@ -236,14 +236,18 @@ class NodeView extends JsonView
             /** @var NodeInterface $node */
             $parent = $node->getParent();
             if ($parent !== null) {
-                $addNode($parent, false);
-                $findParent($parent);
+                if ($this->privilegeManager->isGranted(NodeTreePrivilege::class, new NodePrivilegeSubject($parent))) {
+                    $addNode($parent, false);
+                    $findParent($parent);
+                }
             }
         };
 
         foreach ($nodes as $node) {
-            $addNode($node, true);
-            $findParent($node);
+            if ($this->privilegeManager->isGranted(NodeTreePrivilege::class, new NodePrivilegeSubject($node))) {
+                $addNode($node, true);
+                $findParent($node);
+            }
         }
 
         $treeNodes = array();


### PR DESCRIPTION
When using the search field or node type filter in the node tree,
the NodeTreePrivilege policies aren't taken into account.

Resolves #1867