### PR TITLE
BUGFIX: Fix Fusion exception after login to Neos

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -131,7 +131,7 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
 		tagName = 'div'
 		@position = 'after neosBackendDocumentNodeData'
 		attributes = Neos.Fusion:Attributes {
-			data-preview-uri = NodeUri {
+			data-preview-uri = Neos.Neos:NodeUri {
 				node = ${q(documentNode).context({'workspaceName': documentNode.context.workspace.baseWorkspace.name}).get(0)}
 			}
 		}


### PR DESCRIPTION
The Fusion configuration of `neosBackendMetaData.attributes.data-preview-uri`
lacked a fully qualified Fusion object name, leading to an expansion to
`Neos.Fusion:NodeUri`. That does not exist, leading to an exception right after
login.

Fixes #1971
