### PR TITLE
TASK: Redirect through Neos.Ui package if it is installed

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -18,6 +18,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages\Message;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Context;
@@ -100,6 +101,12 @@ class WorkspacesController extends AbstractModuleController
      * @Flow\Inject
      */
     protected $contentDimensionPresetSource;
+
+    /**
+     * @var PackageManager
+     * @Flow\Inject
+     */
+    protected $packageManager;
 
     /**
      * @return void
@@ -335,6 +342,11 @@ class WorkspacesController extends AbstractModuleController
         $mainRequest = $this->controllerContext->getRequest()->getMainRequest();
         /** @var ActionRequest $mainRequest */
         $this->uriBuilder->setRequest($mainRequest);
+
+        if ($this->packageManager->isPackageAvailable('Neos.Neos.Ui')) {
+            $this->redirect('index', 'Backend', 'Neos.Neos.Ui', ['node' => $context->getNode($targetNode->getPath())]);
+        }
+
         $this->redirect('show', 'Frontend\\Node', 'Neos.Neos', ['node' => $context->getNode($targetNode->getPath())]);
     }
 


### PR DESCRIPTION
resolves #2081


**What I did**

After a discussion with @daniellienert and @johannessteu we have decided to redirect to a node in backend via Neos.Ui if Neos.Ui is installed. Otherwise, e.g. when the old Ui is used, the node gets redirected through the `NodeController`.

Currently it is loaded always via `NodeController` and in most cases (when Neos.Ui is installed) the node is loaded in frontend without ui.

**How I did it**

I have added a check via `PackageManager` for Neos.Ui and redirect the backend links via Neos.Ui `indexAction` if it's installed.

**How to verify it**

Go into the Neos-Backend Workspace-Module. If you have unpublished changes in a workspace there is an "review"-Button. In the review-Section click on the edit-Link as described in #2081. In case you have installed the new Neos.Ui you will see the node in frontend-mode with - eventually - only in backend/hidden - prototypes. 
