### PR TITLE
DOCS: Document custom background color for editPreviewMode

### DIFF
--- a/Neos.Neos/Documentation/ExtendingNeos/CustomEditPreviewMode.rst
+++ b/Neos.Neos/Documentation/ExtendingNeos/CustomEditPreviewMode.rst
@@ -34,6 +34,8 @@ Edit/preview modes are added to the Neos-Backend via *Settings.yaml*.
             width: 800
             # sets the height of the iframe (React UI only)
             height: 600
+            # custom background color for content canvas
+            backgroundColor: '#ffffff'
 
 The settings ``isEditingMode`` and ``isPreviewMode`` are controlling whether the mode will show up in the section "Edit"
 or "Preview" of the Neos-Backend. The major difference between both sections is that inside "Preview" section the inline


### PR DESCRIPTION
This PR adds documentation for the newlty introduced `backgroundColor` option for custom `editPreviewModes`

related: https://github.com/neos/neos-ui/pull/1864