### PR TITLE
FEATURE: Add Fusion prototypes `Join`, `Loop`, `Map`, `Reduce` and `DataStructure`

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractCollectionImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractCollectionImplementation.php
@@ -15,16 +15,10 @@ use Neos\Fusion\Exception as FusionException;
 
 /**
  * Abstract implementation of a collection renderer for Fusion.
+ * @deprecated since Neos 4.2 in favor of MapImplementation
  */
-abstract class AbstractCollectionImplementation extends AbstractFusionObject
+abstract class AbstractCollectionImplementation extends MapImplementation
 {
-    /**
-     * The number of rendered nodes, filled only after evaluate() was called.
-     *
-     * @var integer
-     */
-    protected $numberOfRenderedNodes;
-
     /**
      * Render the array collection by triggering the itemRenderer for every element
      *
@@ -36,29 +30,11 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function getItemName()
+    public function getItems()
     {
-        return $this->fusionValue('itemName');
-    }
-
-    /**
-     * @return string
-     */
-    public function getItemKey()
-    {
-        return $this->fusionValue('itemKey');
-    }
-
-    /**
-     * If set iteration data (index, cycle, isFirst, isLast) is available in context with the name given.
-     *
-     * @return string
-     */
-    public function getIterationName()
-    {
-        return $this->fusionValue('iterationName');
+        return $this->getCollection();
     }
 
     /**
@@ -69,7 +45,7 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function evaluate()
     {
-        return implode('', $this->evaluateAsArray());
+        return implode('', parent::evaluate());
     }
 
     /**
@@ -80,66 +56,6 @@ abstract class AbstractCollectionImplementation extends AbstractFusionObject
      */
     public function evaluateAsArray()
     {
-        $collection = $this->getCollection();
-
-        $result = [];
-        if ($collection === null) {
-            return $result;
-        }
-        $this->numberOfRenderedNodes = 0;
-        $itemName = $this->getItemName();
-        if ($itemName === null) {
-            throw new FusionException('The Collection needs an itemName to be set.', 1344325771);
-        }
-        $itemKey = $this->getItemKey();
-        $iterationName = $this->getIterationName();
-        $collectionTotalCount = count($collection);
-        foreach ($collection as $collectionKey => $collectionElement) {
-            $context = $this->runtime->getCurrentContext();
-            $context[$itemName] = $collectionElement;
-            if ($itemKey !== null) {
-                $context[$itemKey] = $collectionKey;
-            }
-            if ($iterationName !== null) {
-                $context[$iterationName] = $this->prepareIterationInformation($collectionTotalCount);
-            }
-
-            $this->runtime->pushContextArray($context);
-            $result[] =  $this->runtime->render($this->path . '/itemRenderer');
-            $this->runtime->popContext();
-            $this->numberOfRenderedNodes++;
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param integer $collectionCount
-     * @return array
-     */
-    protected function prepareIterationInformation($collectionCount)
-    {
-        $iteration = [
-            'index' => $this->numberOfRenderedNodes,
-            'cycle' => ($this->numberOfRenderedNodes + 1),
-            'isFirst' => false,
-            'isLast' => false,
-            'isEven' => false,
-            'isOdd' => false
-        ];
-
-        if ($this->numberOfRenderedNodes === 0) {
-            $iteration['isFirst'] = true;
-        }
-        if (($this->numberOfRenderedNodes + 1) === $collectionCount) {
-            $iteration['isLast'] = true;
-        }
-        if (($this->numberOfRenderedNodes + 1) % 2 === 0) {
-            $iteration['isEven'] = true;
-        } else {
-            $iteration['isOdd'] = true;
-        }
-
-        return $iteration;
+        return parent::evaluate();
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ArrayImplementation.php
@@ -11,67 +11,20 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Utility\Exception\InvalidPositionException;
-use Neos\Utility\PositionalArraySorter;
-use Neos\Fusion;
 
 /**
  * The old "COA" object
+ * @deprecated since Neos 4.2 in favor of JoinImplementation
  */
-class ArrayImplementation extends AbstractArrayFusionObject
+class ArrayImplementation extends JoinImplementation
 {
     /**
-     * {@inheritdoc}
+     * Arrays are always concatenated with an empty string
      *
      * @return string
      */
-    public function evaluate()
+    public function getGlue()
     {
-        $sortedChildFusionKeys = $this->sortNestedFusionKeys();
-
-        if (count($sortedChildFusionKeys) === 0) {
-            return null;
-        }
-
-        $output = '';
-        foreach ($sortedChildFusionKeys as $key) {
-            try {
-                $output .= $this->fusionValue($key);
-            } catch (\Exception $e) {
-                $output .= $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
-            }
-        }
-
-        return $output;
-    }
-
-    /**
-     * Sort the Fusion objects inside $this->properties depending on:
-     * - numerical ordering
-     * - position meta-property
-     *
-     * This will ignore all properties defined in "@ignoreProperties" in Fusion
-     *
-     * @see PositionalArraySorter
-     *
-     * @return array an ordered list of keys
-     * @throws Fusion\Exception if the positional string has an unsupported format
-     */
-    protected function sortNestedFusionKeys()
-    {
-        $arraySorter = new PositionalArraySorter($this->properties, '__meta.position');
-        try {
-            $sortedFusionKeys = $arraySorter->getSortedKeys();
-        } catch (InvalidPositionException $exception) {
-            throw new Fusion\Exception('Invalid position string', 1345126502, $exception);
-        }
-
-        foreach ($this->ignoreProperties as $ignoredPropertyName) {
-            $key = array_search($ignoredPropertyName, $sortedFusionKeys);
-            if ($key !== false) {
-                unset($sortedFusionKeys[$key]);
-            }
-        }
-        return $sortedFusionKeys;
+        return '';
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -1,0 +1,82 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion\Core\Runtime;
+use Neos\Utility\Exception\InvalidPositionException;
+use Neos\Utility\PositionalArraySorter;
+use Neos\Fusion;
+
+/**
+ * Fusion object to render and array of key value pairs by evaluating all properties
+ */
+class DataStructureImplementation extends AbstractArrayFusionObject
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function evaluate()
+    {
+        $sortedChildFusionKeys = $this->sortNestedFusionKeys();
+
+        if (count($sortedChildFusionKeys) === 0) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($sortedChildFusionKeys as $key) {
+            try {
+                $value = $this->fusionValue($key);
+            } catch (\Exception $e) {
+                $value = $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
+            }
+            if ($value === null && $this->runtime->getLastEvaluationStatus() === Runtime::EVALUATION_SKIPPED) {
+                continue;
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sort the Fusion objects inside $this->properties depending on:
+     * - numerical ordering
+     * - position meta-property
+     *
+     * This will ignore all properties defined in "@ignoreProperties" in Fusion
+     *
+     * @see PositionalArraySorter
+     *
+     * @return array an ordered list of key value pairs
+     * @throws Fusion\Exception if the positional string has an unsupported format
+     */
+    protected function sortNestedFusionKeys()
+    {
+        $arraySorter = new PositionalArraySorter($this->properties, '__meta.position');
+        try {
+            $sortedFusionKeys = $arraySorter->getSortedKeys();
+        } catch (InvalidPositionException $exception) {
+            throw new Fusion\Exception('Invalid position string', 1345126502, $exception);
+        }
+
+        foreach ($this->ignoreProperties as $ignoredPropertyName) {
+            $key = array_search($ignoredPropertyName, $sortedFusionKeys);
+            if ($key !== false) {
+                unset($sortedFusionKeys[$key]);
+            }
+        }
+        return $sortedFusionKeys;
+    }
+}

--- a/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
@@ -13,31 +13,33 @@ namespace Neos\Fusion\FusionObjects;
 
 
 /**
- * Render a Fusion collection of nodes
- *
- * //tsPath collection *Collection
- * //tsPath itemRenderer the TS object which is triggered for each element in the node collection
- * @deprecated since Neos 4.2 in favor of LoopImplementation
+ * Fusion object to render a list of items as single concatenated string
  */
-class CollectionImplementation extends AbstractCollectionImplementation
+class JoinImplementation extends DataStructureImplementation
 {
+
     /**
-     * Collections are always concatenated with an empty string
+     * Get the glue to insert between items
      *
      * @return string
      */
     public function getGlue()
     {
-        return '';
+        return $this->fusionValue('__meta/glue') ?? '';
     }
 
     /**
-     * Evaluate the collection nodes
+     * {@inheritdoc}
      *
      * @return string
      */
     public function evaluate()
     {
-        return parent::evaluate();
+        $glue = $this->getGlue();
+        $parentResult = parent::evaluate();
+        if ($parentResult !== []) {
+            return implode($glue, $parentResult);
+        }
+        return null;
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/LoopImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/LoopImplementation.php
@@ -13,22 +13,22 @@ namespace Neos\Fusion\FusionObjects;
 
 
 /**
- * Render a Fusion collection of nodes
+ * Render a Fusion collection of using the itemRenderer
  *
- * //tsPath collection *Collection
- * //tsPath itemRenderer the TS object which is triggered for each element in the node collection
- * @deprecated since Neos 4.2 in favor of LoopImplementation
+ * //fusionPath items *Collection
+ * //fusionPath itemRenderer the Fusion object which is triggered for each element in the node collection
  */
-class CollectionImplementation extends AbstractCollectionImplementation
+class LoopImplementation extends MapImplementation
 {
+
     /**
-     * Collections are always concatenated with an empty string
+     * Get the glue to insert between items
      *
      * @return string
      */
     public function getGlue()
     {
-        return '';
+        return $this->fusionValue('__meta/glue') ?? '';
     }
 
     /**
@@ -38,6 +38,7 @@ class CollectionImplementation extends AbstractCollectionImplementation
      */
     public function evaluate()
     {
-        return parent::evaluate();
+        $glue = $this->getGlue();
+        return implode($glue, parent::evaluate());
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
@@ -1,0 +1,135 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion\Exception as FusionException;
+
+/**
+ * Map a collection of items using the itemRenderer
+ *
+ * //fusionPath items *Collection
+ * //fusionPath itemRenderer the Fusion object which is triggered for each item
+ */
+class MapImplementation extends AbstractFusionObject
+{
+    /**
+     * The number of rendered nodes, filled only after evaluate() was called.
+     *
+     * @var integer
+     */
+    protected $numberOfRenderedNodes;
+
+    /**
+     * @return array
+     */
+    public function getItems()
+    {
+        return $this->fusionValue('items');
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemName()
+    {
+        return $this->fusionValue('itemName');
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemKey()
+    {
+        return $this->fusionValue('itemKey');
+    }
+
+    /**
+     * If set iteration data (index, cycle, isFirst, isLast) is available in context with the name given.
+     *
+     * @return string
+     */
+    public function getIterationName()
+    {
+        return $this->fusionValue('iterationName');
+    }
+
+    /**
+     * Evaluate the collection nodes as array
+     *
+     * @return array
+     * @throws FusionException
+     */
+    public function evaluate()
+    {
+        $collection = $this->getItems();
+
+        $result = [];
+        if ($collection === null) {
+            return $result;
+        }
+        $this->numberOfRenderedNodes = 0;
+        $itemName = $this->getItemName();
+        if ($itemName === null) {
+            throw new FusionException('The Collection needs an itemName to be set.', 1344325771);
+        }
+        $itemKey = $this->getItemKey();
+        $iterationName = $this->getIterationName();
+        $collectionTotalCount = count($collection);
+        foreach ($collection as $collectionKey => $collectionElement) {
+            $context = $this->runtime->getCurrentContext();
+            $context[$itemName] = $collectionElement;
+            if ($itemKey !== null) {
+                $context[$itemKey] = $collectionKey;
+            }
+            if ($iterationName !== null) {
+                $context[$iterationName] = $this->prepareIterationInformation($collectionTotalCount);
+            }
+
+            $this->runtime->pushContextArray($context);
+            $result[$collectionKey] =  $this->runtime->render($this->path . '/itemRenderer');
+            $this->runtime->popContext();
+            $this->numberOfRenderedNodes++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param integer $collectionCount
+     * @return array
+     */
+    protected function prepareIterationInformation($collectionCount)
+    {
+        $iteration = [
+            'index' => $this->numberOfRenderedNodes,
+            'cycle' => ($this->numberOfRenderedNodes + 1),
+            'isFirst' => false,
+            'isLast' => false,
+            'isEven' => false,
+            'isOdd' => false
+        ];
+
+        if ($this->numberOfRenderedNodes === 0) {
+            $iteration['isFirst'] = true;
+        }
+        if (($this->numberOfRenderedNodes + 1) === $collectionCount) {
+            $iteration['isLast'] = true;
+        }
+        if (($this->numberOfRenderedNodes + 1) % 2 === 0) {
+            $iteration['isEven'] = true;
+        } else {
+            $iteration['isOdd'] = true;
+        }
+
+        return $iteration;
+    }
+}

--- a/Neos.Fusion/Classes/FusionObjects/RawArrayImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/RawArrayImplementation.php
@@ -11,35 +11,11 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Fusion\Core\Runtime;
 
 /**
  * Evaluate sub objects to an array (instead of a string as ArrayImplementation does)
+ * @deprecated Will be removed with Neos 6
  */
-class RawArrayImplementation extends ArrayImplementation
+class RawArrayImplementation extends DataStructureImplementation
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @return array
-     */
-    public function evaluate()
-    {
-        $sortedChildFusionKeys = $this->sortNestedFusionKeys();
-
-        if (count($sortedChildFusionKeys) === 0) {
-            return [];
-        }
-
-        $output = [];
-        foreach ($sortedChildFusionKeys as $key) {
-            $value = $this->fusionValue($key);
-            if ($value === null && $this->runtime->getLastEvaluationStatus() === Runtime::EVALUATION_SKIPPED) {
-                continue;
-            }
-            $output[$key] = $value;
-        }
-
-        return $output;
-    }
 }

--- a/Neos.Fusion/Classes/FusionObjects/RawCollectionImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/RawCollectionImplementation.php
@@ -17,6 +17,7 @@ namespace Neos\Fusion\FusionObjects;
  *
  * //tsPath collection *Collection
  * //tsPath itemRenderer the TS object which is triggered for each element in the node collection
+ * @deprecated since Neos 4.2 in favor of MapImplementation
  */
 class RawCollectionImplementation extends AbstractCollectionImplementation
 {
@@ -27,6 +28,6 @@ class RawCollectionImplementation extends AbstractCollectionImplementation
      */
     public function evaluate()
     {
-        return parent::evaluateAsArray();
+        return array_values(parent::evaluateAsArray());
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/ReduceImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ReduceImplementation.php
@@ -1,0 +1,156 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion\Exception as FusionException;
+
+/**
+ * Reduce an array to a single value.
+ *
+ * //fusionPath items *Collection
+ * //fusionPath itemReducer the Fusion object which is triggered for each item
+ */
+class ReduceImplementation extends AbstractFusionObject
+{
+    /**
+     * The number of rendered nodes, filled only after evaluate() was called.
+     *
+     * @var integer
+     */
+    protected $numberOfRenderedNodes;
+
+    /**
+     * The list items that shall be reduced to a single value
+     *
+     * @return iterable
+     */
+    public function getItems()
+    {
+        return $this->fusionValue('items');
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemName()
+    {
+        return $this->fusionValue('itemName');
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemKey()
+    {
+        return $this->fusionValue('itemKey');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCarryName()
+    {
+        return $this->fusionValue('carryName');
+    }
+
+    /**
+     * @return string
+     */
+    public function getInitialValue()
+    {
+        return $this->fusionValue('initialValue');
+    }
+
+    /**
+     * If set iteration data (index, cycle, isFirst, isLast) is available in context with the name given.
+     *
+     * @return string
+     */
+    public function getIterationName()
+    {
+        return $this->fusionValue('iterationName');
+    }
+
+    /**
+     * Reduce the given items to a single value
+     *
+     * @return mixed
+     * @throws FusionException
+     */
+    public function evaluate()
+    {
+        $items = $this->getItems();
+        $value = $this->getInitialValue();
+
+        if ($items === null) {
+            return $value;
+        }
+        $this->numberOfRenderedNodes = 0;
+        $itemName = $this->getItemName();
+        if ($itemName === null) {
+            throw new FusionException('The Reduction needs an itemName to be set.', 1537890155);
+        }
+        $carryName = $this->getCarryName();
+        if ($carryName === null) {
+            throw new FusionException('The Reduction needs an carryName to be set.', 1537890148);
+        }
+        $itemKeyName = $this->getItemKey();
+        $iterationName = $this->getIterationName();
+        $collectionTotalCount = count($items);
+        foreach ($items as $itemKey => $item) {
+            $context = $this->runtime->getCurrentContext();
+            $context[$itemName] = $item;
+            $context[$carryName] = $value;
+            if ($itemKeyName !== null) {
+                $context[$itemKeyName] = $itemKey;
+            }
+            if ($iterationName !== null) {
+                $context[$iterationName] = $this->prepareIterationInformation($collectionTotalCount);
+            }
+            $this->runtime->pushContextArray($context);
+            $value = $this->runtime->render($this->path . '/itemReducer');
+            $this->runtime->popContext();
+            $this->numberOfRenderedNodes++;
+        }
+        return $value;
+    }
+
+    /**
+     * @param integer $collectionCount
+     * @return array
+     */
+    protected function prepareIterationInformation($collectionCount)
+    {
+        $iteration = [
+            'index' => $this->numberOfRenderedNodes,
+            'cycle' => ($this->numberOfRenderedNodes + 1),
+            'isFirst' => false,
+            'isLast' => false,
+            'isEven' => false,
+            'isOdd' => false
+        ];
+
+        if ($this->numberOfRenderedNodes === 0) {
+            $iteration['isFirst'] = true;
+        }
+        if (($this->numberOfRenderedNodes + 1) === $collectionCount) {
+            $iteration['isLast'] = true;
+        }
+        if (($this->numberOfRenderedNodes + 1) % 2 === 0) {
+            $iteration['isEven'] = true;
+        } else {
+            $iteration['isOdd'] = true;
+        }
+
+        return $iteration;
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -1,5 +1,7 @@
 prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
+prototype(Neos.Fusion:Join).@class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'
+prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
 prototype(Neos.Fusion:Template).@class = 'Neos\\Fusion\\FusionObjects\\TemplateImplementation'
 prototype(Neos.Fusion:Case).@class = 'Neos\\Fusion\\FusionObjects\\CaseImplementation'
 prototype(Neos.Fusion:Matcher).@class = 'Neos\\Fusion\\FusionObjects\\MatcherImplementation'
@@ -27,6 +29,26 @@ prototype(Neos.Fusion:RawCollection) {
   itemName = 'item'
   itemKey = 'itemKey'
   iterationName = 'iterator'
+}
+prototype(Neos.Fusion:Loop) {
+  @class = 'Neos\\Fusion\\FusionObjects\\LoopImplementation'
+  itemName = 'item'
+  itemKey = 'itemKey'
+  iterationName = 'iterator'
+}
+prototype(Neos.Fusion:Maping) {
+  @class = 'Neos\\Fusion\\FusionObjects\\MapImplementation'
+  itemName = 'item'
+  itemKey = 'itemKey'
+  iterationName = 'iterator'
+}
+prototype(Neos.Fusion:Reduce) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ReduceImplementation'
+  itemName = 'item'
+  itemKey = 'itemKey'
+  carryName = 'carry'
+  iterationName = 'iterator'
+  initialValue = null
 }
 
 # Render an HTTP response header

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Fusion Dictionary
+ */
+class DataStructureTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('dataStructure/basicOrdering');
+        $this->assertEquals([10 => 'Xtest10', 100 => 'Xtest100'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function positionalOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('dataStructure/positionalOrdering');
+        $this->assertEquals(['c' => 'Xbefore', 'f' => 'Xmiddle', 'a' => 'Xafter'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function startEndOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('dataStructure/startEndOrdering');
+        $this->assertEquals(['c' => 'Xbefore', 'f' => 'Xmiddle', 'a' => 'Xafter'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function advancedStartEndOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('dataStructure/advancedStartEndOrdering');
+        $this->assertEquals(['e' => 'Xe', 'd' => 'Xd', 'foobar' => 'Xfoobar', 'f' => 'Xf', 'g' => 'Xg', 100 => 'X100', 'b' => 'Xb', 'a' => 'Xa', 'c' => 'Xc'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function ignoredPropertiesWork()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('dataStructure/ignoreProperties');
+        $this->assertEquals(['c' => 'Xbefore', 'a' => 'Xafter'], $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -1,0 +1,88 @@
+prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+dataStructure.basicOrdering = Neos.Fusion:DataStructure {
+	100 = Neos.Fusion:TestRenderer
+	100.test = 'test100'
+
+	10 = Neos.Fusion:TestRenderer
+	10.test = 'test10'
+}
+
+dataStructure.positionalOrdering = Neos.Fusion:DataStructure {
+	c = Neos.Fusion:TestRenderer
+	c.test = 'before'
+	c.@position = '10'
+
+	a = Neos.Fusion:TestRenderer
+	a.test = 'after'
+	a.@position = '100'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'middle'
+	f.@position = '50'
+}
+
+dataStructure.startEndOrdering = Neos.Fusion:DataStructure {
+	a = Neos.Fusion:TestRenderer
+	a.test = 'after'
+	a.@position = 'end'
+
+	c = Neos.Fusion:TestRenderer
+	c.test = 'before'
+	c.@position = 'start'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'middle'
+	f.@position = '50'
+}
+
+# expected ordering:
+# - e
+# - d
+# - foobar
+# - f
+# - g
+# - 100
+# - b
+# - a
+# - c
+dataStructure.advancedStartEndOrdering = Neos.Fusion:DataStructure {
+	a = Neos.Fusion:TestRenderer
+	a.test = 'a'
+	a.@position = 'end 10'
+
+	b = Neos.Fusion:TestRenderer
+	b.test = 'b'
+	b.@position = 'end'
+
+	c = Neos.Fusion:TestRenderer
+	c.test = 'c'
+	c.@position = 'end 20'
+
+	d = Neos.Fusion:TestRenderer
+	d.test = 'd'
+	d.@position = 'start'
+
+	e = Neos.Fusion:TestRenderer
+	e.test = 'e'
+	e.@position = 'start 10'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'f'
+	f.@position = '50'
+
+	100 = Neos.Fusion:TestRenderer
+	100.test = '100'
+
+	foobar = Neos.Fusion:TestRenderer
+	foobar.test = 'foobar'
+
+	g = Neos.Fusion:TestRenderer
+	g.test = 'g'
+	g.@position = '90'
+}
+
+dataStructure.ignoreProperties < dataStructure.positionalOrdering {
+	@ignoreProperties = ${['f']}
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Join.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Join.fusion
@@ -1,0 +1,97 @@
+prototype(Neos.Fusion:Join).@class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+join.basicOrdering = Neos.Fusion:Join {
+	100 = Neos.Fusion:TestRenderer
+	100.test = 'test100'
+
+	10 = Neos.Fusion:TestRenderer
+	10.test = 'test10'
+}
+
+join.positionalOrdering = Neos.Fusion:Join {
+	c = Neos.Fusion:TestRenderer
+	c.test = 'before'
+	c.@position = '10'
+
+	a = Neos.Fusion:TestRenderer
+	a.test = 'after'
+	a.@position = '100'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'middle'
+	f.@position = '50'
+}
+
+join.startEndOrdering = Neos.Fusion:Join {
+	a = Neos.Fusion:TestRenderer
+	a.test = 'after'
+	a.@position = 'end'
+
+	c = Neos.Fusion:TestRenderer
+	c.test = 'before'
+	c.@position = 'start'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'middle'
+	f.@position = '50'
+}
+
+# expected ordering:
+# - e
+# - d
+# - foobar
+# - f
+# - g
+# - 100
+# - b
+# - a
+# - c
+join.advancedStartEndOrdering = Neos.Fusion:Join {
+	a = Neos.Fusion:TestRenderer
+	a.test = 'a'
+	a.@position = 'end 10'
+
+	b = Neos.Fusion:TestRenderer
+	b.test = 'b'
+	b.@position = 'end'
+
+	c = Neos.Fusion:TestRenderer
+	c.test = 'c'
+	c.@position = 'end 20'
+
+	d = Neos.Fusion:TestRenderer
+	d.test = 'd'
+	d.@position = 'start'
+
+	e = Neos.Fusion:TestRenderer
+	e.test = 'e'
+	e.@position = 'start 10'
+
+	f = Neos.Fusion:TestRenderer
+	f.test = 'f'
+	f.@position = '50'
+
+	100 = Neos.Fusion:TestRenderer
+	100.test = '100'
+
+	foobar = Neos.Fusion:TestRenderer
+	foobar.test = 'foobar'
+
+	g = Neos.Fusion:TestRenderer
+	g.test = 'g'
+	g.@position = '90'
+}
+
+join.ignoreProperties < join.positionalOrdering {
+	@ignoreProperties = ${['f']}
+}
+
+join.withGlue = Neos.Fusion:Join {
+  a = 'a'
+  b = 'b'
+  c = 'c'
+  c.@if.no = false
+  d = 'd'
+  @glue = ', '
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Loop.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Loop.fusion
@@ -1,0 +1,36 @@
+prototype(Neos.Fusion:Loop).@class = 'Neos\\Fusion\\FusionObjects\\LoopImplementation'
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+loop.basicLoop = Neos.Fusion:Loop {
+	items = ${items}
+	itemName = 'element'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element}
+	}
+}
+
+loop.basicLoopWithGlue = Neos.Fusion:Loop {
+  @glue = ', '
+  items = ${items}
+  itemName = 'element'
+  itemRenderer = Neos.Fusion:TestRenderer {
+    test = ${element}
+  }
+}
+
+loop.basicLoopOtherContextVariables = Neos.Fusion:Loop {
+  items = ${items}
+	itemName = 'element'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element + other}
+	}
+}
+
+loop.iteration = Neos.Fusion:Loop {
+  items = ${items}
+	itemName = 'element'
+	iterationName = 'iteration'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element + '-' + iteration.index + '-' + iteration.cycle + '-' + iteration.isFirst + '-' + iteration.isLast + '-' + iteration.isOdd + '-' + iteration.isEven}
+	}
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
@@ -1,0 +1,27 @@
+prototype(Neos.Fusion:Map).@class = 'Neos\\Fusion\\FusionObjects\\MapImplementation'
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+map.basicLoop = Neos.Fusion:Map {
+  items = ${items}
+	itemName = 'element'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element}
+	}
+}
+
+map.basicLoopOtherContextVariables = Neos.Fusion:Map {
+  items = ${items}
+	itemName = 'element'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element + other}
+	}
+}
+
+map.iteration = Neos.Fusion:Map {
+	items = ${items}
+	itemName = 'element'
+	iterationName = 'iteration'
+	itemRenderer = Neos.Fusion:TestRenderer {
+		test = ${element + '-' + iteration.index + '-' + iteration.cycle + '-' + iteration.isFirst + '-' + iteration.isLast + '-' + iteration.isOdd + '-' + iteration.isEven}
+	}
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Reduce.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Reduce.fusion
@@ -1,0 +1,37 @@
+prototype(Neos.Fusion:Reduce).@class = 'Neos\\Fusion\\FusionObjects\\ReduceImplementation'
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+
+reduce.basicLoop = Neos.Fusion:Reduce {
+  items = ${items}
+  itemName = 'element'
+  carryName = 'carry'
+  initialValue = ${initialValue}
+  itemReducer = Neos.Fusion:TestRenderer {
+    test = ${carry + element}
+  }
+}
+
+reduce.additionLoop = Neos.Fusion:Reduce {
+  items = ${items}
+  itemName = 'element'
+  carryName = 'carry'
+  initialValue = ${initialValue}
+  itemReducer = ${carry + element}
+}
+
+reduce.basicLoopOtherContextVariables = Neos.Fusion:Reduce {
+  items = ${items}
+  itemName = 'element'
+  carryName = 'carry'
+  itemReducer = Neos.Fusion:TestRenderer {
+    test = ${carry + element + other}
+  }
+}
+
+reduce.iteration = Neos.Fusion:Reduce {
+  items = ${items}
+  itemName = 'element'
+  carryName = 'carry'
+  iterationName = 'iteration'
+  itemReducer = ${carry + '::' + element + '-' + iteration.index + '-' + iteration.cycle + '-' + iteration.isFirst + '-' + iteration.isLast + '-' + iteration.isOdd + '-' + iteration.isEven}
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Fusion Concat
+ */
+class JoinTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('join/basicOrdering');
+        $this->assertEquals('Xtest10Xtest100', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function positionalOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('join/positionalOrdering');
+        $this->assertEquals('XbeforeXmiddleXafter', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function startEndOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('join/startEndOrdering');
+        $this->assertEquals('XbeforeXmiddleXafter', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function advancedStartEndOrderingWorks()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('join/advancedStartEndOrdering');
+        $this->assertEquals('XeXdXfoobarXfXgX100XbXaXc', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function ignoredPropertiesWork()
+    {
+        $view = $this->buildView();
+
+        $view->setFusionPath('join/ignoreProperties');
+        $this->assertEquals('XbeforeXafter', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function glueWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('join/withGlue');
+        $this->assertEquals('a, b, d', $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Iteration Fusion object
+ *
+ */
+class LoopTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicCollectionWorks()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->setFusionPath('loop/basicLoop');
+        $this->assertEquals('Xelement1Xelement2', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicCollectionWorksWithGlue()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->setFusionPath('loop/basicLoopWithGlue');
+        $this->assertEquals('Xelement1, Xelement2', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicCollectionWorksAndStillContainsOtherContextVariables()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->assign('other', 'var');
+        $view->setFusionPath('loop/basicLoopOtherContextVariables');
+        $this->assertEquals('Xelement1varXelement2var', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function emptyCollectionReturnsEmptyString()
+    {
+        $view = $this->buildView();
+        $view->assign('items', null);
+        $view->setFusionPath('loop/basicLoop');
+        $this->assertEquals('', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function iterationInformationIsAddedToCollection()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2', 'element3', 'element4']);
+        $view->setFusionPath('loop/iteration');
+        $this->assertEquals('Xelement1-0-1-1--1-Xelement2-1-2----1Xelement3-2-3---1-Xelement4-3-4--1--1', $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Mapping Fusion object
+ *
+ */
+class MapTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicCollectionWorks()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->setFusionPath('map/basicLoop');
+        $this->assertEquals(['Xelement1','Xelement2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicCollectionWorksAndPreservesKeys()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['foo' => 'element1', 'bar' => 'element2']);
+        $view->setFusionPath('map/basicLoop');
+        $this->assertEquals(['foo' => 'Xelement1', 'bar' => 'Xelement2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicCollectionWorksAndStillContainsOtherContextVariables()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->assign('other', 'var');
+        $view->setFusionPath('map/basicLoopOtherContextVariables');
+        $this->assertEquals(['Xelement1var','Xelement2var'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function emptyCollectionReturnsEmptyArray()
+    {
+        $view = $this->buildView();
+        $view->assign('items', null);
+        $view->setFusionPath('map/basicLoop');
+        $this->assertEquals([], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function iterationInformationIsAddedToCollection()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2', 'element3', 'element4']);
+        $view->setFusionPath('map/iteration');
+        $this->assertEquals(['Xelement1-0-1-1--1-','Xelement2-1-2----1','Xelement3-2-3---1-','Xelement4-3-4--1--1'], $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Reduction Fusion object
+ *
+ */
+class ReduceTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function basicReductionWorks()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->assign('initialValue', 'InitialValue::');
+        $view->setFusionPath('reduce/basicLoop');
+        $this->assertEquals('XXInitialValue::element1element2', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicReductionAddsNumbers()
+    {
+        $view = $this->buildView();
+        $view->assign('items', [1,2,3,4]);
+        $view->assign('initialValue', 5);
+        $view->setFusionPath('reduce/additionLoop');
+        $this->assertEquals(15, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicReductionWorksAndStillContainsOtherContextVariables()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->assign('other', 'var');
+        $view->setFusionPath('reduce/basicLoopOtherContextVariables');
+        $this->assertEquals('XXelement1varelement2var', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function emptyReductionReturnsInitialValue()
+    {
+        $initialValue = '::InitialValue::';
+        $view = $this->buildView();
+        $view->assign('items', null);
+        $view->assign('initialValue', $initialValue);
+        $view->setFusionPath('reduce/basicLoop');
+        $this->assertEquals($initialValue, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function iterationInformationIsAddedToReduction()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2', 'element3', 'element4']);
+        $view->setFusionPath('reduce/iteration');
+        $this->assertEquals('::element1-0-1-1--1-::element2-1-2----1::element3-2-3---1-::element4-3-4--1--1', $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -1,0 +1,136 @@
+<?php
+namespace Neos\Fusion\Tests\Unit\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Fusion\Core\Runtime;
+use Neos\Fusion\FusionObjects\DataStructureImplementation;
+
+/**
+ * Testcase for the Fusion Concat object
+ */
+class DataStructureImplementationTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function evaluateWithEmptyArrayRendersEmptyArray()
+    {
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $path = 'array/test';
+        $fusionObjectName = 'Neos.Fusion:DataStructure';
+        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        $result = $renderer->evaluate();
+        $this->assertSame($result, []);
+    }
+
+    /**
+     * @return array
+     */
+    public function positionalSubElements()
+    {
+        return [
+            [
+                'Position end should put element to end',
+                ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['/first', '/second']
+            ],
+            [
+                'Position start should put element to start',
+                ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
+                ['/first', '/second']
+            ],
+            [
+                'Position start should respect priority',
+                ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
+                ['/first', '/second']
+            ],
+            [
+                'Position end should respect priority',
+                ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
+                ['/first', '/second']
+            ],
+            [
+                'Positional numbers are in the middle',
+                ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
+                ['/first', '/second', '/third', '/last']
+            ],
+            [
+                'Position before adds before named element if present',
+                ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['/first', '/second']
+            ],
+            [
+                'Position before adds after start if named element not present',
+                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
+                ['/first', '/second', '/third']
+            ],
+            [
+                'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
+                ['third' => [], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
+                ['/first', '/second', '/third']
+            ],
+            [
+                'Position before works recursively',
+                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['/first', '/second', '/third']
+            ],
+            [
+                'Position after adds after named element if present',
+                ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['/first', '/second']
+            ],
+            [
+                'Position after adds before end if named element not present',
+                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['/first', '/second', '/third']
+            ],
+            [
+                'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
+                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
+                ['/first', '/second', '/third']
+            ],
+            [
+                'Position after works recursively',
+                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['/first', '/second', '/third']
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider positionalSubElements
+     *
+     * @param string $message
+     * @param array $subElements
+     * @param array $expectedKeyOrder
+     */
+    public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
+    {
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+
+        $mockRuntime->expects($this->any())->method('evaluate')->will($this->returnCallback(function ($path) use (&$renderedPaths) {
+            $renderedPaths[] = $path;
+        }));
+
+        $path = '';
+        $fusionObjectName = 'Neos.Fusion:DataStructure';
+        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        foreach ($subElements as $key => $value) {
+            $renderer[$key] = $value;
+        }
+        $renderer->evaluate();
+
+        $this->assertSame($expectedKeyOrder, $renderedPaths, $message);
+    }
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -14,11 +14,23 @@ This package contains general-purpose Fusion objects, which are usable both with
 Neos.Fusion:Array
 -----------------
 
+:[key]: (string) A nested definition (simple value, expression or object) that evaluates to a string
+:[key].@ignoreProperties: (array) A list of properties to ignore from being "rendered" during evaluation
+:[key].@position: (string/integer) Define the ordering of the nested definition
+
+.. note:: The Neos.Fusion:Array object has been renamed to Neos.Fusion:Join the old name is DEPRECATED;
+
+.. _Neos_Fusion__Join:
+
+Neos.Fusion:Join
+----------------
+
 Render multiple nested definitions and concatenate the results.
 
 :[key]: (string) A nested definition (simple value, expression or object) that evaluates to a string
 :[key].@ignoreProperties: (array) A list of properties to ignore from being "rendered" during evaluation
 :[key].@position: (string/integer) Define the ordering of the nested definition
+:@glue: (string) The glue used to join the items together (default = '').
 
 The order in which nested definitions are evaluated are specified using their
 ``@position`` meta property. For this argument, the following sort order applies:
@@ -55,7 +67,7 @@ Example Ordering::
 	# order (o1 ... o9) is *always* fixed, no matter in which order the
 	# individual statements are defined.
 
-	myArray = Neos.Fusion:Array {
+	myArray = Neos.Fusion:Join {
 		o1 = Neos.NodeTypes:Text
 		o1.@position = 'start 12'
 		o2 = Neos.NodeTypes:Text
@@ -87,7 +99,7 @@ to use ``@position`` and meaningful keys in your application, and not numeric on
 
 Example of numeric keys (discouraged)::
 
-	myArray = Neos.Fusion:Array {
+	myArray = Neos.Fusion:Join {
 		10 = Neos.NodeTypes:Text
 		20 = Neos.NodeTypes:Text
 	}
@@ -105,6 +117,8 @@ Render each item in ``collection`` using ``itemRenderer``.
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
 :itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
+
+.. note:: The Neos.Fusion:Collection object is DEPRECATED use Neos.Fusion:Loop instead.
 
 Example using an object ``itemRenderer``::
 
@@ -137,7 +151,71 @@ Render each item in ``collection`` using ``itemRenderer`` and return the result 
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
+:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
+
+.. note:: The Neos.Fusion:RawCollection object is DEPRECATED use Neos.Fusion:Map instead.**
+
+.. _Neos_Fusion__Loop:
+
+Neos.Fusion:Loop
+----------------
+
+Render each item in ``items`` using ``itemRenderer``.
+
+:items: (array/Iterable, **required**) The array or iterable to iterate over
+:itemName: (string, defaults to ``item``) Context variable name for each item
+:itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
+:iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
+:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
+:@glue: (string) The glue used to join the items together (default = '').
+
+Example using an object ``itemRenderer``::
+
+	myCollection = Neos.Fusion:Collection {
+		items = ${[1, 2, 3]}
+		itemName = 'element'
+		itemRenderer = Neos.Fusion:Template {
+			templatePath = 'resource://...'
+			element = ${element}
+		}
+	}
+
+
+Example using an expression ``itemRenderer``::
+
+	myCollection = Neos.Fusion:Collection {
+		items = ${[1, 2, 3]}
+		itemName = 'element'
+		itemRenderer = ${element * 2}
+	}
+
+.. _Neos_Fusion__Map:
+
+Neos.Fusion:Map
+---------------
+
+Render each item in ``items`` using ``itemRenderer`` and return the result as an array (opposed to *string* for :ref:`Neos_Fusion__Collection`)
+
+:items: (array/Iterable, **required**) The array or iterable to iterate over
+:itemName: (string, defaults to ``item``) Context variable name for each item
+:itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
+:iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
+:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
+
+.. _Neos_Fusion__Reduce:
+
+Neos.Fusion:Reduce
+------------------
+
+Reduce the given items to a single value by using ``itemRenderer``.
+
+:items: (array/Iterable, **required**) The array or iterable to iterate over
+:itemName: (string, defaults to ``item``) Context variable name for each item
+:itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
+:carryName: (string, defaults to ``carry``) Context variable that contains the result of the last iteration
+:iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
+:itemReducer: (mixed, **required**) The reducer definition (simple value, expression or object) that will be applied for every item.
+:initialValue: (mixed, defaults to ``null``) The value that is passed to the first iteration or returned if the items are empty
 
 .. _Neos_Fusion__Case:
 
@@ -248,11 +326,11 @@ Example::
 		bold = false
 
 		renderer = Neos.Fusion:Tag {
-			attributes.class = Neos.Fusion:RawArray {
+			attributes.class = Neos.Fusion:DataStructure {
 				component = 'component'
 				bold = ${props.bold ? 'component--bold' : false}
 			}
-			content = Neos.Fusion:Array {
+			content = Neos.Fusion:Join {
 				headline = Neos.Fusion:Tag {
 					tagName = ${props.titleTagName}
 					content = ${props.title}
@@ -280,7 +358,7 @@ Example as a standalone augmenter::
 
 	augmentedContent = Neos.Fusion:Augmenter {
 
-		content = Neos.Fusion:Array {
+		content = Neos.Fusion:Join {
 			title = Neos.Fusion:Tag {
 				@if.hasContent = ${this.content}
 				tagName = 'h2'
@@ -364,6 +442,21 @@ Evaluate nested definitions as an array (opposed to *string* for :ref:`Neos_Fusi
 
 .. tip:: For simple cases an expression with an array literal ``${[1, 2, 3]}`` might be easier to read
 
+.. note:: The Neos.Fusion:RawArray object has been renamed to Neos.Fusion:DataStructure the old name is DEPRECATED;
+
+.. _Neos_Fusion__Tag:
+
+
+Neos.Fusion:DataStructure
+--------------------
+
+Evaluate nested definitions as an array (opposed to *string* for :ref:`Neos_Fusion__Array`)
+
+:[key]: (mixed) A nested definition (simple value, expression or object), ``[key]`` will be used for the resulting array key
+:[key].@position: (string/integer) Define the ordering of the nested definition
+
+.. tip:: For simple cases an expression with an array literal ``${[1, 2, 3]}`` might be easier to read
+
 .. _Neos_Fusion__Tag:
 
 Neos.Fusion:Tag
@@ -414,7 +507,7 @@ Example:
 
 	attributes = Neos.Fusion:Attributes {
 		foo = 'bar'
-		class = Neos.Fusion:RawArray {
+		class = Neos.Fusion:DataStructure {
 			class1 = 'class1'
 			class2 = 'class2'
 		}


### PR DESCRIPTION
The difference between ``RawArray``, ``Array``, ``RawCollection`` and ``Collection`` was often hard to get for new developers. To overcome this, the old confusing names are deprecated, and new prototypes are introduced which are easier to understand and emphasize the declarative nature of Fusion.

``Neos.Fusion:Join``

The prototype concatenates the fusion values of all fusion-properties and returns the result as a string. This prototype replaces ``Neos.Fusion:Array`` which is deprecated.

In addition to the behavior of the ``Array`` ``Join`` allows to define the ``@glue`` used for concatenating the parts.

``Neos.Fusion:Loop``

The ``Loop`` prototype iterates over the given items with the itemRenderer and returns the concatenated result as a string. The prototype replaces ``Neos.Fusion:Collection`` which is deprecated.

Other than in ``Collection`` the items are passed with the key ``items`` instead of ``collection``.

In addition to the behavior of the classic ``Collection`` ``Loop ``  allows defining the ``@glue`` used for concatenating the items. 

``Neos.Fusion:DataStructure``

The ``DataStructure`` prototype returns an associative array with all fusion keys evaluated. The prototype replaces ``Neos.Fusion:RawArray`` which is deprecated.

``Neos.Fusion:Map``

The ``Map`` iterates over the given ``items`` and returns the result as an array.  The prototype replaces ``Neos.Fusion:RawCollection`` which is deprecated.

Other than ``RawCollection`` the items are passed with the key ``items`` instead of ``collection`` and the keys of the given ``items`` are preserved.

``Neos.Fusion:Reduce``

The `Neos.Fusion:Reduce` prototype is added which reduces the given items to a single value by using ``itemRenderer`` with the following properties.

- `items` (array/Iterable, **required**) The array or iterable to iterate over
- `itemName`: (string, defaults to `item`) Context variable name for each item
- `itemKey`: (string, defaults to `itemKey`) Context variable name for each item key, when working with an array
- `carryName`: (string, defaults to `carry`) Context variable that contains the result of the last iteration
- `iterationName`: (string, defaults to `iterator`) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
- `itemReducer`: (mixed, **required**) The reducer definition (simple value, expression or object) that will be applied for every item.
- `initialValue`: (mixed, defaults to `null`) The value that is passed to the first iteration or returned if the items are empty
