### PR TITLE
FEATURE: Allow custom attributes to be added to `ContentElementWrapping`

### DIFF
--- a/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
@@ -46,6 +46,16 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
     }
 
     /**
+     * Additional attributes to be rendered in the ContentElementWrapping
+     *
+     * @return array
+     */
+    public function getAdditionalAttributes()
+    {
+        return $this->fusionValue('additionalAttributes') ?? [];
+    }
+
+    /**
      * Evaluate this Fusion object and return the result
      *
      * @return mixed
@@ -75,10 +85,10 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
         }
 
         if ($this->fusionValue('renderCurrentDocumentMetadata')) {
-            return $this->contentElementWrappingService->wrapCurrentDocumentMetadata($node, $content, $this->getContentElementFusionPath());
+            return $this->contentElementWrappingService->wrapCurrentDocumentMetadata($node, $content, $this->getContentElementFusionPath(), $this->getAdditionalAttributes());
         }
 
-        return $this->contentElementWrappingService->wrapContentObject($node, $content, $this->getContentElementFusionPath());
+        return $this->contentElementWrappingService->wrapContentObject($node, $content, $this->getContentElementFusionPath(), $this->getAdditionalAttributes());
     }
 
     /**

--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -66,15 +66,16 @@ class ContentElementWrappingService
      * @param NodeInterface $node
      * @param string $content
      * @param string $fusionPath
+     * @param array $additionalAttributes additional attributes in the form ['<attribute-name>' => '<attibute-value>', ...] to be rendered in the element wrapping
      * @return string
      */
-    public function wrapContentObject(NodeInterface $node, $content, $fusionPath)
+    public function wrapContentObject(NodeInterface $node, $content, $fusionPath, array $additionalAttributes = [])
     {
         if ($this->needsMetadata($node, false) === false) {
             return $content;
         }
 
-        $attributes = [];
+        $attributes = $additionalAttributes;
         $attributes['data-node-__typoscript-path'] = $fusionPath; // @deprecated
         $attributes['data-node-__fusion-path'] = $fusionPath;
         $attributes['tabindex'] = 0;
@@ -89,15 +90,16 @@ class ContentElementWrappingService
      * @param NodeInterface $node
      * @param string $content
      * @param string $fusionPath
+     * @param array $additionalAttributes additional attributes in the form ['<attribute-name>' => '<attibute-value>', ...] to be rendered in the element wrapping
      * @return string
      */
-    public function wrapCurrentDocumentMetadata(NodeInterface $node, $content, $fusionPath)
+    public function wrapCurrentDocumentMetadata(NodeInterface $node, $content, $fusionPath, array $additionalAttributes = [])
     {
         if ($this->needsMetadata($node, true) === false) {
             return $content;
         }
 
-        $attributes = [];
+        $attributes = $additionalAttributes;
         $attributes['data-node-__typoscript-path'] = $fusionPath; // @deprecated
         $attributes['data-node-__fusion-path'] = $fusionPath;
         $attributes = $this->addGenericEditingMetadata($attributes, $node);

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentElementWrapping.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentElementWrapping.fusion
@@ -7,6 +7,8 @@ prototype(Neos.Neos:ContentElementWrapping) {
 	@class = 'Neos\\Neos\\Fusion\\ContentElementWrappingImplementation'
 	node = ${node}
 	value = ${value}
+	# Additional attributes in the form '<attribute-name>': '<attribute-value>' that will be rendered in the ContentElementWrapping
+	additionalAttributes = Neos.Fusion:RawArray
 	# This should only be set to TRUE to render the metadata for the currently rendered document node as that is treated differently.
 	renderCurrentDocumentMetadata = FALSE
 }


### PR DESCRIPTION
This extends the `ContentElementWrapping` in order to allow
additional attributes to be added via Fusion or PHP.

This is useful to augment content and/or to affect its styling
in the Neos backend.

Example (Fusion):
Add the wrapped node's type to a new `data-_node-type` attribute
for all `ContentElementWrapping` instances::

    prototype(Neos.Neos:ContentElementWrapping) {
        additionalAttributes {
            'data-_node-type' = ${node.nodeType.name}
        }
    }

Example (Fusion):
Add a custom class attribute to a single instance::

    @process.contentElementWrapping = Neos.Neos:ContentElementWrapping {
        additionalAttributes.class = 'some-additional-class'
    }

Example (PHP)::

    $this->contentElementWrappingService->wrapContentObject($node, $output, $fusionPath, ['custom-attribute' => 'attribute-value']);

Resolves: #1879