### PR TITLE
FEATURE: Add `CanRender` Fusion prototype

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/CanRenderImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CanRenderImplementation.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\FusionObjects\AbstractFusionObject;
+
+/**
+ * CanRender Fusion-Object
+ *
+ * The CanRender Fusion object checks whether the given type can be rendered
+ */
+class CanRenderImplementation extends AbstractFusionObject
+{
+    /**
+     * Fusion type which shall be rendered
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->tsValue('type');
+    }
+
+    /**
+     * @return boolean
+     */
+    public function evaluate()
+    {
+        return $this->runtime->canRender('/type<' . $this->getType() . '>');
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -7,6 +7,7 @@ prototype(Neos.Fusion:Renderer).@class = 'Neos\\Fusion\\FusionObjects\\RendererI
 prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
 prototype(Neos.Fusion:Debug).@class = 'Neos\\Fusion\\FusionObjects\\DebugImplementation'
 prototype(Neos.Fusion:Component).@class = 'Neos\\Fusion\\FusionObjects\\ComponentImplementation'
+prototype(Neos.Fusion:CanRender).@class = 'Neos\\Fusion\\FusionObjects\\CanRenderImplementation'
 
 prototype(Neos.Fusion:Collection) {
 	@class = 'Neos\\Fusion\\FusionObjects\\CollectionImplementation'

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -520,8 +520,9 @@ Example::
 Neos.Fusion:CanRender
 ---------------------
 
-Check whether a fusion prototype can be rendered. For beeing renderable a prototype must exist and have an
-implementation class. The implementation class can be defined indirectly via base prototypes.
+Check whether a Fusion prototype can be rendered. For being renderable a prototype must exist and have an implementation class, or inherit from an existing renderable prototype.
+
+The implementation class can be defined indirectly via base prototypes.
 
 :type: (string) The prototype name that is checked
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -517,6 +517,19 @@ Example::
 		}
 	}
 
+Neos.Fusion:CanRender
+---------------------
+
+Check whether a fusion prototype can be rendered. For beeing renderable a prototype must exist and have an
+implementation class. The implementation class can be defined indirectly via base prototypes.
+
+:type: (string) The prototype name that is checked
+
+Example::
+
+	canRender = Neos.Fusion:CanRender {
+		type = 'My.Package:Prototype'
+	}
 
 Neos.Neos Fusion Objects
 =============================

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -520,9 +520,7 @@ Example::
 Neos.Fusion:CanRender
 ---------------------
 
-Check whether a Fusion prototype can be rendered. For being renderable a prototype must exist and have an implementation class, or inherit from an existing renderable prototype.
-
-The implementation class can be defined indirectly via base prototypes.
+Check whether a Fusion prototype can be rendered. For being renderable a prototype must exist and have an implementation class, or inherit from an existing renderable prototype. The implementation class can be defined indirectly via base prototypes.
 
 :type: (string) The prototype name that is checked
 


### PR DESCRIPTION
The prototype checks wether the given type is renderable by fusion. Which means
that the prototype exists and has an implementation class or is based on a prototype that
has one.