### PR TITLE
BUGFIX: Typo in WorkspaceException #1395841899

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Service/PublishingService.php
@@ -169,7 +169,7 @@ class PublishingService implements PublishingServiceInterface
     protected function doDiscardNode(NodeInterface $node, array &$alreadyDiscardedNodeIdentifiers = [])
     {
         if ($node->getWorkspace()->getBaseWorkspace() === null) {
-            throw new WorkspaceException('Nodes in a in a workspace without a base workspace cannot be discarded.', 1395841899);
+            throw new WorkspaceException('Nodes in a workspace without a base workspace cannot be discarded.', 1395841899);
         }
         if ($node->getPath() === '/') {
             return;


### PR DESCRIPTION
Duplicate "in a".