### PR TITLE
BUGFIX: Exclude shadow nodes in findOneByIdentifier

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Repository/NodeDataRepository.php
@@ -345,6 +345,11 @@ class NodeDataRepository extends Repository
         }
 
         $queryBuilder = $this->createQueryBuilder($workspaces);
+        if ($removedNodes === false) {
+            $queryBuilder->andWhere('n.movedTo IS NULL OR n.removed = FALSE');
+        } else {
+            $queryBuilder->andWhere('n.movedTo IS NULL');
+        }
         if ($dimensions !== null) {
             $this->addDimensionJoinConstraintsToQueryBuilder($queryBuilder, $dimensions);
         } else {

--- a/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/MoveNode.feature
+++ b/TYPO3.TYPO3CR/Tests/Behavior/Features/Basic/MoveNode.feature
@@ -29,6 +29,22 @@ Feature: Move node
     Then I should have 0 nodes
 
   @fixtures
+  Scenario: Move an unpublished node (into) in user workspace and get by identifier
+    Given I have the following nodes:
+      | Identifier                           | Path                     | Node Type                  | Properties             | Workspace  |
+      | c0fe0360-399b-11e8-b7ef-b7f4bc6ded24 | /sites/typo3cr/service-1 | TYPO3.TYPO3CR.Testing:Page | {"title": "Service 1"} | user-admin |
+    When I get a node by path "/sites/typo3cr/service-1" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I move the node into the node with path "/sites/typo3cr/service"
+    And I get a node by identifier "c0fe0360-399b-11e8-b7ef-b7f4bc6ded24" with the following context:
+      | Workspace  |
+      | user-admin |
+    Then I should have the following nodes:
+      | Path                             |
+      | /sites/typo3cr/service/service-1 |
+
+  @fixtures
   Scenario: Move a node (into) in user workspace and get nodes on path
     When I get a node by path "/sites/typo3cr/service" with the following context:
       | Workspace  |


### PR DESCRIPTION
Added a filtering for `movedTo` like we already do in `filterNodeDataByBestMatchInContext`.

See description of the discovered behavior in https://github.com/neos/neos-ui/issues/1523#issuecomment-379247165.

Closes #1986