### PR TITLE
TASK: Improve NodePrivilege performance

### DIFF
--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
@@ -40,6 +40,11 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
     protected $nodeContextClassName = NodePrivilegeContext::class;
 
     /**
+     * @var NodePrivilegeContext
+     */
+    protected $nodeContext;
+
+    /**
      * @var MethodPrivilegeInterface
      */
     protected $methodPrivilege;
@@ -59,6 +64,7 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
         }
         $this->initialized = true;
         $this->eelCompilingEvaluator = $this->objectManager->get(CompilingEvaluator::class);
+        $this->nodeContext = new $this->nodeContextClassName();
         $this->initializeMethodPrivilege();
     }
 

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
@@ -95,11 +95,11 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
             return $this->methodPrivilege->matchesSubject($subject);
         }
 
-        $evaluator = $this->objectManager->get(CompilingEvaluator::class);
+        $this->initialize();
         $nodeContext = new $this->nodeContextClassName($subject->getNode());
         $eelContext = new Context($nodeContext);
 
-        return $evaluator->evaluate($this->getParsedMatcher(), $eelContext);
+        return $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
     }
 
     /**
@@ -134,6 +134,17 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
         $methodPrivilegeTarget = new PrivilegeTarget($this->privilegeTarget->getIdentifier() . '__methodPrivilege', MethodPrivilege::class, $methodPrivilegeMatcher);
         $methodPrivilegeTarget->injectObjectManager($this->objectManager);
         $this->methodPrivilege = $methodPrivilegeTarget->createPrivilege($this->getPermission(), $this->getParameters());
+    }
+
+    /**
+     * Evaluates the matcher with this objects nodeContext and returns the result.
+     *
+     * @return mixed
+     */
+    protected function evaluateNodeContext()
+    {
+        $eelContext = new Context($this->nodeContext);
+        return $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
@@ -40,11 +40,6 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
     protected $nodeContextClassName = NodePrivilegeContext::class;
 
     /**
-     * @var NodePrivilegeContext
-     */
-    protected $nodeContext;
-
-    /**
      * @var MethodPrivilegeInterface
      */
     protected $methodPrivilege;
@@ -63,19 +58,8 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
             return;
         }
         $this->initialized = true;
-
-        $this->nodeContext = new $this->nodeContextClassName();
-        $eelContext = new Context($this->nodeContext);
-
-        $this->eelCompilingEvaluator = new CompilingEvaluator();
-
-        $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
-
-        $methodPrivilegeMatcher = $this->buildMethodPrivilegeMatcher();
-
-        $methodPrivilegeTarget = new PrivilegeTarget($this->privilegeTarget->getIdentifier() . '__methodPrivilege', MethodPrivilege::class, $methodPrivilegeMatcher);
-        $methodPrivilegeTarget->injectObjectManager($this->objectManager);
-        $this->methodPrivilege = $methodPrivilegeTarget->createPrivilege($this->getPermission(), $this->getParameters());
+        $this->eelCompilingEvaluator = $this->objectManager->get(CompilingEvaluator::class);
+        $this->initializeMethodPrivilege();
     }
 
     /**
@@ -85,7 +69,7 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
      */
     public function getCacheEntryIdentifier()
     {
-        $this->initialize();
+        $this->initializeEvaluator();
         return $this->methodPrivilege->getCacheEntryIdentifier();
     }
 
@@ -100,16 +84,16 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', AbstractNodePrivilege::class, NodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417014368);
         }
 
-        $this->initialize();
-
         if ($subject instanceof MethodPrivilegeSubject) {
+            $this->initializeMethodPrivilege();
             return $this->methodPrivilege->matchesSubject($subject);
         }
 
+        $evaluator = $this->objectManager->get(CompilingEvaluator::class);
         $nodeContext = new $this->nodeContextClassName($subject->getNode());
         $eelContext = new Context($nodeContext);
 
-        return $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
+        return $evaluator->evaluate($this->getParsedMatcher(), $eelContext);
     }
 
     /**
@@ -119,7 +103,7 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
      */
     public function matchesMethod($className, $methodName)
     {
-        $this->initialize();
+        $this->initializeMethodPrivilege();
         return $this->methodPrivilege->matchesMethod($className, $methodName);
     }
 
@@ -128,8 +112,22 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
      */
     public function getPointcutFilterComposite()
     {
-        $this->initialize();
+        $this->initializeMethodPrivilege();
         return $this->methodPrivilege->getPointcutFilterComposite();
+    }
+
+    /**
+     * @throws \Neos\Flow\Security\Exception
+     */
+    protected function initializeMethodPrivilege()
+    {
+        if ($this->methodPrivilege !== null) {
+            return;
+        }
+        $methodPrivilegeMatcher = $this->buildMethodPrivilegeMatcher();
+        $methodPrivilegeTarget = new PrivilegeTarget($this->privilegeTarget->getIdentifier() . '__methodPrivilege', MethodPrivilege::class, $methodPrivilegeMatcher);
+        $methodPrivilegeTarget->injectObjectManager($this->objectManager);
+        $this->methodPrivilege = $methodPrivilegeTarget->createPrivilege($this->getPermission(), $this->getParameters());
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePrivilege.php
@@ -69,7 +69,7 @@ abstract class AbstractNodePrivilege extends AbstractPrivilege implements Method
      */
     public function getCacheEntryIdentifier()
     {
-        $this->initializeEvaluator();
+        $this->initializeMethodPrivilege();
         return $this->methodPrivilege->getCacheEntryIdentifier();
     }
 

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
@@ -51,7 +51,7 @@ abstract class AbstractNodePropertyPrivilege extends AbstractNodePrivilege
         }
 
         if ($subject instanceof MethodPrivilegeSubject) {
-            $this->initializeMethodPrivilege();
+            $this->initialize();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
@@ -50,8 +50,9 @@ abstract class AbstractNodePropertyPrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', ReadNodePropertyPrivilege::class, PropertyAwareNodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417018448);
         }
 
