### PR TITLE
BUGFIX: Fix typo in cache documentation

### DIFF
--- a/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
+++ b/Neos.Neos/Documentation/CreatingASite/ContentCache.rst
@@ -200,7 +200,7 @@ The following methods are provided by default to create all kind of patterns of 
 ``Everything``
   Flushes cache entries for every changed node.
 
-``${Neos.Caching.nodeTypeTag('[My.Package:NodeTypeName]', node}``
+``${Neos.Caching.nodeTypeTag('[My.Package:NodeTypeName]', node)}``
   Flushes cache entries if any node with the given node type changes. ``[My.Package:NodeTypeName]`` needs to be
   replaced by any node type name. Inheritance will be taken into account, so for a changed node of type
   ``Neos.NodeTypes:Page`` the tags ``NodeType_Neos.NodeTypes:Page`` and ``NodeType_Neos.Neos:Document``


### PR DESCRIPTION
**What I did**
Fixed a small typo in the caching documentation.

**How I did it**

**How to verify it**

**Checklist**

- [X] Code follows the PSR-2 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
