### PR TITLE
BUGFIX: Unable to replace asset from the media browser

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -30,6 +30,7 @@ use Neos\Media\Domain\Model\ThumbnailConfiguration;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Strategy\AssetUsageStrategyInterface;
 use Neos\Media\Exception\AssetServiceException;
+use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 use Neos\Utility\Arrays;
 
 /**


### PR DESCRIPTION
This change add a missing use statement for `Neos\RedirectHandler\Storage\RedirectStorageInterface` in `AssetService`. With this statement the replacement of an asset from the medialib browser is not possible.

This bug affect user with the RedirectHandler package, without this package the replacement works fine.