### PR TITLE
FEATURE: Add ``@apply`` meta-keyword to the Fusion-language

### DIFF
--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -1,0 +1,275 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for basic Fusion spread rendering
+ *
+ */
+class ApplyTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function eelValueRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValue');
+        $this->assertEquals('original eel expression', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithSingleSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithSingleSpread');
+        $this->assertEquals('altered eel expression', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithInvalidFusionObjectSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithInvalidFusionObjectSpread');
+        $this->assertEquals('original eel expression', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithInvalidExpressionSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithInvalidExpressionSpread');
+        $this->assertEquals('original eel expression', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueInvalidCyclicExpressionSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueInvalidCyclicExpressionSpread');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithFusionObjectSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithFusionObjectSpread');
+        $this->assertEquals('altered eel expression', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithMultipleSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithMultipleSpreads');
+        $this->assertEquals('altered eel expression 3', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithMultipleOrderedSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithMultipleOrderedSpreads');
+        $this->assertEquals('altered eel expression to be evaluated last', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithProcessorRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithProcessor');
+        $this->assertEquals('foo:original eel expression:bar', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function eelValueWithProcessorAndSingleSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderEelValueWithProcessorAndSingleSpread');
+        $this->assertEquals('foo:altered eel expression:bar', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function valueWithNonMatchingIfConditionRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderValueWithNonMatchingIfCondition');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function valueWithNonMatchingIfConditionThatUseSpreadValuesRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderValueWithNonMatchingIfConditionThatUseSpreadValues');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function valueWithNonMatchingIfConditionIfSpreadAltersValueRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderValueWithNonMatchingIfConditionIfSpreadAltersValue');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function valueWithNonMatchingIfConditionIfSpreadAltersValueAndEnabledConditionRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderValueWithNonMatchingIfConditionIfSpreadAltersValueAndEnabledCondition');
+        $this->assertEquals('altered value', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function valueWithMatchingIfConditionThatUseSpreadValuesRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderValueWithMatchingIfConditionThatUseSpreadValues');
+        $this->assertEquals('enabled value', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function prototypeWithNonMatchingIfConditionRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderPrototypeWithNonMatchingIfCondition');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function prototypeWithNonMatchingIfConditionThatUseSpreadValuesRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderPrototypeWithNonMatchingIfConditionThatUseSpreadValues');
+        $this->assertEquals(null, $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function prototypeWithMatchingIfConditionThatUseSpreadValuesRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderPrototypeWithMatchingIfConditionThatUseSpreadValues');
+        $this->assertEquals('enabled value', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function nestedPrototypeRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderNestedPrototype');
+        $this->assertEquals('expression from nested prototypes', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function nestedPrototypeOverriddenWithSpreadsRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderNestedPrototypeOverriddenWithSpreads');
+        $this->assertEquals('i can change this', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function collectionWithoutSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderCollectionWithoutSpread');
+        $this->assertEquals('X1X2X2X3', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function collectionWithSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderCollectionWithSpread');
+        $this->assertEquals('X1X2X2X3', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function rendererWithTypeAndElementSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderRendererWithTypeAndElementSpread');
+        $this->assertEquals('XValueAppliedViaElementSpread', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function arrayWithSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderRawArrayWithSpread');
+        $this->assertEquals([
+            'key' => 'original value',
+            'alter' => 'altered value',
+            'add' => 'added value'
+        ], $view->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function arrayWithPositionAndSpreadRendering()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderArrayWithPositionAndSpread');
+        $this->assertEquals('startmiddleModifiedendModified', $view->render()
+        );
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
@@ -1,0 +1,143 @@
+prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\View\\Fixtures\\TestRenderer'
+prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
+prototype(Neos.Fusion:Collection).@class = 'Neos\\Fusion\\FusionObjects\\CollectionImplementation'
+prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
+prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
+prototype(Neos.Fusion:Renderer).@class = 'Neos\\Fusion\\FusionObjects\\RendererImplementation'
+
+prototype(Neos.Fusion:EelValue) < prototype(Neos.Fusion:Value) {
+  value = ${'original eel expression'}
+}
+
+apply.renderEelValue = Neos.Fusion:EelValue
+
+apply.renderEelValueWithSingleSpread = Neos.Fusion:EelValue {
+  @apply.alterValue = ${{value:'altered eel expression'}}
+}
+
+apply.renderEelValueWithFusionObjectSpread = Neos.Fusion:EelValue {
+  @apply.alterValue = Neos.Fusion:RawArray {
+    value = 'altered eel expression'
+  }
+}
+
+apply.renderEelValueWithInvalidFusionObjectSpread = Neos.Fusion:EelValue {
+  @apply.alterValue = Neos.Fusion:Value {
+    value = 'an fusion objects that retuns not an array!!!'
+  }
+}
+
+apply.renderEelValueWithInvalidExpressionSpread = Neos.Fusion:EelValue {
+  @apply.alterValue = ${'an expression but not an array!!!'}
+}
+
+apply.renderEelValueInvalidCyclicExpressionSpread = Neos.Fusion:EelValue {
+  @apply.alterValue = ${{value: this.value}}
+}
+
+apply.renderEelValueWithMultipleSpreads = Neos.Fusion:EelValue {
+  @apply.alterValue1 = ${{value:'altered eel expression 1'}}
+  @apply.alterValue2 = ${{value:'altered eel expression 2'}}
+  @apply.alterValue3 = ${{value:'altered eel expression 3'}}
+}
+
+apply.renderEelValueWithMultipleOrderedSpreads = Neos.Fusion:EelValue {
+  @apply.alterValue1 {
+    expression = ${{value:'altered eel expression to be evaluated last'}}
+    @position = 'end'
+  }
+  @apply.alterValue2 = ${{value:'altered eel expression'}}
+}
+
+prototype(Neos.Fusion:EelValueWithProcessor) < prototype(Neos.Fusion:Value) {
+  value = ${'original eel expression'}
+  value.@process.wrap = ${'foo:' + value + ':bar'}
+}
+
+apply.renderEelValueWithProcessor = Neos.Fusion:EelValueWithProcessor
+
+apply.renderEelValueWithProcessorAndSingleSpread = Neos.Fusion:EelValueWithProcessor {
+  @apply.alterValue = ${{value:'altered eel expression'}}
+}
+
+prototype(Neos.Fusion:ValueWithCondition) < prototype(Neos.Fusion:Value) {
+  value = ${'enabled value'}
+  value.@if.isEnabled = ${this.enabled}
+  enabled = false
+}
+
+apply.renderValueWithNonMatchingIfCondition = Neos.Fusion:ValueWithCondition
+
+apply.renderValueWithNonMatchingIfConditionThatUseSpreadValues = Neos.Fusion:ValueWithCondition {
+  @apply.disable = ${{enabled:false}}
+}
+
+apply.renderValueWithMatchingIfConditionThatUseSpreadValues = Neos.Fusion:ValueWithCondition {
+  @apply.enable = ${{enabled:true}}
+}
+
+apply.renderValueWithNonMatchingIfConditionIfSpreadAltersValue = Neos.Fusion:ValueWithCondition {
+  @apply.value = ${{value:'altered value'}}
+}
+
+apply.renderValueWithNonMatchingIfConditionIfSpreadAltersValueAndEnabledCondition = Neos.Fusion:ValueWithCondition {
+  @apply.value = ${{value:'altered value', enabled:true}}
+}
+
+apply.renderPrototypeWithNonMatchingIfCondition = Neos.Fusion:ValueWithCondition
+
+apply.renderPrototypeWithNonMatchingIfConditionThatUseSpreadValues = Neos.Fusion:ValueWithCondition {
+  @apply.disable = ${{enabled:false}}
+}
+
+apply.renderPrototypeWithMatchingIfConditionThatUseSpreadValues = Neos.Fusion:ValueWithCondition {
+  @apply.enable = ${{enabled:true}}
+}
+
+prototype(Neos.Fusion:NestedPrototype) < prototype(Neos.Fusion:Value) {
+  value = Neos.Fusion:Value {
+    value = 'expression from nested prototypes'
+  }
+}
+
+apply.renderNestedPrototype = Neos.Fusion:NestedPrototype
+
+apply.renderNestedPrototypeOverriddenWithSpreads = Neos.Fusion:NestedPrototype {
+  @apply.alterValue = ${{value: 'i can change this'}}
+}
+
+apply.renderCollectionWithoutSpread = Neos.Fusion:Collection {
+  collection = ${[{test:1},{test:2},{test:2},{test:3}]}
+  itemName = 'item'
+  itemRenderer = Neos.Fusion:TestRenderer {
+    test = ${item.test}
+  }
+}
+
+apply.renderCollectionWithSpread = Neos.Fusion:Collection {
+  collection = ${[{test:1},{test:2},{test:2},{test:3}]}
+  itemName = 'item'
+  itemRenderer = Neos.Fusion:TestRenderer {
+    @apply.applyItem = ${item}
+  }
+}
+
+apply.renderRendererWithTypeAndElementSpread = Neos.Fusion:Renderer {
+  type = 'Neos.Fusion:TestRenderer'
+  element.@apply.applyValues = ${{test: 'ValueAppliedViaElementSpread'}}
+}
+
+apply.renderRawArrayWithSpread = Neos.Fusion:RawArray {
+  key = 'original value'
+  alter = 'original value'
+  @apply.applyValues = ${{alter: 'altered value', add: 'added value' }}
+}
+
+apply.renderArrayWithPositionAndSpread = Neos.Fusion:Array {
+  last = 'end'
+  last.@position = 'end'
+  middle = 'middle'
+  first = 'start'
+  first.@position = 'start'
+  @apply.applyValues = ${{last: 'endModified', middle: 'middleModified'}}
+}

--- a/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
+++ b/Neos.Neos/Documentation/CreatingASite/Fusion/InsideFusion.rst
@@ -519,6 +519,72 @@ a property using the ``@if`` meta-property::
 
 Multiple conditions can be used, and if one of them doesn't return ``true`` the condition stops evaluation.
 
+Apply
+=====
+
+``@apply`` allows to override multiple properties of a fusion-prototype with a single expression. This is useful
+when complex data structures are mapped to fusion prototypes.
+
+The example shows the rendering of a ``teaserList``-array by using a Teaser-Component and passing all keys from each
+teaser to the fusion Object::
+
+	teasers = Neos.Fusion:Collection {
+		collection = ${teaserList}
+		itemName = 'teaser'
+		itemRenderer = Vendor.Site:Teaser {
+			@apply.teaser = ${teaser}
+		}
+	}
+
+The code avoids passing down each fusion-property explicitly to the child component. A similar concept with different
+syntax from the JavaScript world is known as ES6-Spreads.
+
+Another use-case is to use ``Neos.Fusion:Renderer`` to render a prototype while type and properties are based on data
+from the context::
+
+	example = Neos.Fusion:Renderer {
+		type = ${data.type}
+		element.@apply.properties = ${data.properties}
+	}
+
+That way some meta-programming can used in fusion and both prototype and properties are decided late in the rendering
+by the fusion runtime.
+
+How it works
+------------
+
+The keys below ``@apply`` are evaluated before the fusion-object and the ``@context`` and are initialized.
+Each key below ``@apply`` must return a key-value map (values other than an array it are ignored). During
+the evaluation of each fusion-path the values from ``@apply`` are always checked first.
+
+If a property is defined via ``@apply`` this value is returned without evaluating the fusionPath.
+
+The ``@process`` and ``@if``-rules of the original fusion-key are still applied even if a value from ``@apply``
+is returned.
+
+Since ``@apply`` is evaluated first the overwritten values are already present during the evaluation of ``@context``
+and will overlay the properties of ``this`` if they are accessed.
+
+``@apply`` supports the same extended syntax and ordering as fusion processors and supports multiple keys.
+The evaluation order is defined via ``@position``, the keys that are evaluated last will override previously defined keys.
+This is also similar to the rules for ``@process``::
+
+	test = Vendor.Site:Prototype {
+		@apply.contextValue {
+			@position = 'start'
+			expression = ${ arrayValueFromContext }
+		}
+		@apply.fusionObject {
+			@position = 'end'
+			expression = Neos.Fusion:RawArray {
+				value = "altered value"
+			}
+		}
+	}
+
+Other than ``@context`` ``@apply`` is only valid for a single fusion path, so when subpathes or children are
+rendered they are not affected by the parents ``@apply`` unless they are explicitly passed down.
+
 Debugging
 =========
 


### PR DESCRIPTION
``@apply`` allows to override multiple properties of a fusion-prototype with a single expression. This is useful when complex data structures are mapped to fusion prototypes.

The example shows the rendering of a ``teaserList``-array by using a Teaser-Component and passing all keys from each teaser to the fusion Object.

```
teasers = Neos.Fusion:Collection {
	collection = ${teaserList}
	itemName = 'teaser'
	itemRenderer = Vendor.Site:Teaser {
		@apply.teasers = ${teaser}
	}
}
```

The code avoids passing down each fusion-property explicitly to the child component. A similar concept with different syntax from the JavaScript world is known as ES6-Spreads.

Another use-case is to use ``Neos.Fusion:Renderer`` to render a prototype while type and properties are based on data from the context.

```
example = Neos.Fusion:Renderer {
	type = ${data.type}
	element.@apply.properties = ${data.properties}
}
```

That way some meta-programming can used in fusion and both prototype and properties are decided late in the rendering by the fusion runtime.

The keys below ``@apply`` are evaluated before the fusion-object and the ``@context`` and are initialized. Each key below ``@apply`` must return a key-value map (values other than an array it are ignored). During the evaluation of each fusion-path the values from ``@apply`` are always checked first.

If a property is defined via ``@apply`` this value is returned without evaluating the fusionPath.

The ``@process`` and ``@if``-rules of the original fusion-key are still applied even if a value from ``@apply`` is returned.

Since ``@apply`` is evaluated first the overwritten values are already present during the evaluation of ``@context`` and will overlay the properties of ``this`` if they are accessed.

``@apply`` supports the same extended syntax and ordering as fusion processors and supports multiple keys. The evaluation order is defined via ``@position``, the keys that are evaluated last will override previously defined keys. This is also similar to the rules for ``@process``.

```
test = Vendor.Site:Prototype {
	@apply.contextValue {
		@position = 'start'
		expression = ${ arrayValueFromContext }
	}
	@apply.fusionObject {
		@position = 'end'
		expression = Neos.Fusion:RawArray {
			value = "altered value"
		}
	}
}
```

Other than ``@context`` ``@apply`` is only valid for a single fusion path, so when subpathes or children are rendered they are not affected by the parents ``@apply`` unless they are explicitly passed down.