### PR TITLE
!!! TASK: Scope fusion-namespaces to current file and remove default `Neos.Neos`-namespace

### DIFF
--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -618,10 +618,6 @@ class Parser implements ParserInterface
     {
         $include = trim($include);
         $parser = new Parser();
-        // transfer current namespaces to new parser
-        foreach ($this->objectTypeNamespaces as $key => $objectTypeNamespace) {
-            $parser->setObjectTypeNamespace($key, $objectTypeNamespace);
-        }
 
         if (strpos($include, 'resource://') !== 0) {
             // Resolve relative paths

--- a/Neos.Fusion/Migrations/Code/Version20180211175500.php
+++ b/Neos.Fusion/Migrations/Code/Version20180211175500.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Expand Neos.Neos-FusionObjects without namespace to fully qualified names
+ */
+class Version20180211175500 extends AbstractMigration
+{
+    /**
+     * The name of all prototypes from Neos.Neos that could be used without
+     * namespace previously because the `default`-namespace was overwritten
+     * in Neos
+     *
+     * @var array
+     */
+    protected $namesToMigrate = [
+        'BreadcrumbMenu',
+        'Content',
+        'Menu',
+        'ContentCase',
+        'ContentCollectionRenderer',
+        'ContentCollection',
+        'ContentComponent',
+        'ContentElementEditable',
+        'ContentElementWrapping',
+        'ConvertNodeUris',
+        'ConvertUris',
+        'DimensionsMenu',
+        'Document',
+        'DocumentMetadata',
+        'Editable',
+        'FallbackNode',
+        'ImageUri',
+        'ImageTag',
+        'Menu',
+        'NodeUri',
+        'Page',
+        'Plugin',
+        'PluginView',
+        'PrimaryContent',
+        'Shortcut',
+        'RawContent'
+    ];
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Fusion-20180211175500';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        foreach ($this->namesToMigrate as $name) {
+            // fusion object assignments
+            $this->searchAndReplaceRegex('/(?<=\\=)([\\s]*)(' . preg_quote($name) . ')(?=[$\\s\\{])/u', '$1Neos.Neos:$2', ['ts2', 'fusion']);
+            // prototype declarations
+            $this->searchAndReplaceRegex('/(?<=prototype\\()(' . preg_quote($name) . ' )(?=\\))/u', 'Neos.Neos:$1', ['ts2', 'fusion']);
+        }
+    }
+}

