### PR TITLE
TASK: Un-remove removed auto created child nodes in node repair

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Command/NodeCommandControllerPlugin.php
@@ -353,9 +353,13 @@ HELPTEXT;
                     try {
                         $childNode = $node->getNode($childNodeName);
                         $childNodeIdentifier = Utility::buildAutoCreatedChildNodeIdentifier($childNodeName, $node->getIdentifier());
-                        if ($childNode === null) {
+                        if ($childNode === null || $childNode->isRemoved() === true) {
                             if ($dryRun === false) {
-                                $node->createNode($childNodeName, $childNodeType, $childNodeIdentifier);
+                                if ($childNode === null) {
+                                    $node->createNode($childNodeName, $childNodeType, $childNodeIdentifier);
+                                } else {
+                                    $node->setRemoved(false);
+                                }
                                 $this->output->outputLine('Auto created node named "%s" in "%s"', array($childNodeName, $node->getPath()));
                             } else {
                                 $this->output->outputLine('Missing node named "%s" in "%s"', array($childNodeName, $node->getPath()));


### PR DESCRIPTION
When running the `createMissingChildNodes` in the `node:repair` command, check if a child node exists but has been removed, and if so un-remove it.