### PR TITLE
TASK: Change NodeData movedTo from ManyToOne to OneToOne

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -209,7 +209,7 @@ class NodeData extends AbstractNodeData
      * If a node data is moved a "shadow" node data is inserted that references the new node data
      *
      * @var NodeData
-     * @ORM\ManyToOne
+     * @ORM\OneToOne
      * @ORM\JoinColumn(onDelete="SET NULL")
      */
     protected $movedTo;


### PR DESCRIPTION
A node can only be moved to one other node, so ManyToOne was never
correct.

See https://github.com/neos/neos-development-collection/issues/1908