--- a/Neos.Fusion/Migrations/Code/Version20180211184832.php
+++ b/Neos.Fusion/Migrations/Code/Version20180211184832.php
@@ -1,0 +1,93 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Utility\Arrays;
+use Neos\Utility\Files;
+
+/**
+ * Remove namespace aliases and replace them with the package keys
+ */
+class Version20180211184832 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Fusion-20180211184832';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $namespaces = $this->findDeclaredFusionNamespaces();
+        foreach ($namespaces as $alias => $packageKey) {
+            // remove namespace declarations
+            $this->searchAndReplaceRegex('/^[\\s]*namespace:[\\s]*' . preg_quote($alias) . '[\\s]*\\=[\\s]*' . preg_quote($packageKey) . '[\\s]*$/um', '', ['ts2', 'fusion']);
+            // expand alias in fusion object assignments
+            $this->searchAndReplaceRegex('/(?<=\\=)([\\s]*)(' . preg_quote($alias) . ')(?=\\:[\\w\\.]+[$\\s\\{])/u', '$1' . $packageKey, ['ts2', 'fusion']);
+            // expand alias in prototype declarations
+            $this->searchAndReplaceRegex('/(?<=prototype\\()(' . preg_quote($alias) . ')(?=\\:[\\w\\.]+\\))/um', $packageKey, ['ts2', 'fusion']);
+        }
+    }
+
+
+    /**
+     * Find all declared fusion namespaces for the currently migrated package
+     *
+     * @return array an array with namespace alias as key and packageKey as value
+     * @throws \Neos\Utility\Exception\FilesException
+     */
+    protected function findDeclaredFusionNamespaces() {
+        $namespaces = [];
+        foreach (Files::getRecursiveDirectoryGenerator($this->targetPackageData['path'].'/Resources/Private', null, true) as $pathAndFilename) {
+            $pathInfo = pathinfo($pathAndFilename);
+            if (!isset($pathInfo['filename'])) {
+                continue;
+            }
+            if (strpos($pathAndFilename, 'Migrations/Code') !== false) {
+                continue;
+            }
+
+            if (array_key_exists('extension', $pathInfo) && ($pathInfo['extension'] == 'ts2' || $pathInfo['extension'] == 'fusion')) {
+                $namespaceDeclarationMatches = [];
+                $count = preg_match_all(
+                    '/^namespace:[\\s]*(?P<alias>[\\w\\.]+)[\\s]*\\=[\\s]*(?P<packageKey>[\\w\\.]+)[\\s]*$/um',
+                    file_get_contents($pathAndFilename),
+                    $namespaceDeclarationMatches,
+                    PREG_SET_ORDER
+                );
+                if ($count > 0) {
+                    foreach($namespaceDeclarationMatches as $match) {
+                        if (!array_key_exists($match['alias'], $namespaces)) {
+                            $namespaces[$match['alias']] = $match['packageKey'];
+                        } else {
+                            if ($namespaces[$match['alias']] !== $match['packageKey']) {
+                                $this->showWarning(
+                                    sprintf(
+                                        'Namespace-alias "%s" was declared multiple times for different aliases %s is used',
+                                        $match['alias'],
+                                        $namespaces[$match['alias']]
+                                    )
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return $namespaces;
+    }
+}

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -739,11 +739,8 @@ class ParserTest extends UnitTestCase
         // Check that values were overridden by fixture #17:
         $expectedParseTree['__prototypes']['Neos.Foo:Bar2']['baz'] = 'New Value';
 
-        // Set the default namespace to Neos.Neos - that's what Neos does as well in Domain\Service\FusionService:
-        $this->parser->setObjectTypeNamespace('default', 'Neos.Neos');
-
         $text = array(
-            '__objectType' => 'Neos.Neos:Text',
+            '__objectType' => 'Neos.Fusion:Text',
             '__value' => null,
             '__eelExpression' => null
         );

--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -117,16 +117,6 @@ class FusionService
     protected $packageManager;
 
     /**
-     * Initializes the parser
-     *
-     * @return void
-     */
-    public function initializeObject()
-    {
-        $this->fusionParser->setObjectTypeNamespace('default', 'Neos.Neos');
-    }
-
-    /**
      * Create a runtime for the given site node
      *
      * @param \Neos\ContentRepository\Domain\Model\NodeInterface $currentSiteNode

--- a/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
@@ -359,8 +359,8 @@ Fully qualified identifiers can be used everywhere an identifier is used::
 
 	prototype(Neos.Neos:ContentCollection) < prototype(Neos.Neos:Collection)
 
-In Neos Fusion a ``default`` namespace of ``Neos.Neos`` is set. So whenever ``Page`` is used in
-Fusion within Neos, it is a shortcut for ``Neos.Neos:Page``.
+In Fusion a ``default`` namespace of ``Neos.Fusion`` is set. So whenever ``Value`` is used in
+Fusion, it is a shortcut for ``Neos.Fusion:Value``.
 
 Custom namespace aliases can be defined using the following syntax::
 
@@ -370,7 +370,7 @@ Custom namespace aliases can be defined using the following syntax::
 	video = Acme.Demo:YouTube
 	video = Foo:YouTube
 
-.. warning:: These declarations are not scoped to the file they are in, but apply globally (at least currently, we plan to change that in the future). So you should be careful there!
+.. warning:: These declarations are scoped to the file they are in and have to be declared in every fusion file where they shall be used.
 
 Setting Properties On a Fusion Object
 =========================================

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -525,9 +525,6 @@ The Fusion objects defined in the Neos package contain all Fusion objects which
 are needed to integrate a site. Often, it contains generic Fusion objects
 which do not need a particular node type to work on.
 
-As Neos.Neos is the default namespace, the Fusion objects do not need to be
-prefixed with Neos.Neos.
-
 .. _Neos_Neos__Page:
 
 Page


### PR DESCRIPTION
Namespaces were previously transported over `include` boundaries and
thus could end up being declared in packages differently depending on how
the Fusion code was included. This could easily lead to confusion.

With this change namespaces are handled like in PHP and are only valid for the
Fusion file they are declared in.

In addition this removes the overwriting of the `default` namespace `Neos.Fusion` 
with `Neos.Neos` inside of Neos wich could lead to Fusion code failing if used 
in another context.
