### PR TITLE
BUGFIX: Fix SCSS import for Fontawesome files

### DIFF
--- a/Neos.Neos/Resources/Private/Styles/Neos.scss
+++ b/Neos.Neos/Resources/Private/Styles/Neos.scss
@@ -6,9 +6,9 @@
 @import "Mixins";
 @import "Fonts";
 @import "../../Public/Library/fontawesome/scss/fontawesome.scss";
-@import "../../Public/Library/fontawesome/scss/fa-brands.scss";
-@import "../../Public/Library/fontawesome/scss/fa-regular.scss";
-@import "../../Public/Library/fontawesome/scss/fa-solid.scss";
+@import "../../Public/Library/fontawesome/scss/brands.scss";
+@import "../../Public/Library/fontawesome/scss/regular.scss";
+@import "../../Public/Library/fontawesome/scss/solid.scss";
 @import "Icons";
 
 .neos {


### PR DESCRIPTION
This fixes an issue in Neos.scss which referred to wrong filenames
for importing Fontawesome styles.
