### PR TITLE
TASK: Refactor NodeDataRepository to use DoctrineRepository

### DIFF
--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -493,7 +493,7 @@ class NodeDataTest extends UnitTestCase
         $workspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $nodeDataRepository = $this->getAccessibleMock(NodeDataRepository::class, array('setRemoved', 'update', 'remove'), array(), '', false);
-        $this->inject($nodeDataRepository, 'entityClassName', NodeData::class);
+        $this->inject($nodeDataRepository, 'objectType', NodeData::class);
         $this->inject($nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
 
         $currentNode = $this->getAccessibleMock(NodeData::class, array('addOrUpdate'), array('/foo', $workspace));
@@ -517,7 +517,7 @@ class NodeDataTest extends UnitTestCase
         $workspace->expects($this->once())->method('getBaseWorkspace')->will($this->returnValue(null));
 
         $nodeDataRepository = $this->getAccessibleMock(NodeDataRepository::class, array('remove', 'update'), array(), '', false);
-        $this->inject($nodeDataRepository, 'entityClassName', NodeData::class);
+        $this->inject($nodeDataRepository, 'objectType', NodeData::class);
         $this->inject($nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
 
         $currentNode = $this->getAccessibleMock(NodeData::class, null, array('/foo', $workspace));

--- a/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
@@ -11,7 +11,9 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Repository;
  * source code.
  */
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
+use Neos\Flow\Persistence\Doctrine\Mapping\ClassMetadata;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
@@ -47,15 +49,18 @@ class NodeDataRepositoryTest extends UnitTestCase
         $this->mockQueryBuilder = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
         $this->mockQueryBuilder->expects($this->any())->method('getQuery')->will($this->returnValue($this->mockQuery));
 
-        $this->nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->setMethods(array('getNodeDataForParentAndNodeType', 'filterNodesOverlaidInBaseWorkspace', 'getNodeTypeFilterConstraintsForDql', 'createQueryBuilder', 'addPathConstraintToQueryBuilder', 'filterNodeDataByBestMatchInContext'))->getMock();
+        $mockEntityManager = $this->createMock(EntityManager::class);
+        $mockClassMetaData = $this->createMock(ClassMetadata::class);
+
+        $this->nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->setConstructorArgs([$mockEntityManager, $mockClassMetaData])->setMethods(array('getNodeDataForParentAndNodeType', 'filterNodesOverlaidInBaseWorkspace', 'getNodeTypeFilterConstraintsForDql', 'createQueryBuilderForWorkspaces', 'addPathConstraintToQueryBuilder', 'filterNodeDataByBestMatchInContext'))->getMock();
         $this->nodeDataRepository->expects($this->any())->method('filterNodesOverlaidInBaseWorkspace')->will($this->returnCallback(function (array $foundNodes, Workspace $baseWorkspace, $dimensions) {
             return $foundNodes;
         }));
-        $this->nodeDataRepository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($this->mockQueryBuilder));
+        $this->nodeDataRepository->expects($this->any())->method('createQueryBuilderForWorkspaces')->will($this->returnValue($this->mockQueryBuilder));
         $this->nodeDataRepository->expects($this->any())->method('filterNodeDataByBestMatchInContext')->will($this->returnArgument(0));
 
         // The repository needs an explicit entity class name because of the generated mock class name
-        $this->inject($this->nodeDataRepository, 'entityClassName', NodeData::class);
+        $this->inject($this->nodeDataRepository, 'objectType', NodeData::class);
         $this->inject($this->nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
     }
 


### PR DESCRIPTION
The NodeDataRepository inherited from the generic Repository but uses lots of DQL queries. This changes the base repository to Doctrine and uses its findAllIterator.