### PR TITLE
(Event Sourced) FEATURE: Add method `findReferencingNodes` to content-subgraph

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
@@ -52,6 +52,13 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findReferencedNodes(Domain\ValueObject\NodeIdentifier $nodeIdentifier, Domain\ValueObject\PropertyName $name = null): array;
 
     /**
+     * @param Domain\ValueObject\NodeIdentifier $nodeIdentifier
+     * @param Domain\ValueObject\PropertyName $name
+     * @return NodeInterface[]
+     */
+    public function findReferencingNodes(Domain\ValueObject\NodeIdentifier $nodeIdentifier, Domain\ValueObject\PropertyName $name = null): array;
+
+    /**
      * @param \Neos\ContentRepository\Domain\Context\NodeAggregate\NodeAggregateIdentifier $nodeAggregateIdentifier
      * @return NodeInterface|null
      */

--- a/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithDimensions.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithDimensions.feature
@@ -77,6 +77,10 @@ Feature: Node References with Dimensions
       | Key               | Value                   | Type   |
       | referenceProperty | dest-nodeAgg-identifier | Uuid[] |
 
+    And I expect the Node "[dest-node-identifier]" to be referenced by:
+      | Key               | Value                     | Type   |
+      | referenceProperty | source-nodeAgg-identifier | Uuid[] |
+
   Scenario: Ensure that the reference can be read in fallback dimension
 
     And I am in content stream "[cs-identifier]" and Dimension Space Point {"language": "ch"}
@@ -85,11 +89,19 @@ Feature: Node References with Dimensions
       | Key               | Value                   | Type   |
       | referenceProperty | dest-nodeAgg-identifier | Uuid[] |
 
+    And I expect the Node "[dest-node-identifier]" to be referenced by:
+      | Key               | Value                     | Type   |
+      | referenceProperty | source-nodeAgg-identifier | Uuid[] |
+
   Scenario: Ensure that the reference cannot be read in independent dimension
 
     And I am in content stream "[cs-identifier]" and Dimension Space Point {"language": "en"}
 
     Then I expect the Node "[source-node-identifier]" to have the references:
+      | Key               | Value | Type   |
+      | referenceProperty |       | Uuid[] |
+
+    And I expect the Node "[dest-node-identifier]" to be referenced by:
       | Key               | Value | Type   |
       | referenceProperty |       | Uuid[] |
 

--- a/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithoutDimensions.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithoutDimensions.feature
@@ -71,7 +71,7 @@ Feature: Node References without Dimensions
       | nodeTypeName                  | Neos.ContentRepository:NodeWithReferences |                        |
       | dimensionSpacePoint           | {"coordinates": []}                       | json                   |
       | visibleDimensionSpacePoints   | {"points":[{"coordinates":[]}]}           | DimensionSpacePointSet |
-      | nodeIdentifier                | dest-2-node-identifier                    | Uuid                   |
+      | nodeIdentifier                | dest-3-node-identifier                    | Uuid                   |
       | parentNodeIdentifier          | rn-identifier                             | Uuid                   |
       | nodeName                      | dest-3                                    |                        |
       | propertyDefaultValuesAndTypes | {}                                        | json                   |
@@ -91,6 +91,34 @@ Feature: Node References without Dimensions
     Then I expect the Node "[source-node-identifier]" to have the references:
       | Key               | Value                     | Type   |
       | referenceProperty | dest-1-nodeAgg-identifier | Uuid[] |
+
+    And I expect the Node "[dest-1-node-identifier]" to be referenced by:
+      | Key               | Value                     | Type   |
+      | referenceProperty | source-nodeAgg-identifier | Uuid[] |
+
+  Scenario: Ensure that references between nodes can be set and red
+
+    When the command "SetNodeReferences" is executed with payload:
+      | Key                                 | Value                                               | Type   |
+      | contentStreamIdentifier             | cs-identifier                                       | Uuid   |
+      | nodeIdentifier                      | source-node-identifier                              | Uuid   |
+      | propertyName                        | referencesProperty                                  |        |
+      | destinationNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
+
+    And the graph projection is fully up to date
+    And I am in content stream "[cs-identifier]" and Dimension Space Point {}
+
+    Then I expect the Node "[source-node-identifier]" to have the references:
+      | Key                | Value                                               | Type   |
+      | referencesProperty | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
+
+    And I expect the Node "[dest-2-node-identifier]" to be referenced by:
+      | Key                | Value                     | Type   |
+      | referencesProperty | source-nodeAgg-identifier | Uuid[] |
+
+    And I expect the Node "[dest-3-node-identifier]" to be referenced by:
+      | Key                | Value                     | Type   |
+      | referencesProperty | source-nodeAgg-identifier | Uuid[] |
 
   Scenario: Ensure that references between nodes can be set and overwritten
 
@@ -181,3 +209,28 @@ Feature: Node References without Dimensions
     Then I expect the Node "[source-node-identifier]" to have the references:
       | Key                | Value | Type   |
       | referencesProperty |       | Uuid[] |
+
+  Scenario: Ensure that references from multiple nodes read from the opposing side
+
+    When the command "SetNodeReferences" is executed with payload:
+      | Key                                 | Value                     | Type   |
+      | contentStreamIdentifier             | cs-identifier             | Uuid   |
+      | nodeIdentifier                      | source-node-identifier    | Uuid   |
+      | propertyName                        | referenceProperty         |        |
+      | destinationNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
+
+    And the command "SetNodeReferences" is executed with payload:
+      | Key                                 | Value                     | Type   |
+      | contentStreamIdentifier             | cs-identifier             | Uuid   |
+      | nodeIdentifier                      | dest-2-node-identifier    | Uuid   |
+      | propertyName                        | referenceProperty         |        |
+      | destinationNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
+
+    And the graph projection is fully up to date
+
+    And I am in content stream "[cs-identifier]" and Dimension Space Point {}
+
+    Then I expect the Node "[dest-1-node-identifier]" to be referenced by:
+      | Key               | Value                                               | Type   |
+      | referenceProperty | source-nodeAgg-identifier,dest-2-nodeAgg-identifier | Uuid[] |
+


### PR DESCRIPTION
This allows to find all nodes the are referencing the target and optionally filter by propertyName. 
In this case no order of the references can be expected as ordering happens for outgoing references only.