### PR TITLE
BUGFIX: Fix asset references detection for nodes even more

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -235,6 +235,14 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
                 continue;
             }
 
+            $flowQuery = new FlowQuery([$node]);
+            $documentNode = $flowQuery->closest('[instanceof TYPO3.Neos:Document]')->get(0);
+            // this should actually never happen, too.
+            if (!$documentNode) {
+                $inaccessibleRelations[] = $inaccessibleRelation;
+                continue;
+            }
+
             $site = $node->getContext()->getCurrentSite();
             foreach ($existingSites as $existingSite) {
                 /** @var Site $existingSite **/
@@ -243,9 +251,6 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
                     $site = $existingSite;
                 }
             }
-
-            $flowQuery = new FlowQuery([$node]);
-            $documentNode = $flowQuery->closest('[instanceof TYPO3.Neos:Document]')->get(0);
 
             $relatedNodes[$site->getNodeName()]['site'] = $site;
             $relatedNodes[$site->getNodeName()]['nodes'][] = [


### PR DESCRIPTION
Even after #1762 showing asset usage sometimes fails, with an error
that can only be explained by `documentNode` being null when trying
to render a reference.

This change adds another safety net for that case.