+        $this->initialize();
+        $this->evaluateNodeContext();
         if ($subject instanceof MethodPrivilegeSubject) {
-            $this->initialize();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/AbstractNodePropertyPrivilege.php
@@ -50,8 +50,8 @@ abstract class AbstractNodePropertyPrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', ReadNodePropertyPrivilege::class, PropertyAwareNodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417018448);
         }
 
-        $this->initialize();
         if ($subject instanceof MethodPrivilegeSubject) {
+            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -43,8 +43,8 @@ class CreateNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', CreateNodePrivilege::class, CreateNodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417014353);
         }
 
+        $this->initialize();
         if ($subject instanceof MethodPrivilegeSubject) {
-            $this->initialize();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -43,7 +43,7 @@ class CreateNodePrivilege extends AbstractNodePrivilege
         }
 
         if ($subject instanceof MethodPrivilegeSubject) {
-            $this->initializeMethodPrivilege();
+            $this->initialize();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -11,7 +11,6 @@ namespace Neos\ContentRepository\Security\Authorization\Privilege\Node;
  * source code.
  */
 
-use Neos\Eel\Context;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeSubject;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeSubjectInterface;
 use Neos\Flow\Security\Exception\InvalidPrivilegeTypeException;

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -48,6 +48,8 @@ class CreateNodePrivilege extends AbstractNodePrivilege
                 return false;
             }
 
+            $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), new Context($this->nodeContext));
+
             $joinPoint = $subject->getJoinPoint();
             $allowedCreationNodeTypes = $this->nodeContext->getCreationNodeTypes();
             $actualNodeType = $joinPoint->getMethodName() === 'createNodeFromTemplate' ? $joinPoint->getMethodArgument('nodeTemplate')->getNodeType()->getName() : $joinPoint->getMethodArgument('nodeType')->getName();

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Security\Authorization\Privilege\Node;
  * source code.
  */
 
+use Neos\Eel\Context;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeSubject;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeSubjectInterface;
 use Neos\Flow\Security\Exception\InvalidPrivilegeTypeException;

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -44,12 +44,11 @@ class CreateNodePrivilege extends AbstractNodePrivilege
         }
 
         $this->initialize();
+        $this->evaluateNodeContext();
         if ($subject instanceof MethodPrivilegeSubject) {
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }
-
-            $this->eelCompilingEvaluator->evaluate($this->getParsedMatcher(), new Context($this->nodeContext));
 
             $joinPoint = $subject->getJoinPoint();
             $allowedCreationNodeTypes = $this->nodeContext->getCreationNodeTypes();

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -42,8 +42,8 @@ class CreateNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', CreateNodePrivilege::class, CreateNodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417014353);
         }
 
-        $this->initialize();
         if ($subject instanceof MethodPrivilegeSubject) {
+            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
@@ -32,8 +32,8 @@ class EditNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', EditNodePrivilege::class, NodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417017239);
         }
 
-        $this->initializeMethodPrivilege();
         if ($subject instanceof MethodPrivilegeSubject === true) {
+            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
@@ -32,8 +32,8 @@ class EditNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', EditNodePrivilege::class, NodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417017239);
         }
 
+        $this->initializeMethodPrivilege();
         if ($subject instanceof MethodPrivilegeSubject === true) {
-            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/EditNodePrivilege.php
@@ -32,8 +32,8 @@ class EditNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', EditNodePrivilege::class, NodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417017239);
         }
 
-        $this->initialize();
         if ($subject instanceof MethodPrivilegeSubject === true) {
+            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/ReadNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/ReadNodePrivilege.php
@@ -57,7 +57,7 @@ class ReadNodePrivilege extends EntityPrivilege
         }
         $nodeContext = new NodePrivilegeContext($subject->getNode());
         $eelContext = new Context($nodeContext);
-        $eelCompilingEvaluator = new CompilingEvaluator();
+        $eelCompilingEvaluator = $this->objectManager->get(CompilingEvaluator::class);
         $eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
         return $eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
     }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/RemoveNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/RemoveNodePrivilege.php
@@ -32,8 +32,8 @@ class RemoveNodePrivilege extends AbstractNodePrivilege
             throw new InvalidPrivilegeTypeException(sprintf('Privileges of type "%s" only support subjects of type "%s" or "%s", but we got a subject of type: "%s".', RemoveNodePrivilege::class, NodePrivilegeSubject::class, MethodPrivilegeSubject::class, get_class($subject)), 1417017296);
         }
 
-        $this->initialize();
         if ($subject instanceof MethodPrivilegeSubject) {
+            $this->initializeMethodPrivilege();
             if ($this->methodPrivilege->matchesSubject($subject) === false) {
                 return false;
             }


### PR DESCRIPTION
Node privileges did a lot of unnecessary initialization
and didn't properly fetch the CompilingEvaluator instance
possibly wasting cache hits.

This fixes some of those problems which should improve Node
security performance quite a bit.
