### PR TITLE
BUGFIX: Make sure to materialize as few nodes as possible

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -1014,6 +1014,9 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function unsetContentObject()
     {
+        if ($this->getContentObject() === null) {
+            return;
+        }
         $this->materializeNodeDataAsNeeded();
         $this->nodeData->unsetContentObject();
 

--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/Domain/Model/Node.php
@@ -16,7 +16,6 @@ use TYPO3\Flow\Cache\CacheAwareInterface;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\TYPO3CR\Domain\Factory\NodeFactory;
-use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\Context;
 use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
@@ -448,11 +447,11 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setWorkspace(Workspace $workspace)
     {
-        if (!$this->isNodeDataMatchingContext()) {
-            $this->materializeNodeData();
-        }
         if ($this->getWorkspace()->getName() === $workspace->getName()) {
             return;
+        }
+        if (!$this->isNodeDataMatchingContext()) {
+            $this->materializeNodeData();
         }
         $this->nodeData->setWorkspace($workspace);
         $this->context->getFirstLevelNodeCache()->flush();
@@ -491,11 +490,11 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setIndex($index)
     {
-        if (!$this->isNodeDataMatchingContext()) {
-            $this->materializeNodeData();
-        }
         if ($this->getIndex() === $index) {
             return;
+        }
+        if (!$this->isNodeDataMatchingContext()) {
+            $this->materializeNodeData();
         }
         $this->nodeData->setIndex($index);
         $this->context->getFirstLevelNodeCache()->flush();
@@ -936,10 +935,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function removeProperty($propertyName)
     {
-        $this->materializeNodeDataAsNeeded();
         if (!$this->hasProperty($propertyName)) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->removeProperty($propertyName);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -986,10 +985,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setContentObject($contentObject)
     {
-        $this->materializeNodeDataAsNeeded();
         if ($this->getContentObject() === $contentObject) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->setContentObject($contentObject);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -1031,11 +1030,11 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setNodeType(NodeType $nodeType)
     {
-        if (!$this->isNodeDataMatchingContext()) {
-            $this->materializeNodeData();
-        }
         if ($this->getNodeType() === $nodeType) {
             return;
+        }
+        if (!$this->isNodeDataMatchingContext()) {
+            $this->materializeNodeData();
         }
         $this->nodeData->setNodeType($nodeType);
 
@@ -1300,10 +1299,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setHidden($hidden)
     {
-        $this->materializeNodeDataAsNeeded();
         if ($this->isHidden() === $hidden) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->setHidden($hidden);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -1330,10 +1329,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setHiddenBeforeDateTime(\DateTime $dateTime = null)
     {
-        $this->materializeNodeDataAsNeeded();
         if ($this->getHiddenBeforeDateTime() instanceof \DateTime && $dateTime instanceof \DateTime && $this->getHiddenBeforeDateTime()->format(\DateTime::W3C) === $dateTime->format(\DateTime::W3C)) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->setHiddenBeforeDateTime($dateTime);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -1360,10 +1359,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setHiddenAfterDateTime(\DateTime $dateTime = null)
     {
-        $this->materializeNodeDataAsNeeded();
         if ($this->getHiddenAfterDateTime() instanceof \DateTimeInterface && $dateTime instanceof \DateTimeInterface && $this->getHiddenAfterDateTime()->format(\DateTime::W3C) === $dateTime->format(\DateTime::W3C)) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->setHiddenAfterDateTime($dateTime);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -1390,10 +1389,10 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setHiddenInIndex($hidden)
     {
-        $this->materializeNodeDataAsNeeded();
         if ($this->isHiddenInIndex() === $hidden) {
             return;
         }
+        $this->materializeNodeDataAsNeeded();
         $this->nodeData->setHiddenInIndex($hidden);
 
         $this->context->getFirstLevelNodeCache()->flush();
@@ -1420,11 +1419,11 @@ class Node implements NodeInterface, CacheAwareInterface
      */
     public function setAccessRoles(array $accessRoles)
     {
-        if (!$this->isNodeDataMatchingContext()) {
-            $this->materializeNodeData();
-        }
         if ($this->getAccessRoles() === $accessRoles) {
             return;
+        }
+        if (!$this->isNodeDataMatchingContext()) {
+            $this->materializeNodeData();
         }
         $this->nodeData->setAccessRoles($accessRoles);
 

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
@@ -228,6 +228,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node = $this->setUpNodeWithNonMatchingContext();
         $node->expects($this->once())->method('materializeNodeDataAsNeeded');
 
+        $node->getNodeData()->expects($this->once())->method('getContentObject')->will($this->returnValue(new \stdClass()));
         $node->getNodeData()->expects($this->once())->method('unsetContentObject');
 
         $node->unsetContentObject();

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
@@ -166,7 +166,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function setPropertyOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
-        $node->expects($this->once())->method('shallowMaterializeNodeData');
+        $node->expects($this->once())->method('materializeNodeDataAsNeeded');
 
         $node->getNodeData()->expects($this->once())->method('setProperty')->with('propertyName', 'value');
 
@@ -205,7 +205,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $contentObject = new \stdClass();
 
         $node = $this->setUpNodeWithNonMatchingContext();
-        $node->expects($this->once())->method('shallowMaterializeNodeData');
+        $node->expects($this->once())->method('materializeNodeDataAsNeeded');
 
         $node->getNodeData()->expects($this->once())->method('setContentObject')->with($contentObject);
 
@@ -226,7 +226,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function unsetContentObjectOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
-        $node->expects($this->once())->method('shallowMaterializeNodeData');
+        $node->expects($this->once())->method('materializeNodeDataAsNeeded');
 
         $node->getNodeData()->expects($this->once())->method('unsetContentObject');
 
@@ -361,7 +361,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $context->expects($this->any())->method('getTargetDimensions')->will($this->returnValue(array()));
         $context->expects($this->any())->method('getFirstLevelNodeCache')->will($this->returnValue($mockFirstLevelNodeCache));
 
-        $node = $this->getMockBuilder(Node::class)->setMethods(array_merge(array('materializeNodeData', 'shallowMaterializeNodeData'), $configurableMethods))->setConstructorArgs(array($nodeData, $context))->getMock();
+        $node = $this->getMockBuilder(Node::class)->setMethods(array_merge(array('materializeNodeData', 'materializeNodeDataAsNeeded'), $configurableMethods))->setConstructorArgs(array($nodeData, $context))->getMock();
         return $node;
     }
 

--- a/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
+++ b/TYPO3.TYPO3CR/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
@@ -153,6 +153,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function setIndexOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
+        $node->expects($this->once())->method('materializeNodeData');
 
         $node->getNodeData()->expects($this->once())->method('setIndex')->with(5);
 
@@ -165,6 +166,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function setPropertyOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
+        $node->expects($this->once())->method('shallowMaterializeNodeData');
 
         $node->getNodeData()->expects($this->once())->method('setProperty')->with('propertyName', 'value');
 
@@ -203,6 +205,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $contentObject = new \stdClass();
 
         $node = $this->setUpNodeWithNonMatchingContext();
+        $node->expects($this->once())->method('shallowMaterializeNodeData');
 
         $node->getNodeData()->expects($this->once())->method('setContentObject')->with($contentObject);
 
@@ -223,6 +226,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function unsetContentObjectOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
+        $node->expects($this->once())->method('shallowMaterializeNodeData');
 
         $node->getNodeData()->expects($this->once())->method('unsetContentObject');
 
@@ -237,6 +241,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
 
         $node = $this->setUpNodeWithNonMatchingContext();
+        $node->expects($this->once())->method('materializeNodeData');
 
         $node->getNodeData()->expects($this->once())->method('setNodeType')->with($nodeType);
 
@@ -356,8 +361,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $context->expects($this->any())->method('getTargetDimensions')->will($this->returnValue(array()));
         $context->expects($this->any())->method('getFirstLevelNodeCache')->will($this->returnValue($mockFirstLevelNodeCache));
 
-        $node = $this->getMockBuilder(Node::class)->setMethods(array_merge(array('materializeNodeData'), $configurableMethods))->setConstructorArgs(array($nodeData, $context))->getMock();
-        $node->expects($this->once())->method('materializeNodeData');
+        $node = $this->getMockBuilder(Node::class)->setMethods(array_merge(array('materializeNodeData', 'shallowMaterializeNodeData'), $configurableMethods))->setConstructorArgs(array($nodeData, $context))->getMock();
         return $node;
     }
 


### PR DESCRIPTION
For property changes there is no necessity to materialize
auto-created child nodes as well. In projects with deeply
nested auto-created node structures this behaviour could
quickly generate huge amounts of changed nodes therefore
we should only materialize child nodes for structural
changes.

All of this is only valid for workspace materializations though,
in case dimensions need to be materialized as well, we need to
materialize all child nodes as well for consistency.
