### PR TITLE
TASK: Don't show protected package property as that will go away

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
@@ -43,8 +43,7 @@ class PackagesController extends AbstractModuleController
                 'name' => $package->getComposerManifest('name'),
                 'type' => $package->getComposerManifest('type'),
                 'description' => $package->getComposerManifest('description'),
-                'isFrozen' => $this->packageManager->isPackageFrozen($package->getPackageKey()),
-                'isProtected' => $package->isProtected()
+                'isFrozen' => $this->packageManager->isPackageFrozen($package->getPackageKey())
             );
         }
         ksort($packageGroups);

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Packages/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Packages/Index.html
@@ -12,7 +12,6 @@
       <th>{neos:backend.translate(id: 'packages.key', source: 'Modules', package: 'Neos.Neos')}</th>
       <th>{neos:backend.translate(id: 'packages.type', source: 'Modules', package: 'Neos.Neos')}</th>
       <th class="neos-aCenter neos-span1">Frozen</th>
-      <th class="neos-aCenter neos-span1">Protected</th>
     </thead>
     <tbody>
       <f:for each="{packageGroups}" key="packageGroup" as="packages">
@@ -23,7 +22,6 @@
           <td class="neos-priority2">&nbsp;</td>
           <td class="neos-priority3">&nbsp;</td>
           <td class="neos-priority3">&nbsp;</td>
-          <td class="neos-priority1"> </td>
           <td class="neos-priority1"> </td>
           <td class="neos-priority1"> </td>
         </tr>
@@ -50,7 +48,6 @@
               </label>
             </td>
             <td class="neos-priority1 neos-aCenter"><i class="icon-{f:if(condition: package.isFrozen, then: 'check', else: 'times')}"></i></td>
-            <td class="neos-priority1 neos-aCenter"><i class="icon-{f:if(condition: package.isProtected, then: 'check', else: 'times')}"></i></td>
           </tr>
         </f:for>
       </f:for>


### PR DESCRIPTION
The ``protected`` property of packages doesn't make much sense anymore
now that disabling is gone. It will be removed in Flow and in
preparation should no longer be shown here.
