### PR TITLE
BUGFIX: Fix DocTools settings

### DIFF
--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -1,40 +1,3 @@
-
-TYPO3:
-  DocTools:
-    collections:
-      Media:
-        commandReferences:
-          - 'Media:Commands'
-        references:
-          - 'Media:ViewHelpers'
-          - 'Media:Validators'
-    commandReferences:
-      'Media:Commands':
-        title: 'Media Command Reference'
-        packageKeys:
-          - Neos.Media
-        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/Commands.rst'
-    references:
-      'Media:Validators':
-        title: 'Media Validator Reference'
-        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/Validators.rst'
-        affectedClasses:
-          parentClassName: Neos\Flow\Validation\Validator\AbstractValidator
-          classNamePattern: '/^TYPO3\\Media\\Validator\\.*$/i'
-        parser:
-          implementationClassName: TYPO3\DocTools\Domain\Service\FlowValidatorClassParser
-      'Media:ViewHelpers':
-        title: 'Media ViewHelper Reference'
-        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/ViewHelpers.rst'
-        affectedClasses:
-          parentClassName: Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
-          classNamePattern: '/^TYPO3\\Media\\ViewHelpers\\.*$/i'
-        parser:
-          implementationClassName: TYPO3\DocTools\Domain\Service\FluidViewHelperClassParser
-          options:
-            namespaces:
-              typo3.media: Neos\Media\ViewHelpers
-
 Neos:
   Flow:
     persistence:
@@ -94,3 +57,39 @@ Neos:
         supportedExtensions:
           - ttf
           - otf
+
+  DocTools:
+    collections:
+      Media:
+        commandReferences:
+          - 'Media:Commands'
+        references:
+          - 'Media:ViewHelpers'
+          - 'Media:Validators'
+    commandReferences:
+      'Media:Commands':
+        title: 'Media Command Reference'
+        packageKeys:
+          - Neos.Media
+        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/Commands.rst'
+    references:
+      'Media:Validators':
+        title: 'Media Validator Reference'
+        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/Validators.rst'
+        affectedClasses:
+          parentClassName: Neos\Flow\Validation\Validator\AbstractValidator
+          classNamePattern: '/^TYPO3\\Media\\Validator\\.*$/i'
+        parser:
+          implementationClassName: TYPO3\DocTools\Domain\Service\FlowValidatorClassParser
+      'Media:ViewHelpers':
+        title: 'Media ViewHelper Reference'
+        savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/ViewHelpers.rst'
+        affectedClasses:
+          parentClassName: Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
+          classNamePattern: '/^TYPO3\\Media\\ViewHelpers\\.*$/i'
+        parser:
+          implementationClassName: TYPO3\DocTools\Domain\Service\FluidViewHelperClassParser
+          options:
+            namespaces:
+              typo3.media: Neos\Media\ViewHelpers
+

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -78,18 +78,18 @@ Neos:
         savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/Validators.rst'
         affectedClasses:
           parentClassName: Neos\Flow\Validation\Validator\AbstractValidator
-          classNamePattern: '/^TYPO3\\Media\\Validator\\.*$/i'
+          classNamePattern: '/^Neos\\Media\\Validator\\.*$/i'
         parser:
-          implementationClassName: TYPO3\DocTools\Domain\Service\FlowValidatorClassParser
+          implementationClassName: Neos\DocTools\Domain\Service\FlowValidatorClassParser
       'Media:ViewHelpers':
         title: 'Media ViewHelper Reference'
         savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Media/Documentation/References/ViewHelpers.rst'
         affectedClasses:
           parentClassName: Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
-          classNamePattern: '/^TYPO3\\Media\\ViewHelpers\\.*$/i'
+          classNamePattern: '/^Neos\\Media\\ViewHelpers\\.*$/i'
         parser:
-          implementationClassName: TYPO3\DocTools\Domain\Service\FluidViewHelperClassParser
+          implementationClassName: Neos\DocTools\Domain\Service\FluidViewHelperClassParser
           options:
             namespaces:
-              typo3.media: Neos\Media\ViewHelpers
+              neos.media: Neos\Media\ViewHelpers
 


### PR DESCRIPTION
The settings were defined in the wrong namespace and still used `TYPO3` in
some places.
