### PR TITLE
TASK: Fix the pencil icon in the mediabrowser

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -114,7 +114,7 @@
             <f:then>
                 <h2>
                     {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
-                    <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil', else: 'fas fa-plus')}"></i></span>
+                    <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
                 </h2>
             </f:then>
             <f:else>
@@ -138,7 +138,7 @@
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <div class="neos-sidelist-edit-actions">
-                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil"></i></f:link.action>
+                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                             <button type="submit" class="neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                         </div>
                     </li>
@@ -186,7 +186,7 @@
     <div class="neos-media-aside-group">
         <h2>
             {neos:backend.translate(id: 'tags', package: 'Neos.Media.Browser')}
-            <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: tags, then: 'fas fa-pencil', else: 'fas fa-plus')}"></i></span>
+            <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: tags, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
         </h2>
         <ul class="neos-media-aside-list">
             <li class="neos-media-list-all">
@@ -208,7 +208,7 @@
                         <span class="count">{tag.count}</span>
                     </f:link.action>
                     <div class="neos-sidelist-edit-actions">
-                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil"></i></f:link.action>
+                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                         <button class="neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="fas fa-trash"></i></button>
                     </div>
                 </li>


### PR DESCRIPTION
Look like `pencil` is only available in the pro version, we need to use `pencil-alt` 