### PR TITLE
(Event Sourced) BUGFIX: Fix typo in variable name `DestinationNodeAggregateIdentifiers`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
@@ -425,12 +425,12 @@ class GraphProjector implements ProjectorInterface
             ]);
 
             // set new
-            foreach ($event->getDestinationtNodeAggregateIdentifiers() as $position => $destinationtNodeIdentifier) {
+            foreach ($event->getDestinationNodeAggregateIdentifiers() as $position => $destinationNodeIdentifier) {
                 $this->getDatabaseConnection()->insert('neos_contentgraph_referencerelation', [
                     'name' => $event->getPropertyName(),
                     'position' => $position,
                     'nodeanchorpoint' => $nodeAnchorPoint,
-                    'destinationnodeaggregateidentifier' => $destinationtNodeIdentifier,
+                    'destinationnodeaggregateidentifier' => $destinationNodeIdentifier,
                 ]);
             }
         });

--- a/Neos.ContentRepository/Classes/Domain/Context/Node/Command/SetNodeReferences.php
+++ b/Neos.ContentRepository/Classes/Domain/Context/Node/Command/SetNodeReferences.php
@@ -27,7 +27,7 @@ final class SetNodeReferences
     /**
      * @var NodeAggregateIdentifier[]
      */
-    private $destinationtNodeAggregateIdentifiers;
+    private $destinationNodeAggregateIdentifiers;
 
     /**
      * @var PropertyName
@@ -40,18 +40,18 @@ final class SetNodeReferences
      * @param ContentStreamIdentifier $contentStreamIdentifier
      * @param NodeIdentifier $nodeIdentifier
      * @param PropertyName $propertyName
-     * @param array $destinationtNodeAggregateIdentifiers
+     * @param array $destinationNodeAggregateIdentifiers
      */
     public function __construct(
         ContentStreamIdentifier $contentStreamIdentifier,
         NodeIdentifier $nodeIdentifier,
         PropertyName $propertyName,
-        array $destinationtNodeAggregateIdentifiers
+        array $destinationNodeAggregateIdentifiers
     ) {
         $this->contentStreamIdentifier = $contentStreamIdentifier;
         $this->nodeIdentifier = $nodeIdentifier;
         $this->propertyName = $propertyName;
-        $this->destinationtNodeAggregateIdentifiers = $destinationtNodeAggregateIdentifiers;
+        $this->destinationNodeAggregateIdentifiers = $destinationNodeAggregateIdentifiers;
     }
 
     /**
@@ -73,9 +73,9 @@ final class SetNodeReferences
     /**
      * @return NodeAggregateIdentifier[]
      */
