### PR TITLE
TASK: Also search for $searchTerm as identifier

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Controller\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Validation\Validator\NodeIdentifierValidator;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Property\Exception;
@@ -107,13 +108,13 @@ class NodesController extends ActionController
             }
         }
 
-
-
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
         $nodes = [];
 
         //If there is a Node with $searchTerm as identifier, also return it.
-        if ($contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface) {
+        if (preg_match(NodeIdentifierValidator::PATTERN_MATCH_NODE_IDENTIFIER, $searchTerm) !== 0
+            && $contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface
+        ) {
             $nodes[] = $contentContext->getNodeByIdentifier($searchTerm);
         }
 

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -107,9 +107,21 @@ class NodesController extends ActionController
             }
         }
 
+
+
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
+        $nodes = [];
+        
+        //If there is a Node with $searchTerm as identifier, also return it.
+        if($contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface) {
+            $nodes[] = $contentContext->getNodeByIdentifier($searchTerm);
+        }
+
         if ($nodeIdentifiers === array()) {
-            $nodes = $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode);
+            $nodes = array_merge(
+                $nodes, 
+                $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode)
+            );
         } else {
             $nodes = array_map(function ($identifier) use ($contentContext) {
                 return $contentContext->getNodeByIdentifier($identifier);

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -111,15 +111,15 @@ class NodesController extends ActionController
 
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
         $nodes = [];
-        
+
         //If there is a Node with $searchTerm as identifier, also return it.
-        if($contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface) {
+        if ($contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface) {
             $nodes[] = $contentContext->getNodeByIdentifier($searchTerm);
         }
 
         if ($nodeIdentifiers === array()) {
             $nodes = array_merge(
-                $nodes, 
+                $nodes,
                 $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode)
             );
         } else {

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -111,7 +111,6 @@ class NodesController extends ActionController
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
         $nodes = [];
 
-        //If there is a Node with $searchTerm as identifier, also return it.
         if (preg_match(NodeIdentifierValidator::PATTERN_MATCH_NODE_IDENTIFIER, $searchTerm) !== 0
             && $contentContext->getNodeByIdentifier($searchTerm) instanceof NodeInterface
         ) {


### PR DESCRIPTION
**What I did**
Added a search for NodeIdentifier when calling `\Neos\Neos\Controller\Service\NodesController::indexAction()`.

That is very helpful, if you have to find one node under thousands (with same NodeType).

**How I did it**
See the diff... 

**How to verify it**
Put an Identifier into a reference/references field in inspector. You should get the correct Node back.
![bildschirmfoto 2018-02-13 um 17 00 23](https://user-images.githubusercontent.com/9807101/36159821-ff9fb058-10df-11e8-831e-6a9c01b12736.png)

