### PR TITLE
BUGFIX: Ensure account identifier is always added to events

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/AbstractIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/AbstractIntegrationService.php
@@ -12,35 +12,13 @@ namespace TYPO3\Neos\EventLog\Integrations;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Security\Context;
 use TYPO3\Neos\EventLog\Domain\Service\EventEmittingService;
 
 abstract class AbstractIntegrationService
 {
     /**
      * @Flow\Inject
-     * @var Context
-     */
-    protected $securityContext;
-
-    /**
-     * @Flow\Inject
      * @var EventEmittingService
      */
     protected $eventEmittingService;
-
-    /**
-     * Try to set the current account identifier emitting the events, if possible
-     *
-     * @return void
-     */
-    protected function initializeAccountIdentifier()
-    {
-        if ($this->securityContext->canBeInitialized()) {
-            $account = $this->securityContext->getAccount();
-            if ($account !== null) {
-                $this->eventEmittingService->setCurrentAccountIdentifier($account->getAccountIdentifier());
-            }
-        }
-    }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/EntityIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/EntityIntegrationService.php
@@ -18,7 +18,6 @@ use TYPO3\Eel\Exception;
 use TYPO3\Eel\Utility;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Log\SystemLoggerInterface;
-use TYPO3\Neos\EventLog\Domain\Service\EventEmittingService;
 
 /**
  * Monitors entity changes
@@ -35,12 +34,6 @@ class EntityIntegrationService extends AbstractIntegrationService
      * @var ObjectManager
      */
     protected $entityManager;
-
-    /**
-     * @Flow\Inject
-     * @var EventEmittingService
-     */
-    protected $eventEmittingService;
 
     /**
      * @Flow\Inject(lazy=FALSE)
@@ -97,7 +90,6 @@ class EntityIntegrationService extends AbstractIntegrationService
                 $entityMonitoringConfiguration = $this->monitorEntitiesSetting[$className];
 
                 if (isset($entityMonitoringConfiguration['events']['created'])) {
-                    $this->initializeAccountIdentifier();
                     $data = array();
                     foreach ($entityMonitoringConfiguration['data'] as $key => $eelExpression) {
                         $data[$key] = Utility::evaluateEelExpression($eelExpression, $this->eelEvaluator, array('entity' => $entity));
@@ -115,7 +107,6 @@ class EntityIntegrationService extends AbstractIntegrationService
                 $entityMonitoringConfiguration = $this->monitorEntitiesSetting[$className];
 
                 if (isset($entityMonitoringConfiguration['events']['deleted'])) {
-                    $this->initializeAccountIdentifier();
                     $data = array();
                     foreach ($entityMonitoringConfiguration['data'] as $key => $eelExpression) {
                         $data[$key] = Utility::evaluateEelExpression($eelExpression, $this->eelEvaluator, array('entity' => $entity));

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
@@ -51,12 +51,12 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     /**
      * @var array
      */
-    protected $changedNodes = array();
+    protected $changedNodes = [];
 
     /**
      * @var array
      */
-    protected $currentNodeAddEvents = array();
+    protected $currentNodeAddEvents = [];
 
     /**
      * @var boolean
@@ -76,7 +76,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     /**
      * @var array
      */
-    protected $scheduledNodeEventUpdates = array();
+    protected $scheduledNodeEventUpdates = [];
 
     /**
      * React on the Doctrine preFlush event and trigger the respective internal node events
@@ -100,7 +100,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         }
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->generate(self::NODE_ADDED, array(), NodeEvent::class);
+        $nodeEvent = $this->eventEmittingService->generate(self::NODE_ADDED, [], NodeEvent::class);
         $this->currentNodeAddEvents[] = $nodeEvent;
         $this->eventEmittingService->pushContext($nodeEvent);
     }
@@ -137,9 +137,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         }
 
         if (!isset($this->changedNodes[$node->getContextPath()])) {
-            $this->changedNodes[$node->getContextPath()] = array(
-                'node' => $node
-            );
+            $this->changedNodes[$node->getContextPath()] = ['node' => $node];
         }
     }
 
@@ -166,9 +164,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             return;
         }
         if (!isset($this->changedNodes[$node->getContextPath()])) {
-            $this->changedNodes[$node->getContextPath()] = array(
-                'node' => $node
-            );
+            $this->changedNodes[$node->getContextPath()] = ['node' => $node];
         }
         if (!isset($this->changedNodes[$node->getContextPath()]['oldLabel'])) {
             $this->changedNodes[$node->getContextPath()]['oldLabel'] = $node->getLabel();
@@ -214,13 +210,11 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         }
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->emit(self::NODE_REMOVED, array(), NodeEvent::class);
+        $nodeEvent = $this->eventEmittingService->emit(self::NODE_REMOVED, [], NodeEvent::class);
         $nodeEvent->setNode($node);
     }
 
     /**
-     *
-     *
      * @param NodeInterface $node
      * @param Workspace $targetWorkspace
      * @return void
@@ -230,7 +224,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     }
 
     /**
-     *
+     * Emits a "Node Copy" event
      *
      * @param NodeInterface $sourceNode
      * @param NodeInterface $targetParentNode
@@ -250,16 +244,14 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         $this->currentlyCopying = true;
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->emit(self::NODE_COPY, array(
+        $nodeEvent = $this->eventEmittingService->emit(self::NODE_COPY, [
             'copiedInto' => $targetParentNode->getContextPath()
-        ), NodeEvent::class);
+        ], NodeEvent::class);
         $nodeEvent->setNode($sourceNode);
         $this->eventEmittingService->pushContext();
     }
 
     /**
-     *
-     *
      * @param NodeInterface $copiedNode
      * @param NodeInterface $targetParentNode
      * @return void
@@ -279,7 +271,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     }
 
     /**
-     *
+     * Emits a "Node Move" event
      *
      * @param NodeInterface $movedNode
      * @param NodeInterface $referenceNode
@@ -294,22 +286,19 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         $this->currentlyMoving += 1;
 
         /* @var $nodeEvent NodeEvent */
-        $nodeEvent = $this->eventEmittingService->emit(self::NODE_MOVE, array(
+        $nodeEvent = $this->eventEmittingService->emit(self::NODE_MOVE, [
             'referenceNode' => $referenceNode->getContextPath(),
             'moveOperation' => $moveOperation
-        ), NodeEvent::class);
+        ], NodeEvent::class);
         $nodeEvent->setNode($movedNode);
         $this->eventEmittingService->pushContext();
     }
 
     /**
-     *
-     *
      * @param NodeInterface $movedNode
      * @param NodeInterface $referenceNode
      * @param integer $moveOperation
      * @return void
-     *
      * @throws \Exception
      */
     public function afterNodeMove(NodeInterface $movedNode, NodeInterface $referenceNode, $moveOperation)