-    public function getDestinationtNodeAggregateIdentifiers(): array
+    public function getDestinationNodeAggregateIdentifiers(): array
     {
-        return $this->destinationtNodeAggregateIdentifiers;
+        return $this->destinationNodeAggregateIdentifiers;
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Domain/Context/Node/Event/NodeReferencesWereSet.php
+++ b/Neos.ContentRepository/Classes/Domain/Context/Node/Event/NodeReferencesWereSet.php
@@ -33,7 +33,7 @@ final class NodeReferencesWereSet implements EventInterface, CopyableAcrossConte
     /**
      * @var NodeAggregateIdentifier[]
      */
-    private $destinationtNodeAggregateIdentifiers;
+    private $destinationNodeAggregateIdentifiers;
 
     /**
      * @var PropertyName
@@ -47,20 +47,20 @@ final class NodeReferencesWereSet implements EventInterface, CopyableAcrossConte
      * @param DimensionSpacePointSet $dimensionSpacePointSet
      * @param NodeIdentifier $nodeIdentifier
      * @param PropertyName $referenceNodeIdentifier
-     * @param array $destinationtNodeIdentifiers
+     * @param array $destinationNodeIdentifiers
      */
     public function __construct(
         ContentStreamIdentifier $contentStreamIdentifier,
         DimensionSpacePointSet $dimensionSpacePointSet,
         NodeIdentifier $nodeIdentifier,
         PropertyName $propertyName,
-        array $destinationtNodeAggregateIdentifiers
+        array $destinationNodeAggregateIdentifiers
     ) {
         $this->contentStreamIdentifier = $contentStreamIdentifier;
         $this->dimensionSpacePointSet = $dimensionSpacePointSet;
         $this->nodeIdentifier = $nodeIdentifier;
         $this->propertyName = $propertyName;
-        $this->destinationtNodeAggregateIdentifiers = $destinationtNodeAggregateIdentifiers;
+        $this->destinationNodeAggregateIdentifiers = $destinationNodeAggregateIdentifiers;
     }
 
     /**
@@ -90,9 +90,9 @@ final class NodeReferencesWereSet implements EventInterface, CopyableAcrossConte
     /**
      * @return array
      */
-    public function getDestinationtNodeAggregateIdentifiers(): array
+    public function getDestinationNodeAggregateIdentifiers(): array
     {
-        return $this->destinationtNodeAggregateIdentifiers;
+        return $this->destinationNodeAggregateIdentifiers;
     }
 
     /**
@@ -112,7 +112,7 @@ final class NodeReferencesWereSet implements EventInterface, CopyableAcrossConte
             $this->dimensionSpacePointSet,
             $this->nodeIdentifier,
             $this->propertyName,
-            $this->destinationtNodeAggregateIdentifiers
+            $this->destinationNodeAggregateIdentifiers
         );
     }
 }

--- a/Neos.ContentRepository/Classes/Domain/Context/Node/NodeCommandHandler.php
+++ b/Neos.ContentRepository/Classes/Domain/Context/Node/NodeCommandHandler.php
@@ -425,7 +425,7 @@ final class NodeCommandHandler
                 $dimensionSpacePointsSet,
                 $command->getNodeIdentifier(),
                 $command->getPropertyName(),
-                $command->getDestinationtNodeAggregateIdentifiers()
+                $command->getDestinationNodeAggregateIdentifiers()
             );
 
             $this->nodeEventPublisher->publishMany(

--- a/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithDimensions.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithDimensions.feature
@@ -61,11 +61,11 @@ Feature: Node References with Dimensions
 
 
     And the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                   | Type   |
-      | contentStreamIdentifier              | cs-identifier           | Uuid   |
-      | nodeIdentifier                       | source-node-identifier  | Uuid   |
-      | propertyName                         | referenceProperty       |        |
-      | destinationtNodeAggregateIdentifiers | dest-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                   | Type   |
+      | contentStreamIdentifier             | cs-identifier           | Uuid   |
+      | nodeIdentifier                      | source-node-identifier  | Uuid   |
+      | propertyName                        | referenceProperty       |        |
+      | destinationNodeAggregateIdentifiers | dest-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
 

--- a/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithoutDimensions.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencesWithoutDimensions.feature
@@ -46,7 +46,7 @@ Feature: Node References without Dimensions
       | nodeTypeName                  | Neos.ContentRepository:NodeWithReferences |                        |
       | dimensionSpacePoint           | {"coordinates": []}                       | json                   |
       | visibleDimensionSpacePoints   | {"points":[{"coordinates":[]}]}           | DimensionSpacePointSet |
-      | nodeIdentifier                | dest-node-identifier                      | Uuid                   |
+      | nodeIdentifier                | dest-1-node-identifier                    | Uuid                   |
       | parentNodeIdentifier          | rn-identifier                             | Uuid                   |
       | nodeName                      | dest-1                                    |                        |
       | propertyDefaultValuesAndTypes | {}                                        | json                   |
@@ -59,7 +59,7 @@ Feature: Node References without Dimensions
       | nodeTypeName                  | Neos.ContentRepository:NodeWithReferences |                        |
       | dimensionSpacePoint           | {"coordinates": []}                       | json                   |
       | visibleDimensionSpacePoints   | {"points":[{"coordinates":[]}]}           | DimensionSpacePointSet |
-      | nodeIdentifier                | dest-node-identifier                      | Uuid                   |
+      | nodeIdentifier                | dest-2-node-identifier                    | Uuid                   |
       | parentNodeIdentifier          | rn-identifier                             | Uuid                   |
       | nodeName                      | dest-2                                    |                        |
       | propertyDefaultValuesAndTypes | {}                                        | json                   |
@@ -71,7 +71,7 @@ Feature: Node References without Dimensions
       | nodeTypeName                  | Neos.ContentRepository:NodeWithReferences |                        |
       | dimensionSpacePoint           | {"coordinates": []}                       | json                   |
       | visibleDimensionSpacePoints   | {"points":[{"coordinates":[]}]}           | DimensionSpacePointSet |
-      | nodeIdentifier                | dest-node-identifier                      | Uuid                   |
+      | nodeIdentifier                | dest-2-node-identifier                    | Uuid                   |
       | parentNodeIdentifier          | rn-identifier                             | Uuid                   |
       | nodeName                      | dest-3                                    |                        |
       | propertyDefaultValuesAndTypes | {}                                        | json                   |
@@ -79,11 +79,11 @@ Feature: Node References without Dimensions
   Scenario: Ensure that a reference between nodes can be set and read
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                     | Type   |
-      | contentStreamIdentifier              | cs-identifier             | Uuid   |
-      | nodeIdentifier                       | source-node-identifier    | Uuid   |
-      | propertyName                         | referenceProperty         |        |
-      | destinationtNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                     | Type   |
+      | contentStreamIdentifier             | cs-identifier             | Uuid   |
+      | nodeIdentifier                      | source-node-identifier    | Uuid   |
+      | propertyName                        | referenceProperty         |        |
+      | destinationNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -95,11 +95,11 @@ Feature: Node References without Dimensions
   Scenario: Ensure that references between nodes can be set and overwritten
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                                               | Type   |
-      | contentStreamIdentifier              | cs-identifier                                       | Uuid   |
-      | nodeIdentifier                       | source-node-identifier                              | Uuid   |
-      | propertyName                         | referencesProperty                                  |        |
-      | destinationtNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                                               | Type   |
+      | contentStreamIdentifier             | cs-identifier                                       | Uuid   |
+      | nodeIdentifier                      | source-node-identifier                              | Uuid   |
+      | propertyName                        | referencesProperty                                  |        |
+      | destinationNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -109,11 +109,11 @@ Feature: Node References without Dimensions
       | referencesProperty | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                     | Type   |
-      | contentStreamIdentifier              | cs-identifier             | Uuid   |
-      | nodeIdentifier                       | source-node-identifier    | Uuid   |
-      | propertyName                         | referencesProperty        |        |
-      | destinationtNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                     | Type   |
+      | contentStreamIdentifier             | cs-identifier             | Uuid   |
+      | nodeIdentifier                      | source-node-identifier    | Uuid   |
+      | propertyName                        | referencesProperty        |        |
+      | destinationNodeAggregateIdentifiers | dest-1-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -125,11 +125,11 @@ Feature: Node References without Dimensions
   Scenario: Ensure that references between nodes can be set and reordered
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                                               | Type   |
-      | contentStreamIdentifier              | cs-identifier                                       | Uuid   |
-      | nodeIdentifier                       | source-node-identifier                              | Uuid   |
-      | propertyName                         | referencesProperty                                  |        |
-      | destinationtNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                                               | Type   |
+      | contentStreamIdentifier             | cs-identifier                                       | Uuid   |
+      | nodeIdentifier                      | source-node-identifier                              | Uuid   |
+      | propertyName                        | referencesProperty                                  |        |
+      | destinationNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -139,11 +139,11 @@ Feature: Node References without Dimensions
       | referencesProperty | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                                               | Type   |
-      | contentStreamIdentifier              | cs-identifier                                       | Uuid   |
-      | nodeIdentifier                       | source-node-identifier                              | Uuid   |
-      | propertyName                         | referencesProperty                                  |        |
-      | destinationtNodeAggregateIdentifiers | dest-3-nodeAgg-identifier,dest-2-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                                               | Type   |
+      | contentStreamIdentifier             | cs-identifier                                       | Uuid   |
+      | nodeIdentifier                      | source-node-identifier                              | Uuid   |
+      | propertyName                        | referencesProperty                                  |        |
+      | destinationNodeAggregateIdentifiers | dest-3-nodeAgg-identifier,dest-2-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -155,11 +155,11 @@ Feature: Node References without Dimensions
   Scenario: Ensure that references between nodes can be deleted
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                                               | Type   |
-      | contentStreamIdentifier              | cs-identifier                                       | Uuid   |
-      | nodeIdentifier                       | source-node-identifier                              | Uuid   |
-      | propertyName                         | referencesProperty                                  |        |
-      | destinationtNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
+      | Key                                 | Value                                               | Type   |
+      | contentStreamIdentifier             | cs-identifier                                       | Uuid   |
+      | nodeIdentifier                      | source-node-identifier                              | Uuid   |
+      | propertyName                        | referencesProperty                                  |        |
+      | destinationNodeAggregateIdentifiers | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}
@@ -169,11 +169,11 @@ Feature: Node References without Dimensions
       | referencesProperty | dest-2-nodeAgg-identifier,dest-3-nodeAgg-identifier | Uuid[] |
 
     When the command "SetNodeReferences" is executed with payload:
-      | Key                                  | Value                  | Type   |
-      | contentStreamIdentifier              | cs-identifier          | Uuid   |
-      | nodeIdentifier                       | source-node-identifier | Uuid   |
-      | propertyName                         | referencesProperty     |        |
-      | destinationtNodeAggregateIdentifiers |                        | Uuid[] |
+      | Key                                 | Value                  | Type   |
+      | contentStreamIdentifier             | cs-identifier          | Uuid   |
+      | nodeIdentifier                      | source-node-identifier | Uuid   |
+      | propertyName                        | referencesProperty     |        |
+      | destinationNodeAggregateIdentifiers |                        | Uuid[] |
 
     And the graph projection is fully up to date
     And I am in content stream "[cs-identifier]" and Dimension Space Point {}


### PR DESCRIPTION
Remove obsolete letter `t` that was a leftover from previous refactorings.