### PR TITLE
FEATURE: CacheEntries should respect the workspace they rely on

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/WorkspaceRepository.php
@@ -11,14 +11,18 @@ namespace Neos\ContentRepository\Domain\Repository;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\QueryInterface;
+use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Persistence\Repository;
 
 /**
  * The repository for workspaces
  *
  * @Flow\Scope("singleton")
+ * @method QueryResultInterface findByBaseWorkspace($baseWorkspace)
+ * @method Workspace findByIdentifier($baseWorkspace)
  */
 class WorkspaceRepository extends Repository
 {

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -109,7 +109,6 @@ class ContentCacheFlusher
 
         $nodeIdentifier = $node->getIdentifier();
         foreach ($this->workspacesToFlush[$node->getWorkspace()->getName()] as $workspaceName => $workspaceHash) {
-
             $this->registerChangeOnNodeIdentifier($workspaceHash .'_'. $nodeIdentifier);
             $this->registerChangeOnNodeType($node->getNodeType()->getName(), $nodeIdentifier, $workspaceHash);
 

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -14,7 +14,6 @@ namespace Neos\Neos\Fusion\Cache;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
@@ -24,6 +23,7 @@ use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Neos\Fusion\Helper\CachingHelper;
+use Psr\Log\LoggerInterface;
 
 /**
  * This service flushes Fusion content caches triggered by node changes.
@@ -44,7 +44,7 @@ class ContentCacheFlusher
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $systemLogger;
 
@@ -253,7 +253,7 @@ class ContentCacheFlusher
             foreach ($this->tagsToFlush as $tag => $logMessage) {
                 $affectedEntries = $this->contentCache->flushByTag($tag);
                 if ($affectedEntries > 0) {
-                    $this->systemLogger->log(sprintf('Content cache: Removed %s entries %s', $affectedEntries, $logMessage), LOG_DEBUG);
+                    $this->systemLogger->debug(sprintf('Content cache: Removed %s entries %s', $affectedEntries, $logMessage));
                 }
             }
         }

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -107,8 +107,8 @@ class ContentCacheFlusher
             return;
         }
 
+        $nodeIdentifier = $node->getIdentifier();
         foreach ($this->workspacesToFlush[$node->getWorkspace()->getName()] as $workspaceName => $workspaceHash) {
-            $nodeIdentifier = $node->getIdentifier();
 
             $this->registerChangeOnNodeIdentifier($workspaceHash .'_'. $nodeIdentifier);
             $this->registerChangeOnNodeType($node->getNodeType()->getName(), $nodeIdentifier, $workspaceHash);

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -98,7 +98,10 @@ class ContentCacheFlusher
     public function registerNodeChange(NodeInterface $node)
     {
         $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
-        $this->resolveWorkspaceChain($node->getWorkspace());
+
+        if (empty($this->workspacesToFlush[$node->getWorkspace()->getName()])) {
+            $this->resolveWorkspaceChain($node->getWorkspace());
+        }
 
         if (!array_key_exists($node->getWorkspace()->getName(), $this->workspacesToFlush)) {
             return;
@@ -248,7 +251,6 @@ class ContentCacheFlusher
     {
         if ($this->tagsToFlush !== []) {
             foreach ($this->tagsToFlush as $tag => $logMessage) {
-                $this->systemLogger->log('flushing tag ' . $tag);
                 $affectedEntries = $this->contentCache->flushByTag($tag);
                 if ($affectedEntries > 0) {
                     $this->systemLogger->log(sprintf('Content cache: Removed %s entries %s', $affectedEntries, $logMessage), LOG_DEBUG);

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -11,8 +11,10 @@ namespace Neos\Neos\Fusion\Cache;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\SystemLoggerInterface;
+use Neos\Flow\Log\PsrSystemLoggerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
@@ -21,6 +23,7 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Neos\Fusion\Helper\CachingHelper;
 
 /**
  * This service flushes Fusion content caches triggered by node changes.
@@ -41,14 +44,30 @@ class ContentCacheFlusher
 
     /**
      * @Flow\Inject
-     * @var SystemLoggerInterface
+     * @var PsrSystemLoggerInterface
      */
     protected $systemLogger;
 
     /**
      * @var array
      */
-    protected $tagsToFlush = array();
+    protected $tagsToFlush = [];
+
+    /**
+     * @var CachingHelper
+     */
+    protected $cachingHelper;
+
+    /**
+     * @Flow\Inject
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var array
+     */
+    protected $workspacesToFlush = [];
 
     /**
      * @Flow\Inject
@@ -74,50 +93,106 @@ class ContentCacheFlusher
      *
      * @param NodeInterface $node The node which has changed in some way
      * @return void
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
      */
     public function registerNodeChange(NodeInterface $node)
     {
         $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
+        $this->resolveWorkspaceChain($node->getWorkspace());
 
-        $this->registerChangeOnNodeType($node->getNodeType()->getName(), $node->getIdentifier());
-        $this->registerChangeOnNodeIdentifier($node->getIdentifier());
+        if (!array_key_exists($node->getWorkspace()->getName(), $this->workspacesToFlush)) {
+            return;
+        }
 
-        $originalNode = $node;
-        while ($node->getDepth() > 1) {
-            $node = $node->getParent();
-            // Workaround for issue #56566 in Neos.ContentRepository
-            if ($node === null) {
-                break;
+        foreach ($this->workspacesToFlush[$node->getWorkspace()->getName()] as $workspaceName => $workspaceHash) {
+            $nodeIdentifier = $node->getIdentifier();
+
+            $this->registerChangeOnNodeIdentifier($workspaceHash .'_'. $nodeIdentifier);
+            $this->registerChangeOnNodeType($node->getNodeType()->getName(), $nodeIdentifier, $workspaceHash);
+
+            $nodeInWorkspace = $node;
+            while ($nodeInWorkspace->getDepth() > 1) {
+                $nodeInWorkspace = $nodeInWorkspace->getParent();
+                // Workaround for issue #56566 in Neos.ContentRepository
+                if ($nodeInWorkspace === null) {
+                    break;
+                }
+                $tagName = 'DescendantOf_' . $workspaceHash . '_' . $nodeInWorkspace->getIdentifier();
+                $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $node->getPath());
             }
-            $tagName = 'DescendantOf_' . $node->getIdentifier();
-            $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $originalNode->getPath());
         }
     }
 
     /**
-     * @param string $nodeIdentifier
+     * @param Workspace $workspace
+     * @return void
      */
-    public function registerChangeOnNodeIdentifier($nodeIdentifier)
+    protected function resolveWorkspaceChain(Workspace $workspace)
     {
-        $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
-        $this->tagsToFlush['Node_' . $nodeIdentifier] = sprintf('which were tagged with "Node_%s" because that identifier has changed.', $nodeIdentifier);
+        $cachingHelper = $this->getCachingHelper();
 
-        // Note, as we don't have a node here we cannot go up the structure.
-        $tagName = 'DescendantOf_' . $nodeIdentifier;
-        $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $nodeIdentifier);
+        $this->workspacesToFlush[$workspace->getName()][$workspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspace->getName());
+        $this->resolveTagsForChildWorkspaces($workspace, $workspace->getName());
     }
 
     /**
+     * @param Workspace $workspace
+     * @param string $startingPoint
+     * @return void
+     */
+    protected function resolveTagsForChildWorkspaces(Workspace $workspace, string $startingPoint)
+    {
+        $cachingHelper = $this->getCachingHelper();
+        $this->workspacesToFlush[$startingPoint][$workspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspace->getName());
+
+        $childWorkspaces = $this->workspaceRepository->findByBaseWorkspace($workspace->getName());
+        if ($childWorkspaces->valid()) {
+            foreach ($childWorkspaces as $childWorkspace) {
+                $this->resolveTagsForChildWorkspaces($childWorkspace, $startingPoint);
+            }
+        }
+    }
+
+    /**
+     * Pleas use registerNodeChange() if possible. This method is a low-level api. If you do use this method make sure
+     * that $cacheIdentifier contains the workspacehash as well as the node identifier: $workspaceHash .'_'. $nodeIdentifier
+     * The workspacehash can be received via $this->getCachingHelper()->renderWorkspaceTagForContextNode($workpsacename)
+     *
+     * @param string $cacheIdentifier
+     */
+    public function registerChangeOnNodeIdentifier($cacheIdentifier)
+    {
+        $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
+        $this->tagsToFlush['Node_' . $cacheIdentifier] = sprintf('which were tagged with "Node_%s" because that identifier has changed.', $cacheIdentifier);
+
+        // Note, as we don't have a node here we cannot go up the structure.
+        $tagName = 'DescendantOf_' . $cacheIdentifier;
+        $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $cacheIdentifier);
+    }
+
+    /**
+     * This is a low-level api. Please use registerNodeChange() if possible. Otherwise make sure that $nodeTypePrefix
+     * is set up correctly and contains the workspacehash wich can be received via
+     * $this->getCachingHelper()->renderWorkspaceTagForContextNode($workpsacename)
+     *
      * @param string $nodeTypeName
      * @param string $referenceNodeIdentifier
+     * @param string $nodeTypePrefix
+     *
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
      */
