### PR TITLE
TASK: Improve Fusion debugging experience

### DIFF
--- a/Neos.Fusion/Classes/DebugMessage.php
+++ b/Neos.Fusion/Classes/DebugMessage.php
@@ -12,7 +12,7 @@ namespace Neos\Fusion;
  */
 
 /**
- * A DTO to transport internal debugging messages
+ * A DTO for transporting internal debugging messages
  */
 class DebugMessage
 {

--- a/Neos.Fusion/Classes/DebugMessage.php
+++ b/Neos.Fusion/Classes/DebugMessage.php
@@ -1,0 +1,92 @@
+<?php
+namespace Neos\Fusion;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A DTO to transport internal debugging messages
+ */
+class DebugMessage
+{
+    /**
+     * @var int
+     */
+    protected $level;
+
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var mixed
+     */
+    protected $data;
+
+    /**
+     * @var bool
+     */
+    protected $plaintext;
+
+    public function __construct(string $title, string $path, $data, bool $plaintext, int $level = LOG_DEBUG)
+    {
+        $this->title = $title;
+        $this->path = $path;
+        $this->data = $data;
+        $this->plaintext = $plaintext;
+        $this->level = $level;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPlaintext(): bool
+    {
+        return $this->plaintext;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+}

--- a/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
@@ -30,6 +30,12 @@ class DebugDumpImplementation extends AbstractFusionObject
      */
     protected $stack;
 
+    public function isEnabled() : bool
+    {
+        return $this->fusionValue('enabled') ?: false;
+    }
+
+
     /**
      * Return the values in a human readable form
      *
@@ -37,7 +43,7 @@ class DebugDumpImplementation extends AbstractFusionObject
      */
     public function evaluate()
     {
-        if ($this->stack->hasMessage()) {
+        if ($this->stack->hasMessage() && $this->isEnabled()) {
             $this->getRuntime()->setEnableContentCache(false);
             $this->stack->dump();
         }

--- a/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
@@ -12,13 +12,12 @@ namespace Neos\Fusion\FusionObjects;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\DebugMessage;
 use Neos\Fusion\Service\DebugStack;
 
 /**
  * A Fusion object for dumping debugging fusion-values
  *
- * This need to be use as processor.
+ * This needs to be used as a processor
  *
  * @api
  */

--- a/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugDumpImplementation.php
@@ -1,0 +1,46 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\DebugMessage;
+use Neos\Fusion\Service\DebugStack;
+
+/**
+ * A Fusion object for dumping debugging fusion-values
+ *
+ * This need to be use as processor.
+ *
+ * @api
+ */
+class DebugDumpImplementation extends AbstractFusionObject
+{
+    /**
+     * @var DebugStack
+     * @Flow\Inject
+     */
+    protected $stack;
+
+    /**
+     * Return the values in a human readable form
+     *
+     * @return string
+     */
+    public function evaluate()
+    {
+        if ($this->stack->hasMessage()) {
+            $this->getRuntime()->setEnableContentCache(false);
+            $this->stack->dump();
+        }
+        return $this->fusionValue('value');
+    }
+}

--- a/Neos.Fusion/Classes/Service/DebugStack.php
+++ b/Neos.Fusion/Classes/Service/DebugStack.php
@@ -29,7 +29,7 @@ class DebugStack
         $this->data[] = $data;
     }
 
-    public function hasMessage()
+    public function hasMessage(): bool
     {
         return count($this->data) > 0;
     }
@@ -37,9 +37,14 @@ class DebugStack
     public function dump()
     {
         $data = $this->data;
-        $this->data = [];
+        $this->flush();
         foreach ($data as $debugMessage) {
             \Neos\Flow\var_dump($debugMessage->getData(), $debugMessage->getTitle(), false, $debugMessage->isPlaintext());
         }
+    }
+
+    public function flush()
+    {
+        $this->data = [];
     }
 }

--- a/Neos.Fusion/Classes/Service/DebugStack.php
+++ b/Neos.Fusion/Classes/Service/DebugStack.php
@@ -1,0 +1,45 @@
+<?php
+namespace Neos\Fusion\Service;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\DebugMessage;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class DebugStack
+{
+    /**
+     * @var DebugMessage[]
+     */
+    protected $data = [];
+
+    public function register(DebugMessage $data)
+    {
+        $this->data[] = $data;
+    }
+
+    public function hasMessage()
+    {
+        return count($this->data) > 0;
+    }
+
+    public function dump()
+    {
+        $data = $this->data;
+        $this->data = [];
+        foreach ($data as $debugMessage) {
+            \Neos\Flow\var_dump($debugMessage->getData(), $debugMessage->getTitle(), false, $debugMessage->isPlaintext());
+        }
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -5,10 +5,16 @@ prototype(Neos.Fusion:Case).@class = 'Neos\\Fusion\\FusionObjects\\CaseImplement
 prototype(Neos.Fusion:Matcher).@class = 'Neos\\Fusion\\FusionObjects\\MatcherImplementation'
 prototype(Neos.Fusion:Renderer).@class = 'Neos\\Fusion\\FusionObjects\\RendererImplementation'
 prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
-prototype(Neos.Fusion:Debug).@class = 'Neos\\Fusion\\FusionObjects\\DebugImplementation'
 prototype(Neos.Fusion:Component).@class = 'Neos\\Fusion\\FusionObjects\\ComponentImplementation'
 prototype(Neos.Fusion:CanRender).@class = 'Neos\\Fusion\\FusionObjects\\CanRenderImplementation'
-
+prototype(Neos.Fusion:DebugDump) {
+  @class = 'Neos\\Fusion\\FusionObjects\\DebugDumpImplementation'
+  value = ${value}
+}
+prototype(Neos.Fusion:Debug) {
+  @class = 'Neos\\Fusion\\FusionObjects\\DebugImplementation'
+  value = ${value}
+}
 prototype(Neos.Fusion:Collection) {
 	@class = 'Neos\\Fusion\\FusionObjects\\CollectionImplementation'
 	itemName = 'item'

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -10,6 +10,7 @@ prototype(Neos.Fusion:CanRender).@class = 'Neos\\Fusion\\FusionObjects\\CanRende
 prototype(Neos.Fusion:DebugDump) {
   @class = 'Neos\\Fusion\\FusionObjects\\DebugDumpImplementation'
   value = ${value}
+  enabled = true
 }
 prototype(Neos.Fusion:Debug) {
   @class = 'Neos\\Fusion\\FusionObjects\\DebugImplementation'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
@@ -11,6 +11,8 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Service\DebugStack;
+
 /**
  * Testcase for the Debug object
  *
@@ -18,14 +20,30 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
 class DebugTest extends AbstractFusionObjectTest
 {
     /**
+     * @var DebugStack
+     */
+    protected $debugStack;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->debugStack = $this->objectManager->get(DebugStack::class);
+        $this->debugStack->flush();
+    }
+
+    /**
      * @test
      */
     public function debugEmptyValue()
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/empty');
-        $lines = explode(chr(10), $view->render());
-        $this->assertEquals($lines[1], 'NULL');
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
+        $this->assertEquals('NULL', $lines[1]);
     }
 
     /**
@@ -35,8 +53,12 @@ class DebugTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/null');
-        $lines = explode(chr(10), $view->render());
-        $this->assertEquals($lines[1], 'NULL');
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
+        $this->assertEquals('NULL', $lines[1]);
     }
 
     /**
@@ -46,8 +68,12 @@ class DebugTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/nullWithTitle');
-        $lines = explode(chr(10), $view->render());
-        $this->assertEquals('Title', $lines[0]);
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
+        $this->assertEquals('Title @ debug/nullWithTitle<Neos.Fusion:Debug>.value', $lines[0]);
         $this->assertEquals('NULL', $lines[1]);
     }
 
@@ -58,7 +84,11 @@ class DebugTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/eelExpression');
-        $lines = explode(chr(10), $view->render());
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
         $this->assertEquals('string "hello world" (11)', $lines[1]);
     }
 
@@ -69,7 +99,11 @@ class DebugTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/fusionObjectExpression');
-        $lines = explode(chr(10), $view->render());
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
         $this->assertEquals('string "hello world" (11)', $lines[1]);
     }
 
@@ -80,9 +114,14 @@ class DebugTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('debug/multipleValues');
-        $lines = explode(chr(10), $view->render());
-        $this->assertEquals('array(2)', $lines[1]);
-        $this->assertEquals(' string "foo" (3) => string "foo" (3)', $lines[2]);
-        $this->assertEquals(' string "bar" (3) => string "bar" (3)', $lines[3]);
+        $view->render();
+        ob_start();
+        $this->debugStack->dump();
+        $result = ob_get_clean();
+        $lines = explode(chr(10), $result);
+        $this->assertEquals('@ debug/multipleValues<Neos.Fusion:Debug>.foo', $lines[0]);
+        $this->assertEquals('string "foo" (3)', $lines[1]);
+        $this->assertEquals('@ debug/multipleValues<Neos.Fusion:Debug>.bar', $lines[3]);
+        $this->assertEquals('string "bar" (3)', $lines[4]);
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
@@ -26,6 +26,6 @@ debug.fusionObjectExpression = Debug {
 }
 
 debug.multipleValues = Debug {
-  foo = 'foo'
-  bar = 'bar'
+	foo = 'foo'
+	bar = 'bar'
 }

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -227,7 +227,7 @@ Example::
         documentPath = ${documentNode.path}
   }
 
-  # the initial value is not changed, so you can plug the Debug prototype anywhere in your Fusion code
+  # the initial value is not changed, so you can define the Debug prototype anywhere in your Fusion code
 
 
 .. _Neos_Fusion__Component:

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -218,19 +218,16 @@ Shows the result of Fusion Expressions directly.
 
 Example::
 
-  debugObject = Debug {
+  valueToDebug = "hello neos world"
+  valueToDebug.@process.debug = Neos.Fusion:Debug {
         title = 'Debug of hello world'
-
-        # If only the "value"-key is given it is debugged directly,
-        # otherwise all keys except "title" and "plaintext" are debugged.
-        value = "hello neos world"
 
         # Additional values for debugging
         documentTitle = ${q(documentNode).property('title')}
         documentPath = ${documentNode.path}
   }
 
-  # the value of this object is the formatted debug output of all keys given to the object
+  # the initial value is not changed, so you can plug the Debug prototype anywhere in your Fusion code
 
 
 .. _Neos_Fusion__Component:

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -207,5 +207,7 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
 		}
 	}
 
+  @process.debugDump = Neos.Fusion:DebugDump
+
 	@exceptionHandler = 'Neos\\Neos\\Fusion\\ExceptionHandlers\\PageHandler'
 }


### PR DESCRIPTION
This change introduce a DebugStack to store all the debugging
message created with `Neos.Fusion:Debug`, to avoid breaking
the rendering when using var_dump before the HTTP request has
been send, this change flush the DebugStack at the end of the
page rendering. The new `Neos.Fusion:DebugDump` can be used as a
Fusion processor to flush the stack at any point during the
rendering.

The `DebugMessage` is used as a DTO to transport the debugging
informations. It contains a currently unused property `level`.
This property can be used in the future to use a logging backend to
store debugging informations or integrate with protocols like Chrome
Logger to send the debugging informations in the browser directly.