### PR TITLE
BUGFIX: FileTypeIconViewHelper should work with new $asset argument

### DIFF
--- a/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
@@ -75,7 +75,9 @@ class FileTypeIconViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(AssetInterface $file = null, AssetInterface $asset = null, string $filename = null, $width = null, $height = null)
     {
-        $asset = $file;
+        if ($asset === null) {
+            $asset = $file;
+        }
         if ($asset === null && $filename === null) {
             throw new \InvalidArgumentException('You must either specify "asset" or "filename" for the ' . __CLASS__ . '.', 1524039575);
         }


### PR DESCRIPTION
If the newly added `$asset` argument is used, it's ignored and overridden to the deprecated `$file` argument.

Resolves #2186