### PR TITLE
TASK: Add optional node type inheritance to CreateNodePrivilege

### DIFF
--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilegeContext.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilegeContext.php
@@ -11,7 +11,6 @@ namespace Neos\ContentRepository\Security\Authorization\Privilege\Node;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
 
@@ -43,13 +42,14 @@ class CreateNodePrivilegeContext extends NodePrivilegeContext
 
         if ($includeSubNodeTypes) {
             $creationNodeTypeNames = [];
-            foreach ($this->creationNodeTypes as $creationNodeType) {
-                foreach ($this->nodeTypeManager->getSubNodeTypes($creationNodeType) as $subNodeType) {
-                    /** @var NodeType $subNodeType */
-                    $creationNodeTypeNames[$subNodeType->getName()] = true;
+            foreach ($this->creationNodeTypes as $creationNodeTypeName) {
+                $creationNodeTypeNames[$creationNodeTypeName] = true;
+                $subNodeTypes = $this->nodeTypeManager->getSubNodeTypes($creationNodeTypeName, false);
+                foreach ($subNodeTypes as $subNodeTypeName => $subNodeType) {
+                    $creationNodeTypeNames[$subNodeTypeName] = true;
                 }
             }
-            $this->creationNodeTypes = array_merge($this->creationNodeTypes, array_keys($creationNodeTypeNames));
+            $this->creationNodeTypes = array_keys($creationNodeTypeNames);
         }
 
         return true;

--- a/Neos.ContentRepository/Classes/Service/AuthorizationService.php
+++ b/Neos.ContentRepository/Classes/Service/AuthorizationService.php
@@ -109,7 +109,7 @@ class AuthorizationService
             }
         }
         $implicitlyDeniedNodeTypes = array_diff($abstainedCreationNodeTypes, $grantedCreationNodeTypes);
-        return array_merge($implicitlyDeniedNodeTypes, $deniedCreationNodeTypes);
+        return array_unique(array_merge($implicitlyDeniedNodeTypes, $deniedCreationNodeTypes));
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Behavior/Features/Security/CreateNodePrivilege.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/Security/CreateNodePrivilege.feature
@@ -4,13 +4,11 @@ Feature: Privilege to restrict creation of nodes
     Given I have the following policies:
     """
     privilegeTargets:
-
       'Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege':
+        'Neos.ContentRepository.Testing:Service':
+          matcher: 'isDescendantNodeOf("/sites/content-repository/service/") && nodeIsOfType("Neos.ContentRepository.Testing:Document") && createdNodeIsOfType("Neos.ContentRepository.Testing:Text")'
 
-        'Neos.ContentRepository:Service':
-          matcher: 'isDescendantNodeOf("/sites/content-repository/service/") && nodeIsOfType("Neos.ContentRepository.Testing:Document") && createdNodeIsOfType("Neos.NodeTypes:Text")'
-
-        'Neos.ContentRepository:Company':
+        'Neos.ContentRepository.Testing:Company':
           matcher: 'isDescendantNodeOf("68ca0dcd-2afb-ef0e-1106-a5301e65b8a0")'
 
     roles:
@@ -25,19 +23,35 @@ Feature: Privilege to restrict creation of nodes
 
       'Neos.ContentRepository:Administrator':
         privileges:
-          -
-            privilegeTarget: 'Neos.ContentRepository:Service'
+          - privilegeTarget: 'Neos.ContentRepository.Testing:Service'
             permission: GRANT
-          -
-            privilegeTarget: 'Neos.ContentRepository:Company'
+          - privilegeTarget: 'Neos.ContentRepository.Testing:Company'
             permission: GRANT
       """
     And I have the following nodes:
