### PR TITLE
TASK: Make sure documentnodeidentifier index is not overlooked

### DIFF
--- a/Neos.Neos/Classes/EventLog/Domain/Model/Event.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/Event.php
@@ -22,9 +22,12 @@ use Neos\Flow\Annotations as Flow;
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\Table(
  *    indexes={
- *        @ORM\Index(name="eventtype",columns={"eventtype"})
+ *        @ORM\Index(name="eventtype",columns={"eventtype"}),
+ *        @ORM\Index(name="documentnodeidentifier", columns={"documentnodeidentifier"})
  *    }
  * )
+ * The "documentnodeidentifier" index defined above targets the NodeEvent, and needs to be here so Doctrine migrations
+ * picks it up, otherwise Doctrine would never create this index. See https://github.com/doctrine/doctrine2/issues/6248
  */
 class Event
 {

--- a/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
@@ -26,8 +26,10 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
  * A specific event which is used for ContentRepository Nodes (i.e. content).
  *
  * @Flow\Entity
- * @ORM\InheritanceType("SINGLE_TABLE")
- * The following annotation is not correctly picked up so doctrine migrations would never create this index. It is still contained in the migration.
+ *
+ * The following annotation is not picked up by Doctrine migrations and thus included in the Event class as well.
+ * See https://github.com/doctrine/doctrine2/issues/6248
+ *
  * @ORM\Table(
  *    indexes={
  *      @ORM\Index(name="documentnodeidentifier", columns={"documentnodeidentifier"})


### PR DESCRIPTION
The `documentnodeidentifier` index defined in `NodeEvent` is not picked
up by Doctrine Migrations when generating a migration. This leads to
it's removal being included in new migrations, and it has actually been
removed unnoticed in the past.

This change adds it to the `Event` class as well, so it is picked up
correctly. See https://github.com/doctrine/doctrine2/issues/6248