### PR TITLE
BUGFIX: Fix regression in dimension menu introduced by #1159

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -148,7 +148,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      * @param array $targetDimensions
      * @return string
      */
-    protected function itemLabel(string $pinnedDimensionName, NodeInterface $nodeInDimensions, array $targetDimensions): string
+    protected function itemLabel(string $pinnedDimensionName, NodeInterface $nodeInDimensions = null, array $targetDimensions = null): string
     {
         if ($nodeInDimensions === null && $pinnedDimensionName === null) {
             $itemLabel = '';


### PR DESCRIPTION
This fixes a regression in dimension menu (introduced by #1159) by 
adding `null` as default arguments back in.