### PR TITLE
FEATURE: Improve remove unused assets filter

### DIFF
--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -187,7 +187,7 @@ class MediaCommandController extends CommandController
                 break;
             }
 
-            if (!($asset instanceof Asset)) {
+            if (!$asset instanceof Asset) {
                 continue;
             }
             if (!$asset instanceof AssetSourceAwareInterface) {
@@ -196,7 +196,7 @@ class MediaCommandController extends CommandController
             if ($filterByAssetSourceIdentifier !== '' && $asset->getAssetSourceIdentifier() !== $filterByAssetSourceIdentifier) {
                 continue;
             }
-            if ($onlyTags === '' && !($assetTagsMatchFilterTags($asset->getTags(), $onlyTags))) {
+            if ($onlyTags !== '' && $assetTagsMatchFilterTags($asset->getTags(), $onlyTags) === false) {
                 continue;
             }
             if ($asset->getUsageCount() !== 0) {

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -149,9 +149,10 @@ class MediaCommandController extends CommandController
      * @param bool $quiet If set, only errors will be displayed.
      * @param bool $assumeYes If set, "yes" is assumed for the "shall I remove ..." dialogs
      * @param string $onlyTags Comma-separated list of asset tags, that should be taken into account
+     * @param int $limit Limit the result of unused assets displayed and removed for this run.
      * @return void
      */
-    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '')
+    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '', int $limit = 0)
     {
         $iterator = $this->assetRepository->findAllIterator();
         $assetCount = $this->assetRepository->countAll();
@@ -181,6 +182,10 @@ class MediaCommandController extends CommandController
         foreach ($this->assetRepository->iterate($iterator) as $asset) {
             !$quiet && $this->output->progressAdvance(1);
 
+            if($unusedAssetCount === $limit) {
+                break;
+            }
+
             if (!($asset instanceof Asset)) {
                 continue;
             }
@@ -193,7 +198,6 @@ class MediaCommandController extends CommandController
             if (trim($onlyTags) && !($assetTagsMatchFilterTags($asset->getTags(), $onlyTags))) {
                 continue;
             }
-
             if ($asset->getUsageCount() !== 0) {
                 continue;
             }

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -167,25 +167,30 @@ class MediaCommandController extends CommandController
         !$quiet && $this->output->progressStart($assetCount);
 
         foreach ($this->assetRepository->iterate($iterator) as $asset) {
-            if ($asset instanceof Asset && $asset->getUsageCount() === 0) {
-                if (!$asset instanceof AssetSourceAwareInterface) {
-                    continue;
-                }
-                if ($filterByAssetSourceIdentifier !== '' && $asset->getAssetSourceIdentifier() !== $filterByAssetSourceIdentifier) {
-                    continue;
-                }
-
-                $fileSize = str_pad(Files::bytesToSizeString($asset->getResource()->getFileSize()), 9, ' ', STR_PAD_LEFT);
-
-                $unusedAssets[] = $asset;
-                $tableRowsByAssetSource[$asset->getAssetSourceIdentifier()][] = [
-                    $asset->getIdentifier(),
-                    $asset->getResource()->getFilename(),
-                    $fileSize
-                ];
-                $unusedAssetCount++;
-                $unusedAssetsTotalSize += $asset->getResource()->getFileSize();
+            if (!($asset instanceof Asset)) {
+                continue;
             }
+            if (!$asset instanceof AssetSourceAwareInterface) {
+                continue;
+            }
+            if ($filterByAssetSourceIdentifier !== '' && $asset->getAssetSourceIdentifier() !== $filterByAssetSourceIdentifier) {
+                continue;
+            }
+            if ($asset->getUsageCount() !== 0) {
+                continue;
+            }
+
+            $fileSize = str_pad(Files::bytesToSizeString($asset->getResource()->getFileSize()), 9, ' ', STR_PAD_LEFT);
+
+            $unusedAssets[] = $asset;
+            $tableRowsByAssetSource[$asset->getAssetSourceIdentifier()][] = [
+                $asset->getIdentifier(),
+                $asset->getResource()->getFilename(),
+                $fileSize
+            ];
+            $unusedAssetCount++;
+            $unusedAssetsTotalSize += $asset->getResource()->getFileSize();
+
             !$quiet && $this->output->progressAdvance(1);
         }
 

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -171,7 +171,8 @@ class MediaCommandController extends CommandController
         $assetTagsMatchFilterTags = function (Collection $assetTags, string $filterTags): bool {
             $filterTagValues = Arrays::trimExplode(',', $filterTags);
             $assetTagValues = [];
-            foreach ($assetTags as $tag) { /** @var Tag $tag */
+            foreach ($assetTags as $tag) {
+                /** @var Tag $tag */
                 $assetTagValues[] = $tag->getLabel();
             }
             return count(array_intersect($filterTagValues, $assetTagValues)) > 0;
@@ -182,7 +183,7 @@ class MediaCommandController extends CommandController
         foreach ($this->assetRepository->iterate($iterator) as $asset) {
             !$quiet && $this->output->progressAdvance(1);
 
-            if($unusedAssetCount === $limit) {
+            if ($unusedAssetCount === $limit) {
                 break;
             }
 

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -196,7 +196,7 @@ class MediaCommandController extends CommandController
             if ($filterByAssetSourceIdentifier !== '' && $asset->getAssetSourceIdentifier() !== $filterByAssetSourceIdentifier) {
                 continue;
             }
-            if (trim($onlyTags) && !($assetTagsMatchFilterTags($asset->getTags(), $onlyTags))) {
+            if ($onlyTags === '' && !($assetTagsMatchFilterTags($asset->getTags(), $onlyTags))) {
                 continue;
             }
             if ($asset->getUsageCount() !== 0) {


### PR DESCRIPTION
Improves the media:removeunused command

- Adds the option "onlyTags", which can be given as comma-separated list of tag labels to filter the assets that should be checked.
- Adds a flag --limit to limit the result of unused assets displayed and removed for a single run.