-    public function registerChangeOnNodeType($nodeTypeName, $referenceNodeIdentifier = null)
+    public function registerChangeOnNodeType($nodeTypeName, $referenceNodeIdentifier = null, $nodeTypePrefix = '')
     {
         $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
 
         $nodeTypesToFlush = $this->getAllImplementedNodeTypeNames($this->nodeTypeManager->getNodeType($nodeTypeName));
+
+        if (strlen($nodeTypePrefix) > 0) {
+            $nodeTypePrefix = rtrim($nodeTypePrefix, '_') . '_';
+        }
+
         foreach ($nodeTypesToFlush as $nodeTypeNameToFlush) {
-            $this->tagsToFlush['NodeType_' . $nodeTypeNameToFlush] = sprintf('which were tagged with "NodeType_%s" because node "%s" has changed and was of type "%s".', $nodeTypeNameToFlush, ($referenceNodeIdentifier ? $referenceNodeIdentifier : ''), $nodeTypeName);
+            $this->tagsToFlush['NodeType_' . $nodeTypePrefix . $nodeTypeNameToFlush] = sprintf('which were tagged with "NodeType_%s" because node "%s" has changed and was of type "%s".', $nodeTypeNameToFlush, ($referenceNodeIdentifier ? $referenceNodeIdentifier : ''), $nodeTypeName);
         }
     }
 
@@ -145,16 +220,21 @@ class ContentCacheFlusher
             return;
         }
 
