### PR TITLE
BUGFIX: Make NodeConverter method interface compatible

### DIFF
--- a/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
+++ b/TYPO3.TYPO3CR/Classes/TYPO3/TYPO3CR/TypeConverter/NodeConverter.php
@@ -133,7 +133,7 @@ class NodeConverter extends AbstractTypeConverter
      * @return mixed An object or \TYPO3\Flow\Error\Error if the input format is not supported or could not be converted for other reasons
      * @throws NodeException
      */
-    public function convertFrom($source, $targetType = null, array $subProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $subProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
         if (is_string($source)) {
             $source = array('__contextNodePath' => $source);


### PR DESCRIPTION
This fixes a method signature mistake where
the convertFrom method does not match its
inheritants resp. the interface, leading to errors
in PHP >7.1.

Can you guys do me a favor and and merge this to 2.3 as well as create a tag for the (abandoned) composer package typo3/typo3cr? Need this for a legacy project.
Thanks!

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->
