### PR TITLE
TASK: Pass affected entities to flush as array, not one-by-one

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1191,9 +1191,7 @@ class NodeDataRepository extends Repository
     {
         foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
             if ($className === $this->entityClassName) {
-                foreach ($entities as $entityToPersist) {
-                    $this->entityManager->flush($entityToPersist);
-                }
+                $this->entityManager->flush($entities);
                 $this->emitRepositoryObjectsPersisted();
                 break;
             }


### PR DESCRIPTION
The `NodeDataRepository.persistEntities()` method looped over the
entities and passed them to `flush()` one-by-one. They can be passed
as the array at hand directly.