+        $cachingHelper = $this->getCachingHelper();
+
         foreach ($this->assetService->getUsageReferences($asset) as $reference) {
             if (!$reference instanceof AssetUsageInNodeProperties) {
                 continue;
             }
 
-            $this->registerChangeOnNodeIdentifier($reference->getNodeIdentifier());
-            $this->registerChangeOnNodeType($reference->getNodeTypeName(), $reference->getNodeIdentifier());
+            $workspaceHash = $cachingHelper->renderWorkspaceTagForContextNode($reference->getWorkspaceName());
+
+            $this->registerChangeOnNodeIdentifier($workspaceHash . '_' . $reference->getNodeIdentifier());
+            $this->registerChangeOnNodeType($reference->getNodeTypeName(), $reference->getNodeIdentifier(), $workspaceHash);
 
             $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
-            $tagName = 'AssetDynamicTag_' . $assetIdentifier;
+
+            $tagName = 'AssetDynamicTag_' . $workspaceHash . '_' . $assetIdentifier;
             $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because asset "%s" has changed.', $tagName, $assetIdentifier);
         }
     }
@@ -166,8 +246,9 @@ class ContentCacheFlusher
      */
     public function shutdownObject()
     {
-        if ($this->tagsToFlush !== array()) {
+        if ($this->tagsToFlush !== []) {
             foreach ($this->tagsToFlush as $tag => $logMessage) {
+                $this->systemLogger->log('flushing tag ' . $tag);
                 $affectedEntries = $this->contentCache->flushByTag($tag);
                 if ($affectedEntries > 0) {
                     $this->systemLogger->log(sprintf('Content cache: Removed %s entries %s', $affectedEntries, $logMessage), LOG_DEBUG);
@@ -189,5 +270,17 @@ class ContentCacheFlusher
 
         $types = array_unique($types);
         return $types;
+    }
+
+    /**
+     * @return CachingHelper
+     */
+    protected function getCachingHelper(): CachingHelper
+    {
+        if (!$this->cachingHelper instanceof CachingHelper) {
+            $this->cachingHelper = new CachingHelper();
+        }
+
+        return $this->cachingHelper;
     }
 }

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Fusion\Helper;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Neos\Exception;
@@ -49,7 +50,7 @@ class CachingHelper implements ProtectedContextAwareInterface
             if (!$node instanceof NodeInterface) {
                 throw new Exception(sprintf('One of the elements in array passed to this helper was not a Node, but of type: "%s".', gettype($node)), 1437169991);
             }
-            $prefixedNodeIdentifiers[] = $prefix . '_' . $this->renderWorkspaceTagForContextNode($node) . '_' . $node->getIdentifier();
+            $prefixedNodeIdentifiers[] = $prefix . '_' . $this->renderWorkspaceTagForContextNode($node->getContext()->getWorkspace()->getName()) . '_' . $node->getIdentifier();
         }
         return $prefixedNodeIdentifiers;
     }
@@ -61,6 +62,7 @@ class CachingHelper implements ProtectedContextAwareInterface
      *
      * @param mixed $nodes (A single Node or array or \Traversable of Nodes)
      * @return array
+     * @throws Exception
      */
     public function nodeTag($nodes)
     {
@@ -102,7 +104,7 @@ class CachingHelper implements ProtectedContextAwareInterface
         $workspaceTag = '';
 
         if ($contextNode instanceof NodeInterface) {
-            $workspaceTag = $this->renderWorkspaceTagForContextNode($contextNode) .'_';
+            $workspaceTag = $this->renderWorkspaceTagForContextNode($contextNode->getContext()->getWorkspace()->getName()) .'_';
         }
 
         if (is_string($nodeType)) {
@@ -127,6 +129,7 @@ class CachingHelper implements ProtectedContextAwareInterface
      *
      * @param mixed $nodes (A single Node or array or \Traversable of Nodes)
      * @return array
+     * @throws Exception
      */
     public function descendantOfTag($nodes)
     {
@@ -134,12 +137,12 @@ class CachingHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * @param NodeInterface $contextNode
+     * @param string $contextNode
      * @return string
      */
-    public function renderWorkspaceTagForContextNode(NodeInterface $contextNode)
+    public function renderWorkspaceTagForContextNode(string $workspaceName)
     {
-        return '%' . md5($contextNode->getWorkspace()->getName()) . '%';
+        return '%' . md5($workspaceName) . '%';
     }
 
     /**

--- a/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -59,9 +59,9 @@ path::
 
 			entryTags {
 				# Whenever the node changes the matched condition could change
-				1 = ${'Node_' + documentNode.identifier}
+				1 = ${Neos.Caching.nodeTag(documentNode)}
 				# Whenever one of the parent nodes changes the layout could change
-				2 = ${'DescendantOf_' + documentNode.identifier}
+				2 = ${Neos.Caching.descendantOfTag(documentNode)}
 			}
 		}
 	}
@@ -158,7 +158,7 @@ In the ``@cache`` meta property the following subproperties are allowed:
 				2 = 'documentNode'
 			}
 			entryTags {
-				1 = ${'Node_' + node.identifier}
+				1 = ${Neos.Caching.nodeTag(node)}
 			}
 		}
 	}
@@ -191,27 +191,32 @@ Cache Entry Tags
 
 Neos will automatically flush a set of tags whenever nodes are created, changed, published or discarded.
 The exact set of tags depends on the node hierarchy and node type of the changed node. You should assign tags that
-mathches one of these patterns in your configuration. You can use an Eel expression to build the pattern depending on
+matches one of these patterns in your configuration. You can use an Eel expression to build the pattern depending on
 any context variable including the node identifier or type.
 
-The following patterns of tags will be flushed by Neos:
+To create the correct tags for your node it is important to make use if our CachingHelper.
+The following methods are provided by default to create all kind of patterns of tags wich will be flushed by Neos:
 
 ``Everything``
   Flushes cache entries for every changed node.
 
-``NodeType_[My.Package:NodeTypeName]``
+``${Neos.Caching.nodeTypeTag('[My.Package:NodeTypeName]', node}``
   Flushes cache entries if any node with the given node type changes. ``[My.Package:NodeTypeName]`` needs to be
   replaced by any node type name. Inheritance will be taken into account, so for a changed node of type
   ``Neos.NodeTypes:Page`` the tags ``NodeType_Neos.NodeTypes:Page`` and ``NodeType_Neos.Neos:Document``
-  (and some more) will be flushed.
+  (and some more) will be flushed. The second property node is needed to calculate the correct context to create tags for.
+  Notice: In earlier versions of Neos we just used a plain String ``NodeType_[My.Package:NodeTypeName]`` which could lead into
+  unwanted cache flush behaviours
 
-``Node_[Identifier]``
-  Flushes cache entries if a node with the given identifier changes. ``Identifier`` needs to be replaced by a valid node
-  identifier.
+``${Neos.Caching.nodeTag(node)}``
+  Flushes cache entries if the node changes.
+  Notice: In earlier versions of Neos we just used a plain String ``Node_[Identifier]`` which could lead into
+  unwanted cache flush behaviours. ``Identifier`` had to be replaced by a valid node identifier.
 
-``DescendantOf_[Identifier]``
-  Flushes cache entries if a child node of the node with the given identifier changes. ``Identifier`` need to be
-  replaced by a valid node identifier.
+``${Neos.Caching.descendantOfTag(node)}``
+  Flushes cache entries if a child node of the node changes.
+  Notice: In earlier versions of Neos we just used a plain String ``DescendantOf_[Identifier]`` which could lead into
+  unwanted cache flush behaviours. ``Identifier`` had to be replaced by a valid node identifier.
 
 Example::
 
@@ -222,13 +227,13 @@ Example::
 			#...
 
 			entryTags {
-				1 = ${'Node_' + node.identifier}
-				2 = ${'DescendantOf_' + contentCollectionNode.identifier}
+				1 = ${Neos.Caching.nodeTag(node)}
+				2 = ${Neos.Caching.descendantOfTag(contentCollectionNode)}
 			}
 		}
 	}
 
-The ``ContentCollection`` cache configuration declares a tag that will flush the cache entry for the collection if
+The ``ContentCollection`` cache configuration declares tags that will flush the cache entry for the collection if
 any of it's descendants (direct or indirect child) changes. So editing a node inside the collection will flush the
 whole collection cache entry and cause it to re-render.
 
@@ -240,10 +245,15 @@ whole collection cache entry and cause it to re-render.
   	@cache {
   		mode = 'cached'
   		entryTags {
-  			1 = ${'Node_' + node.identifier}
+  			1 = ${Neos.Caching.nodeTag(node)}
   			2 = ... additional entry tags ...
   		}
   	}
+
+
+	Notice: In earlier versions of Neos there might be some problems with unwanted cache flush behaviours. To make sure
+	to avoid this always use the CachingEelHelper. See https://github.com/neos/neos-development-collection/issues/2096
+	for more informations
 
 Default cache configuration
 ===========================

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -73,7 +73,7 @@ root {
 		}
 		entryTags {
 			# Whenever the node changes the matched condition could change
-			1 = ${'Node_' + documentNode.identifier}
+			1 = ${Neos.Caching.nodeTag(documentNode)}
 			# Whenever one of the parent nodes changes the layout could change
 			2 = ${Neos.Caching.nodeTag(q(documentNode).parents())}
 		}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -72,8 +72,8 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
 		}
 
 		entryTags {
-			1 = ${'DescendantOf_' + node.identifier}
-			2 = ${'Node_' + node.identifier}
+			1 = ${Neos.Caching.descendantOfTag(node)}
+			2 = ${Neos.Caching.nodeTag(node)}
 		}
 
 		maximumLifetime = ${q(node).context({'invisibleContentShown': true}).children().cacheLifetime()}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
@@ -30,7 +30,7 @@ prototype(Neos.Neos:Menu) < prototype(Neos.Fusion:Template) {
 			documentNode = ${documentNode}
 		}
 		entryTags {
-			1 = 'NodeType_Neos.Neos:Document'
+			1 = ${Neos.Caching.nodeTypeTag('NodeType_Neos.Neos:Document', documentNode)}
 		}
 	}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
@@ -30,7 +30,7 @@ prototype(Neos.Neos:Menu) < prototype(Neos.Fusion:Template) {
 			documentNode = ${documentNode}
 		}
 		entryTags {
-			1 = ${Neos.Caching.nodeTypeTag('NodeType_Neos.Neos:Document', documentNode)}
+			1 = ${Neos.Caching.nodeTypeTag('Neos.Neos:Document', documentNode)}
 		}
 	}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -203,7 +203,7 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
 			documentNode = ${node}
 		}
 		entryTags {
-			1 = ${'Node_' + node.identifier}
+			1 = ${Neos.Caching.nodeTag(node)}
 		}
 	}
 

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Tests\Functional\Fusion\Cache;
 
 /*

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -1,0 +1,234 @@
+<?php
+namespace Neos\Neos\Tests\Functional\Fusion\Cache;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
+use Neos\Neos\Fusion\Helper\CachingHelper;
+use Neos\Utility\ObjectAccess;
+
+/**
+ * Tests the CachingHelper
+ */
+class ContentCacheFlusherTest extends FunctionalTestCase
+{
+
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * @var ContentCacheFlusher
+     */
+    protected $contentCacheFlusher;
+
+    /**
+     * @var ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     *
+     */
+    public function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        parent::setUp();
+
+        $this->workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
+        $this->contentCacheFlusher = $this->objectManager->get(ContentCacheFlusher::class);
+
+        $this->context = $this->contextFactory->create(['workspaceName' => 'live']);
+        $siteImportService = $this->objectManager->get(\Neos\Neos\Domain\Service\SiteImportService::class);
+        $siteImportService->importFromFile(__DIR__ . '/Fixtures/CacheableNodes.xml', $this->context);
+
+        // Assume an empty state for $contentCacheFlusher - this is needed as importing nodes will register
+        // changes to the ContentCacheFlusher
+        $this->inject($this->contentCacheFlusher, 'workspacesToFlush', []);
+        $this->inject($this->contentCacheFlusher, 'tagsToFlush', []);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+    }
+
+    /**
+     *
+     */
+    public function flushingANodeWillResolveAllWorkspacesToFlush()
+    {
+        // Add more workspaces
+        $workspaceFirstLevel = new Workspace('first-level');
+        $workspaceSecondLevel = new Workspace('second-level');
+        $workspaceAlsoOnSecondLevel = new Workspace('also-second-level');
+        $workspaceThirdLevel = new Workspace('third-level');
+
+        // And build up a chain
+        $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
+        $workspaceThirdLevel->setBaseWorkspace($workspaceSecondLevel);
+        $workspaceSecondLevel->setBaseWorkspace($workspaceFirstLevel);
+        $workspaceAlsoOnSecondLevel->setBaseWorkspace($workspaceFirstLevel);
+        $workspaceFirstLevel->setBaseWorkspace($liveWorkspace);
+
+        $this->workspaceRepository->add($workspaceFirstLevel);
+        $this->workspaceRepository->add($workspaceSecondLevel);
+        $this->workspaceRepository->add($workspaceAlsoOnSecondLevel);
+        $this->workspaceRepository->add($workspaceThirdLevel);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        // Make sure that we do have multiple workspaces set up in our database
+        $this->assertEquals(5, $this->workspaceRepository->countAll());
+
+        // Create/Fetch a node in workspace "first-level"
+        $fistLevelContext = $this->contextFactory->create(['workspaceName' => $workspaceFirstLevel->getName()]);
+        $nodeInFirstLevelWorkspace = $fistLevelContext->getRootNode();
+
+        // When the node is flushed we expect three workspaces to be flushed
+        $this->contentCacheFlusher->registerNodeChange($nodeInFirstLevelWorkspace);
+
+        $workspacesToFlush = ObjectAccess::getProperty($this->contentCacheFlusher, 'workspacesToFlush', true);
+        $workspaceChain = $workspacesToFlush['first-level'];
+
+        $this->assertArrayNotHasKey('live', $workspaceChain);
+        $this->assertArrayHasKey('first-level', $workspaceChain);
+        $this->assertArrayHasKey('second-level', $workspaceChain);
+        $this->assertArrayHasKey('also-second-level', $workspaceChain);
+        $this->assertArrayHasKey('third-level', $workspaceChain);
+    }
+
+    /**
+     * @test
+     */
+    public function aNodeChangeWillRegisterNodeIdentifierTagsForAllWorkspaces()
+    {
+        $workspaceFirstLevel = new Workspace('first-level');
+
+        $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
+        $workspaceFirstLevel->setBaseWorkspace($liveWorkspace);
+        $this->workspaceRepository->add($workspaceFirstLevel);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $nodeIdentifier = 'c381f64d-4269-429a-9c21-6d846115addd';
+        $nodeToFlush = $this->context->getNodeByIdentifier($nodeIdentifier);
+
+        $this->contentCacheFlusher->registerNodeChange($nodeToFlush);
+
+        $tagsToFlush = ObjectAccess::getProperty($this->contentCacheFlusher, 'tagsToFlush', true);
+
+        $cachingHelper = new CachingHelper();
+
+        $workspacesToTest = [];
+        $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
+        $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
+
+        foreach ($workspacesToTest as $name => $workspaceHash) {
+            $this->assertArrayHasKey('Node_'.$workspaceHash.'_'.$nodeIdentifier, $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('DescendantOf_'.$workspaceHash.'_'.$nodeIdentifier, $tagsToFlush, 'on workspace ' . $name);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function aNodeChangeWillRegisterNodeTypeTagsForAllWorkspaces()
+    {
+        $workspaceFirstLevel = new Workspace('first-level');
+
+        $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
+        $workspaceFirstLevel->setBaseWorkspace($liveWorkspace);
+        $this->workspaceRepository->add($workspaceFirstLevel);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $nodeIdentifier = 'c381f64d-4269-429a-9c21-6d846115addd';
+        $nodeToFlush = $this->context->getNodeByIdentifier($nodeIdentifier);
+
+        $this->contentCacheFlusher->registerNodeChange($nodeToFlush);
+
+        $tagsToFlush = ObjectAccess::getProperty($this->contentCacheFlusher, 'tagsToFlush', true);
+
+        $cachingHelper = new CachingHelper();
+
+        $workspacesToTest = [];
+        $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
+        $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
+
+        foreach ($workspacesToTest as $name => $workspaceHash) {
+            $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.Neos:Content', $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.Neos:Node', $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.NodeTypes:Text', $tagsToFlush, 'on workspace ' . $name);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function aNodeChangeWillRegisterAllDescendantOfTagsForAllWorkspaces()
+    {
+        $workspaceFirstLevel = new Workspace('first-level');
+
+        $liveWorkspace = $this->workspaceRepository->findByIdentifier('live');
+        $workspaceFirstLevel->setBaseWorkspace($liveWorkspace);
+        $this->workspaceRepository->add($workspaceFirstLevel);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $nodeIdentifier = 'c381f64d-4269-429a-9c21-6d846115addd';
+        $nodeToFlush = $this->context->getNodeByIdentifier($nodeIdentifier);
+
+        $this->contentCacheFlusher->registerNodeChange($nodeToFlush);
+
+        $tagsToFlush = ObjectAccess::getProperty($this->contentCacheFlusher, 'tagsToFlush', true);
+
+        $cachingHelper = new CachingHelper();
+
+        $workspacesToTest = [];
+        $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
+        $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
+
+        foreach ($workspacesToTest as $name => $workspaceHash) {
+            $this->assertArrayHasKey('DescendantOf_'.$workspaceHash.'_c381f64d-4269-429a-9c21-6d846115addd', $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('DescendantOf_'.$workspaceHash.'_c381f64d-4269-429a-9c21-6d846115adde', $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('DescendantOf_'.$workspaceHash.'_c381f64d-4269-429a-9c21-6d846115addf', $tagsToFlush, 'on workspace ' . $name);
+        }
+    }
+
+    public function tearDown()
+    {
+        $this->contextFactory->reset();
+        parent::tearDown();
+    }
+}

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Neos\Tests\Functional\Fusion\Cache;
 
 /*
@@ -54,9 +53,6 @@ class ContentCacheFlusherTest extends FunctionalTestCase
      */
     protected $nodeDataRepository;
 
-    /**
-     *
-     */
     public function setUp()/* The :void return type declaration that should be here would cause a BC issue */
     {
         parent::setUp();
@@ -79,9 +75,6 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
     }
 
-    /**
-     *
-     */
     public function flushingANodeWillResolveAllWorkspacesToFlush()
     {
         // Add more workspaces

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -27,7 +27,6 @@ use Neos\Utility\ObjectAccess;
  */
 class ContentCacheFlusherTest extends FunctionalTestCase
 {
-
     protected static $testablePersistenceEnabled = true;
 
     /**

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/Fixtures/CacheableNodes.xml
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/Fixtures/CacheableNodes.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!--
+      NOTE: This fixture is for the test Neos\Neos\Tests\Functional\Fusion\Cache\ContentCacheFlusherTest
+       -->
+    <site name="example" state="1" siteResourcesPackageKey="Neos.Neos" siteNodeName="example">
+        <nodes formatVersion="2.0">
+            <node identifier="c381f64d-4269-429a-9c21-6d846115addf" nodeName="text-1">
+                <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                    <dimensions/>
+                    <accessRoles __type="array"/>
+                    <creationDateTime __type="object" __classname="DateTime">2016-07-06T13:04:23+02:00</creationDateTime>
+                    <lastModificationDateTime __type="object" __classname="DateTime">2016-07-06T13:26:57+02:00</lastModificationDateTime>
+                    <lastPublicationDateTime __type="object" __classname="DateTime">2016-07-06T13:26:56+02:00</lastPublicationDateTime>
+                    <properties>
+                        <uriPathSegment __type="string">example1</uriPathSegment>
+                    </properties>
+                </variant>
+                <node identifier="c381f64d-4269-429a-9c21-6d846115adde" nodeName="text-2">
+                    <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                        <dimensions/>
+                        <accessRoles __type="array"/>
+                        <creationDateTime __type="object" __classname="DateTime">2016-01-06T13:04:23+02:00</creationDateTime>
+                        <lastModificationDateTime __type="object" __classname="DateTime">2016-01-06T13:26:57+02:00</lastModificationDateTime>
+                        <lastPublicationDateTime __type="object" __classname="DateTime">2016-01-06T13:26:56+02:00</lastPublicationDateTime>
+                        <properties>
+                            <uriPathSegment __type="string">example2</uriPathSegment>
+                        </properties>
+                    </variant>
+                    <node identifier="c381f64d-4269-429a-9c21-6d846115addd" nodeName="text-3">
+                        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                            <dimensions/>
+                            <accessRoles __type="array"/>
+                            <creationDateTime __type="object" __classname="DateTime">2016-08-06T13:04:23+02:00</creationDateTime>
+                            <lastModificationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:57+02:00</lastModificationDateTime>
+                            <lastPublicationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:56+02:00</lastPublicationDateTime>
+                            <properties>
+                                <uriPathSegment __type="string">example3</uriPathSegment>
+                            </properties>
+                        </variant>
+                    </node>
+                </node>
+            </node>
+        </nodes>
+    </site>
+</root>

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -25,13 +25,11 @@ use Neos\Neos\Fusion\Helper\CachingHelper;
  */
 class ContentCacheFlusherTest extends UnitTestCase
 {
-
     /**
      * @test
      */
     public function theWorkspaceChainWillOnlyEvaluatedIfNeeded()
     {
-
         $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
         $contentCacheFlusher->expects($this->never())->method('resolveWorkspaceChain');
         $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeIdentifier');

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace Neos\Neos\Tests\Unit\Fusion\Cache;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping\Cache;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
+use Neos\Neos\Fusion\Helper\CachingHelper;
+
+/**
+ * Tests the CachingHelper
+ */
+class ContentCacheFlusherTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function theWorkspaceChainWillOnlyEvaluatedIfNeeded()
+    {
+
+        $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
+        $contentCacheFlusher->expects($this->never())->method('resolveWorkspaceChain');
+        $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeIdentifier');
+        $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeType');
+
+        $this->inject($contentCacheFlusher, 'workspacesToFlush', ['live' => ['some-hash']]);
+
+        $workspace = new Workspace('live');
+
+        $nodeType = new NodeType('Some.Node:Type', [], []);
+
+        $nodeMock = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $nodeMock->expects($this->any())->method('getWorkspace')->willReturn($workspace);
+        $nodeMock->expects($this->any())->method('getNodeType')->willReturn($nodeType);
+
+        $contentCacheFlusher->registerNodeChange($nodeMock);
+    }
+}

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Cache;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Service\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Fusion\Helper\CachingHelper;
 
@@ -98,10 +99,13 @@ class CachingHelperTest extends UnitTestCase
         $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
 
-        $contextNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $contextNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+        $contextMock->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
 
-        $hashedWorkspaceName = $cacheHelper->renderWorkspaceTagForContextNode($contextNode);
+        $contextNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $contextNode->expects($this->any())->method('getContext')->willReturn($contextMock);
+
+        $hashedWorkspaceName = $cacheHelper->renderWorkspaceTagForContextNode($workspaceName);
 
         $nodeTypeName1 = 'Neos.Neos:Foo';
         $nodeTypeName2 = 'Neos.Neos:Bar';
@@ -170,18 +174,20 @@ class CachingHelperTest extends UnitTestCase
         $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
 
+        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+        $contextMock->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+
         $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
         $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $node->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $node->expects($this->any())->method('getContext')->willReturn($contextMock);
         $node->expects($this->any())->method('getIdentifier')->willReturn($nodeIdentifier);
 
         $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
         $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $anotherNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $anotherNode->expects($this->any())->method('getContext')->willReturn($contextMock);
         $anotherNode->expects($this->any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
 
-        // As we use the same workspace mock for all nodes it is ok to use this mocked node to generate the workspace hash
-        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($node);
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($workspaceName);
 
         return [
             [$node, ['Node_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
@@ -217,18 +223,20 @@ class CachingHelperTest extends UnitTestCase
         $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
 
+        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+        $contextMock->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+
         $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
         $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $node->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $node->expects($this->any())->method('getContext')->willReturn($contextMock);
         $node->expects($this->any())->method('getIdentifier')->willReturn($nodeIdentifier);
 
         $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
         $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $anotherNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $anotherNode->expects($this->any())->method('getContext')->willReturn($contextMock);
         $anotherNode->expects($this->any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
 
-        // As we use the same workspace mock for all nodes it is ok to use this mocked node to generate the workspace hash
-        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($node);
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($workspaceName);
 
         return [
             [$node, ['DescendantOf_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -11,7 +11,10 @@ namespace Neos\Neos\Tests\Unit\Fusion\Helper;
  * source code.
  */
 
+use Doctrine\ORM\Mapping\Cache;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Fusion\Helper\CachingHelper;
 
@@ -21,7 +24,7 @@ use Neos\Neos\Fusion\Helper\CachingHelper;
 class CachingHelperTest extends UnitTestCase
 {
     /**
-     * Provides datasets for teseting the CachingHelper::nodeTypeTag method.
+     * Provides datasets for testing the CachingHelper::nodeTypeTag method.
      *
      * @return array
      */
@@ -79,6 +82,175 @@ class CachingHelperTest extends UnitTestCase
     {
         $helper = new CachingHelper();
         $actualResult = $helper->nodeTypeTag($input);
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * Provides datasets for testing the CachingHelper::nodeTypeTag method with an context node.
+     *
+     * @return array
+     */
+    public function nodeTypeTagWithContextNodeDataProvider()
+    {
+        $cacheHelper = new CachingHelper();
+
+        $workspaceName = 'live';
+        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
+        $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
+
+        $contextNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $contextNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+
+        $hashedWorkspaceName = $cacheHelper->renderWorkspaceTagForContextNode($contextNode);
+
+        $nodeTypeName1 = 'Neos.Neos:Foo';
+        $nodeTypeName2 = 'Neos.Neos:Bar';
+        $nodeTypeName3 = 'Neos.Neos:Moo';
+
+        $nodeTypeObject1 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
+        $nodeTypeObject1->expects(self::any())->method('getName')->willReturn($nodeTypeName1);
+
+        $nodeTypeObject2 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
+        $nodeTypeObject2->expects(self::any())->method('getName')->willReturn($nodeTypeName2);
+
+        $nodeTypeObject3 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
+        $nodeTypeObject3->expects(self::any())->method('getName')->willReturn($nodeTypeName3);
+
+        return [
+            [$nodeTypeName1, $contextNode, 'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1],
+            [[$nodeTypeName1, $nodeTypeName2, $nodeTypeName3], $contextNode,
+                [
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName2,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName3
+                ]
+            ],
+            [$nodeTypeObject1, $contextNode, 'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1],
+            [[$nodeTypeName1, $nodeTypeObject2, $nodeTypeObject3], $contextNode,
+                [
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName2,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName3
+                ]
+            ],
+            [(new \ArrayObject([$nodeTypeObject1, $nodeTypeObject2, $nodeTypeObject3])), $contextNode,
+                [
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName2,
+                    'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName3
+                ]
+            ],
+            [(object)['stdClass' => 'will do nothing'], $contextNode, '']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nodeTypeTagWithContextNodeDataProvider
+     *
+     * @param $input
+     * @param $contextNode
+     * @param $expectedResult
+     */
+    public function nodeTypeTagRespectsContextNodesWorkspace($input, $contextNode, $expectedResult)
+    {
+        $helper = new CachingHelper();
+        $actualResult = $helper->nodeTypeTag($input, $contextNode);
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     *
+     */
+    public function nodeDataProvider()
+    {
+        $cachingHelper = new CachingHelper();
+
+        $workspaceName = 'live';
+        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
+        $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
+
+        $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
+        $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $node->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $node->expects($this->any())->method('getIdentifier')->willReturn($nodeIdentifier);
+
+        $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
+        $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $anotherNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $anotherNode->expects($this->any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
+
+        // As we use the same workspace mock for all nodes it is ok to use this mocked node to generate the workspace hash
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($node);
+
+        return [
+            [$node, ['Node_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
+            [[$node], ['Node_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
+            [[$node, $anotherNode], [
+                'Node_' . $hashedWorkspaceName.'_'.$nodeIdentifier,
+                'Node_' . $hashedWorkspaceName.'_'.$anotherNodeIdentifier
+            ]]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nodeDataProvider
+     *
+     * @param $nodes
+     * @param $expectedResult
+     */
+    public function nodeTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
+    {
+        $helper = new CachingHelper();
+        $actualResult = $helper->nodeTag($nodes);
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+    /**
+     *
+     */
+    public function descendantOfDataProvider()
+    {
+        $cachingHelper = new CachingHelper();
+
+        $workspaceName = 'live';
+        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
+        $workspaceMock->expects($this->any())->method('getName')->willReturn($workspaceName);
+
+        $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
+        $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $node->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $node->expects($this->any())->method('getIdentifier')->willReturn($nodeIdentifier);
+
+        $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
+        $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $anotherNode->expects($this->any())->method('getWorkspace')->willReturn($workspaceMock);
+        $anotherNode->expects($this->any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
+
+        // As we use the same workspace mock for all nodes it is ok to use this mocked node to generate the workspace hash
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($node);
+
+        return [
+            [$node, ['DescendantOf_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
+            [[$node], ['DescendantOf_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
+            [[$node, $anotherNode], [
+                'DescendantOf_' . $hashedWorkspaceName.'_'.$nodeIdentifier,
+                'DescendantOf_' . $hashedWorkspaceName.'_'.$anotherNodeIdentifier
+            ]]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider descendantOfDataProvider
+     *
+     * @param $nodes
+     * @param $expectedResult
+     */
+    public function descendantOfTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
+    {
+        $helper = new CachingHelper();
+        $actualResult = $helper->descendantOfTag($nodes);
         $this->assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
@@ -13,7 +13,7 @@ prototype(Neos.NodeTypes.ContentReferences:ContentReferences) < prototype(Neos.N
       node = ${node}
     }
     entryTags {
-      1 = ${'Node_' + node.identifier}
+      1 = ${Neos.Caching.nodeTag(node)}
       2 = ${Neos.Caching.nodeTag(referenceNodesArray)}
       3 = ${Neos.Caching.descendantOfTag(referenceNodesArray)}
     }

--- a/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
@@ -33,8 +33,9 @@ prototype(Neos.NodeTypes.Navigation:Navigation) < prototype(Neos.Neos:Content) {
       node = ${node}
     }
     entryTags {
-      1 = 'NodeType_Neos.Neos:Document'
-      2 = ${'Node_' + node.identifier}
+      1 = ${Neos.Caching.nodeTypeTag('NodeType_Neos.Neos:Document', node)}
+      2 = ${Neos.Caching.nodeTag(node)}
+
     }
   }
 }

--- a/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
@@ -33,9 +33,8 @@ prototype(Neos.NodeTypes.Navigation:Navigation) < prototype(Neos.Neos:Content) {
       node = ${node}
     }
     entryTags {
-      1 = ${Neos.Caching.nodeTypeTag('NodeType_Neos.Neos:Document', node)}
+      1 = ${Neos.Caching.nodeTypeTag('Neos.Neos:Document', node)}
       2 = ${Neos.Caching.nodeTag(node)}
-
     }
   }
 }


### PR DESCRIPTION
Resolves #2096

- [X] CacheHelper should prefix the Workspace correct
- [X] Use the CachingHelper instead of Hardcoded Tags 
- [x] ContentCacheFlusher should generate correct Tags to flush
- [x] Update Documentation
- [x] Check if some code migrations are possible