@@ -327,7 +316,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     }
 
     /**
-     *
+     * Emits a "Node Adopt" event
      *
      * @param NodeInterface $node
      * @param Context $context
@@ -342,11 +331,11 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
 
         if ($this->currentlyAdopting === 0) {
             /* @var $nodeEvent NodeEvent */
-            $nodeEvent = $this->eventEmittingService->emit(self::NODE_ADOPT, array(
+            $nodeEvent = $this->eventEmittingService->emit(self::NODE_ADOPT, [
                 'targetWorkspace' => $context->getWorkspaceName(),
                 'targetDimensions' => $context->getTargetDimensions(),
                 'recursive' => $recursive
-            ), NodeEvent::class);
+            ], NodeEvent::class);
             $nodeEvent->setNode($node);
             $this->eventEmittingService->pushContext();
         }
@@ -355,8 +344,6 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
     }
 
     /**
-     *
-     *
      * @param NodeInterface $node
      * @param Context $context
      * @param $recursive
@@ -394,7 +381,7 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
 
             if (isset($data['oldLabel']) && isset($data['newLabel'])) {
                 if ($data['oldLabel'] !== $data['newLabel']) {
-                    $nodeEvent = $this->eventEmittingService->emit(self::NODE_LABEL_CHANGED, array('oldLabel' => $data['oldLabel'], 'newLabel' => $data['newLabel']), NodeEvent::class);
+                    $nodeEvent = $this->eventEmittingService->emit(self::NODE_LABEL_CHANGED, ['oldLabel' => $data['oldLabel'], 'newLabel' => $data['newLabel']], NodeEvent::class);
                     $nodeEvent->setNode($node);
                 }
                 unset($data['oldLabel']);
@@ -407,12 +394,10 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             }
         }
 
-        $this->changedNodes = array();
+        $this->changedNodes = [];
     }
 
     /**
-     *
-     *
      * @param NodeInterface $node
      * @param Workspace $targetWorkspace
      * @return void
@@ -429,19 +414,18 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             return;
         }
 
-        $this->scheduledNodeEventUpdates[$documentNode->getContextPath()] = array(
-
+        $this->scheduledNodeEventUpdates[$documentNode->getContextPath()] = [
             'workspaceName' => $node->getContext()->getWorkspaceName(),
-            'nestedNodeIdentifiersWhichArePublished' => array(),
+            'nestedNodeIdentifiersWhichArePublished' => [],
             'targetWorkspace' => $targetWorkspace->getName(),
             'documentNode' => $documentNode
-        );
+        ];
 
         $this->scheduledNodeEventUpdates[$documentNode->getContextPath()]['nestedNodeIdentifiersWhichArePublished'][] = $node->getIdentifier();
     }
 
     /**
-     *
+     * Binds events to a Node.Published event for each document node published
      *
      * @return void
      */
