### PR TITLE
BUGFIX: Fix caching of sub node types in NodeTypeManager

### DIFF
--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
@@ -354,4 +354,16 @@ class NodeTypeManagerTest extends UnitTestCase
         $this->prepareNodeTypeManager($nodeTypesFixture);
         $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Sub');
     }
+
+    /**
+     * @test
+     */
+    public function getSubNodeTypesWithDifferentIncludeFlagValuesReturnsCorrectValues()
+    {
+        $subNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject', true);
+        $this->assertArrayHasKey('Neos.ContentRepository.Testing:AbstractType', $subNodeTypes);
+
+        $subNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject', false);
+        $this->assertArrayNotHasKey('Neos.ContentRepository.Testing:AbstractType', $subNodeTypes);
+    }
 }


### PR DESCRIPTION
The method `NodeTypeManager->getSubNodeTypes(...)` cached results
regardless of the `$includeAbstractNodeTypes` flag. This causes issues
where the first invocation caches results including / not including abstract
node types for further invocations with different flag values.

Fixes #2126 