### PR TITLE
BUGFIX: Fix Node migration without filter

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Service/NodeMigration.php
+++ b/Neos.ContentRepository/Classes/Migration/Service/NodeMigration.php
@@ -100,9 +100,11 @@ class NodeMigration
         foreach ($this->nodeFilterService->getFilterExpressions($migrationDescription['filters'], $baseQuery) as $filterExpression) {
             $filterExpressions[] = $filterExpression;
         }
-
+        
         $query = new Query(NodeData::class);
-        $query->matching(call_user_func_array([new Expr(), 'andX'], $filterExpressions));
+        if ($filterExpressions !== []) {
+            $query->matching(call_user_func_array([new Expr(), 'andX'], $filterExpressions));
+        }
         $iterator = $query->getQueryBuilder()->getQuery()->iterate();
 
         $processed = 0;


### PR DESCRIPTION
This change test if the migration contains a filter before creating the
contrains. Without this change the migration fails with an empty WHERE
clause.

This bug impact the migration `20150716212459`. This migration is used to
define default dimensions on all nodes.