### PR TITLE
TASK: Remove base prototype and template path from autogenerated fusion for Node and Document

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/DefaultContentPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultContentPrototypeGenerator.php
@@ -27,4 +27,11 @@ class DefaultContentPrototypeGenerator extends DefaultPrototypeGenerator
      * @var string
      */
     protected $basePrototypeName = 'Neos.Neos:Content';
+
+    /**
+     * The template path in the package where templates are found
+     *
+     * @var string
+     */
+    protected $templatePath = 'Private/Templates/NodeTypes';
 }

--- a/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
@@ -17,6 +17,7 @@ use Neos\Flow\Annotations as Flow;
  * Generate a Fusion prototype definition based on Neos.Neos:Document
  *
  * @Flow\Scope("singleton")
+ * @deprecated will be removed with Neos 5
  * @api
  */
 class DefaultDocumentPrototypeGenerator extends DefaultPrototypeGenerator

--- a/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
@@ -22,10 +22,4 @@ use Neos\Flow\Annotations as Flow;
  */
 class DefaultDocumentPrototypeGenerator extends DefaultPrototypeGenerator
 {
-    /**
-     * The Name of the prototype that is extended
-     *
-     * @var string
-     */
-    protected $basePrototypeName = null;
 }

--- a/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultDocumentPrototypeGenerator.php
@@ -27,5 +27,5 @@ class DefaultDocumentPrototypeGenerator extends DefaultPrototypeGenerator
      *
      * @var string
      */
-    protected $basePrototypeName = 'Neos.Neos:Document';
+    protected $basePrototypeName = null;
 }

--- a/Neos.Neos/Classes/Domain/Service/DefaultPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultPrototypeGenerator.php
@@ -29,6 +29,13 @@ class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
     protected $basePrototypeName = null;
 
     /**
+     * The node template path inside the package resources
+     *
+     * @var string
+     */
+    protected $templatePath = null;
+
+    /**
      * Generate a Fusion prototype definition for a given node type
      *
      * A node will be rendered by Neos.Neos:Content by default with a template in
@@ -45,14 +52,16 @@ class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
         }
 
         $output = 'prototype(' . $nodeType->getName() . ')';
-        if ($this->basePrototypeName) {
+        if ($this->basePrototypeName !== null) {
             $output .= ' < prototype(' . $this->basePrototypeName . ')';
         }
         $output .= ' {' . chr(10);
 
-        list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
-        $templatePath = 'resource://' . $packageKey . '/Private/Templates/NodeTypes/' . $relativeName . '.html';
-        $output .= "\t" . 'templatePath = \'' . $templatePath . '\'' . chr(10);
+        if ($this->templatePath !== null) {
+            list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
+            $nodeTemplatePath = 'resource://' . $packageKey . '/' . $this->templatePath . '/' . $relativeName . '.html';
+            $output .= "\t" . 'templatePath = \'' . $nodeTemplatePath . '\'' . chr(10);
+        }
 
         foreach ($nodeType->getProperties() as $propertyName => $propertyConfiguration) {
             if (isset($propertyName[0]) && $propertyName[0] !== '_') {

--- a/Neos.Neos/Classes/Domain/Service/DefaultPrototypeGenerator.php
+++ b/Neos.Neos/Classes/Domain/Service/DefaultPrototypeGenerator.php
@@ -26,7 +26,7 @@ class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
      *
      * @var string
      */
-    protected $basePrototypeName = 'Neos.Fusion:Template';
+    protected $basePrototypeName = null;
 
     /**
      * Generate a Fusion prototype definition for a given node type
@@ -44,7 +44,11 @@ class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
             return '';
         }
 
-        $output = 'prototype(' . $nodeType->getName() . ') < prototype(' . $this->basePrototypeName . ') {' . chr(10);
+        $output = 'prototype(' . $nodeType->getName() . ')';
+        if ($this->basePrototypeName) {
+            $output .= ' < prototype(' . $this->basePrototypeName . ')';
+        }
+        $output .= ' {' . chr(10);
 
         list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
         $templatePath = 'resource://' . $packageKey . '/Private/Templates/NodeTypes/' . $relativeName . '.html';

--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -4,7 +4,7 @@
   abstract: TRUE
   options:
     fusion:
-      prototypeGenerator: ~
+      prototypeGenerator: Neos\Neos\Domain\Service\DefaultPrototypeGenerator
   ui:
     inspector:
       tabs:
@@ -129,6 +129,9 @@
     nodeTypes:
       '*': FALSE
       'Neos.Neos:Document': TRUE
+  options:
+    fusion:
+      prototypeGenerator: Neos\Neos\Domain\Service\DefaultDocumentPrototypeGenerator
   ui:
     label: 'Document'
     search:

--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -4,7 +4,7 @@
   abstract: TRUE
   options:
     fusion:
-      prototypeGenerator: Neos\Neos\Domain\Service\DefaultPrototypeGenerator
+      prototypeGenerator: ~
   ui:
     inspector:
       tabs:
@@ -129,9 +129,6 @@
     nodeTypes:
       '*': FALSE
       'Neos.Neos:Document': TRUE
-  options:
-    fusion:
-      prototypeGenerator: Neos\Neos\Domain\Service\DefaultDocumentPrototypeGenerator
   ui:
     label: 'Document'
     search:


### PR DESCRIPTION
The base prototypes and templatePathes are not set by the prototypeGenrator for Neos.Neos:Node and Neos.Neos:Document any more.  For convenience reasons the prototypes for each NodeTypes are declared without base prototype and template all node properties are made accessible as fusion props.