-      | Identifier                           | Path                        | Node Type                      | Properties           | Workspace |
-      | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites                      | unstructured                   |                      | live      |
+      | Identifier                           | Path                                   | Node Type                               | Properties           | Workspace |
+      | ecf40ad1-3119-0a43-d02e-55f8b5aa3c70 | /sites                                 | unstructured                            |                      | live      |
       | fd5ba6e1-4313-b145-1004-dad2f1173a35 | /sites/content-repository              | Neos.ContentRepository.Testing:Document | {"title": "Home"}    | live      |
       | 68ca0dcd-2afb-ef0e-1106-a5301e65b8a0 | /sites/content-repository/company      | Neos.ContentRepository.Testing:Document | {"title": "Company"} | live      |
       | 52540602-b417-11e3-9358-14109fd7a2dd | /sites/content-repository/service      | Neos.ContentRepository.Testing:Document | {"title": "Service"} | live      |
+
+  @Isolated @fixtures
+  Scenario: creating text nodes under company is granted to administrators
+    Given I am authenticated with role "Neos.ContentRepository:Administrator"
+    And I get a node by path "/sites/content-repository/company" with the following context:
+      | Workspace |
+      | live      |
+    Then I should be granted to create a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text"
+    And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
+
+  @Isolated @fixtures
+  Scenario: creating text nodes under company is denied to everybody
+    Given I am not authenticated
+    And I get a node by path "/sites/content-repository/company" with the following context:
+      | Workspace |
+      | live      |
+    Then I should not be granted to create a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text"
+    And I should get the list of all available node types as denied node types for this node from the node authorization service
 
   @Isolated @fixtures
   Scenario: creating text nodes under service is denied to everybody
@@ -45,8 +59,8 @@ Feature: Privilege to restrict creation of nodes
     And I get a node by path "/sites/content-repository/service" with the following context:
       | Workspace |
       | live      |
-    Then I should not be granted to create a new "mynewtext" child node of type "Neos.NodeTypes:Text"
-    And I should get FALSE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.NodeTypes:Text" is granted
+    Then I should not be granted to create a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text"
+    And I should get FALSE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
 
   @Isolated @fixtures
   Scenario: creating image nodes under service is granted to everybody
@@ -54,8 +68,8 @@ Feature: Privilege to restrict creation of nodes
     And I get a node by path "/sites/content-repository/service" with the following context:
       | Workspace |
       | live      |
-    Then I should be granted to create a new "mynewimage" child node of type "Neos.NodeTypes:Image"
-    And I should get TRUE when asking the node authorization service if creating a new "mynewimage" child node of type "Neos.NodeTypes:Image" is granted
+    Then I should be granted to create a new "mynewimage" child node of type "Neos.ContentRepository.Testing:Image"
+    And I should get TRUE when asking the node authorization service if creating a new "mynewimage" child node of type "Neos.ContentRepository.Testing:Image" is granted
 
   @Isolated @fixtures
   Scenario: creating text nodes under service is granted to administrators
@@ -63,8 +77,8 @@ Feature: Privilege to restrict creation of nodes
     And I get a node by path "/sites/content-repository/service" with the following context:
       | Workspace |
       | live      |
-    Then I should be granted to create a new "mynewtext" child node of type "Neos.NodeTypes:Text"
-    And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.NodeTypes:Text" is granted
+    Then I should be granted to create a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text"
+    And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
 
   @Isolated @fixtures
   Scenario: creating text nodes under service is denied to everybody
@@ -73,23 +87,5 @@ Feature: Privilege to restrict creation of nodes
       | Workspace |
       | live      |
     Then I should get the following list of denied node types for this node from the node authorization service:
-      | nodeTypeName              |
-      | Neos.NodeTypes:Text |
-
-  @Isolated @fixtures
-  Scenario: creating text nodes under company is granted to administrators
-    Given I am authenticated with role "Neos.ContentRepository:Administrator"
-    And I get a node by path "/sites/content-repository/company" with the following context:
-      | Workspace |
-      | live      |
-    Then I should be granted to create a new "mynewtext" child node of type "Neos.NodeTypes:Text"
-    And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.NodeTypes:Text" is granted
-
-  @Isolated @fixtures
-  Scenario: creating text nodes under company is denied to everybody
-    Given I am not authenticated
-    And I get a node by path "/sites/content-repository/company" with the following context:
-      | Workspace |
-      | live      |
-    Then I should not be granted to create a new "mynewtext" child node of type "Neos.NodeTypes:Text"
-    And I should get the list of all available node types as denied node types for this node from the node authorization service
+      | nodeTypeName                        |
+      | Neos.ContentRepository.Testing:Text |

