### PR TITLE
BUGFIX: Fix non-unique unique index on NodeData

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -893,7 +893,7 @@ HELPTEXT;
             ->from(NodeData::class, 'n')
             ->where('n.nodeType = :nodeType')
             ->andWhere('n.workspace = :workspace')
-            ->andWhere('n.movedTo IS NULL OR n.removed = :removed')
+            ->andWhere('n.isMoved = FALSE OR n.removed = :removed')
             ->setParameter('nodeType', $nodeType)
             ->setParameter('workspace', $workspaceName)
             ->setParameter('removed', false, \PDO::PARAM_BOOL);

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -895,7 +895,7 @@ class NodeData extends AbstractNodeData
     {
         $sourceNodeData = $this;
         $originalPath = $this->path;
-        if ($originalPath === $targetPath && $this->workspace->getName() === $targetWorkspace) {
+        if ($originalPath === $targetPath && $this->workspace->getName() === $targetWorkspace->getName()) {
             return $this;
         }
 

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -899,6 +899,12 @@ class NodeData extends AbstractNodeData
             return $this;
         }
 
+        if ($this->workspace->getBaseWorkspace() === null && $this->workspace->getName() === $targetWorkspace->getName()) {
+            $sourceNodeData->setPath($targetPath, false);
+            $this->addOrUpdate($sourceNodeData);
+            return $sourceNodeData;
+        }
+
         $targetPathShadowNodeData = $this->getExistingShadowNodeDataInExactWorkspace($targetPath, $targetWorkspace, $sourceNodeData->getDimensionValues());
 
         if ($this->workspace->getName() !== $targetWorkspace->getName()) {

--- a/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
@@ -475,7 +475,7 @@ class Workspace
         $sourceNodeData = $sourceNode->getNodeData();
 
         // The source node is a regular, not moved node and the target node is a moved shadow node
-        if (!$sourceNode->getNodeData()->isRemoved() && $sourceNode->getNodeData()->getMovedTo() === null && $targetNodeData->isRemoved() && $targetNodeData->getMovedTo() !== null) {
+        if (!$sourceNode->getNodeData()->isRemoved() && $sourceNode->getNodeData()->isMoved() === false && $targetNodeData->isRemoved() && $targetNodeData->isMoved()) {
             $sourceNodeData->move($sourceNodeData->getPath(), $targetNodeData->getWorkspace());
             return;
         }

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -274,7 +274,7 @@ class NodeDataRepository extends Repository
         }
         $this->addPathConstraintToQueryBuilder($queryBuilder, $path);
         if ($onlyShadowNodes) {
-            $queryBuilder->andWhere('n.movedTo IS NOT NULL AND n.removed = TRUE');
+            $queryBuilder->andWhere('n.isMoved = TRUE AND n.removed = TRUE');
         }
 
         $query = $queryBuilder->getQuery();
@@ -1347,7 +1347,7 @@ class NodeDataRepository extends Repository
         $queryBuilder->select('n')
             ->from(NodeData::class, 'n')
             ->where('n.workspace = :workspace')
-            ->andWhere('n.movedTo IS NULL OR n.removed = :removed')
+            ->andWhere('n.isMoved = FALSE OR n.removed = :removed')
             ->orderBy('n.path', 'ASC')
             ->setParameter('workspace', $workspace)
             ->setParameter('removed', false, \PDO::PARAM_BOOL);
@@ -1586,9 +1586,9 @@ class NodeDataRepository extends Repository
             $dimensions = [];
         }
         if ($includeRemovedNodes === false) {
-            $queryBuilder->andWhere('n.movedTo IS NULL OR n.removed = FALSE');
+            $queryBuilder->andWhere('n.isMoved = FALSE OR n.removed = FALSE');
         } else {
-            $queryBuilder->andWhere('n.movedTo IS NULL');
+            $queryBuilder->andWhere('n.isMoved = FALSE');
         }
         $queryBuilder->andWhere('n.identifier IN (:identifier)')
             ->setParameter('identifier', $nodeIdentifier);

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1201,6 +1201,17 @@ class NodeDataRepository extends Repository
     }
 
     /**
+     * Persists the passed entity and all cascading dependencies
+     *
+     * @param NodeData $entity
+     * @return void
+     */
+    public function persistEntity(NodeData $entity)
+    {
+        $this->entityManager->flush($entity);
+    }
+
+    /**
      * Signals that persistEntities() in this repository finished correctly.
      *
      * @Flow\Signal

--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
@@ -106,6 +106,9 @@ class NodeImportService
         'removed' => array(
             'columnType' => \PDO::PARAM_BOOL
         ),
+        'ismoved' => array(
+            'columnType' => \PDO::PARAM_BOOL
+        ),
         'hidden' => array(
             'columnType' => \PDO::PARAM_BOOL
         ),
@@ -291,6 +294,7 @@ class NodeImportService
                     'sortingIndex' => $xmlReader->getAttribute('sortingIndex'),
                     'version' => $xmlReader->getAttribute('version'),
                     'removed' => (boolean)$xmlReader->getAttribute('removed'),
+                    'ismoved' => false,
                     'hidden' => (boolean)$xmlReader->getAttribute('hidden'),
                     'hiddenInIndex' => (boolean)$xmlReader->getAttribute('hiddenInIndex'),
                     'path' => $path,

--- a/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
@@ -172,7 +172,7 @@ class NodeService implements NodeServiceInterface
         /** @var NodeData $existingNodeData */
         $existingNodeDataObjects = $this->nodeDataRepository->findByPathWithoutReduce($nodePath, $node->getWorkspace(), true);
         foreach ($existingNodeDataObjects as $existingNodeData) {
-            if ($existingNodeData->getMovedTo() !== null && $existingNodeData->getMovedTo() === $node->getNodeData()) {
+            if ($existingNodeData->isMoved() && $existingNodeData->getMovedTo() === $node->getNodeData()) {
                 return true;
             }
         }

--- a/Neos.ContentRepository/Classes/Domain/Service/PublishingService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/PublishingService.php
@@ -182,7 +182,7 @@ class PublishingService implements PublishingServiceInterface
 
         $possibleShadowNodeData = $this->nodeDataRepository->findOneByMovedTo($node->getNodeData());
         if ($possibleShadowNodeData instanceof NodeData) {
-            if ($possibleShadowNodeData->getMovedTo() !== null) {
+            if ($possibleShadowNodeData->isMoved()) {
                 $parentBasePath = $node->getPath();
                 $affectedChildNodeDataInSameWorkspace = $this->nodeDataRepository->findByParentAndNodeType($parentBasePath, null, $node->getWorkspace(), null, false, true);
                 foreach ($affectedChildNodeDataInSameWorkspace as $affectedChildNodeData) {

--- a/Neos.ContentRepository/Classes/Service/Utility/NodePublishingDependencySolver.php
+++ b/Neos.ContentRepository/Classes/Service/Utility/NodePublishingDependencySolver.php
@@ -109,8 +109,8 @@ class NodePublishingDependencySolver
             }
 
             // Add a dependency for a moved-to reference
-            $movedToNodeData = $node->getNodeData()->getMovedTo();
-            if ($movedToNodeData !== null) {
+            if ($node->getNodeData()->isMoved()) {
+                $movedToNodeData = $node->getNodeData()->getMovedTo();
                 $movedToHash = spl_object_hash($movedToNodeData);
                 if (!isset($this->nodesByNodeData[$movedToHash])) {
                     throw new WorkspaceException('Cannot publish a list of nodes with missing dependency (' . $node->getPath() . ' needs ' . $movedToNodeData->getPath() . ' to be published)', 1416483470);

--- a/Neos.ContentRepository/Migrations/Mysql/Version20180305172923.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20180305172923.php
@@ -1,0 +1,50 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Fix uniqe index for nodedata(identifier, workspace, dimensionshash, ismoved)
+ */
+class Version20180305172923 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Fix uniqe index for nodedata(identifier, workspace, dimensionshash, ismoved)';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX IDX_CE6515692D45FE4D, ADD UNIQUE INDEX UNIQ_CE6515692D45FE4D (movedto)');
+        $this->addSql('DROP INDEX UNIQ_CE651569772E836A8D94001992F8FB012D45FE4D ON neos_contentrepository_domain_model_nodedata');
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata ADD ismoved TINYINT(1) NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CE651569772E836A8D94001992F8FB01E3AD3CF ON neos_contentrepository_domain_model_nodedata (identifier, workspace, dimensionshash, ismoved)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX UNIQ_CE6515692D45FE4D, ADD INDEX IDX_CE6515692D45FE4D (movedto)');
+        $this->addSql('DROP INDEX UNIQ_CE651569772E836A8D94001992F8FB01E3AD3CF ON neos_contentrepository_domain_model_nodedata');
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP ismoved');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CE651569772E836A8D94001992F8FB012D45FE4D ON neos_contentrepository_domain_model_nodedata (identifier, workspace, dimensionshash, movedto)');
+    }
+}

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20180305154900.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20180305154900.php
@@ -1,0 +1,52 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Fix uniqe index for nodedata(identifier, workspace, dimensionshash, ismoved)
+ */
+class Version20180305154900 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Fix uniqe index for nodedata(identifier, workspace, dimensionshash, ismoved)';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('DROP INDEX uniq_ce651569772e836a8d94001992f8fb012d45fe4d');
+        $this->addSql('DROP INDEX idx_ce6515692d45fe4d');
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata ADD ismoved BOOLEAN NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CE6515692D45FE4D ON neos_contentrepository_domain_model_nodedata (movedto)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CE651569772E836A8D94001992F8FB01E3AD3CF ON neos_contentrepository_domain_model_nodedata (identifier, workspace, dimensionshash, ismoved)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('DROP INDEX UNIQ_CE6515692D45FE4D');
+        $this->addSql('DROP INDEX UNIQ_CE651569772E836A8D94001992F8FB01E3AD3CF');
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP ismoved');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ce651569772e836a8d94001992f8fb012d45fe4d ON neos_contentrepository_domain_model_nodedata (identifier, workspace, dimensionshash, movedto)');
+        $this->addSql('CREATE INDEX idx_ce6515692d45fe4d ON neos_contentrepository_domain_model_nodedata (movedto)');
+    }
+}

