### PR TITLE
TASK: Require neos/neos-ui* as default backend UI

### DIFF
--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -16,7 +16,9 @@
         "neos/fusion": "~4.0.0",
         "neos/fluid-adaptor": "~5.0.0",
         "behat/transliterator": "~1.0",
-        "neos/media": "~4.0.0"
+        "neos/media": "~4.0.0",
+        "neos/neos-ui": "~1.0.0",
+        "neos/neos-ui-compiled": "~1.0.0"
     },
     "suggest": {
         "neos/site-kickstarter": "Helps with creating new site packages for Neos.",


### PR DESCRIPTION
As the new react backend has become default, it should be required by neos/neos directly.