### PR TITLE
BUGFIX: Column NodeType should be abstract

### DIFF
--- a/Neos.NodeTypes/Configuration/NodeTypes.Content.Overrides.yaml
+++ b/Neos.NodeTypes/Configuration/NodeTypes.Content.Overrides.yaml
@@ -48,6 +48,7 @@
 
 # Neos.NodeTypes.ColumnLayouts
 'Neos.NodeTypes:Column':
+  abstract: true
   superTypes:
     'Neos.NodeTypes.ColumnLayouts:Column': true
 


### PR DESCRIPTION
The `Neos.NodeTypes:Column` NodeType was always abstract, the 
abtract property isn't inherited down so it must be set again
on any inheriting NodeType. So to have Column abstract it must
declare so (again).

Fixes: #2071