--- a/Neos.ContentRepository/Tests/Behavior/Features/Security/CreateNodePrivilege.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/Security/CreateNodePrivilege.feature
@@ -5,8 +5,11 @@ Feature: Privilege to restrict creation of nodes
     """
     privilegeTargets:
       'Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege':
-        'Neos.ContentRepository.Testing:Service':
-          matcher: 'isDescendantNodeOf("/sites/content-repository/service/") && nodeIsOfType("Neos.ContentRepository.Testing:Document") && createdNodeIsOfType("Neos.ContentRepository.Testing:Text")'
+        'Neos.ContentRepository.Testing:ServiceText':
+          matcher: 'isDescendantNodeOf("/sites/content-repository/service/") && createdNodeIsOfType("Neos.ContentRepository.Testing:Text")'
+
+        'Neos.ContentRepository.Testing:ServiceTextSubnodes':
+          matcher: 'isDescendantNodeOf("/sites/content-repository/service/") && createdNodeIsOfType("Neos.ContentRepository.Testing:Text", true)'
 
         'Neos.ContentRepository.Testing:Company':
           matcher: 'isDescendantNodeOf("68ca0dcd-2afb-ef0e-1106-a5301e65b8a0")'
@@ -23,10 +26,16 @@ Feature: Privilege to restrict creation of nodes
 
       'Neos.ContentRepository:Administrator':
         privileges:
-          - privilegeTarget: 'Neos.ContentRepository.Testing:Service'
-            permission: GRANT
           - privilegeTarget: 'Neos.ContentRepository.Testing:Company'
             permission: GRANT
+
+      'Neos.ContentRepository.Testing:CreateServiceText':
+        - privilegeTarget: 'Neos.ContentRepository.Testing:ServiceText'
+          permission: GRANT
+
+      'Neos.ContentRepository.Testing:CreateServiceTextSubnodes':
+        - privilegeTarget: 'Neos.ContentRepository.Testing:ServiceTextSubnodes'
+          permission: GRANT
       """
     And I have the following nodes:
       | Identifier                           | Path                                   | Node Type                               | Properties           | Workspace |
@@ -63,6 +72,15 @@ Feature: Privilege to restrict creation of nodes
     And I should get FALSE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
 
   @Isolated @fixtures
+  Scenario: creating TextWithImage nodes under service is denied to everybody
+    Given I am not authenticated
+    And I get a node by path "/sites/content-repository/service" with the following context:
+      | Workspace |
+      | live      |
+    Then I should not be granted to create a new "mynewtextwithimage" child node of type "Neos.ContentRepository.Testing:TextWithImage"
+    And I should get FALSE when asking the node authorization service if creating a new "mynewtextwithimage" child node of type "Neos.ContentRepository.Testing:TextWithImage" is granted
+
+  @Isolated @fixtures
   Scenario: creating image nodes under service is granted to everybody
     Given I am not authenticated
     And I get a node by path "/sites/content-repository/service" with the following context:
@@ -72,8 +90,29 @@ Feature: Privilege to restrict creation of nodes
     And I should get TRUE when asking the node authorization service if creating a new "mynewimage" child node of type "Neos.ContentRepository.Testing:Image" is granted
 
   @Isolated @fixtures
-  Scenario: creating text nodes under service is granted to administrators
-    Given I am authenticated with role "Neos.ContentRepository:Administrator"
+  Scenario: unauthenticated users cannot create Text or TextWithImage nodes under service
+    Given I am not authenticated
+    And I get a node by path "/sites/content-repository/service" with the following context:
+      | Workspace |
+      | live      |
+    Then I should get the following list of denied node types for this node from the node authorization service:
+      | nodeTypeName                                 |
+      | Neos.ContentRepository.Testing:Text          |
+      | Neos.ContentRepository.Testing:TextWithImage |
+
+  @Isolated @fixtures
+  Scenario: CreateServiceText role cannot create TextWithImage nodes under service
+    Given I am authenticated with role "Neos.ContentRepository.Testing:CreateServiceText"
+    And I get a node by path "/sites/content-repository/service" with the following context:
+      | Workspace |
+      | live      |
+    Then I should get the following list of denied node types for this node from the node authorization service:
+      | nodeTypeName                                 |
+      | Neos.ContentRepository.Testing:TextWithImage |
+
+  @Isolated @fixtures
+  Scenario: creating text nodes under service is granted to role CreateServiceText
+    Given I am authenticated with role "Neos.ContentRepository.Testing:CreateServiceText"
     And I get a node by path "/sites/content-repository/service" with the following context:
       | Workspace |
       | live      |
