### PR TITLE
TASK: Use correct icon for history module

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -310,7 +310,7 @@ Neos:
             label: 'Neos.Neos:Modules:history.label'
             controller: 'Neos\Neos\Controller\Module\Management\HistoryController'
             description: 'Neos.Neos:Modules:history.description'
-            icon: fas fa-calendar
+            icon: fas fa-calendar-alt
       administration:
         label: 'Neos.Neos:Modules:administration.label'
         controller: 'Neos\Neos\Controller\Module\AdministrationController'


### PR DESCRIPTION
Since switching to a newer version of Font Awesome the icon for the history module has changed to a less detailed version, making it less clear.

Before 4.0:
![image](https://user-images.githubusercontent.com/903567/46665137-46b30a00-cbc3-11e8-88ac-12b6a7b8d1c9.png)

Before change:
![image](https://user-images.githubusercontent.com/903567/46665066-fcca2400-cbc2-11e8-8885-b928e5fbff45.png)

After change:
![image](https://user-images.githubusercontent.com/903567/46665073-05225f00-cbc3-11e8-940e-541d97fcccd2.png)

Be aware that this is not visible in the new UI content module as the icons there are replaced with SVGs where it's actually using the alt version.