### PR TITLE
BUGFIX: Call `getAvailablePackages` in packages-module

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
@@ -33,7 +33,7 @@ class PackagesController extends AbstractModuleController
     public function indexAction()
     {
         $packageGroups = array();
-        foreach ($this->packageManager->getActivePackages() as $package) {
+        foreach ($this->packageManager->getAvailablePackages() as $package) {
             /** @var Package $package */
             $packagePath = substr($package->getPackagepath(), strlen(FLOW_PATH_PACKAGES));
             $packageGroup = substr($packagePath, 0, strpos($packagePath, '/'));


### PR DESCRIPTION
The previously called method `getActivePackages` has been removed in a previous commit.