--- a/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
@@ -242,6 +242,7 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         $shadowNode = $this->nodeDataRepository->findShadowNodeByPath('/foo/bar/baz', $this->groupWorkspace, $groupContext->getDimensions());
         $this->assertInstanceOf(NodeData::class, $shadowNode);
         $this->assertNotNull($shadowNode->getMovedTo());
+        $this->assertTrue($shadowNode->isMoved());
         $this->assertTrue($shadowNode->isRemoved());
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -80,7 +80,8 @@ class NodeImportServiceTest extends UnitTestCase
                     'en_US',
                     'en_UK'
                 )
-            )
+            ),
+            'ismoved' => false
         );
         $nodeImportService->expects($this->once())->method('persistNodeData')->will($this->returnCallback(function ($nodeData) use (&$actualNodeData) {
             unset($nodeData['Persistence_Object_Identifier']);
@@ -136,7 +137,8 @@ class NodeImportServiceTest extends UnitTestCase
             ),
             'accessRoles' => array(),
             'dimensionValues' => array(
-            )
+            ),
+            'ismoved' => false
         );
         $actualIdentifier = null;
         $nodeImportService->expects($this->once())->method('persistNodeData')->will($this->returnCallback(function ($nodeData) use (&$actualNodeData, &$actualIdentifier) {
@@ -248,6 +250,7 @@ class NodeImportServiceTest extends UnitTestCase
                 'dimensionValues' => array(
                     'language' => array('en_US')
                 ),
+                'ismoved' => false
             ),
             array(
                 'identifier' => 'e45e3b2c-3f14-2c14-6230-687fa4696504',
@@ -296,7 +299,8 @@ class NodeImportServiceTest extends UnitTestCase
                 'accessRoles' => array(),
                 'dimensionValues' => array(
                     'language' => array('en_US')
-                )
+                ),
+                'ismoved' => false
             )
         );
         $nodeImportService->expects($this->atLeastOnce())->method('persistNodeData')->will($this->returnCallback(function ($nodeData) use (&$actualNodeDatas) {
@@ -367,7 +371,8 @@ class NodeImportServiceTest extends UnitTestCase
                 'accessRoles' => array(),
                 'dimensionValues' => array(
                     'language' => array('en_US')
-                )
+                ),
+                'ismoved' => false
             )
         );
         $nodeImportService->expects($this->atLeastOnce())->method('persistNodeData')->will($this->returnCallback(function ($nodeData) use (&$actualNodeDatas) {

--- a/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
@@ -88,6 +88,7 @@ class NodePublishingDependencySolverTest extends UnitTestCase
     {
         $mockNodeData = $this->getMockBuilder(NodeData::class)->setConstructorArgs(array($path, $this->mockWorkspace))->getMock();
         $mockNodeData->expects($this->any())->method('getMovedTo')->will($this->returnValue($movedTo));
+        $mockNodeData->expects($this->any())->method('isMoved')->will($this->returnValue($movedTo !== null));
         $mockNodeData->expects($this->any())->method('getPath')->will($this->returnValue($path));
         $mockNode = $this->getMockBuilder(Node::class)->setConstructorArgs(array($mockNodeData, $this->mockContext))->getMock();
         $mockNode->expects($this->any())->method('getNodeData')->will($this->returnValue($mockNodeData));


### PR DESCRIPTION
This removes `movedTo` from the index, as it is nullable and null is
always a distinct value. Instead a boolean flag `isMoved` is added.

Related code is adjusted as needed to handle the new flag, use it in
tests and queries.

The correct index now breaks renaming/moving of nodes, thus exposing a
flaw in the code flow.

See https://github.com/neos/neos-development-collection/issues/1908
