### PR TITLE
TASK: Remove unneeded ternerary operation

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1379,7 +1379,7 @@ class NodeDataRepository extends Repository
                 ->from(NodeData::class, 'n')
                 ->where('n.pathHash = :pathHash')
                 ->setParameter('pathHash', md5($nodePath));
-            $result = (count($queryBuilder->getQuery()->getResult()) > 0 ? true : false);
+            $result = count($queryBuilder->getQuery()->getResult()) > 0;
         });
 
         return $result;


### PR DESCRIPTION
I've found this while going through the code ...
I think there is no reason for this operation