### PR TITLE
TASK: Remove whitespace from history module node link

### DIFF
--- a/TYPO3.Neos/Resources/Private/Templates/Module/Management/History/NodeLink.html
+++ b/TYPO3.Neos/Resources/Private/Templates/Module/Management/History/NodeLink.html
@@ -1,5 +1,4 @@
-{namespace neos=TYPO3\Neos\ViewHelpers}
-<f:if condition="{event.node}">
+{namespace neos=TYPO3\Neos\ViewHelpers}<f:if condition="{event.node}">
 	<f:then><neos:link.node node="{event.node}">{event.data.nodeLabel}</neos:link.node></f:then>
 	<f:else><span title="{neos:backend.translate(id: 'history.nodeRemovedInMeantime', source: 'Modules')}">{event.data.nodeLabel}</span></f:else>
 </f:if>


### PR DESCRIPTION
Without it a space is inserted at first in the quoted link.