### PR TITLE
BUGFIX: Flickering upload dropzone in media module

### DIFF
--- a/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
+++ b/TYPO3.Neos/Resources/Private/Styles/Media/_Media.scss
@@ -881,6 +881,10 @@
 		&.neos-upload-area-active {
 			border-color: #fff;
 
+			div {
+				pointer-events: none;
+			}
+
 			i {
 				display: inline;
 			}

--- a/TYPO3.Neos/Resources/Public/Styles/Neos.css
+++ b/TYPO3.Neos/Resources/Public/Styles/Neos.css
@@ -13882,6 +13882,9 @@
 .neos.media-browser .neos-upload-area.neos-upload-area-active {
   border-color: #fff;
 }
+.neos.media-browser .neos-upload-area.neos-upload-area-active div {
+  pointer-events: none;
+}
 .neos.media-browser .neos-upload-area.neos-upload-area-active i {
   display: inline;
 }


### PR DESCRIPTION
Prevent flickering when dragging a file over the label inside the dropzone.

Fixes: #1889