### PR TITLE
BUGFIX: Declare mixin node types as abstract

### DIFF
--- a/Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
+++ b/Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
@@ -1,29 +1,36 @@
 # To prevent any breaking change, we map the separate packages the old NodeTypes package
 
 'Neos.NodeTypes:ContentImageMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:ContentImageMixin': true
 
 'Neos.NodeTypes:ImageMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:ImageMixin': true
 
 'Neos.NodeTypes:ImageAlignmentMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:ImageAlignmentMixin': true
 
 'Neos.NodeTypes:ImageCaptionMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:ImageCaptionMixin': true
 
 'Neos.NodeTypes:LinkMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:LinkMixin': true
 
 'Neos.NodeTypes:TextMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:TextMixin': true
 
 'Neos.NodeTypes:TitleMixin':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:TitleMixin': true


### PR DESCRIPTION
The mixins in this package are not declared abstract. This leads to issues with
Elasticsearch indexing. Abstract node types are not mapped, but these mixins
are not abstract, thus they are mapped. Any mapping configuration that is
applied to `Neos.Neos:Node` must therefore also be applied to all mixins,
if any conflicts appear between fields (e.g. `_all`).