### PR TITLE
TASK: Add fusionObjects `RawMenu`, `RawDimensionsMenu` and `RawBreadcrumbMenu`

### DIFF
--- a/Neos.Neos/Classes/Fusion/RawDimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/RawDimensionsMenuImplementation.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Neos\Fusion;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A Fusion RawDimensionMenu object
+ */
+class RawDimensionsMenuImplementation extends DimensionsMenuImplementation
+{
+
+    /**
+     * @return array
+     */
+    public function evaluate()
+    {
+        return $this->getItems();
+    }
+}

--- a/Neos.Neos/Classes/Fusion/RawMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/RawMenuImplementation.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Neos\Fusion;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A Fusion RawMenu object
+ */
+class RawMenuImplementation extends MenuImplementation
+{
+
+    /**
+     * @return array
+     */
+    public function evaluate()
+    {
+        return $this->getItems();
+    }
+}

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -20,6 +20,9 @@ include: Prototypes/ContentElementEditable.fusion
 include: Prototypes/NodeUri.fusion
 include: Prototypes/ImageUri.fusion
 include: Prototypes/FallbackNode.fusion
+include: Prototypes/RawMenu.fusion
+include: Prototypes/RawBreadcrumbMenu.fusion
+include: Prototypes/RawDimensionsMenu.fusion
 
 # The root matcher used to start rendering in Neos
 #

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/RawBreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/RawBreadcrumbMenu.fusion
@@ -1,0 +1,5 @@
+# Neos.Neos:RawBreadcrumbMenu provides a breadcrumb navigation based on menu items.
+#
+prototype(Neos.Neos:RawBreadcrumbMenu) < prototype(Neos.Neos:RawMenu) {
+	itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
+}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/RawDimensionsMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/RawDimensionsMenu.fusion
@@ -1,0 +1,17 @@
+# Neos.Neos:RawDimensionsMenu provides dimension (e.g. language) menu rendering
+#
+prototype(Neos.Neos:RawDimensionsMenu) < prototype(Neos.Neos:RawMenu) {
+	@class = 'Neos\\Neos\\Fusion\\RawDimensionsMenuImplementation'
+
+	# if documents which are hidden in index should be rendered or not
+	renderHiddenInIndex = true
+
+	# name of the dimension to use (optional)
+	# dimension = 'language'
+
+	# list of presets, if the default order should be overridden, only used with "dimension" set
+	# presets = ${['en_US']}
+
+	# if true, items for all presets will be included, ignoring dimension constraints
+	includeAllPresets = false
+}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/RawMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/RawMenu.fusion
@@ -1,0 +1,15 @@
+# Neos.Neos:RawMenu provides basic menu rendering
+#
+prototype(Neos.Neos:RawMenu) {
+	@class = 'Neos\\Neos\\Fusion\\RawMenuImplementation'
+
+	node = ${node}
+	items = ${this.items}
+
+	entryLevel = ${this.startingPoint ? 0 : 1}
+	maximumLevels = 2
+
+	filter = 'Neos.Neos:Document'
+
+	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\ContextDependentHandler'
+}


### PR DESCRIPTION
Add fusionObjects `Neos.Neos:RawMenu`, `Neos.Neos:RawDimensionsMenu` and `Neos.Neos:RawBreadcrumbMenu`

The fusion objects return arrays of objects with the properties `node`, `state`, `label` and `menuLevel`. The `RawDimensionsMenu` additionally returns the keys `dimension` and `targetDimensions` for each item.

All fusion-configurations that do not belong to rendering from `Neos.Neos:Menu`, `Neos.Neos:DimensionsMenu` and `Neos.Neos:BreadcrumbMenu`
are supported.