### PR TITLE
!!! TASK: Add very basic document prototype and template

### DIFF
--- a/Neos.NodeTypes/Resources/Private/Fusion/Documents/Page.fusion
+++ b/Neos.NodeTypes/Resources/Private/Fusion/Documents/Page.fusion
@@ -1,0 +1,10 @@
+prototype(Neos.NodeTypes:Page) < prototype(Neos.Neos:Page) {
+    body {
+        templatePath = 'resource://Neos.NodeTypes/Private/Templates/Documents/Page.html'
+        content {
+            main = Neos.Neos:PrimaryContent {
+                nodePath = 'main'
+            }
+        }
+    }
+}

--- a/Neos.NodeTypes/Resources/Private/Templates/Documents/Page.html
+++ b/Neos.NodeTypes/Resources/Private/Templates/Documents/Page.html
@@ -1,0 +1,1 @@
+{content.main -> f:format.raw()}


### PR DESCRIPTION
Add very basic prototype and template to ensure `Neos.NodeTypes:Page` works out of the box.

This is marked breaking since it can lead to unexpected behaviour if you only have the `page` path defined. But it is fairly easy to get your project up to speed with minimal code changes. See: 
https://github.com/neos/Neos.Demo/pull/42 (`page = Neos.NodeTypes:Page` as a fallback)
