### PR TITLE
BUGFIX: fix generation of i18n lables for the creationDialog

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -150,8 +150,11 @@ class NodeTypeConfigurationEnrichmentAspect
                 $propertyConfiguration['ui']['label'] = $this->getPropertyLabelTranslationId($nodeTypeLabelIdPrefix, $propertyName);
             }
 
-            if (isset($propertyConfiguration['ui']['inspector']['editor'])) {
-                $this->applyInspectorEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $propertyConfiguration);
+            if (isset($propertyConfiguration['ui']['inspector']['editor']) && isset($propertyConfiguration['ui']['inspector']['editorOptions'])) {
+                $translationIdGenerator = function ($path) use ($nodeTypeLabelIdPrefix, $propertyName) {
+                    return $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, $path);
+                };
+                $this->applyEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $propertyConfiguration['ui']['inspector']['editor'], $propertyConfiguration['ui']['inspector']['editorOptions'], $translationIdGenerator);
             }
 
             if (isset($propertyConfiguration['ui']['aloha']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['aloha'], 'placeholder')) {
@@ -200,39 +203,39 @@ class NodeTypeConfigurationEnrichmentAspect
     /**
      * @param string $nodeTypeLabelIdPrefix
      * @param string $propertyName
-     * @param array $propertyConfiguration
+     * @param string $editorName
+     * @param array $editorOptions
+     * @param callable $translationIdGenerator
      * @return void
      */
-    protected function applyInspectorEditorLabels($nodeTypeLabelIdPrefix, $propertyName, array &$propertyConfiguration)
+    protected function applyEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $editorName, array &$editorOptions, $translationIdGenerator)
     {
-        $editorName = $propertyConfiguration['ui']['inspector']['editor'];
-
         switch ($editorName) {
             case 'Neos.Neos/Inspector/Editors/SelectBoxEditor':
-                if (isset($propertyConfiguration['ui']['inspector']['editorOptions']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['inspector']['editorOptions'], 'placeholder')) {
-                    $propertyConfiguration['ui']['inspector']['editorOptions']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'selectBoxEditor.placeholder');
+                if (isset($editorOptions) && $this->shouldFetchTranslation($editorOptions, 'placeholder')) {
+                    $editorOptions['placeholder'] = $translationIdGenerator('selectBoxEditor.placeholder');
                 }
 
-                if (!isset($propertyConfiguration['ui']['inspector']['editorOptions']['values']) || !is_array($propertyConfiguration['ui']['inspector']['editorOptions']['values'])) {
+                if (!isset($editorOptions['values']) || !is_array($editorOptions['values'])) {
                     break;
                 }
-                foreach ($propertyConfiguration['ui']['inspector']['editorOptions']['values'] as $value => &$optionConfiguration) {
+                foreach ($editorOptions['values'] as $value => &$optionConfiguration) {
                     if ($optionConfiguration === null) {
                         continue;
                     }
                     if ($this->shouldFetchTranslation($optionConfiguration)) {
-                        $optionConfiguration['label'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'selectBoxEditor.values.' . $value);
+                        $optionConfiguration['label'] = $translationIdGenerator('selectBoxEditor.values.' . $value);
                     }
                 }
                 break;
             case 'Neos.Neos/Inspector/Editors/CodeEditor':
-                if ($this->shouldFetchTranslation($propertyConfiguration['ui']['inspector']['editorOptions'], 'buttonLabel')) {
-                    $propertyConfiguration['ui']['inspector']['editorOptions']['buttonLabel'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'codeEditor.buttonLabel');
+                if ($this->shouldFetchTranslation($editorOptions, 'buttonLabel')) {
+                    $editorOptions['buttonLabel'] = $translationIdGenerator('codeEditor.buttonLabel');
                 }
                 break;
             case 'Neos.Neos/Inspector/Editors/TextFieldEditor':
-                if (isset($propertyConfiguration['ui']['inspector']['editorOptions']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['inspector']['editorOptions'], 'placeholder')) {
-                    $propertyConfiguration['ui']['inspector']['editorOptions']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'textFieldEditor.placeholder');
+                if (isset($editorOptions) && $this->shouldFetchTranslation($editorOptions, 'placeholder')) {
+                    $editorOptions['placeholder'] = $translationIdGenerator('textFieldEditor.placeholder');
                 }
                 break;
         }
@@ -278,11 +281,18 @@ class NodeTypeConfigurationEnrichmentAspect
 
         $creationDialogConfiguration = Arrays::getValueByPath($configuration, 'ui.creationDialog.elements');
         if (is_array($creationDialogConfiguration)) {
-            foreach ($creationDialogConfiguration as $elementName => $elementConfiguration) {
+            $creationDialogConfiguration = &$configuration['ui']['creationDialog']['elements'];
+            foreach ($creationDialogConfiguration as $elementName => &$elementConfiguration) {
+                if (isset($elementConfiguration['ui']['editor']) && isset($elementConfiguration['ui']['editorOptions'])) {
+                    $translationIdGenerator = function ($path) use ($nodeTypeLabelIdPrefix, $elementName) {
+                        return $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'creationDialog', $elementName . '.' . $path);
+                    };
+                    $this->applyEditorLabels($nodeTypeLabelIdPrefix, $elementName, $elementConfiguration['ui']['editor'], $elementConfiguration['ui']['editorOptions'], $translationIdGenerator);
+                }
                 if (!is_array($elementConfiguration) || !$this->shouldFetchTranslation($elementConfiguration['ui'])) {
                     continue;
                 }
-                $configuration['ui']['creationDialog']['elements'][$elementName]['ui']['label'] = $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'creationDialog', $elementName);
+                $elementConfiguration['ui']['label'] = $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'creationDialog', $elementName);
             }
         }
     }


### PR DESCRIPTION
This PR fixes support for I18n labels of editorOptions in the creationDialog.

**How to verify it**

```yaml
  ui:
    creationDialog:
      elements:
        test:
          type: string
          ui:
            label: i18n
            editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
            editorOptions:
              values:
                1:
                  label: i18n
                2:
                  label: i18n
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
	<file original="" product-name="Test.Test" source-language="en" datatype="plaintext">
		<body>
			<trans-unit id="creationDialog.test" xml:space="preserve">
				<source>Number of columns</source>
			</trans-unit>
			<trans-unit id="creationDialog.test.selectBoxEditor.values.1" xml:space="preserve">
				<source>1 test</source>
			</trans-unit>
			<trans-unit id="creationDialog.test.selectBoxEditor.values.2" xml:space="preserve">
				<source>2 test</source>
			</trans-unit>
			<trans-unit id="ui.label" xml:space="preserve">
				<source>Test label</source>
			</trans-unit>
		</body>
	</file>
</xliff>
```
