### PR TITLE
TASK: ``ReadNodePrivilege`` evaluates EEL expression only once

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Security/Authorization/Privilege/Node/ReadNodePrivilege.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Security/Authorization/Privilege/Node/ReadNodePrivilege.php
@@ -58,7 +58,6 @@ class ReadNodePrivilege extends EntityPrivilege
         $nodeContext = new NodePrivilegeContext($subject->getNode());
         $eelContext = new Context($nodeContext);
         $eelCompilingEvaluator = new CompilingEvaluator();
-        $eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
         return $eelCompilingEvaluator->evaluate($this->getParsedMatcher(), $eelContext);
     }
 }


### PR DESCRIPTION
The ``ReadNodePrivilege`` evaluates it's EEL evaluator twice unnecessarily,
there's some caching however it should optimize some cases.