### PR TITLE
TASK: Enable i18n for node creation dialog

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -271,6 +271,16 @@ class NodeTypeConfigurationEnrichmentAspect
                 }
             }
         }
+
+        $creationDialogConfiguration = Arrays::getValueByPath($configuration, 'ui.creationDialog.elements');
+        if (is_array($creationDialogConfiguration)) {
+            foreach ($creationDialogConfiguration as $elementName => $elementConfiguration) {
+                if (!is_array($elementConfiguration) || !$this->shouldFetchTranslation($elementConfiguration['ui'])) {
+                    continue;
+                }
+                $configuration['ui']['creationDialog']['elements'][$elementName]['ui']['label'] = $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'creationDialog', $elementName);
+            }
+        }
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Document.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Document.xlf
@@ -14,6 +14,9 @@
 			<trans-unit id="properties._hiddenInIndex" xml:space="preserve">
 				<source>Hide in menus</source>
 			</trans-unit>
+			<trans-unit id="creationDialog.title" xml:space="preserve">
+				<source>Title</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
In the same time, the "Title" label for a new Document node is
added to the language files. The creationDialog configuration
for this node type is inside Neos.Neos.Ui.

Fixes: neos/neos-ui#1539