### PR TITLE
BUGFIX: Hide inaccessible nodes in dimensionmenu

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -101,7 +101,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
                 $nodeInDimensions = $this->findAcceptableNode($allowedCombination, $allDimensionPresets);
             }
 
-            if ($nodeInDimensions !== null && $this->isNodeHidden($nodeInDimensions)) {
+            if ($nodeInDimensions !== null && ($this->isNodeHidden($nodeInDimensions) || $this->isNodeParentHidden($nodeInDimensions))) {
                 $nodeInDimensions = null;
             }
 
@@ -208,5 +208,19 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
         }
 
         return $targetDimensions;
+    }
+
+    /**
+     * Returns TRUE if the node has a inaccessible parent.
+     *
+     * @param NodeInterface $node
+     * @return boolean
+     */
+    protected function isNodeParentHidden(NodeInterface $node)
+    {
+        $rootNode = $node->getContext()->getRootNode();
+        $nodesOnPath = $node->getContext()->getNodesOnPath($rootNode, $node);
+
+        return count($nodesOnPath) < $node->getDepth();
     }
 }

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -214,9 +214,9 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      * Returns TRUE if the node has a inaccessible parent.
      *
      * @param NodeInterface $node
-     * @return boolean
+     * @return bool
      */
-    protected function isNodeParentHidden(NodeInterface $node)
+    protected function isNodeParentHidden(NodeInterface $node): bool
     {
         $rootNode = $node->getContext()->getRootNode();
         $nodesOnPath = $node->getContext()->getNodesOnPath($rootNode, $node);

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -101,7 +101,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
                 $nodeInDimensions = $this->findAcceptableNode($allowedCombination, $allDimensionPresets);
             }
 
-            if ($nodeInDimensions !== null && ($this->isNodeHidden($nodeInDimensions) || $this->isNodeParentHidden($nodeInDimensions))) {
+            if ($nodeInDimensions !== null && ($this->isNodeHidden($nodeInDimensions) || $this->hasHiddenNodeParent($nodeInDimensions))) {
                 $nodeInDimensions = null;
             }
 
@@ -216,7 +216,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      * @param NodeInterface $node
      * @return bool
      */
-    protected function isNodeParentHidden(NodeInterface $node): bool
+    protected function hasHiddenNodeParent(NodeInterface $node): bool
     {
         $rootNode = $node->getContext()->getRootNode();
         $nodesOnPath = $node->getContext()->getNodesOnPath($rootNode, $node);


### PR DESCRIPTION
**What I did**

Previously the dimensionmenu rendered nodes which
had hidden parents and thus created invalid urls which caused 404 errors.

This also caused the alternate language links in
the neos/seo package to render invalid urls which
caused errors for search engines.

**How I did it**

With this change each node is checked if there
is a node missing in its rootline for whatever reason.

**How to verify it**

1. In the demo site go to a subpage on the 3rd or deeper level
2. Create german translation
3. Hide parent page of german translation
4. Check if link to german translation is still rendered in dimensionmenu on the top right 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
