### PR TITLE
TASK: Adds documentation for dynamically hiding editors in Neos UI

### DIFF
--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
@@ -11,9 +11,32 @@ All configuration values that begin with ``ClientEval:`` are dynamically evaluat
 the client side. They are written in plain JavaScript (evaluated with ``eval``) and
 have ``node`` variable in the scope pointing to the currently focused node, with all
 transient inspector changes applied. For now it is only related to the nodetypes
-inspector configuration, but in the future may be extended to the other parts of
-the user interface.
+label and inspector configuration (with the exception of the group and position), but
+in the future may be extended to the other parts of the user interface.
 
+The following data is available in the ``node`` variable:
+
+``children``
+  An array of all direct children of the node containing an object with the ``nodeType``
+  of each child.
+
+``depth``
+  The depth of the node in the node tree.
+
+``identifier``
+  The identifier of the node.
+
+``label``
+  The label with which the node is displayed inside the Neos UI.
+
+``name``
+  The name of the node.
+
+``nodeType``
+  The Node Type of the node.
+
+``properties``
+  An object with key–value pairs of all properties of the node.
 
 A few Practical Examples
 ========================
@@ -22,7 +45,7 @@ Hiding one property when the other one is not set
 -------------------------------------------------
 
 Here is an example how to hide the property ``borderColor`` if ``borderWidth`` is empty
-by changing its group name to a non-existant value:
+by hiding it in the inspector:
 
 .. code-block:: yaml
 
@@ -37,7 +60,7 @@ by changing its group name to a non-existant value:
         type: string
         ui:
           inspector:
-            group: 'ClientEval:node.properties.borderWidth ? "style" : "invalid-group"'
+            hidden: 'ClientEval:node.properties.borderWidth ? false : true'
 
 Dependent SelectBoxes
 ---------------------

--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -354,7 +354,7 @@ The following options are allowed:
         Position inside the inspector group, small numbers are sorted on top.
 
       ``hidden``
-        If `true`, the editor of this property won't be shown in the inspector group. Used for :ref:`dynamic-configuration-processing`.
+        If `true`, the editor of this property won't be shown in the inspector group. May be used for :ref:`dynamic-configuration-processing`.
 
       ``editor``
         Name of the JavaScript Editor Class which is instantiated to edit this element in the inspector.

--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/NodeTypeDefinition.rst
@@ -353,6 +353,9 @@ The following options are allowed:
       ``position``
         Position inside the inspector group, small numbers are sorted on top.
 
+      ``hidden``
+        If `true`, the editor of this property won't be shown in the inspector group. Used for :ref:`dynamic-configuration-processing`.
+
       ``editor``
         Name of the JavaScript Editor Class which is instantiated to edit this element in the inspector.
 

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -115,11 +115,11 @@ additionalProperties:
 
                       'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
 
-                          'position': { type: ['integer', 'null'], description: 'Position inside the inspector group, small numbers are sorted on top.' }
+                      'position': { type: ['integer', 'null'], description: 'Position inside the inspector group, small numbers are sorted on top.' }
 
-                          'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the editor of this property won't be shown in the inspector group.' }
+                      'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the editor of this property won't be shown in the inspector group.' }
 
-                          'editor': { type: ['string', 'null'], description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
+                      'editor': { type: ['string', 'null'], description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
 
                       'editorOptions': { type: dictionary, description: 'options for the given editor' }
 

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -224,7 +224,7 @@ additionalProperties:
 
                   'position': { type: integer, description: 'Position of the view, small numbers are sorted on top' }
 
-                  'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the editor of this property won't be shown in the inspector group.' }
+                  'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the view won't be shown in the inspector group.' }
 
         'creationDialog':
           type: dictionary

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -115,9 +115,11 @@ additionalProperties:
 
                       'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
 
-                      'position': { type: integer, description: 'Position inside the inspector group, small numbers are sorted on top' }
+                          'position': { type: ['integer', 'null'], description: 'Position inside the inspector group, small numbers are sorted on top.' }
 
-                      'editor': { type: string, description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
+                          'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the editor of this property won't be shown in the inspector group.' }
+
+                          'editor': { type: ['string', 'null'], description: 'Name of the JavaScript Editor Class which is instanciated to edit this element in the inspector.' }
 
                       'editorOptions': { type: dictionary, description: 'options for the given editor' }
 

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -224,6 +224,8 @@ additionalProperties:
 
                   'position': { type: integer, description: 'Position of the view, small numbers are sorted on top' }
 
+                  'hidden': { type: ['boolean', 'null'], description: 'If TRUE, the editor of this property won't be shown in the inspector group.' }
+
         'creationDialog':
           type: dictionary
           additionalProperties: FALSE


### PR DESCRIPTION
Replaces https://github.com/neos/neos-development-collection/pull/2180 in favor of merging to branch 3.3.

---

Relates Neos UI Issue https://github.com/neos/neos-ui/issues/1682 and PR https://github.com/neos/neos-ui/pull/2118

**What I did**

Added documentation for dynamically hiding editors in Neos UI. See Issue https://github.com/neos/neos-ui/issues/1682 and PR https://github.com/neos/neos-ui/pull/2118 there.