### PR TITLE
BUGFIX: Convert uris destroys address tag

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -144,7 +144,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
         $processedContent = preg_replace_callback(
-            '~<a.*?href="(.*?)".*?>~i',
+            '~<a .*?href="(.*?)".*?>~i',
             function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $noOpenerString) {
                 list($linkText, $linkHref) = $matches;
                 $uriHost = parse_url($linkHref, PHP_URL_HOST);


### PR DESCRIPTION
ConvertUris applied to markup containing an
<address> tag and an <a>-tag destroys the address tag
because the regex matches the address tag and inserts
the href there.