### PR TITLE
BUGFIX: Avoid getPath() on null in LinkingService

### DIFF
--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -289,7 +289,7 @@ class LinkingService
             ->uriFor('show', array('node' => $resolvedNode), 'Frontend\Node', 'Neos.Neos');
 
         $siteNode = $resolvedNode->getContext()->getCurrentSiteNode();
-        if (NodePaths::isSubPathOf($siteNode->getPath(), $resolvedNode->getPath())) {
+        if ($siteNode instanceof NodeInterface && NodePaths::isSubPathOf($siteNode->getPath(), $resolvedNode->getPath())) {
             /** @var Site $site */
             $site = $resolvedNode->getContext()->getCurrentSite();
         } else {


### PR DESCRIPTION
When the context of the "resolved" node does not have a "current" site
in `LinkingService.createNodeUri()` a fatal error was triggered. This
adds a check and handles the case like a site node path mismatch.