### PR TITLE
FEATURE: Friendlier error pages for setup / missing homepage

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -468,21 +468,14 @@ Neos:
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseException
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseConnectionException
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseStructureException
-            options:
-              templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Index.html'
+            options: &welcomeTemplate
+              templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Welcome.html'
               layoutRootPath: 'resource://Neos.Neos/Private/Layouts/'
               format: html
-              variables:
-                showSetupLink: true
           noHomepageException:
             matchingExceptionClassNames:
               - Neos\Neos\Routing\Exception\NoHomepageException
-            options:
-              templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Index.html'
-              layoutRootPath: 'resource://Neos.Neos/Private/Layouts/'
-              format: html
-              variables:
-                showSetupLink: true
+            options: *welcomeTemplate
       debugger:
         ignoredClasses:
           Neos\\Neos\\Domain\\Service\\ContentContextFactory: true

--- a/Neos.Neos/Resources/Private/Styles/Foundation/_variables.scss
+++ b/Neos.Neos/Resources/Private/Styles/Foundation/_variables.scss
@@ -20,8 +20,9 @@ $white:                 #fff !default;
 
 // Accent colors
 // -------------------------
-$blue:                  #049cdb !default;
+$blue:                  #00ADEE !default; // neos brand light blue
 $blueDark:              #0064cd !default;
+$blueVeryDark:          #26224C !default; // neos brand dark blue
 $green:                 #46a546 !default;
 $red:                   #9d261d !default;
 $yellow:                #ffc40d !default;

--- a/Neos.Neos/Resources/Private/Styles/Login.scss
+++ b/Neos.Neos/Resources/Private/Styles/Login.scss
@@ -202,8 +202,12 @@ html,
 			width: 100%;
 			height: $unit;
 
