### PR TITLE
FEATURE: Translate paginate widget links

### DIFF
--- a/Neos.ContentRepository/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
+++ b/Neos.ContentRepository/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
@@ -16,7 +16,7 @@
 					<li class="previous">
 						<f:if condition="{pagination.previousPage} > 1">
 							<f:then>
-								<f:widget.link action="index" arguments="{currentPage: pagination.previousPage}">previous</f:widget.link>
+								<f:widget.link action="index" arguments="{currentPage: pagination.previousPage}">{f:translate(id: 'previous')}</f:widget.link>
 							</f:then>
 							<f:else>
 								<f:widget.link action="index">previous</f:widget.link>
@@ -63,7 +63,7 @@
 				</f:if>
 				<f:if condition="{pagination.nextPage}">
 					<li class="next">
-						<f:widget.link action="index" arguments="{currentPage: pagination.nextPage}">next</f:widget.link>
+						<f:widget.link action="index" arguments="{currentPage: pagination.nextPage}">{f:translate(id: 'next')}</f:widget.link>
 					</li>
 				</f:if>
 			</ul>

--- a/Neos.ContentRepository/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.ContentRepository/Resources/Private/Translations/en/Main.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.ContentRepository" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="next" xml:space="preserve">
+				<source>next</source>
+			</trans-unit>
+			<trans-unit id="previous" xml:space="preserve">
+				<source>previous</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
**What I did**
Translate the previous/next links in the paginate widget in Neos.ContentRepository.

**How I did it**
Adapt the widget template and copy/adapt Translations from Neos.Media

**How to verify it**
- use or create a new node type based on a fluid template
- in that node type's fluid template, use the pagination widget from Neos.ContentRepository
- do not override the pagination widget's default template
- create a node of said node type
- translate the page containing it
- visit the frontend in a language other than english
- see how the previous/next links shine

**Checklist**

- [x] Code follows the PSR-2 coding style
  - PSR-2 yes, but the translation files I copied from are a happy mix of tabs and spaces. Tried to keep that the same for the newly created translation files because I suspect these normally come from a professional translation software which I don't want to interfere with.
- [ ] Tests have been created, run and adjusted as needed
  - only 63% of unit tests run locally before phpunit crashes due to some "Magick"-related issue
  - I don't know how to create a test for this feature or whether that is applicable here at all
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
  - I need help with that (https://discuss.neos.io/t/creating-a-pull-request/506 says "features always go to the master branch"?)