@@ -455,9 +439,8 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         $entityManager = $this->entityManager;
 
         foreach ($this->scheduledNodeEventUpdates as $documentPublish) {
-
             /* @var $nodeEvent NodeEvent */
-            $nodeEvent = $this->eventEmittingService->emit(self::DOCUMENT_PUBLISHED, array(), NodeEvent::class);
+            $nodeEvent = $this->eventEmittingService->emit(self::DOCUMENT_PUBLISHED, [], NodeEvent::class);
             $nodeEvent->setNode($documentPublish['documentNode']);
             $nodeEvent->setWorkspaceName($documentPublish['targetWorkspace']);
             $this->persistenceManager->whitelistObject($nodeEvent);
@@ -479,20 +462,18 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
                 ->getQuery()->execute();
         }
 
-        $this->scheduledNodeEventUpdates = array();
+        $this->scheduledNodeEventUpdates = [];
     }
 
     /**
-     *
-     *
      * @return void
      */
     public function reset()
     {
-        $this->changedNodes = array();
-        $this->scheduledNodeEventUpdates = array();
+        $this->changedNodes = [];
+        $this->scheduledNodeEventUpdates = [];
         $this->currentlyAdopting = false;
         $this->currentlyCopying = false;
-        $this->currentNodeAddEvents = array();
+        $this->currentNodeAddEvents = [];
     }
 }

--- a/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/EventLog/Integrations/TYPO3CRIntegrationService.php
@@ -340,7 +340,6 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
             return;
         }
 
-        $this->initializeAccountIdentifier();
         if ($this->currentlyAdopting === 0) {
             /* @var $nodeEvent NodeEvent */
             $nodeEvent = $this->eventEmittingService->emit(self::NODE_ADOPT, array(
@@ -387,8 +386,6 @@ class TYPO3CRIntegrationService extends AbstractIntegrationService
         if (count($this->currentNodeAddEvents) > 0) {
             return;
         }
-
-        $this->initializeAccountIdentifier();
 
         foreach ($this->changedNodes as $nodePath => $data) {
             $node = $data['node'];


### PR DESCRIPTION
For some events (e.g. copying) the account identifier is not set since it's not initialized.
Instead of doing it manually for each event type it's done before generating an event so it's always done.

Resolves: #1914