### PR TITLE
BUGFIX: Add null check in getOtherNodeVariants()

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -342,7 +342,7 @@ class Node implements NodeInterface, CacheAwareInterface
         return array_filter(
             $this->context->getNodeVariantsByIdentifier($this->getIdentifier()),
             function ($node) {
-                return ($node->getNodeData() !== $this->nodeData);
+                return ($node instanceof NodeInterface && $node->getNodeData() !== $this->nodeData);
             }
         );
     }


### PR DESCRIPTION
This avoids a fatal error in case variants of the node are not accessible
for some reason.

Fixes #1896