### PR TITLE
FEATURE: Add update authenticationProviderName to edit Account

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -201,7 +201,8 @@ class UsersController extends AbstractModuleController
         $this->view->assignMultiple([
             'account' => $account,
             'user' => $this->userService->getUser($account->getAccountIdentifier(), $account->getAuthenticationProviderName()),
-            'availableRoles' => $this->policyService->getRoles()
+            'availableRoles' => $this->policyService->getRoles(),
+            'providers' => $this->getAuthenticationProviders()
         ]);
     }
 
@@ -211,10 +212,11 @@ class UsersController extends AbstractModuleController
      * @param Account $account The account to update
      * @param array $roleIdentifiers A possibly updated list of roles for the user's primary account
      * @param array $password Expects an array in the format array('<password>', '<password confirmation>')
+     * @param string $authenticationProviderName Optional name of the authentication provider. If not provided the user server uses the default authentication provider
      * @Flow\Validate(argumentName="password", type="\Neos\Neos\Validation\Validator\PasswordValidator", options={ "allowEmpty"=1, "minimum"=1, "maximum"=255 })
      * @return void
      */
-    public function updateAccountAction(Account $account, array $roleIdentifiers, array $password = [])
+    public function updateAccountAction(Account $account, array $roleIdentifiers, array $password = [], $authenticationProviderName = null)
     {
         $user = $this->userService->getUser($account->getAccountIdentifier(), $account->getAuthenticationProviderName());
         if ($user === $this->currentUser) {
@@ -233,6 +235,7 @@ class UsersController extends AbstractModuleController
         }
 
         $this->userService->setRolesForAccount($account, $roleIdentifiers);
+        $this->userService->setAuthenticationProviderNameForAccount($account, $authenticationProviderName);
         $this->addFlashMessage('The account has been updated.', 'Account updated', Message::SEVERITY_OK);
         $this->redirect('edit', null, null, ['user' => $user]);
     }

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -453,7 +453,7 @@ class UserService
 
     /**
      * Override or set the authenticationProviderName for Account
-     * 
+     *
      * @param Account $account
      * @param string|null $authenticationProviderName
      * @return void

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -459,7 +459,7 @@ class UserService
      * @return void
      * @api
      */
-    public function setAuthenticationProviderNameForAccount(Account $account, string $authenticationProviderName = null)
+    public function setAuthenticationProviderNameForAccount(Account $account, string $authenticationProviderName = null) :void
     {
         $currentAuthenticationProviderName = $account->getAuthenticationProviderName();
         $authenticationProviderName = $authenticationProviderName ?: $this->defaultAuthenticationProviderName;

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -452,6 +452,39 @@ class UserService
     }
 
     /**
+     * Override or set the authenticationProviderName for Account
+     * 
+     * @param Account $account
+     * @param string|null $authenticationProviderName
+     * @return void
+     * @api
+     */
+    public function setAuthenticationProviderNameForAccount(Account $account, string $authenticationProviderName = null)
+    {
+        $currentAuthenticationProviderName = $account->getAuthenticationProviderName();
+        $authenticationProviderName = $authenticationProviderName ?: $this->defaultAuthenticationProviderName;
+
+        if ($currentAuthenticationProviderName !== $authenticationProviderName) {
+            $account->setAuthenticationProviderName($authenticationProviderName);
+            $this->accountRepository->update($account);
+            $this->emitAuthenticationProviderNameUpdated($account, $authenticationProviderName);
+        }
+    }
+
+    /**
+     * Signals that the given user has an updated authenticationProviderName
+     *
+     * @param Account $account the account
+     * @param string $authenticationProviderName the updated authenticationProviderName
+     * @return void
+     * @Flow\Signal
+     * @api
+     */
+    public function emitAuthenticationProviderNameUpdated(Account $account, string $authenticationProviderName)
+    {
+    }
+
+    /**
      * Adds the specified role to the given account and potentially carries out further actions which are needed to
      * properly reflect these changes.
      *

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/EditAccount.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/EditAccount.html
@@ -24,6 +24,18 @@
 			</div>
 		</div>
 
+		<f:if condition="{providers -> f:count()} > 1">
+			<f:then>
+				<div class="neos-control-group{f:validation.ifHasErrors(for: 'authenticationProviderName', then: ' neos-error')}">
+					<label class="neos-control-label" for="authenticationProviderName">{neos:backend.translate(id: 'users.new.userData.authenticationProviderName', value: 'Authentication Provider', source: 'Modules', package: 'Neos.Neos')}</label>
+					<div class="neos-controls">
+						<f:form.select name="authenticationProviderName" id="authenticationProviderName" options="{providers}" value="{account.authenticationProviderName}" prependOptionLabel="{neos:backend.translate(id: 'users.new.userData.authenticationProviderName.useDefault', source: 'Modules', value: 'Use system default')}" prependOptionValue="" class="neos-span12" />
+						<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'authenticationProviderName'}"/>
+					</div>
+				</div>
+			</f:then>
+		</f:if>
+
 		<f:if condition="{showRoles}">
 			<div class="neos-control-group">
 				<label class="neos-control-label">{neos:backend.translate(source: 'Modules', id: 'users.roles')}</label>


### PR DESCRIPTION
resolves #2179.

**What I did**

I have added an `setAuthenticationProviderNameForAccount` Method in the `UserService` to update the authenticationProviderName and trigger an signal. This is now used in the edit account section and adds the ability to update the authenticationProviderName for a specific Account in an User.

**How I did it**

I have copied the `f.form:select` from `Users/New.html` to ensure equal data/look.

**How to verify it**

Checkout the branch, edit a user and click edit at one of his account(s). 
