### PR TITLE
FEATURE: Add createMissingSitesNode to node:repair

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -191,6 +191,7 @@ reorderChildNodes
 For all nodes (or only those which match the --node-type filter specified with this
 command) which have configured child nodes, those child nodes are reordered according to the
 position from the parents NodeType configuration.
+
 <u>Missing default properties</u>
 addMissingDefaultValues
 

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -192,9 +192,9 @@ HELPTEXT;
         if ($sitesNode === null) {
             if ($dryRun === false) {
                 $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
-                $this->output->outputLine('Created "%s" node', [SiteService::SITES_ROOT_PATH]);
+                $this->output->outputLine('Missing "%s" node was created', [SiteService::SITES_ROOT_PATH]);
             } else {
-                $this->output->outputLine('Found missing "%s" node', [SiteService::SITES_ROOT_PATH]);
+                $this->output->outputLine('"%s" node is missing!', [SiteService::SITES_ROOT_PATH]);
             }
         }
 

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -110,6 +110,12 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
         switch ($controllerCommandName) {
             case 'repair':
                 return <<<'HELPTEXT'
+<u>Create missing sites node</u>
+createMissingSitesNode
+
+If needed, creates a missing "/sites" node, which is essential for Neos to work
+properly.
+
 <u>Generate missing URI path segments</u>
 generateUriPathSegments
 
@@ -143,7 +149,8 @@ HELPTEXT;
         $this->output = $output;
         $commandMethods = [
             'generateUriPathSegments' => [ 'cleanup' => false ],
-            'removeContentDimensionsFromRootAndSitesNode' => [ 'cleanup' => true ]
+            'removeContentDimensionsFromRootAndSitesNode' => [ 'cleanup' => true ],
+            'createMissingSitesNode' => [ 'cleanup' => true ]
         ];
 
         $skipCommandNames = Arrays::trimExplode(',', ($skip === null ? '' : $skip));
@@ -164,6 +171,34 @@ HELPTEXT;
                     $this->$commandMethodName($workspaceName, $dryRun, $nodeType);
                 }
         }
+    }
+
+    /**
+     * Creates the /sites node if it is missing.
+     *
+     * @param string $workspaceName Name of the workspace to consider (unused)
+     * @param boolean $dryRun Simulate?
+     * @return void
+     */
+    protected function createMissingSitesNode($workspaceName, $dryRun)
+    {
+        $this->output->outputLine('Checking for "%s" node ...', array(SiteService::SITES_ROOT_PATH));
+        $rootNode = $this->contextFactory->create()->getRootNode();
+        // We fetch the workspace to be sure it's known to the persistence manager and persist all
+        // so the workspace and site node are persisted before we import any nodes to it.
+        $rootNode->getContext()->getWorkspace();
+        $this->persistenceManager->persistAll();
+        $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
+        if ($sitesNode === null) {
+            if ($dryRun === false) {
+                $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
+                $this->output->outputLine('Created "%s" node', [SiteService::SITES_ROOT_PATH]);
+            } else {
+                $this->output->outputLine('Found missing "%s" node', [SiteService::SITES_ROOT_PATH]);
+            }
+        }
+
+        $this->persistenceManager->persistAll();
     }
 
     /**


### PR DESCRIPTION
When the `/sites` node is missing, Neos can work quite well, but
at least `removeOrphanNodes` will wreck havoc! So this adds a
task to create the sites node if missing.

Note: since `removeOrphanNodes` is in the CR, which has no
notion of what the nodes inside it mean, this check was added
"separately".