### PR TITLE
BUGFIX: Links to original file in media browser

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -148,7 +148,7 @@
 <f:section name="ContentImage">
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
-        <a href="{assetProxy.originalUri}" target="_blank">
+        <a href="{assetProxy.importStream}" target="_blank">
             <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
         </a>
     </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -54,7 +54,7 @@
                             </f:if>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.filename', package: 'Neos.Media.Browser')}</th>
-                                <td><a href="#" target="_blank">{assetProxy.filename}</a></td>
+                                <td><a href="{assetProxy.importStream}" target="_blank">{assetProxy.filename}</a></td>
                             </tr>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.lastModified', package: 'Neos.Media.Browser')}</th>
@@ -92,6 +92,7 @@
                 </fieldset>
             </div>
             <div class="neos-span6 neos-image-example">
+                <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
                 <f:render section="ContentImage" arguments="{_all}" />
             </div>
         </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -92,7 +92,6 @@
                 </fieldset>
             </div>
             <div class="neos-span6 neos-image-example">
-                <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
                 <f:render section="ContentImage" arguments="{_all}" />
             </div>
         </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -26,7 +26,7 @@
                             </f:if>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.filename', package: 'Neos.Media.Browser')}</th>
-                                <td><a href="#" target="_blank">{assetProxy.filename}</a></td>
+                                <td><a href="{assetProxy.importStream}" target="_blank">{assetProxy.filename}</a></td>
                             </tr>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.lastModified', package: 'Neos.Media.Browser')}</th>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -72,7 +72,7 @@
 <f:section name="ContentImage">
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
-        <a href="{assetProxy.originalUri}" target="_blank">
+        <a href="{assetProxy.importStream}" target="_blank">
             <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
         </a>
     </div>


### PR DESCRIPTION
solves #2184.

[Label removed](https://github.com/neos/neos-development-collection/pull/1745/files#diff-c7dc0c1301d150887e2fa1d56281f022L149) in #1745 and [wrong property](https://github.com/neos/neos-development-collection/pull/1979/files?w=1#diff-c7dc0c1301d150887e2fa1d56281f022R151) used to link to image in #1979.