### PR TITLE
TASK: Adjust test to change in Neos.Neos.Ui

### DIFF
--- a/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
@@ -17,6 +17,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Service\Mapping\NodePropertyConverterService;
+use Neos\Neos\Ui\Fusion\Helper\ActivationHelper;
 
 /**
  * Functional test case which tests the node property converter
@@ -149,6 +150,10 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
      */
     public function complexTypesWithGivenTypeConverterAreConvertedByTypeConverter()
     {
+        $mockActivationHelper = self::getMockBuilder(ActivationHelper::class)->getMock();
+        $mockActivationHelper->expects(self::any())->method('isLegacyBackendEnabled')->willReturn(true);
+        $this->objectManager->setInstance(ActivationHelper::class, $mockActivationHelper);
+
         $propertyValue = $this->getMockForAbstractClass(ImageInterface::class);
         $expected = json_encode([
             '__identity' => null,
@@ -163,7 +168,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
         $nodeType
             ->expects($this->any())
             ->method('getPropertyType')
-            ->willReturn('Neos\Media\Domain\Model\ImageInterface');
+            ->willReturn(ImageInterface::class);
 
         $node = $this
             ->getMockBuilder(Node::class)


### PR DESCRIPTION
The UI package comes with a new image serializer that needs to be
configured so the test sees it's expected result.

This change depends on [1b4562c8b71a595b48fec03fac9cd52b9f8c7a5e](https://github.com/neos/neos-ui/pull/1866/commits/1b4562c8b71a595b48fec03fac9cd52b9f8c7a5e) in the
UI package.
