### PR TITLE
BUGFIX: Avoid inheritance on unset Fusion pathes

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -185,6 +185,7 @@ class ContentCache
     protected function renderContentCacheEntryIdentifier($fusionPath, array $cacheIdentifierValues)
     {
         ksort($cacheIdentifierValues);
+        unset($cacheIdentifierValues['__stopPrototypeInheritanceChain']);
 
         $identifierSource = '';
         foreach ($cacheIdentifierValues as $key => $value) {

--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -185,7 +185,6 @@ class ContentCache
     protected function renderContentCacheEntryIdentifier($fusionPath, array $cacheIdentifierValues)
     {
         ksort($cacheIdentifierValues);
-        unset($cacheIdentifierValues['__stopInheritanceChain']);
 
         $identifierSource = '';
         foreach ($cacheIdentifierValues as $key => $value) {

--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -185,7 +185,7 @@ class ContentCache
     protected function renderContentCacheEntryIdentifier($fusionPath, array $cacheIdentifierValues)
     {
         ksort($cacheIdentifierValues);
-        unset($cacheIdentifierValues['__stopPrototypeInheritanceChain']);
+        unset($cacheIdentifierValues['__stopInheritanceChain']);
 
         $identifierSource = '';
         foreach ($cacheIdentifierValues as $key => $value) {

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -199,7 +199,7 @@ class Parser implements ParserInterface
      *
      * @var array
      */
-    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__valueUnAssignments', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
+    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__stopInheritanceChains', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
 
     /**
      * @Flow\Inject
@@ -518,7 +518,7 @@ class Parser implements ParserInterface
     {
         $objectPathArray = $this->getParsedObjectPath($objectPath);
         $this->setValueInObjectTree($objectPathArray, null);
-        $this->setValueInObjectTree($objectPathArray, ['__valueUnAssignment' => true]);
+        $this->setValueInObjectTree($objectPathArray, ['__stopInheritanceChain' => true]);
     }
 
     /**

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -199,7 +199,7 @@ class Parser implements ParserInterface
      *
      * @var array
      */
-    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
+    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__valueUnAssignments', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
 
     /**
      * @Flow\Inject
@@ -512,11 +512,13 @@ class Parser implements ParserInterface
      *
      * @param string $objectPath The object path as a string
      * @return void
+     * @throws Fusion\Exception
      */
     protected function parseValueUnAssignment($objectPath)
     {
         $objectPathArray = $this->getParsedObjectPath($objectPath);
         $this->setValueInObjectTree($objectPathArray, null);
+        $this->setValueInObjectTree($objectPathArray, ['__valueUnAssignment' => true]);
     }
 
     /**

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -199,7 +199,7 @@ class Parser implements ParserInterface
      *
      * @var array
      */
-    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__stopInheritanceChains', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
+    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__stopInheritanceChain', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
 
     /**
      * @Flow\Inject

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -654,9 +654,6 @@ class Runtime
             $this->configurationOnPathRuntimeCache[$pathUntilNow]['p'] = $currentPrototypeDefinitions;
         }
 
-        // Remove any leftover internal __stopInheritanceChain keys
-        unset($configuration['__stopInheritanceChain']);
-
         return $configuration;
     }
 

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -136,7 +136,7 @@ class Runtime
     /**
      * @var \Closure
      */
-    protected $shouldUnsetClosure;
+    protected $shouldOverrideFirstClosure;
 
 
     /**
@@ -159,8 +159,8 @@ class Runtime
             ];
         };
 
-        $this->shouldUnsetClosure = function ($value): bool {
-            return is_array($value) && isset($value['__valueUnAssignment']);
+        $this->shouldOverrideFirstClosure = function ($key, $firstValue, $secondValue): bool {
+            return is_array($secondValue) && isset($secondValue['__valueUnAssignment']);
         };
     }
 
@@ -683,7 +683,7 @@ class Runtime
         }
 
         if (isset($configuration['__prototypes'])) {
-            $currentPrototypeDefinitions = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeDefinitions, $configuration['__prototypes'], $this->simpleTypeToArrayClosure, $this->shouldUnsetClosure);
+            $currentPrototypeDefinitions = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeDefinitions, $configuration['__prototypes'], $this->simpleTypeToArrayClosure, $this->shouldOverrideFirstClosure);
         }
 
         $currentPathSegmentType = null;
@@ -734,17 +734,17 @@ class Runtime
                         $prototypeName, $currentPathSegmentType), 1427134340);
                 }
 
-                $currentPrototypeWithInheritanceTakenIntoAccount = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeWithInheritanceTakenIntoAccount, $currentPrototypeDefinitions[$prototypeName], $this->simpleTypeToArrayClosure, $this->shouldUnsetClosure);
+                $currentPrototypeWithInheritanceTakenIntoAccount = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeWithInheritanceTakenIntoAccount, $currentPrototypeDefinitions[$prototypeName], $this->simpleTypeToArrayClosure, $this->shouldOverrideFirstClosure);
             }
 
             // We merge the already flattened prototype with the current configuration (in that order),
             // to make sure that the current configuration (not being defined in the prototype) wins.
-            $configuration = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeWithInheritanceTakenIntoAccount, $configuration, $this->simpleTypeToArrayClosure, $this->shouldUnsetClosure);
+            $configuration = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeWithInheritanceTakenIntoAccount, $configuration, $this->simpleTypeToArrayClosure, $this->shouldOverrideFirstClosure);
 
             // If context-dependent prototypes are set (such as prototype("foo").prototype("baz")),
             // we update the current prototype definitions.
             if (isset($currentPrototypeWithInheritanceTakenIntoAccount['__prototypes'])) {
-                $currentPrototypeDefinitions = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeDefinitions, $currentPrototypeWithInheritanceTakenIntoAccount['__prototypes'], $this->simpleTypeToArrayClosure, $this->shouldUnsetClosure);
+                $currentPrototypeDefinitions = Arrays::arrayMergeRecursiveOverruleWithCallback($currentPrototypeDefinitions, $currentPrototypeWithInheritanceTakenIntoAccount['__prototypes'], $this->simpleTypeToArrayClosure, $this->shouldOverrideFirstClosure);
             }
         }
 

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -450,7 +450,7 @@ class Runtime
 
         try {
             if ($this->hasExpressionOrValue($fusionConfiguration)) {
-                return $this->evaluteExpressionOrValueInternal($fusionPath, $fusionConfiguration, $cacheContext, $contextObject);
+                return $this->evaluateExpressionOrValueInternal($fusionPath, $fusionConfiguration, $cacheContext, $contextObject);
             }
             $needToPopApply = $this->prepareApplyValuesForFusionPath($fusionPath, $fusionConfiguration);
             $fusionObject = $this->instantiatefusionObject($fusionPath, $fusionConfiguration);
@@ -520,7 +520,7 @@ class Runtime
      * @param mixed $contextObject
      * @return mixed
      */
-    protected function evaluteExpressionOrValueInternal($fusionPath, $fusionConfiguration, $cacheContext, $contextObject)
+    protected function evaluateExpressionOrValueInternal($fusionPath, $fusionConfiguration, $cacheContext, $contextObject)
     {
         if ($this->evaluateIfCondition($fusionConfiguration, $fusionPath, $contextObject) === false) {
             $this->finalizePathEvaluation($cacheContext);

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -160,7 +160,7 @@ class Runtime
         };
 
         $this->shouldOverrideFirstClosure = function ($key, $firstValue, $secondValue): bool {
-            return is_array($secondValue) && isset($secondValue['__valueUnAssignment']);
+            return is_array($secondValue) && isset($secondValue['__stopInheritanceChain']);
         };
     }
 
@@ -654,8 +654,8 @@ class Runtime
             $this->configurationOnPathRuntimeCache[$pathUntilNow]['p'] = $currentPrototypeDefinitions;
         }
 
-        // Remove any leftover internal __valueUnAssignment keys
-        unset($configuration['__valueUnAssignment']);
+        // Remove any leftover internal __stopInheritanceChain keys
+        unset($configuration['__stopInheritanceChain']);
 
         return $configuration;
     }
@@ -984,8 +984,8 @@ class Runtime
                     continue;
                 }
 
-                # If there is only the internal "__valueUnAssignment" path set, skip evaluation
-                if (count($processorConfiguration[$key]) === 1 && isset($processorConfiguration[$key]['__valueUnAssignment'])) {
+                # If there is only the internal "__stopInheritanceChain" path set, skip evaluation
+                if (count($processorConfiguration[$key]) === 1 && isset($processorConfiguration[$key]['__stopInheritanceChain'])) {
                     continue;
                 }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
@@ -3,7 +3,6 @@ prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImpleme
 prototype(Neos.Fusion:Testing.Throwing).@class = 'Neos\\Fusion\\Tests\\Functional\\FusionObjects\\Fixtures\\FusionObjects\\ThrowingImplementation'
 
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
-prototype(Neos.Fusion:GlobalCacheIdentifiers) >
 prototype(Neos.Fusion:GlobalCacheIdentifiers) < prototype(Neos.Fusion:RawArray)
 
 contentCache.cachedSegment = Neos.Fusion:Array {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Unset.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Unset.fusion
@@ -12,32 +12,32 @@ prototype(Neos.Fusion:ValueUnset2) < prototype(Neos.Fusion:ValueUnset1) {
   }
 }
 
-prototype(Bar) < prototype(Neos.Fusion:Join) {
-  k1 = 'Foo'
-  k2 = 'Bar'
-}
-
-prototype(Foo) < prototype(Neos.Fusion:Join) {
-  foo = Neos.Fusion:Join {
+prototype(Neos.Fusion:NestedPrototypeUnset) < prototype(Neos.Fusion:Join) {
+  value = Neos.Fusion:Join {
     k3 = 'Baz'
     k4 = 'Quux'
   }
 }
 
-prototype(Baz) {
+prototype(Neos.Fusion:TopLevelPrototypeUnset) {
   k1 = 'Foo'
 }
 
-prototype(Baz) >
-prototype(Baz) < prototype(Neos.Fusion:Join) {
+prototype(Neos.Fusion:TopLevelPrototypeUnset) >
+prototype(Neos.Fusion:TopLevelPrototypeUnset) < prototype(Neos.Fusion:Join) {
   k2 = 'Bar'
 }
 
-prototype(Baz) {
+prototype(Neos.Fusion:TopLevelPrototypeUnset) {
   k3 = 'Baz'
 }
 
-unsets {
+prototype(Neos.Fusion:NestedPrototypeUnset2) < prototype(Neos.Fusion:Join) {
+  k1 = 'Foo'
+  k2 = 'Bar'
+}
+
+valueUnset {
   simple = Neos.Fusion:Join
   simple.1 = 'Foo'
   simple.2 = 'Bar'
@@ -45,11 +45,11 @@ unsets {
 
   inheritedPrototypePath = Neos.Fusion:ValueUnset2
 
-  nestedPrototype = Foo
-  nestedPrototype.prototype(Foo).foo >
-  nestedPrototype.prototype(Foo).foo = Bar
+  nestedPrototype = Neos.Fusion:NestedPrototypeUnset
+  nestedPrototype.prototype(Neos.Fusion:NestedPrototypeUnset).value >
+  nestedPrototype.prototype(Neos.Fusion:NestedPrototypeUnset).value = Neos.Fusion:NestedPrototypeUnset2
 
-  topLevelPrototype = Baz {
+  topLevelPrototype = Neos.Fusion:TopLevelPrototypeUnset {
     k4 = 'Quux'
   }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Unset.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Unset.fusion
@@ -1,0 +1,55 @@
+prototype(Neos.Fusion:ValueUnset1) < prototype(Neos.Fusion:Value) {
+  value = Neos.Fusion:Join {
+    1 = 'Foo'
+    2 = 'Bar'
+  }
+}
+
+prototype(Neos.Fusion:ValueUnset2) < prototype(Neos.Fusion:ValueUnset1) {
+  value >
+  value = Neos.Fusion:Join {
+    1 = 'Baz'
+  }
+}
+
+prototype(Bar) < prototype(Neos.Fusion:Join) {
+  k1 = 'Foo'
+  k2 = 'Bar'
+}
+
+prototype(Foo) < prototype(Neos.Fusion:Join) {
+  foo = Neos.Fusion:Join {
+    k3 = 'Baz'
+    k4 = 'Quux'
+  }
+}
+
+prototype(Baz) {
+  k1 = 'Foo'
+}
+
+prototype(Baz) >
+prototype(Baz) < prototype(Neos.Fusion:Join) {
+  k2 = 'Bar'
+}
+
+prototype(Baz) {
+  k3 = 'Baz'
+}
+
+unsets {
+  simple = Neos.Fusion:Join
+  simple.1 = 'Foo'
+  simple.2 = 'Bar'
+  simple.1 >
+
+  inheritedPrototypePath = Neos.Fusion:ValueUnset2
+
+  nestedPrototype = Foo
+  nestedPrototype.prototype(Foo).foo >
+  nestedPrototype.prototype(Foo).foo = Bar
+
+  topLevelPrototype = Baz {
+    k4 = 'Quux'
+  }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -20,10 +20,10 @@ class UnsetTest extends AbstractFusionObjectTest
     public function unsetExamples()
     {
         return [
-            ['unsets/inheritedPrototypePath', 'Baz'],
-            ['unsets/nestedPrototype', 'FooBar'],
-            ['unsets/simple', 'Bar'],
-            ['unsets/topLevelPrototype', 'BarBazQuux']
+            ['valueUnset/inheritedPrototypePath', 'Baz'],
+            ['valueUnset/nestedPrototype', 'FooBar'],
+            ['valueUnset/simple', 'Bar'],
+            ['valueUnset/topLevelPrototype', 'BarBazQuux']
         ];
     }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -35,6 +35,6 @@ class UnsetTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath($path);
-        $this->assertEquals($expected, $view->render());
+        self::assertEquals($expected, $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for unsetting Fusion paths
+ *
+ */
+class UnsetTest extends AbstractFusionObjectTest
+{
+    public function unsetExamples()
+    {
+        return [
+            ['unsets/inheritedPrototypePath', 'Baz'],
+            ['unsets/nestedPrototype', 'FooBar'],
+            ['unsets/simple', 'Bar'],
+            ['unsets/topLevelPrototype', 'BarBazQuux']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider unsetExamples
+     */
+    public function unsetWorks($path, $expected)
+    {
+        $view = $this->buildView();
+        $view->setFusionPath($path);
+        $this->assertEquals($expected, $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -352,10 +352,16 @@ class ParserTest extends UnitTestCase
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture07');
 
         $expectedParseTree = [
+            'object1' => [
+                '__valueUnAssignment' => true
+            ],
             'object3' => [
                 '__objectType' => 'Neos.Fusion:Text',
                 '__value' => null,
-                '__eelExpression' => null
+                '__eelExpression' => null,
+                'value' => [
+                    '__valueUnAssignment' => true
+                ]
             ]
         ];
 

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -353,14 +353,14 @@ class ParserTest extends UnitTestCase
 
         $expectedParseTree = [
             'object1' => [
-                '__valueUnAssignment' => true
+                '__stopInheritanceChain' => true
             ],
             'object3' => [
                 '__objectType' => 'Neos.Fusion:Text',
                 '__value' => null,
                 '__eelExpression' => null,
                 'value' => [
-                    '__valueUnAssignment' => true
+                    '__stopInheritanceChain' => true
                 ]
             ]
         ];


### PR DESCRIPTION
When Fusion pathes are unset with the `>` operator the operations was previously handled by the parser. The drawback was that the parser unset could not affect inherited pathes which were merged into the prototype by the runtime.

This change adds the internal-key `__stopInheritanceChain` to the fusion ast whenever a value is unset. The fusion runtime will stop merging parent prototypes for the pathes where this key is set.

As a common example the following code does not render an empty body but a will render the 
keys  `site` and `node` from the `Neos.Neos:Page` prototype which is totally unexpected and against the intention.
```
prototype(Vendor.Site:ExampleDocument) < prototype(Neos.Neos:Page) {
    body >
    body = Neos.Fusion:Array {
       @position = 'after bodyTag'
       message = "hello world"
   }
}
```

!!! While this is a clear bug this change might break code that relied on the old inconsitent behavior. It is also important that this also avoids inheriting of `@position` keys so if you rely on the ordering you have to add the @position keys again after unsetting like in the example above.

Fixes: #2213, #1109