### PR TITLE
BUGFIX: Fix VH call quote escaping in RelatedAssets.html

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Media/Asset/RelatedNodes.html
@@ -37,7 +37,7 @@
 					<tr class="fold-{site.site.nodeName}">
 						<td>
 							<f:if condition="{documentNode.node.nodeType.ui.icon}">
-								<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label, package: 'TYPO3.Neos')}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
+								<i class="{documentNode.node.nodeType.ui.icon}" title="{f:if(condition: documentNode.node.nodeType.label, then: '{neos:backend.translate(id: documentNode.node.nodeType.label, package: \'TYPO3.Neos\')}', else: documentNode.node.nodeType.name)}" data-neos-toggle="tooltip"></i>
 							</f:if>
 							<f:if condition="{documentNode.node}">
 								<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: documentNode.node})}" data-neos-toggle="tooltip">{documentNode.node.label}</span>
@@ -48,7 +48,7 @@
 								<f:for each="{documentNode.nodes}" as="relatedNode">
 									<li>
 										<f:if condition="{relatedNode.node.nodeType.ui.icon}">
-											<i class="{relatedNode.node.nodeType.ui.icon}" title="{f:if(condition: relatedNode.node.nodeType.label, then: '{neos:backend.translate(id: relatedNode.node.nodeType.label, package: 'TYPO3.Neos')}', else: '{relatedNode.node.nodeType.name}')}" data-neos-toggle="tooltip" data-placement="left"></i>
+											<i class="{relatedNode.node.nodeType.ui.icon}" title="{f:if(condition: relatedNode.node.nodeType.label, then: '{neos:backend.translate(id: relatedNode.node.nodeType.label, package: \'TYPO3.Neos\')}', else: '{relatedNode.node.nodeType.name}')}" data-neos-toggle="tooltip" data-placement="left"></i>
 										</f:if>
 										<span title="{relatedNode.node.path}" data-neos-toggle="tooltip" data-placement="left">{relatedNode.node.label}</span>
 									</li>


### PR DESCRIPTION
A call to a VH inside another VH call was not using correctly escaped
single quotes, breaking parsing.