### PR TITLE
BUGFIX: Skip CSRF protection in logout action

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/LoginController.php
@@ -202,6 +202,8 @@ class LoginController extends AbstractAuthenticationController
      * The possible redirection URI is queried from the redirection service
      * at first, before the actual logout takes place, and the session gets destroyed.
      *
+     * @Flow\SkipCsrfProtection
+     *
      * @return void
      */
     public function logoutAction()


### PR DESCRIPTION
Since we overwrite the `logoutAction` from Flow, we need to annotate it with `@Flow\SkipCsrfProtection` here too.

see neos/flow-development-collection#1014