### PR TITLE
BUGFIX: ImageMagick PDF to Image sometimes results in black background

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -66,6 +66,9 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $im->setImageFormat('png');
             $im->setImageBackgroundColor('white');
             $im->setImageCompose(\Imagick::COMPOSITE_OVER);
+            if (defined('\Imagick::ALPHACHANNEL_FLATTEN')) {
+                $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_FLATTEN);
+            }
             if (defined('\Imagick::ALPHACHANNEL_OFF')) {
                 // ImageMagick >= 7.0, Imagick >= 3.4.3RC1
                 // @see https://pecl.php.net/package/imagick/3.4.3RC1


### PR DESCRIPTION
**What I did**
I want to convert a PDF with transparencies into a thumbnail

**How I did it**
I use the DocumentThumbnailGenerator.

**How to verify it**
Try to convert this (https://goo.gl/xKMEC2) PDF-File