### PR TITLE
BUGFIX: issue #2186 : if "asset" is used, it keeps its value

### DIFF
--- a/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
@@ -75,7 +75,9 @@ class FileTypeIconViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(AssetInterface $file = null, AssetInterface $asset = null, string $filename = null, $width = null, $height = null)
     {
-        $asset = $file;
+        if (!is_null($file) {
+            $asset = $file;
+        }
         if ($asset === null && $filename === null) {
             throw new \InvalidArgumentException('You must either specify "asset" or "filename" for the ' . __CLASS__ . '.', 1524039575);
         }


### PR DESCRIPTION
Fixes  issue #2186

- $file is only set as $asset ($asset = $file)   IF   $file is NOT null ...

**What I did**
- check that $file is NOT null

**How I did it**
- if (!is_null($file))

**How to verify it**
- ?

**Checklist**
- ?

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

- I should have done this **Bugfix** (!) against 4.1, - not master I guess ?