### PR TITLE
BUGFIX: NodeType->isOfType() respects explicitly removed supertypes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -319,12 +319,8 @@ class NodeType
         if ($nodeType === $this->name) {
             return true;
         }
-        foreach ($this->declaredSuperTypes as $superType) {
-            if ($superType !== null && $superType->isOfType($nodeType) === true) {
-                return true;
-            }
-        }
-        return false;
+        $inheritanceChain = $this->buildInheritanceChain();
+        return isset($inheritanceChain[$nodeType]);
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -154,14 +154,36 @@ class NodeTypeTest extends UnitTestCase
      */
     public function nodeTypesCanHaveAnyNumberOfSuperTypes()
     {
-        $baseType = new NodeType('Neos.ContentRepository:Base', array(), array());
+        $baseType = new NodeType('Neos.ContentRepository:Base', [], []);
 
-        $folderType = new NodeType('Neos.ContentRepository.Testing:Document', array($baseType), array());
+        $timeableNodeType = new NodeType('Neos.ContentRepository.Testing:TimeableContent', [], []);
+        $documentType = new NodeType(
+            'Neos.ContentRepository.Testing:Document',
+            [
+                'Neos.ContentRepository:Base' => $baseType,
+                'Neos.ContentRepository.Testing:TimeableContent' => $timeableNodeType,
+            ],
+            []
+        );
 
-        $hideableNodeType = new NodeType('Neos.ContentRepository.Testing:HideableContent', array(), array());
-        $pageType = new NodeType('Neos.ContentRepository.Testing:Page', array($folderType, $hideableNodeType), array());
+        $hideableNodeType = new NodeType('Neos.ContentRepository.Testing:HideableContent', [], []);
+        $pageType = new NodeType(
+            'Neos.ContentRepository.Testing:Page',
+            [
+                'Neos.ContentRepository.Testing:Document' => $documentType,
+                'Neos.ContentRepository.Testing:HideableContent' => $hideableNodeType,
+                'Neos.ContentRepository.Testing:TimeableContent' => null,
+            ],
+            []
+        );
 
-        $this->assertEquals(array($folderType, $hideableNodeType), $pageType->getDeclaredSuperTypes());
+        $this->assertEquals(
+            [
+                'Neos.ContentRepository.Testing:Document' => $documentType,
+                'Neos.ContentRepository.Testing:HideableContent' => $hideableNodeType,
+            ],
+            $pageType->getDeclaredSuperTypes()
+        );
 
         $this->assertTrue($pageType->isOfType('Neos.ContentRepository.Testing:Page'));
         $this->assertTrue($pageType->isOfType('Neos.ContentRepository.Testing:HideableContent'));
@@ -169,6 +191,7 @@ class NodeTypeTest extends UnitTestCase
         $this->assertTrue($pageType->isOfType('Neos.ContentRepository:Base'));
 
         $this->assertFalse($pageType->isOfType('Neos.ContentRepository:Exotic'));
+        $this->assertFalse($pageType->isOfType('Neos.ContentRepository.Testing:TimeableContent'));
     }
 
     /**


### PR DESCRIPTION
**What I did**
`NodeType->isOfType()` returned `true` if a node type inherited another node types inherited node type which was declared as `false` in the NodeTypes `superTypes`.

**How I did it**
Check existence of node type in inheritance chain instead of recursing through super types.

**How to verify it**
```yaml
NodeMixin:
  abstract: true

NodeA:
  superTypes:
    NodeMixin: true

NodeB:
  superTypes:
    NodeA: true
    NodeMixin: false
```
Check it with `$nodeB->isOfType('NodeMixin')`.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
