### PR TITLE
BUGFIX: Use the possible new node name to check it's existance in the move to location

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -553,15 +553,16 @@ class Node implements NodeInterface, CacheAwareInterface
             throw new NodeException('The root node cannot be moved.', 1285005924);
         }
 
-        if ($referenceNode->getParent() !== $this->getParent() && $referenceNode->getParent()->getNode($this->getName()) !== null) {
-            throw new NodeExistsException('Node with path "' . $this->getName() . '" already exists.', 1292503468);
+        $name = $newName !== null ? $newName : $this->getName();
+
+        if ($referenceNode->getParent() !== $this->getParent() && $referenceNode->getParent()->getNode($name) !== null) {
+            throw new NodeExistsException('Node with path "' . $name . '" already exists.', 1292503468);
         }
 
-        if (!$referenceNode->getParent()->willChildNodeBeAutoCreated($this->getName()) && !$referenceNode->getParent()->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
+        if (!$referenceNode->getParent()->willChildNodeBeAutoCreated($name) && !$referenceNode->getParent()->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
             throw new NodeConstraintException('Cannot move ' . $this->__toString() . ' before ' . $referenceNode->__toString(), 1400782413);
         }
 
-        $name = $newName !== null ? $newName : $this->getName();
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_BEFORE);
         if ($referenceNode->getParentPath() !== $this->getParentPath()) {
             $this->setPath(NodePaths::addNodePathSegment($referenceNode->getParentPath(), $name));
@@ -598,15 +599,16 @@ class Node implements NodeInterface, CacheAwareInterface
             throw new NodeException('The root node cannot be moved.', 1316361483);
         }
 
-        if ($referenceNode->getParent() !== $this->getParent() && $referenceNode->getParent()->getNode($this->getName()) !== null) {
-            throw new NodeExistsException('Node with path "' . $this->getName() . '" already exists.', 1292503469);
+        $name = $newName !== null ? $newName : $this->getName();
+
+        if ($referenceNode->getParent() !== $this->getParent() && $referenceNode->getParent()->getNode($name) !== null) {
+            throw new NodeExistsException('Node with path "' . $name . '" already exists.', 1292503469);
         }
 
-        if (!$referenceNode->getParent()->willChildNodeBeAutoCreated($this->getName()) && !$referenceNode->getParent()->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
+        if (!$referenceNode->getParent()->willChildNodeBeAutoCreated($name) && !$referenceNode->getParent()->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
             throw new NodeConstraintException('Cannot move ' . $this->__toString() . ' after ' . $referenceNode->__toString(), 1404648100);
         }
 
-        $name = $newName !== null ? $newName : $this->getName();
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_AFTER);
         if ($referenceNode->getParentPath() !== $this->getParentPath()) {
             $this->setPath(NodePaths::addNodePathSegment($referenceNode->getParentPath(), $name));
@@ -643,15 +645,16 @@ class Node implements NodeInterface, CacheAwareInterface
             throw new NodeException('The root node cannot be moved.', 1346769001);
         }
 
-        if ($referenceNode !== $this->getParent() && $referenceNode->getNode($this->getName()) !== null) {
-            throw new NodeExistsException('Node with path "' . $this->getName() . '" already exists.', 1292503470);
+        $name = $newName !== null ? $newName : $this->getName();
+
+        if ($referenceNode !== $this->getParent() && $referenceNode->getNode($name) !== null) {
+            throw new NodeExistsException('Node with path "' . $name . '" already exists.', 1292503470);
         }
 
-        if (!$referenceNode->willChildNodeBeAutoCreated($this->getName()) && !$referenceNode->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
+        if (!$referenceNode->willChildNodeBeAutoCreated($name) && !$referenceNode->isNodeTypeAllowedAsChildNode($this->getNodeType())) {
             throw new NodeConstraintException('Cannot move ' . $this->__toString() . ' into ' . $referenceNode->__toString(), 1404648124);
         }
 
-        $name = $newName !== null ? $newName : $this->getName();
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_LAST);
         $this->setPath(NodePaths::addNodePathSegment($referenceNode->getPath(), $name));
         $this->nodeDataRepository->persistEntities();

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -879,12 +879,16 @@ class NodesTest extends FunctionalTestCase
         $childNodeA = $parentNode->createNode('child-node-a');
         $childNodeB = $parentNode->createNode('child-node-b');
         $childNodeB1 = $childNodeB->createNode('child-node-b1');
+        $childNodeB2 = $childNodeB->createNode('child-node-not-unique');
+        $childNodeC = $parentNode->createNode('child-node-not-unique');
         $this->persistenceManager->persistAll();
         $childNodeB->moveInto($childNodeA, 'renamed-child-node-b');
+        $childNodeC->moveInto($childNodeB, 'child-node-now-unique');
         $this->persistenceManager->persistAll();
         $this->assertNull($parentNode->getNode('child-node-b'));
         $this->assertSame($childNodeB, $childNodeA->getNode('renamed-child-node-b'));
         $this->assertSame($childNodeB1, $childNodeA->getNode('renamed-child-node-b')->getNode('child-node-b1'));
+        $this->assertSame($childNodeC, $childNodeB->getNode('child-node-now-unique'));
     }
 
     /**


### PR DESCRIPTION
The NodeExistsException was thrown even if the new nodeName does not exist in the new location, because only the old nodeName was checked.

Affected Versions: 3.3+ (I did not check the previous versions because it's not security critical)