@@ -81,11 +120,19 @@ Feature: Privilege to restrict creation of nodes
     And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
 
   @Isolated @fixtures
-  Scenario: creating text nodes under service is denied to everybody
-    Given I am not authenticated
+  Scenario: creating text nodes under service is granted to role CreateServiceTextSubnodes
+    Given I am authenticated with role "Neos.ContentRepository.Testing:CreateServiceTextSubnodes"
     And I get a node by path "/sites/content-repository/service" with the following context:
       | Workspace |
       | live      |
-    Then I should get the following list of denied node types for this node from the node authorization service:
-      | nodeTypeName                        |
-      | Neos.ContentRepository.Testing:Text |
+    Then I should be granted to create a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text"
+    And I should get TRUE when asking the node authorization service if creating a new "mynewtext" child node of type "Neos.ContentRepository.Testing:Text" is granted
+
+  @Isolated @fixtures
+  Scenario: creating TextWithImage nodes under service is granted to role CreateServiceTextSubnodes
+    Given I am authenticated with role "Neos.ContentRepository.Testing:CreateServiceTextSubnodes"
+    And I get a node by path "/sites/content-repository/service" with the following context:
+      | Workspace |
+      | live      |
+    Then I should be granted to create a new "mynewtextwithimage" child node of type "Neos.ContentRepository.Testing:TextWithImage"
+    And I should get TRUE when asking the node authorization service if creating a new "mynewtextwithimage" child node of type "Neos.ContentRepository.Testing:TextWithImage" is granted

--- a/Neos.Neos/Documentation/CreatingASite/Security.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Security.rst
@@ -120,8 +120,8 @@ Node privileges define what can be restricted in relation to accessing and editi
             isDescendantNodeOf("c1e528e2-b495-0622-e71c-f826614ef287")
             && createdNodeIsOfType("Neos.NodeTypes:Text")
 
-  will actually only affect nodes of that type (and subtypes). All users will still be able to create other node types,
-  unless you also add a more generic privilege target:
+  will actually only affect nodes of the type `Neos.NodeTypes:Text` (not even subtypes). All users will still be able to
+  create other node types, unless you also add a more generic privilege target:
 
   .. code-block:: yaml
 
@@ -219,6 +219,7 @@ Usage example:
 
 This defines a privilege target that intercepts creation of Text nodes in the specified node (and all of its child
 nodes).
+To include all sub node types of `Neos.NodeTypes:Text`, use ``createdNodeIsOfType("Neos.NodeTypes:Text", true)``.
 
 EditNodePrivilege
 -----------------
@@ -341,9 +342,10 @@ Inheritance is taken into account, so that specific types also match if a supert
 The second one allows to match on the type of a node that is being created:
 
 Signature:
-  ``createdNodeIsOfType(nodetype-identifier)``
+  ``createdNodeIsOfType(nodetype-identifier[, include-subnodetypes])``
 Parameters:
   * ``nodetype-identifier`` (string|array) an array of supported node type identifiers or a single node type identifier
+  * ``include-subnodetypes`` (bool, optional) if sub node types should be included, defaults to ``false``
 Applicable to:
   matchers of the ``CreateNodePrivilege``
 


### PR DESCRIPTION
If you define a matcher like createdNodeIsOfType("Some.Package:Mixin"), the creation of a node using this mixin should match.
Currently only the final NodeType is checked (ignoring inheritance). Imho here we should do the same inheritance checks as everywhere else.

This is a non-breaking version of #2017, based on the currently lowest maintained branch 3.3 (2.3 is security only).