### PR TITLE
FEATURE: Add globbing to `site`,`user` and `domain` cli-commands

### DIFF
--- a/Neos.Neos/Classes/Command/DomainCommandController.php
+++ b/Neos.Neos/Classes/Command/DomainCommandController.php
@@ -127,56 +127,75 @@ class DomainCommandController extends CommandController
     /**
      * Delete a domain record by hostname
      *
-     * @param string $hostname The hostname to remove
+     * @param string $hostname The hostname to remove (globbing is supported)
      * @return void
      */
     public function deleteCommand($hostname)
     {
-        $domain = $this->domainRepository->findOneByHostname($hostname);
-        if (!$domain instanceof Domain) {
-            $this->outputLine('<error>Domain not found.</error>');
+        $domains = $this->findDomainsByHostnamePattern($hostname);
+        if (empty($domains)) {
+            $this->outputLine('<error>No domain found for hostname-pattern "%s".</error>', [$hostname]);
             $this->quit(1);
         }
-
-        $this->domainRepository->remove($domain);
-        $this->outputLine('Domain entry deleted.');
+        foreach ($domains as $domain) {
+            $this->domainRepository->remove($domain);
+            $this->outputLine('Domain entry "%s" deleted.', [$domain->getHostname()]);
+        }
     }
 
     /**
      * Activate a domain record by hostname
      *
-     * @param string $hostname The hostname to activate
+     * @param string $hostname The hostname to activate (globbing is supported)
      * @return void
      */
     public function activateCommand($hostname)
     {
-        $domain = $this->domainRepository->findOneByHostname($hostname);
-        if (!$domain instanceof Domain) {
-            $this->outputLine('<error>Domain not found.</error>');
+        $domains = $this->findDomainsByHostnamePattern($hostname);
+        if (empty($domains)) {
+            $this->outputLine('<error>No domain found for hostname-pattern "%s".</error>', [$hostname]);
             $this->quit(1);
         }
-
-        $domain->setActive(true);
-        $this->domainRepository->update($domain);
-        $this->outputLine('Domain entry activated.');
+        foreach ($domains as $domain) {
+            $domain->setActive(true);
+            $this->domainRepository->update($domain);
+            $this->outputLine('Domain entry "%s" was activated.', [$domain->getHostname()]);
+        }
     }
 
     /**
      * Deactivate a domain record by hostname
      *
-     * @param string $hostname The hostname to deactivate
+     * @param string $hostname The hostname to deactivate (globbing is supported)
      * @return void
      */
     public function deactivateCommand($hostname)
     {
-        $domain = $this->domainRepository->findOneByHostname($hostname);
-        if (!$domain instanceof Domain) {
-            $this->outputLine('<error>Domain not found.</error>');
+        $domains = $this->findDomainsByHostnamePattern($hostname);
+        if (empty($domains)) {
+            $this->outputLine('<error>No domain found for hostname-pattern "%s".</error>', [$hostname]);
             $this->quit(1);
         }
+        foreach ($domains as $domain) {
+            $domain->setActive(false);
+            $this->domainRepository->update($domain);
+            $this->outputLine('Domain entry "%s" was deactivated.', [$domain->getHostname()]);
+        }
+    }
 
-        $domain->setActive(false);
-        $this->domainRepository->update($domain);
-        $this->outputLine('Domain entry deactivated.');
+    /**
+     * Find domains that match the given hostname with globbing support
+     *
+     * @param string $hostnamePattern pattern for the hostname of the domains
+     * @return array<Domain>
+     */
+    protected function findDomainsByHostnamePattern($hostnamePattern)
+    {
+        return array_filter(
+            $this->domainRepository->findAll()->toArray(),
+            function ($domain) use ($hostnamePattern) {
+                return fnmatch($hostnamePattern, $domain->getHostname());
+            }
+        );
     }
 }

--- a/Neos.Neos/Classes/Command/DomainCommandController.php
+++ b/Neos.Neos/Classes/Command/DomainCommandController.php
@@ -125,7 +125,7 @@ class DomainCommandController extends CommandController
     }
 
     /**
-     * Delete a domain record by hostname
+     * Delete a domain record by hostname (with globbing)
      *
      * @param string $hostname The hostname to remove (globbing is supported)
      * @return void
@@ -144,7 +144,7 @@ class DomainCommandController extends CommandController
     }
 
     /**
-     * Activate a domain record by hostname
+     * Activate a domain record by hostname (with globbing)
      *
      * @param string $hostname The hostname to activate (globbing is supported)
      * @return void
@@ -164,7 +164,7 @@ class DomainCommandController extends CommandController
     }
 
     /**
-     * Deactivate a domain record by hostname
+     * Deactivate a domain record by hostname (with globbing)
      *
      * @param string $hostname The hostname to deactivate (globbing is supported)
      * @return void

--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -275,21 +275,16 @@ class SiteCommandController extends CommandController
      * @param string $siteNode Name for site root nodes to clear only content of this sites (globbing is supported)
      * @return void
      */
-    public function pruneCommand($siteNode = null)
+    public function pruneCommand($siteNode)
     {
-        if ($siteNode !== null) {
-            $sites = $this->findSitesByNodeNamePattern($siteNode);
-            if (empty($sites)) {
-                $this->outputLine('<error>No Site found for pattern "%s".</error>', [$siteNode]);
-                $this->quit(1);
-            }
-            foreach ($sites as $site) {
-                $this->siteService->pruneSite($site);
-                $this->outputLine('Site with root "%s" matched pattern "%s" and has been removed.', [$site->getNodeName(), $siteNode]);
-            }
-        } else {
-            $this->siteService->pruneAll();
-            $this->outputLine('All sites and content have been removed.');
+        $sites = $this->findSitesByNodeNamePattern($siteNode);
+        if (empty($sites)) {
+            $this->outputLine('<error>No Site found for pattern "%s".</error>', [$siteNode]);
+            $this->quit(1);
+        }
+        foreach ($sites as $site) {
+            $this->siteService->pruneSite($site);
+            $this->outputLine('Site with root "%s" matched pattern "%s" and has been removed.', [$site->getNodeName(), $siteNode]);
         }
     }
 

--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -270,7 +270,9 @@ class SiteCommandController extends CommandController
     }
 
     /**
-     * Remove all content and related data - for now. In the future we need some more sophisticated cleanup.
+     * Remove site with content and related data (with globbing)
+     *
+     * In the future we need some more sophisticated cleanup.
      *
      * @param string $siteNode Name for site root nodes to clear only content of this sites (globbing is supported)
      * @return void
@@ -336,7 +338,7 @@ class SiteCommandController extends CommandController
     }
 
     /**
-     * Activate a site
+     * Activate a site (with globbing)
      *
      * This command activates the specified site.
      *
@@ -358,7 +360,7 @@ class SiteCommandController extends CommandController
     }
 
     /**
-     * Deactivate a site
+     * Deactivate a site (with globbing)
      *
      * This command deactivates the specified site.
      *

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -263,9 +263,13 @@ class UserCommandController extends CommandController
      */
     public function setPasswordCommand($username, $password, $authenticationProvider = null)
     {
-        $user = $this->getUserOrFail($username, $authenticationProvider);
+        $user = $this->userService->getUser($username, $authenticationProvider);
+        if (!$user instanceof User) {
+            $this->outputLine('The user "%s" does not exist.', [$username]);
+            $this->quit(1);
+        }
         $this->userService->setUserPassword($user, $password);
-        $this->outputLine('The new password for user "%s" was set.', array($username));
+        $this->outputLine('The new password for user "%s" was set.', [$username]);
     }
 
     /**
@@ -360,24 +364,6 @@ class UserCommandController extends CommandController
                 return fnmatch($usernamePattern, $this->userService->getUsername($user, $authenticationProviderName));
             }
         );
-    }
-
-    /**
-     * Retrieves the given user or fails by exiting with code 1 and a message
-     *
-     * @param string $username Username of the user to find
-     * @param string $authenticationProviderName Name of the authentication provider to use
-     * @return User The user
-     * @throws Exception
-     */
-    protected function getUserOrFail($username, $authenticationProviderName = null)
-    {
-        $user = $this->userService->getUser($username, $authenticationProviderName);
-        if (!$user instanceof User) {
-            $this->outputLine('The user "%s" does not exist.', array($username));
-            $this->quit(1);
-        }
-        return $user;
     }
 
     /**

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -150,7 +150,7 @@ class UserCommandController extends CommandController
     }
 
     /**
-     * Delete a user
+     * Delete a user (with globbing)
      *
      * This command deletes an existing Neos user. All content and data directly related to this user, including but
      * not limited to draft workspace contents, will be removed as well.
@@ -192,7 +192,7 @@ class UserCommandController extends CommandController
     }
 
     /**
-     * Activate a user
+     * Activate a user (with globbing)
      *
      * This command reactivates possibly expired accounts for the given user.
      *
@@ -220,7 +220,7 @@ class UserCommandController extends CommandController
     }
 
     /**
-     * Deactivate a user
+     * Deactivate a user (with globbing)
      *
      * This command deactivates a user by flagging all of its accounts as expired.
      *

--- a/Neos.Neos/Classes/Command/UserCommandController.php
+++ b/Neos.Neos/Classes/Command/UserCommandController.php
@@ -358,12 +358,20 @@ class UserCommandController extends CommandController
      */
     protected function findUsersByUsernamePattern($usernamePattern, $authenticationProviderName = null)
     {
-        return array_filter(
-            $this->userService->getUsers()->toArray(),
-            function ($user) use ($usernamePattern, $authenticationProviderName) {
-                return fnmatch($usernamePattern, $this->userService->getUsername($user, $authenticationProviderName));
+        if (preg_match('/[\\?\\*\\{\\[]/u', $usernamePattern)) {
+            return array_filter(
+                $this->userService->getUsers()->toArray(),
+                function ($user) use ($usernamePattern, $authenticationProviderName) {
+                    return fnmatch($usernamePattern, $this->userService->getUsername($user, $authenticationProviderName));
+                }
+            );
+        } else {
+            $user = $this->userService->getUser($usernamePattern, $authenticationProviderName);
+            if ($user instanceof User) {
+                return [$user];
             }
-        );
+        }
+        return [];
     }
 
     /**

--- a/Neos.Neos/Documentation/Operations/CommandLine.rst
+++ b/Neos.Neos/Documentation/Operations/CommandLine.rst
@@ -58,19 +58,19 @@ These commands allow to manage users. To create an user with administrative priv
 
   ./flow user:create john@doe.com pazzw0rd John Doe --roles Neos.Neos:Administrator
 
-=======================================  ========================================
+=======================================  ===================================================
 Command                                  Description
-=======================================  ========================================
+=======================================  ===================================================
 user:list                                List all users
 user:show                                Shows the given user
 user:create                              Create a new user
-user:delete                              Delete a user
-user:activate                            Activate a user
-user:deactivate                          Deactivate a user
+user:delete                              Delete a user (with globbing)
+user:activate                            Activate a user (with globbing)
+user:deactivate                          Deactivate a user (with globbing)
 user:setpassword                         Set a new password for the given user
-user:addrole                             Add a role to a user
-user:removerole                          Remove a role from a user
-=======================================  ========================================
+user:addrole                             Add a role to a user (with globbing)
+user:removerole                          Remove a role from a user (with globbing)
+=======================================  ===================================================
 
 Workspace Management
 ====================
@@ -81,31 +81,31 @@ create and delete workspaces as well as publish and discard changes.
 One notable difference is that rebasing a workspace is possible from the command line *even if it contains
 unpublished changes*.
 
-=======================================  ========================================
+=======================================  ===================================================
 Command                                  Description
-=======================================  ========================================
+=======================================  ===================================================
 workspace:publish                        Publish changes of a workspace
 workspace:discard                        Discard changes in workspace
 workspace:create                         Create a new workspace
 workspace:delete                         Deletes a workspace
 workspace:rebase                         Rebase a workspace
 workspace:list                           Display a list of existing workspaces
-=======================================  ========================================
+=======================================  ===================================================
 
 Site Management
 ===============
 
-=======================================  ========================================
+=======================================  ===================================================
 Command                                  Description
-=======================================  ========================================
+=======================================  ===================================================
 domain:add                               Add a domain record
 domain:list                              Display a list of available domain
                                          records
-domain:delete                            Delete a domain record
-domain:activate                          Activate a domain record
-domain:deactivate                        Deactivate a domain record
+domain:delete                            Delete a domain record (with globbing)
+domain:activate                          Activate a domain record (with globbing)
+domain:deactivate                        Deactivate a domain record (with globbing)
 site:import                              Import sites content
 site:export                              Export sites content
-site:prune                               Remove all content and related data
+site:prune                               Remove all content and related data (with globbing)
 site:list                                Display a list of available sites
-=======================================  ========================================
+=======================================  ===================================================


### PR DESCRIPTION
Add globbing to the follwing cli-commands:

- `site:prune`
- `site:activate`
- `site:deactivate`
- `domain:delete`
- `domain:activate`
- `domain:deactivate`
- `user:delete`
- `user:activate`
- `user:deactivate`
- `user:addrole`
- `user:removerole`

Additionally the `siteNode` is made a required argument for `site:prune`.
To still remove all sites `./flow site:prune "*"` can be used.  