### PR TITLE
BUGFIX: Respect disabled superTypes when filtering by Node Type

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -319,6 +319,9 @@ class NodeType
         if ($nodeType === $this->name) {
             return true;
         }
+        if (array_key_exists($nodeType, $this->declaredSuperTypes) && $this->declaredSuperTypes[$nodeType] === null) {
+            return false;
+        }
         foreach ($this->declaredSuperTypes as $superType) {
             if ($superType !== null && $superType->isOfType($nodeType) === true) {
                 return true;

--- a/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
@@ -109,6 +109,7 @@
 'Neos.ContentRepository.Testing:Column':
   superTypes:
     'Neos.ContentRepository.Testing:Content': TRUE
+    'Neos.ContentRepository.Testing:ContentMixin': FALSE
   abstract: TRUE
 
 'Neos.ContentRepository.Testing:TwoColumn':
@@ -132,9 +133,13 @@
       type: 'Neos.ContentRepository.Testing:ContentCollection'
 
 'Neos.ContentRepository.Testing:Content':
+  superTypes:
+    'Neos.ContentRepository.Testing:ContentMixin': TRUE
   constraints:
     nodeTypes:
       '*': FALSE
+
+'Neos.ContentRepository.Testing:ContentMixin': []
 
 'Neos.ContentRepository.Testing:Text':
   superTypes:

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
@@ -186,6 +186,19 @@ class FindOperationTest extends AbstractNodeTest
     /**
      * @test
      */
+    public function findByNodeWithInstanceofFilterExcludeNodesWithADisabledCorrespondingSuperType()
+    {
+        $q = new FlowQuery(array($this->node));
+        $foundNodes = $q->find('[instanceof Neos.ContentRepository.Testing:ContentMixin]')->get();
+        $foundNodeTypeNames = array_map(function (NodeInterface $node) {
+            return $node->getNodeType()->getName();
+        }, $foundNodes);
+        $this->assertNotContains('Neos.ContentRepository.Testing:ThreeColumn', $foundNodeTypeNames);
+    }
+
+    /**
+     * @test
+     */
     public function findByNodeWithMultipleInstanceofFilterReturnsMatchingNodesRecursively()
     {
         $q = new FlowQuery(array($this->node));

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -344,6 +344,24 @@ class NodeTypeTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function isOfTypeReturnsFalseForDirectlyDisabledSuperTypes()
+    {
+        $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:Shortcut');
+        $this->assertFalse($nodeType->isOfType('Neos.ContentRepository.Testing:SomeMixin'));
+    }
+
+    /**
+     * @test
+     */
+    public function isOfTypeReturnsFalseForIndirectlyDisabledSuperTypes()
+    {
+        $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:SubShortcut');
+        $this->assertFalse($nodeType->isOfType('Neos.ContentRepository.Testing:SomeMixin'));
+    }
+
+    /**
      * This test asserts that a supertype that has been inherited can be removed by a supertype again.
      * @test
      */


### PR DESCRIPTION
This fixes `NodeType::isOfType()` to return `false` when the given
type is explicitly disabled by the corresponding NodeType or one of
it's super types.

Example:

    'Acme:Animal':
      superTypes:
        'Acme:HasBonesMixin': true

    'Acme:Jellyfish':
      superTypes:
        'Acme:Animal': true
        'Acme:HasBonesMixin': false

With this `NodeTypeManager::getNodeType('Acme.Jellyfish')->isOfType('Acme:HasBonesMixin')`
should return `false` but it didn't.
Respectively a FlowQuery like the following should not return any "Jellyfish"-node (or
nodes with a sub-type): `q(node).find('[instanceof Acme:HasBonesMixin]')` but it did.

Fixes: #1983