### PR TITLE
FEATURE: Ability to use SQL in node migration filters

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Filters/DoctrineFilterInterface.php
+++ b/Neos.ContentRepository/Classes/Migration/Filters/DoctrineFilterInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace Neos\ContentRepository\Migration\Filters;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Doctrine\Query;
+
+interface DoctrineFilterInterface
+{
+    public function getFilterExpressions(Query $baseQuery): array;
+}

--- a/Neos.ContentRepository/Classes/Migration/Filters/NodeType.php
+++ b/Neos.ContentRepository/Classes/Migration/Filters/NodeType.php
@@ -11,15 +11,23 @@ namespace Neos\ContentRepository\Migration\Filters;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
-use Neos\Utility\ObjectAccess;
+use Doctrine\ORM\Query\Expr;
 use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Flow\Persistence\Doctrine\Query;
 
 /**
  * Filter nodes by node type.
  */
-class NodeType implements FilterInterface
+class NodeType implements DoctrineFilterInterface
 {
+    /**
+     * @var NodeTypeManager
+     * @Flow\Inject
+     */
+    protected $nodeTypeManager;
+
     /**
      * The node type to match on.
      *
@@ -30,14 +38,14 @@ class NodeType implements FilterInterface
     /**
      * If set to true also all subtypes of the given nodeType will match.
      *
-     * @var boolean
+     * @var bool
      */
     protected $withSubTypes = false;
 
     /**
      * If set this NodeType is actually excluded instead exclusively included.
      *
-     * @var boolean
+     * @var bool
      */
     protected $exclude = false;
 
@@ -59,7 +67,7 @@ class NodeType implements FilterInterface
      * Note: This can only be used with node types still available in the
      * system!
      *
-     * @param boolean $withSubTypes
+     * @param bool $withSubTypes
      * @return void
      */
     public function setWithSubTypes($withSubTypes)
@@ -70,33 +78,35 @@ class NodeType implements FilterInterface
     /**
      * Whether the filter should exclude the given NodeType instead of including only this node type.
      *
-     * @param boolean $exclude
+     * @param bool $exclude
      */
-    public function setExclude($exclude)
+    public function setExclude(bool $exclude)
     {
         $this->exclude = $exclude;
     }
 
     /**
-     * Returns TRUE if the given node is of the node type this filter expects.
-     *
-     * @param NodeData $node
-     * @return boolean
+     * @param Query $baseQuery
+     * @return array
+     * @throws \Neos\Flow\Persistence\Exception\InvalidQueryException
      */
-    public function matches(NodeData $node)
+    public function getFilterExpressions(Query $baseQuery): array
     {
-        if ($this->withSubTypes === true) {
-            $nodeIsMatchingNodeType = $node->getNodeType()->isOfType($this->nodeTypeName);
+        $nodeTypes = [$this->nodeTypeName];
+        if ($this->withSubTypes) {
+            foreach ($this->nodeTypeManager->getSubNodeTypes($this->nodeTypeName) as $nodeType) {
+                $nodeTypes[] = $nodeType->getName();
+            }
+        }
+
+        $filterExpressions = [];
+
+        if ($this->exclude) {
+            $filterExpressions[] = $baseQuery->logicalNot($baseQuery->in('nodeType', $nodeTypes));
         } else {
-            // This is needed to get the raw string NodeType to prevent errors for NodeTypes that no longer exist.
-            $nodeType = ObjectAccess::getProperty($node, 'nodeType', true);
-            $nodeIsMatchingNodeType = $nodeType === $this->nodeTypeName;
+            $filterExpressions[] = $baseQuery->in('nodeType', $nodeTypes);
         }
 
-        if ($this->exclude === true) {
-            return !$nodeIsMatchingNodeType;
-        }
-
-        return $nodeIsMatchingNodeType;
+        return $filterExpressions;
     }
 }

--- a/Neos.ContentRepository/Classes/Migration/Transformations/RemoveProperty.php
+++ b/Neos.ContentRepository/Classes/Migration/Transformations/RemoveProperty.php
@@ -52,6 +52,7 @@ class RemoveProperty extends AbstractTransformation
      *
      * @param NodeData $node
      * @return void
+     * @throws \Neos\ContentRepository\Exception\NodeException
      */
     public function execute(NodeData $node)
     {

--- a/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
@@ -1,0 +1,105 @@
+<?php
+namespace Neos\ContentRepository\Tests\Functional\Migration\Filters;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Query\Expr;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\Flow\Persistence\Doctrine\Query;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Migration\Filters\NodeType as NodeTypeFilter;
+
+/**
+ * Testcase for the NodeService
+ *
+ */
+class NodeTypeTest extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+    }
+
+    public function getFilterExpressionsDataprovider(): array
+    {
+        return [
+            'nodeTypeOnly' => [
+                'nodeType' => 'Neos.NodeTypes:Page',
+                'withSubTypes' => false,
+                'exclude' => false,
+                'expected' => 'n0_.nodetype IN (\'Neos.NodeTypes:Page\')',
+            ],
+            'nodeTypeAndSubTypes' => [
+                'nodeType' => 'Neos.NodeTypes:Page',
+                'withSubTypes' => true,
+                'exclude' => false,
+                'expected' => 'n0_.nodetype IN (\'Neos.NodeTypes:Page\', \'Neos.Demo:Homepage\')',
+            ],
+            'nodeTypeExclude' => [
+                'nodeType' => 'Neos.NodeTypes:Page',
+                'withSubTypes' => false,
+                'exclude' => true,
+                'expected' => 'NOT (n0_.nodetype IN (\'Neos.NodeTypes:Page\'))',
+            ],
+            'nodeTypeExcludeAndSubTypes' => [
+                'nodeType' => 'Neos.NodeTypes:Page',
+                'withSubTypes' => true,
+                'exclude' => true,
+                'expected' => 'NOT (n0_.nodetype IN (\'Neos.NodeTypes:Page\', \'Neos.Demo:Homepage\'))',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider getFilterExpressionsDataprovider
+     * @param string $nodeType
+     * @param bool $withSubTypes
+     * @param bool $exclude
+     * @param string $expected
+     * @throws \Neos\Flow\Persistence\Exception\InvalidQueryException
+     */
+    public function getFilterExpressions(string $nodeType, bool $withSubTypes, bool $exclude, string $expected)
+    {
+        $nodeTypeFilter = new NodeTypeFilter();
+        $nodeTypeFilter->setNodeType($nodeType);
+        $nodeTypeFilter->setWithSubTypes($withSubTypes);
+        $nodeTypeFilter->setExclude($exclude);
+
+        $filterExpressions = $nodeTypeFilter->getFilterExpressions(new Query(NodeData::class));
+        $query = new Query(NodeData::class);
+        $query->matching(call_user_func_array([new Expr(), 'andX'], $filterExpressions));
+
+        $actual = $query->getSql();
+        $this->assertStringEndsWith(' WHERE ' . $expected, $actual);
+    }
+}

--- a/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
@@ -1,0 +1,272 @@
+<?php
+namespace Neos\ContentRepository\Tests\Functional\Migration;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Migration\Domain\Model\Migration;
+use Neos\ContentRepository\Migration\Service\NodeMigration;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+
+class MigrationTest extends AbstractNodeTest
+{
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+    }
+
+    public function migrationDataprovider(): array
+    {
+        return [
+            'nodeTypeNoSubTypesShouldMatchType' => [
+                'migrationConfiguration' => [
+                    'up' => [
+                        'comments' => '',
+                        'migration' => [
+                            [
+                                'filters' => [
+                                    [
+                                        'type' => 'NodeType',
+                                        'settings' => [
+                                            'nodeType' => 'Neos.ContentRepository.Testing:Page',
+                                        ],
+                                    ],
+                                ],
+                                'transformations' => [
+                                    [
+                                        'type' => 'RemoveProperty',
+                                        'settings' => [
+                                            'property' => 'title',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'down' => [
+                        'comments' => '',
+                        'migration' => [
+                            'filters' => [],
+                            'transformations' => [],
+                        ],
+                    ],
+                ],
+                'migratedNodeIdentifier' => '25eaba22-b8ed-11e3-a8b5-c82a1441d728',
+                'propertyName' => 'title',
+                'expectedBefore' => '<h1>Products</h1>',
+                'expectedAfter' => '',
+            ],
+            'nodeTypeNoSubTypesShouldNotMatchSubtype' => [
+                'migrationConfiguration' => [
+                    'up' => [
+                        'comments' => '',
+                        'migration' => [
+                            [
+                                'filters' => [
+                                    [
+                                        'type' => 'NodeType',
+                                        'settings' => [
+                                            'nodeType' => 'Neos.ContentRepository.Testing:Document'
+                                        ],
+                                    ],
+                                ],
+                                'transformations' => [
+                                    [
+                                        'type' => 'RemoveProperty',
+                                        'settings' => [
+                                            'property' => 'title',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'down' => [
+                        'comments' => '',
+                        'migration' => [
+                            'filters' => [],
+                            'transformations' => [],
+                        ],
+                    ],
+                ],
+                'migratedNodeIdentifier' => '25eaba22-b8ed-11e3-a8b5-c82a1441d728',
+                'propertyName' => 'title',
+                'expectedBefore' => '<h1>Products</h1>',
+                'expectedAfter' => '<h1>Products</h1>',
+            ],
+            'nodeTypeWithSubTypesShouldMatchType' => [
+                'migrationConfiguration' => [
+                    'up' => [
+                        'comments' => '',
+                        'migration' => [
+                            [
+                                'filters' => [
+                                    [
+                                        'type' => 'NodeType',
+                                        'settings' => [
+                                            'nodeType' => 'Neos.ContentRepository.Testing:Document',
+                                            'withSubTypes' => true,
+                                        ],
+                                    ],
+                                ],
+                                'transformations' => [
+                                    [
+                                        'type' => 'RemoveProperty',
+                                        'settings' => [
+                                            'property' => 'title',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'down' => [
+                        'comments' => '',
+                        'migration' => [
+                            'filters' => [],
+                            'transformations' => [],
+                        ],
+                    ],
+                ],
+                'migratedNodeIdentifier' => '1f14f1f6-6118-5ea8-da9b-fc04ddf62e66',
+                'propertyName' => 'title',
+                'expectedBefore' => '<h1>Test Foo</h1>',
+                'expectedAfter' => '',
+            ],
+            'nodeTypeWithSubTypesShouldMatchSubType' => [
+                'migrationConfiguration' => [
+                    'up' => [
+                        'comments' => '',
+                        'migration' => [
+                            [
+                                'filters' => [
+                                    [
+                                        'type' => 'NodeType',
+                                        'settings' => [
+                                            'nodeType' => 'Neos.ContentRepository.Testing:Document',
+                                            'withSubTypes' => true,
+                                        ],
+                                    ],
+                                ],
+                                'transformations' => [
+                                    [
+                                        'type' => 'RemoveProperty',
+                                        'settings' => [
+                                            'property' => 'title',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'down' => [
+                        'comments' => '',
+                        'migration' => [
+                            'filters' => [],
+                            'transformations' => [],
+                        ],
+                    ],
+                ],
+                'migratedNodeIdentifier' => 'b9a53b2b-ae94-7730-2ac7-8f7fc1df72c4',
+                'propertyName' => 'title',
+                'expectedBefore' => '<h1>CMS</h1>',
+                'expectedAfter' => '',
+            ],
+            'nodeTypeWithSubTypesShouldNotMatchType' => [
+                'migrationConfiguration' => [
+                    'up' => [
+                        'comments' => '',
+                        'migration' => [
+                            [
+                                'filters' => [
+                                    [
+                                        'type' => 'NodeType',
+                                        'settings' => [
+                                            'nodeType' => 'Neos.ContentRepository.Testing:Document',
+                                            'withSubTypes' => true,
+                                        ],
+                                    ],
+                                ],
+                                'transformations' => [
+                                    [
+                                        'type' => 'RemoveProperty',
+                                        'settings' => [
+                                            'property' => 'title',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'down' => [
+                        'comments' => '',
+                        'migration' => [
+                            'filters' => [],
+                            'transformations' => [],
+                        ],
+                    ],
+                ],
+                'migratedNodeIdentifier' => 'b1e0e78d-04f3-8fc3-e3d1-e2399f831312',
+                'propertyName' => 'title',
+                'expectedBefore' => '<h1>Do you love Neos Flow?</h1>',
+                'expectedAfter' => '<h1>Do you love Neos Flow?</h1>',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider migrationDataprovider
+     * @param $migrationConfiguration
+     * @param $migratedNodeIdentifier
+     * @param $propertyName
+     * @param $expectedBefore
+     * @param $expectedAfter
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     * @throws \Neos\ContentRepository\Migration\Exception\MigrationException
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws \Neos\Flow\Persistence\Exception\UnknownObjectException
+     */
+    public function migration($migrationConfiguration, $migratedNodeIdentifier, $propertyName, $expectedBefore, $expectedAfter)
+    {
+        /** @var NodeDataRepository $nodeDataRepository */
+        $nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+
+        /** @var Workspace $workspace */
+        $workspace = $this->workspaceRepository->findByIdentifier('live');
+        $documentNode = $workspace->getRootNodeData()->createNodeData('test', $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Document'), '1f14f1f6-6118-5ea8-da9b-fc04ddf62e66');
+        $documentNode->setProperty('title', '<h1>Test Foo</h1>');
+        $this->persistenceManager->update($documentNode);
+        $this->persistenceManager->persistAll();
+
+        /** @var NodeData $nodeData */
+        $nodeData = $nodeDataRepository->findByNodeIdentifier($migratedNodeIdentifier)->getFirst();
+        $this->assertEquals($expectedBefore, $nodeData->getProperty($propertyName));
+
+        $migration = new Migration('20180409182707', $migrationConfiguration);
+        $nodeMigration = new NodeMigration($migration->getUpConfiguration()->getMigration());
+        $nodeMigration->execute();
+        $this->persistenceManager->persistAll();
+
+        $nodeData = $nodeDataRepository->findByNodeIdentifier($migratedNodeIdentifier)->getFirst();
+        $this->assertEquals($expectedAfter, $nodeData->getProperty($propertyName));
+    }
+}


### PR DESCRIPTION
Some node migration filters (e.g. the node type filter) should be done via SQL. This can improve performance dramatically as the database engine does the filtering for us, so we don't need to pull and locally filter all the nodes (which can take a long time if you have many nodes).

Fixes #1976