### PR TITLE
TASK: Correct method signature of DataSourceInterface

### DIFF
--- a/Neos.Neos/Classes/Service/DataSource/DataSourceInterface.php
+++ b/Neos.Neos/Classes/Service/DataSource/DataSourceInterface.php
@@ -38,5 +38,5 @@ interface DataSourceInterface
      * @return mixed JSON serializable data
      * @api
      */
-    public function getData(NodeInterface $node = null, array $arguments);
+    public function getData(NodeInterface $node = null, array $arguments = []);
 }

--- a/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
+++ b/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
@@ -34,7 +34,7 @@ class FormDefinitionDataSource extends AbstractDataSource
      * @param array $arguments
      * @return \Neos\Flow\Persistence\QueryResultInterface
      */
-    public function getData(NodeInterface $node = null, array $arguments)
+    public function getData(NodeInterface $node = null, array $arguments = [])
     {
         $formDefinitions['']['label'] = '';
         $forms = $this->yamlPersistenceManager->listForms();


### PR DESCRIPTION
This adjusts the getData method signature of the DataSourceInterface,
because if the first parameter is optional, the following should also be
optional.
