### PR TITLE
BUGFIX: Fix two errors in media management caused by upmerge

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
@@ -6,10 +6,8 @@
 
 <f:section name="Content">
 	<div class="neos-media-options">
-		<legend>{neos:backend.translate(id: 'media.relatedNodes.referencesTo', source: 'Modules', arguments: {asset:
-			asset.label})}
-			({neos:backend.translate(id: 'media.relatedNodes', quantity: '{asset.usageCount}', arguments: {0:
-			asset.usageCount}, source: 'Modules', package: 'Neos.Neos')})
+		<legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: {asset: asset.label})}
+			({neos:backend.translate(id: 'relatedNodes', quantity: '{asset.usageCount}', arguments: {0:asset.usageCount}, package: 'Neos.Media.Browser')})
 		</legend>
 	</div>
 
@@ -99,7 +97,7 @@
 									<f:then>
 										<neos:link.node node="{nodeInformation.documentNode}" target="_blank"
 														title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: nodeInformation.documentNode.workspace.title})}">
-											<span title="{f:render(partial: '../Module/Shared/DocumentBreadcrumb', arguments: {node: nodeInformation.documentNode})}"
+											<span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: {node: nodeInformation.documentNode})}"
 												  data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
 											<i class="icon-external-link"></i>
 										</neos:link.node>
@@ -120,7 +118,7 @@
 							</td>
 							<td>
 							<f:if condition="{contentDimensions}">
-								<f:render partial="../Module/Shared/NodeContentDimensionsInformation.html" arguments="{contentDimensions: contentDimensions, node: nodeInformation.node}"/>
+								<f:render partial="Module/Shared/NodeContentDimensionsInformation.html" arguments="{contentDimensions: contentDimensions, node: nodeInformation.node}"/>
 							</f:if>
 							</td>
 							<td>

--- a/Neos.Neos/Classes/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
+++ b/Neos.Neos/Classes/Domain/Strategy/AssetUsageInNodePropertiesStrategy.php
@@ -11,17 +11,17 @@ namespace Neos\Neos\Domain\Strategy;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Neos\Domain\Service\SiteService;
-use Neos\Utility\TypeHandling;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Strategy\AbstractAssetUsageStrategy;
-use Neos\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
-use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Controller\CreateContentContextTrait;
-use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
+use Neos\Neos\Domain\Service\SiteService;
+use Neos\Utility\TypeHandling;
 
 /**
  * @Flow\Scope("singleton")


### PR DESCRIPTION
This change adds a missing namespace import to `AssetUsageInNodePropertiesStrategy`
and fixes references to label translations and a partial in the
RelatedNodes template.