### PR TITLE
BUGFIX: Fix rendering of page exceptions

### DIFF
--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
@@ -50,7 +50,7 @@ class PageHandler extends AbstractRenderingExceptionHandler
     /**
      * Handle an exception by displaying an error message inside the Neos backend, if logged in and not displaying the live workspace.
      *
-     * @param array $fusionPath path causing the exception
+     * @param string $fusionPath path causing the exception
      * @param \Exception $exception exception to handle
      * @param integer $referenceCode
      * @return string

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
@@ -12,12 +12,16 @@ namespace Neos\Neos\Fusion\ExceptionHandlers;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Exception as FlowException;
+use Neos\Flow\Http\ContentStream;
+use Neos\Flow\Http\Response;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
+use Neos\Flow\Utility\Environment;
 use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler;
+use Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler;
 use Neos\Neos\Service\ContentElementWrappingService;
-use Neos\Fusion\Core\ExceptionHandlers\ContextDependentHandler;
 
 /**
  * A special exception handler that is used on the outer path to catch all unhandled exceptions and uses other exception
@@ -38,6 +42,12 @@ class PageHandler extends AbstractRenderingExceptionHandler
     protected $contentElementWrappingService;
 
     /**
+     * @Flow\Inject
+     * @var Environment
+     */
+    protected $environment;
+
+    /**
      * Handle an exception by displaying an error message inside the Neos backend, if logged in and not displaying the live workspace.
      *
      * @param array $fusionPath path causing the exception
@@ -47,7 +57,7 @@ class PageHandler extends AbstractRenderingExceptionHandler
      */
     protected function handle($fusionPath, \Exception $exception, $referenceCode)
     {
-        $handler = new ContextDependentHandler();
+        $handler = new HtmlMessageHandler($this->environment->getContext()->isDevelopment());
         $handler->setRuntime($this->runtime);
         $output = $handler->handleRenderingException($fusionPath, $exception);
         $currentContext = $this->runtime->getCurrentContext();
@@ -78,7 +88,29 @@ class PageHandler extends AbstractRenderingExceptionHandler
             'node' => $node
         ));
 
-        return $fluidView->render();
+        return $this->wrapHttpResponse($exception, $fluidView->render());
+    }
+
+    /**
+     * Renders an actual HTTP response including the correct status and cache control header.
+     *
+     * @param \Exception the exception
+     * @param string $bodyContent
+     * @return string
+     */
+    protected function wrapHttpResponse(\Exception $exception, $bodyContent)
+    {
+        $body = fopen('php://temp', 'rw');
+        fputs($body, $bodyContent);
+        rewind($body);
+
+        /** @var Response $response */
+        $response = (new Response())
+            ->withStatus($exception instanceof FlowException ? $exception->getStatusCode() : 500)
+            ->withBody(new ContentStream($body))
+            ->withHeader('Cache-Control', 'no-store');
+
+        return implode("\r\n", $response->renderHeaders()) . "\r\n\r\n" . $response->getContent();
     }
 
     /**


### PR DESCRIPTION
* Return correct HTTP status code of exception screens during Fusion rendering
* Don't hide the exception message in Production Context
* Don't render technical details in Production Context

Fixes: #2133