### PR TITLE
TASK: Enabled variable dumping to the console

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
@@ -31,7 +31,7 @@ class DebugImplementation extends ArrayImplementation
      *
      * @var array
      */
-    protected $ignoreProperties = ['__meta', 'title', 'plaintext'];
+    protected $ignoreProperties = ['__meta', 'title', 'plaintext', 'console', 'separator', 'maxDepth'];
 
     /**
      * @return mixed
@@ -50,6 +50,30 @@ class DebugImplementation extends ArrayImplementation
     }
 
     /**
+     * @return bool|null
+     */
+    public function getConsole()
+    {
+        return $this->fusionValue('console');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSeparator()
+    {
+        return $this->fusionValue('separator');
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxDepth()
+    {
+        return $this->fusionValue('maxDepth');
+    }
+
+    /**
      * Return the values in a human readable form
      *
      * @return void|string
@@ -58,6 +82,9 @@ class DebugImplementation extends ArrayImplementation
     {
         $title = $this->getTitle();
         $plaintext = $this->getPlaintext();
+        $console = $this->getConsole();
+        $separator = $this->getSeparator();
+        $maxDepth = $this->getMaxDepth();
 
         $debugData = array();
         foreach (array_keys($this->properties) as $key) {
@@ -72,7 +99,123 @@ class DebugImplementation extends ArrayImplementation
         } elseif (array_key_exists('value', $debugData) && count($debugData) === 1) {
             $debugData = $debugData['value'];
         }
-
+        if ($console) {
+            return $this->dumpToConsole($debugData, $title, $separator, $maxDepth);
+        }
         return \Neos\Flow\var_dump($debugData, $title, true, $plaintext);
+    }
+
+    /**
+     * Return the values as JSON inside a script tag
+     *
+     * @param mixed $variable           The data that is supposed to be dumped
+     * @param string $title             The title of the data
+     * @param string|null $separator    The seperator used for name and class seperation
+     * @param int|null $maxDepth        Maximum depth of the dump
+     *
+     * @return string
+     */
+    protected function dumpToConsole($variable, $title, $separator, $maxDepth)
+    {
+        $consoleDump = json_encode($this->renderConsoleDump($variable, 0, $title, $separator, $maxDepth));
+        return ('<script>var neosFusionDebug = ' . $consoleDump . '; console.warn(neosFusionDebug);</script>');
+    }
+
+    /**
+     * Function that renders the console dump
+     *
+     * @param mixed $variable           The data rendered for the dump
+     * @param int $depth                Current depth
+     * @param string|null $name         Name of the data
+     * @param string|null $separator    The seperator used for name and class seperation
+     * @param int|null $maxDepth        Maximum depth of the dump
+     *
+     * @return array
+     */
+    protected function renderConsoleDump($variable, $depth, $name, $separator, $maxDepth)
+    {
+        if ($separator === null) {
+            $separator = '::';
+        }
+        if ($name === null) {
+            $name = '';
+        } else {
+            $name .= $separator;
+        }
+        if ($maxDepth === null) {
+            $maxDepth = 5;
+        }
+        $result = [];
+        if ($depth > $maxDepth) {
+            return ['RECURSION ... ' . chr(10)];
+        }
+        if (is_string($variable)) {
+            $croppedValue = (strlen($variable) > 2000) ? substr($variable, 0, 2000) . '…' : $variable;
+            $result[$name . 'string'] = $croppedValue;
+        } elseif (is_numeric($variable)) {
+            $result[$name . gettype($variable)] = $variable;
+        } elseif (is_array($variable)) {
+            $result[$name . 'array'] = $this->renderArray($variable, $depth, $separator, $maxDepth);
+        } elseif (is_object($variable)) {
+            $result[$name . gettype($variable)] =
+                $this->renderObject($variable, $depth, $separator, $maxDepth);
+        } elseif (is_bool($variable)) {
+            $result[$name . 'boolean'] = $variable;
+        } elseif (is_null($variable) || is_resource($variable)) {
+            $result[$name . gettype($variable)] = gettype($variable);
+        } else {
+            $result[$name . gettype($variable)] = 'UNHANDLED TYPE';
+        }
+        return $result;
+    }
+
+    /**
+     * Function that renders an array dump
+     *
+     * @param array $array      Array that is supposed to be dumped
+     * @param int $depth        Current depth
+     * @param string $separator The seperator used for name and class seperation
+     * @param int $maxDepth     Maximum depth of the dump
+     *
+     * @return array
+     */
+    protected function renderArray($array, $depth, $separator, $maxDepth)
+    {
+        $result = [];
+        array_walk($array, function ($value, $key) use (&$result, $depth, $separator, $maxDepth) {
+            $renderedValue = $this->renderConsoleDump($value, $depth + 1, $key, $separator, $maxDepth);
+            $renderedValueTitle = array_keys($renderedValue)[0];
+            $result[$renderedValueTitle] = $renderedValue[$renderedValueTitle];
+            unset($renderedValue);
+            unset($renderedValueTitle);
+        });
+        return $result;
+    }
+
+    /**
+     * Function that renders an object dump
+     *
+     * @param object $object    Object that is supposed to be dumped
+     * @param int $depth        Current depth
+     * @param string $separator The seperator used for name and class seperation
+     * @param int $maxDepth     Maximum depth of the dump
+     *
+     * @return array
+     */
+    protected function renderObject($object, $depth, $separator, $maxDepth)
+    {
+        $result = [];
+        $objectReflection = new \ReflectionObject($object);
+        $properties = $objectReflection->getProperties();
+        foreach ($properties as $property) {
+            $property->setAccessible(true);
+            $value = $property->getValue($object);
+            $renderedValue = $this->renderConsoleDump($value, $depth + 1, $property->getName(), $separator, $maxDepth);
+            $renderedValueTitle = array_keys($renderedValue)[0];
+            $result[$renderedValueTitle] = $renderedValue[$renderedValueTitle];
+            unset($renderedValue);
+            unset($renderedValueTitle);
+        }
+        return $result;
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
@@ -85,4 +85,49 @@ class DebugTest extends AbstractFusionObjectTest
         $this->assertEquals(' string "foo" (3) => string "foo" (3)', $lines[2]);
         $this->assertEquals(' string "bar" (3) => string "bar" (3)', $lines[3]);
     }
+
+    /**
+     * @test
+     */
+    public function consoleOutput()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debug/consoleOutput');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals(
+            '<script>var neosFusionDebug = {"helloWorld::string":"hello world"};'
+            . ' console.warn(neosFusionDebug);</script>',
+            $lines[0]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function consoleOutputWithSeparator()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debug/consoleOutputWithSeparator');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals(
+            '<script>var neosFusionDebug = {"withSeparator:::string":"hello world"};'
+            . ' console.warn(neosFusionDebug);</script>',
+            $lines[0]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function consoleOutputWithMaxDepth()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debug/consoleOutputWithMaxDepth');
+        $lines = explode(chr(10), $view->render());
+        $this->assertEquals(
+            '<script>var neosFusionDebug = {"withMaxDepth::object":["RECURSION ... \n"]};'
+            . ' console.warn(neosFusionDebug);</script>',
+            $lines[0]
+        );
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
@@ -4,28 +4,48 @@ prototype(Neos.Fusion:Debug) {
 	plaintext = TRUE
 }
 
-debug.empty = Debug
+debug.empty = Neos.Fusion:Debug
 
-debug.null = Debug {
+debug.null = Neos.Fusion:Debug {
 	value = NULL
 }
 
-debug.nullWithTitle = Debug {
+debug.nullWithTitle = Neos.Fusion:Debug {
 	title = 'Title'
 	value = NULL
 }
 
-debug.eelExpression = Debug {
+debug.eelExpression = Neos.Fusion:Debug {
 	value = ${'hello' + ' ' + 'world'}
 }
 
-debug.fusionObjectExpression = Debug {
-	value = Value {
+debug.fusionObjectExpression = Neos.Fusion:Debug {
+	value = Neos.Fusion:Value {
 		value = 'hello world'
 	}
 }
 
-debug.multipleValues = Debug {
-  foo = 'foo'
-  bar = 'bar'
+debug.multipleValues = Neos.Fusion:Debug {
+	foo = 'foo'
+	bar = 'bar'
+}
+
+debug.consoleOutput = Neos.Fusion:Debug {
+	title = 'helloWorld'
+	value = ${'hello world'}
+	console = true
+}
+
+debug.consoleOutputWithSeparator = Neos.Fusion:Debug {
+	title = 'withSeparator'
+	value = ${'hello world'}
+	console = true
+	separator = ':::'
+}
+
+debug.consoleOutputWithMaxDepth = Neos.Fusion:Debug {
+	title = 'withMaxDepth'
+	value = ${Configuration}
+	console = true
+	maxDepth = 0
 }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Added the possibility to output debug information to the console by using the option console=true with Fusion Debug.

**How I did it**

**How to verify it**
There are PHPUnit test to test the code. 
To test it manually, add the following to your page:

    @process.addDebugOutput = Neos.Fusion:Value {
                json = Neos.Fusion:Debug {
                    title = 'currentNode'
                    value = ${node}
                    console = true
                    maxDepth = 3
                    separator = '::'
                    @process.addDebugOutput = ${value}
                }
        value = ${value + this.json}
    }

And check the browser console after a reload of the page.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