-			button {
+			button, .btn {
+				text-align: center;
+				text-decoration: none !important;
+				display: block;
 				height: $unit;
+				line-height: $unit;
 				color: #fff;
 				border: none;
 				background-image: none;

--- a/Neos.Neos/Resources/Private/Styles/Welcome.scss
+++ b/Neos.Neos/Resources/Private/Styles/Welcome.scss
@@ -17,10 +17,10 @@
     cursor: pointer;
     position: relative;
     display: block;
-    &:after {
+    &:before {
       content: '▼';
-      position: relative;
-      left: .3rem;
+      padding-right: .4rem;
+      font-size: $fontSizeSmall;
     }
   }
   .neos-error-details-toggle__body {
@@ -28,7 +28,7 @@
   }
 
   &--closed {
-    .neos-error-details-toggle__header:after {
+    .neos-error-details-toggle__header:before {
       content: '▶';
     }
     .neos-error-details-toggle__body {

--- a/Neos.Neos/Resources/Private/Styles/Welcome.scss
+++ b/Neos.Neos/Resources/Private/Styles/Welcome.scss
@@ -1,0 +1,38 @@
+// Core variables and mixins
+@import "compass";
+@import "Foundation/variables";
+
+.neos {
+  color: $white;
+}
+
+.neos-setup-btn {
+  background: $blue;
+  width: 100%;
+}
+
+.neos-error-details-toggle {
+  .neos-error-details-toggle__header {
+    margin-bottom: 0;
+    cursor: pointer;
+    position: relative;
+    display: block;
+    &:after {
+      content: '▼';
+      position: relative;
+      left: .3rem;
+    }
+  }
+  .neos-error-details-toggle__body {
+    overflow: hidden;
+  }
+
+  &--closed {
+    .neos-error-details-toggle__header:after {
+      content: '▶';
+    }
+    .neos-error-details-toggle__body {
+      height: 0;
+    }
+  }
+}

--- a/Neos.Neos/Resources/Private/Templates/Error/Welcome.html
+++ b/Neos.Neos/Resources/Private/Templates/Error/Welcome.html
@@ -1,0 +1,56 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<f:layout name="Default"/>
+
+
+<f:section name="head">
+  <title>Welcome to Neos</title>
+  <link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Login.css', package: 'Neos.Neos')}"/>
+  <link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Welcome.css', package: 'Neos.Neos')}"/>
+  <style type="text/css">
+    .neos-login-box:before {
+      background-image: url({f:uri.resource(path: 'Images/Login/Wallpaper.jpg', package: 'Neos.Neos')});
+    }
+  </style>
+  <script src="{f:uri.resource(path: 'Library/jquery/jquery-2.0.3.js', package:'Neos.Neos')}"></script>
+</f:section>
+
+<f:section name="body">
+  <body class="neos"
+        style="background-image:url({f:uri.resource(path: 'Images/Login/Wallpaper.jpg', package:'Neos.Neos')});">
+  <div class="neos-modal-centered">
+    <main class="neos-login-main">
+      <div class="neos-login-box background-image-active">
+        <figure class="neos-login-box-logo">
+          <img class="neos-login-box-logo-resource"
+               src="{f:uri.resource(path: 'Images/Login/Logo.svg', package:'Neos.Neos')}" width="200px" height="200px"
+               alt="Neos Logo"/>
+        </figure>
+
+        <h1>{neos:backend.translate(id: 'error.exception.welcomeToNeos', package: 'Neos.Neos')}</h1>
+        <div class="neos-login-body neos">
+          <p>{neos:backend.translate(id: 'error.exception.{renderingOptions.renderingGroup}.description', package:
+            'Neos.Neos') -> f:format.nl2br()}</p>
+          <p>{neos:backend.translate(id: 'error.exception.{renderingOptions.renderingGroup}.setupMessage', package:
+            'Neos.Neos')}</p>
+          <div class="neos-actions">
+            <p><a href="/setup" class="btn neos-setup-btn">{neos:backend.translate(id: 'error.exception.goToSetup',
+              package: 'Neos.Neos')}</a></p>
+          </div>
+          <div class="neos-error-details-toggle neos-error-details-toggle--closed">
+            <h4 class="neos-error-details-toggle__header">{neos:backend.translate(id: 'error.exception.technicalInformation', package: 'Neos.Neos')}</h4>
+            <div class="neos-error-details-toggle__body">
+              <h5>{neos:backend.translate(id: 'error.exception.{renderingOptions.renderingGroup}.title', package: 'Neos.Neos')}</h5>
+              <p>#{exception.code}: {exception.message}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <script>
+    $('.neos-error-details-toggle').click(function() {
+      $(this).toggleClass('neos-error-details-toggle--closed');
+    });
+  </script>
+  </body>
+</f:section>

--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -665,8 +665,14 @@
 			</trans-unit>
 
 			<!-- Error handlers -->
+			<trans-unit id="error.exception.welcomeToNeos" xml:space="preserve">
+				<source>Welcome to Neos</source>
+			</trans-unit>
 			<trans-unit id="error.exception.goToSetup" xml:space="preserve">
 				<source>Go to setup</source>
+			</trans-unit>
+			<trans-unit id="error.exception.technicalInformation" xml:space="preserve">
+				<source>Technical Information</source>
 			</trans-unit>
 
 			<trans-unit id="error.exception.noHomepageException.title" xml:space="preserve">
@@ -683,10 +689,10 @@
 				<source>Database Error</source>
 			</trans-unit>
 			<trans-unit id="error.exception.databaseConnectionExceptions.description" xml:space="preserve">
-				<source>Sorry, we detected an error with your database. Check your log files in Data/Logs/* for more information.</source>
+				<source>There is no database connection yet or the Neos database schema has not been created.</source>
 			</trans-unit>
 			<trans-unit id="error.exception.databaseConnectionExceptions.setupMessage" xml:space="preserve">
-				<source>You might want to configure or check your database configuration in the setup.</source>
+				<source>Run the setup to configure your database.</source>
 			</trans-unit>
 
 			<trans-unit id="error.exception.notFoundExceptions.title" xml:space="preserve">

--- a/Neos.Neos/Resources/Public/Styles/Error.css
+++ b/Neos.Neos/Resources/Public/Styles/Error.css
@@ -4156,7 +4156,7 @@ body {
 }
 .neos .neos-row-fluid .neos-offset10:first-child {
   margin-left: 85.10638%;
-  *margin-left: 85.0%;
+  *margin-left: 85%;
 }
 .neos .neos-row-fluid .neos-offset11 {
   margin-left: 95.74468%;

--- a/Neos.Neos/Resources/Public/Styles/Login.css
+++ b/Neos.Neos/Resources/Public/Styles/Login.css
@@ -4167,7 +4167,7 @@ html,
 }
 .neos .neos-row-fluid .neos-offset10:first-child {
   margin-left: 85.10638%;
-  *margin-left: 85.0%;
+  *margin-left: 85%;
 }
 .neos .neos-row-fluid .neos-offset11 {
   margin-left: 95.74468%;
@@ -5355,8 +5355,12 @@ html,
   width: 100%;
   height: 40px;
 }
-.neos .neos-login-box .neos-actions button {
+.neos .neos-login-box .neos-actions button, .neos .neos-login-box .neos-actions .btn {
+  text-align: center;
+  text-decoration: none !important;
+  display: block;
   height: 40px;
+  line-height: 40px;
   color: #fff;
   border: none;
   background-image: none;
@@ -5371,17 +5375,17 @@ html,
   font-family: 'Noto Sans', sans-serif;
   -webkit-font-smoothing: antialiased;
 }
-.neos .neos-login-box .neos-actions button:focus {
+.neos .neos-login-box .neos-actions button:focus, .neos .neos-login-box .neos-actions .btn:focus {
   outline: none;
 }
-.neos .neos-login-box .neos-actions button.neos-login-btn {
+.neos .neos-login-box .neos-actions button.neos-login-btn, .neos .neos-login-box .neos-actions .btn.neos-login-btn {
   background-color: #00b5ff;
   width: 100%;
 }
-.neos .neos-login-box .neos-actions button.neos-hidden {
+.neos .neos-login-box .neos-actions button.neos-hidden, .neos .neos-login-box .neos-actions .btn.neos-hidden {
   display: none;
 }
-.neos .neos-login-box .neos-actions button.neos-disabled {
+.neos .neos-login-box .neos-actions button.neos-disabled, .neos .neos-login-box .neos-actions .btn.neos-disabled {
   cursor: not-allowed;
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=65);
   opacity: 0.65;

--- a/Neos.Neos/Resources/Public/Styles/Neos.css
+++ b/Neos.Neos/Resources/Public/Styles/Neos.css
@@ -4274,7 +4274,7 @@ readers do not read off random characters that represent icons */
 }
 .neos .neos-row-fluid .neos-offset10:first-child {
   margin-left: 85.10638%;
-  *margin-left: 85.0%;
+  *margin-left: 85%;
 }
 .neos .neos-row-fluid .neos-offset11 {
   margin-left: 95.74468%;

--- a/Neos.Neos/Resources/Public/Styles/Welcome.css
+++ b/Neos.Neos/Resources/Public/Styles/Welcome.css
@@ -14,15 +14,15 @@
   position: relative;
   display: block;
 }
-.neos-error-details-toggle .neos-error-details-toggle__header:after {
+.neos-error-details-toggle .neos-error-details-toggle__header:before {
   content: '▼';
-  position: relative;
-  left: .3rem;
+  padding-right: .4rem;
+  font-size: 11.9px;
 }
 .neos-error-details-toggle .neos-error-details-toggle__body {
   overflow: hidden;
 }
-.neos-error-details-toggle--closed .neos-error-details-toggle__header:after {
+.neos-error-details-toggle--closed .neos-error-details-toggle__header:before {
   content: '▶';
 }
 .neos-error-details-toggle--closed .neos-error-details-toggle__body {

--- a/Neos.Neos/Resources/Public/Styles/Welcome.css
+++ b/Neos.Neos/Resources/Public/Styles/Welcome.css
@@ -1,0 +1,30 @@
+@charset "UTF-8";
+.neos {
+  color: #fff;
+}
+
+.neos-setup-btn {
+  background: #00ADEE;
+  width: 100%;
+}
+
+.neos-error-details-toggle .neos-error-details-toggle__header {
+  margin-bottom: 0;
+  cursor: pointer;
+  position: relative;
+  display: block;
+}
+.neos-error-details-toggle .neos-error-details-toggle__header:after {
+  content: '▼';
+  position: relative;
+  left: .3rem;
+}
+.neos-error-details-toggle .neos-error-details-toggle__body {
+  overflow: hidden;
+}
+.neos-error-details-toggle--closed .neos-error-details-toggle__header:after {
+  content: '▶';
+}
+.neos-error-details-toggle--closed .neos-error-details-toggle__body {
+  height: 0;
+}


### PR DESCRIPTION
**What I did**
Changed the error template for "database error" and "missing homepage" to a friendly welcome message, since most users are irritated by the big fat "database error" we greet them with currently.

Old:
![image](https://user-images.githubusercontent.com/10347669/43719553-4f510a70-998e-11e8-8016-3013a109a2e5.png)
![image](https://user-images.githubusercontent.com/10347669/43719580-5ddb703a-998e-11e8-8812-2cacdf558728.png)

New:
![image](https://user-images.githubusercontent.com/10347669/43719599-6f93af0e-998e-11e8-95f6-fe53c9c27139.png)
![image](https://user-images.githubusercontent.com/10347669/43719624-7abda240-998e-11e8-8309-53003a107390.png)
