### PR TITLE
TASK: Set default setting to disable the switch to old UI switch

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -390,7 +390,7 @@ Neos:
     Ui:
       frontendConfiguration:
         legacy:
-          disableLegacyUiSwitch: true
+          enableLegacyUiSwitch: false
 
   Flow:
     aop:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -387,6 +387,11 @@ Neos:
         ö: oe
         ü: ue
 
+    Ui:
+      frontendConfiguration:
+        legacy:
+          disableLegacyUiSwitch: true
+
   Flow:
     aop:
       globalObjects:


### PR DESCRIPTION
This introduces a new Setting to control whether the switch to old UI button should be shown or not.

```
Neos:
  Neos:
    Ui:
      frontendConfiguration:
        legacy:
          enableLegacyUiSwitch: <bool>
```

related https://github.com/neos/neos-ui/pull/1809