### PR TITLE
FEATURE: New NodeDataQuery class with easy to use API and extendable filter/order capabilities

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/AbstractNodeDataOrder.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/AbstractNodeDataOrder.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+abstract class AbstractNodeDataOrder implements NodeDataOrderInterface
+{
+    const ORDER_ASC = 'ASC';
+    const ORDER_DESC = 'DESC';
+
+    /**
+     * @var string
+     */
+    protected $order;
+
+    /**
+     * NodePathOrder constructor.
+     * @param string $order
+     * @throws \Exception
+     */
+    public function __construct(string $order = self::ORDER_ASC)
+    {
+        if ($order !== self::ORDER_ASC && $order !== self::ORDER_DESC) {
+            throw new \InvalidArgumentException(sprintf('Invalid order: %s', $order), 1541496086);
+        }
+        $this->order = $order;
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/AbstractNodeDateTimeFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/AbstractNodeDateTimeFilter.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+use DateTime;
+use Doctrine\ORM\QueryBuilder;
+
+abstract class AbstractNodeDateTimeFilter implements NodeDataFilterInterface
+{
+    const OPERATORS = ['=', '!=', '>', '>=', '<=', '<'];
+
+    /**
+     * @var DateTime
+     */
+    protected $value;
+
+    /**
+     * @var string
+     */
+    protected $operator;
+
+    /**
+     * NodeLastPublicationDateTimeFilter constructor.
+     * @param DateTime $value
+     * @param string $operator
+     */
+    public function __construct(DateTime $value, $operator = '=')
+    {
+        $this->value = $value;
+        if (in_array($operator, self::OPERATORS) === false) {
+            throw new \InvalidArgumentException(sprintf('Invalid operator: %s', $operator), 1541608194);
+        }
+        $this->operator = $operator;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $_value = 'value_' . md5($this->value->format(DateTime::ATOM));
+
+        $queryBuilder
+            ->andWhere(sprintf('n.%s %s :%s', $this->getFieldName(), $this->operator, $_value))
+            ->setParameter($_value, $this->value);
+    }
+
+    abstract protected function getFieldName(): string;
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeCreationDateTimeFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeCreationDateTimeFilter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+class NodeCreationDateTimeFilter extends AbstractNodeDateTimeFilter
+{
+    protected function getFieldName(): string
+    {
+        return 'creationDateTime';
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeCreationDateTimeOrder.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeCreationDateTimeOrder.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+class NodeCreationDateTimeOrder extends AbstractNodeDataOrder
+{
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyOrder(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->orderBy('n.creationDateTime', $this->order);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataFilterInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataFilterInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+interface NodeDataFilterInterface
+{
+    /**
+     * Applies filter to Doctrine query builder.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @return void
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void;
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataOrderInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataOrderInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+interface NodeDataOrderInterface
+{
+    /**
+     * Applies order to Doctrine query builder.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @return void
+     */
+    public function applyOrder(QueryBuilder $queryBuilder): void;
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataQuery.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataQuery.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Doctrine\ORM\QueryBuilder;
+
+class NodeDataQuery
+{
+    /**
+     * Workspace to search
+     *
+     * @var Workspace
+     */
+    protected $workspace;
+
+    /**
+     * Workspace and base workspaces to search
+     *
+     * @var Workspace[]
+     */
+    protected $workspaces;
+
+    /**
+     * Dimensions to search
+     *
+     * @var string[]
+     */
+    protected $dimensions;
+
+    /**
+     * Filters to apply (WHERE)
+     *
+     * @var NodeDataFilterInterface[]
+     */
+    protected $filters = [];
+
+    /**
+     * Orders to apply (ORDER BY)
+     *
+     * @var NodeDataOrderInterface[]
+     */
+    protected $orders = [];
+
+    /**
+     * @Flow\Inject
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @param Workspace $workspace
+     * @param array $dimensions
+     */
+    public function __construct(Workspace $workspace, array $dimensions = [])
+    {
+        $this->workspace = $workspace;
+        $this->dimensions = $dimensions;
+    }
+
+    public function initializeObject(): void
+    {
+        $this->collectBaseWorkspaces();
+    }
+
+    protected function collectBaseWorkspaces(): void
+    {
+        $this->workspaces = $this->nodeDataRepository->collectWorkspaceAndAllBaseWorkspaces($this->workspace);
+    }
+
+    protected function addDimensionJoinConstraints(QueryBuilder $queryBuilder): void
+    {
+        $this->nodeDataRepository->addDimensionJoinConstraintsToQueryBuilder($queryBuilder, $this->dimensions);
+    }
+
+    /**
+     * Create Doctrine query builder with workspace and dimension filters already applied.
+     *
+     * @return QueryBuilder
+     */
+    protected function makeQueryBuilder(): QueryBuilder
+    {
+        $workspaceNames = [];
+        foreach ($this->workspaces as $workspace) {
+            $workspaceNames[] = $workspace->getName();
+        }
+        $queryBuilder = $this->nodeDataRepository->createQueryBuilder($workspaceNames);
+        $this->addDimensionJoinConstraints($queryBuilder);
+        return $queryBuilder;
+    }
+
+    /**
+     * @param NodeData[] $nodes
+     * @return NodeData[]
+     */
+    protected function withoutRemovedNodes(array $nodes): array
+    {
+        return $this->nodeDataRepository->withoutRemovedNodes($nodes);
+    }
+
+    /**
+     * @param NodeData[] $nodes
+     * @return NodeData[]
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     */
+    protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes): array
+    {
+        return $this->nodeDataRepository->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $this->workspaces, $this->dimensions);
+    }
+
+    /**
+     * @param NodeDataFilterInterface $filter
+     * @return NodeDataQuery
+     */
+    public function filter(NodeDataFilterInterface $filter): NodeDataQuery
+    {
+        $this->filters[] = $filter;
+        return $this;
+    }
+
+    /**
+     * @param NodeDataOrderInterface $order
+     * @return NodeDataQuery
+     */
+    public function order(NodeDataOrderInterface $order): NodeDataQuery
+    {
+        $this->orders[] = $order;
+        return $this;
+    }
+
+    /**
+     * Applies filters and orders to Doctrine query builder.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    protected function apply(QueryBuilder $queryBuilder): void
+    {
+        $this->applyFilter($queryBuilder);
+        $this->applyOrder($queryBuilder);
+    }
+
+    /**
+     * Applies filters to Doctrine query builder.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    protected function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        foreach ($this->filters as $filter) {
+            $filter->applyFilter($queryBuilder);
+        }
+    }
+
+    /**
+     * Applies orders to Doctrine query builder.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    protected function applyOrder(QueryBuilder $queryBuilder): void
+    {
+        foreach ($this->orders as $order) {
+            $order->applyOrder($queryBuilder);
+        }
+    }
+
+    /**
+     * Execute query and return nodes.
+     *
+     * @param int $limit
+     * @return array
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     */
+    public function get(?int $limit = null): array
+    {
+        $queryBuilder = $this->makeQueryBuilder();
+        $this->apply($queryBuilder);
+        if ($limit !== null) {
+            $queryBuilder->setMaxResults($limit);
+        }
+        $result = $queryBuilder->getQuery()->getResult();
+        $result = $this->reduceNodeVariantsByWorkspacesAndDimensions($result);
+        $result = $this->withoutRemovedNodes($result);
+        return $result;
+    }
+
+    /**
+     * Count number of nodes a query would return.
+     *
+     * @param int|null $limit
+     * @return int
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     */
+    public function count(?int $limit = null): int
+    {
+        // Until we can do the filter process completely in SQL we must do the counting locally.
+        $result = $this->get($limit);
+        return count($result);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataQuery.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeDataQuery.php
@@ -13,6 +13,7 @@ namespace Neos\ContentRepository\Domain\Repository\Query;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Utility\NodeDataUtility;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Model\NodeData;
@@ -79,12 +80,12 @@ class NodeDataQuery
 
     protected function collectBaseWorkspaces(): void
     {
-        $this->workspaces = $this->nodeDataRepository->collectWorkspaceAndAllBaseWorkspaces($this->workspace);
+        $this->workspaces = NodeDataUtility::collectWorkspaceAndAllBaseWorkspaces($this->workspace);
     }
 
     protected function addDimensionJoinConstraints(QueryBuilder $queryBuilder): void
     {
-        $this->nodeDataRepository->addDimensionJoinConstraintsToQueryBuilder($queryBuilder, $this->dimensions);
+        NodeDataUtility::addDimensionJoinConstraintsToQueryBuilder($queryBuilder, $this->dimensions);
     }
 
     /**
@@ -109,7 +110,7 @@ class NodeDataQuery
      */
     protected function withoutRemovedNodes(array $nodes): array
     {
-        return $this->nodeDataRepository->withoutRemovedNodes($nodes);
+        return NodeDataUtility::withoutRemovedNodes($nodes);
     }
 
     /**
@@ -119,7 +120,7 @@ class NodeDataQuery
      */
     protected function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes): array
     {
-        return $this->nodeDataRepository->reduceNodeVariantsByWorkspacesAndDimensions($nodes, $this->workspaces, $this->dimensions);
+        return NodeDataUtility::reduceNodeVariantsByWorkspacesAndDimensions($nodes, $this->workspaces, $this->dimensions);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeIdentifierFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeIdentifierFilter.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+class NodeIdentifierFilter implements NodeDataFilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $nodeIdentifier;
+
+    /**
+     * NodeIdentifierFilter constructor.
+     * @param string $nodeIdentifier
+     */
+    public function __construct(string $nodeIdentifier)
+    {
+        $this->nodeIdentifier = $nodeIdentifier;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $_identifier = 'identifier_' . md5($this->nodeIdentifier);
+
+        $queryBuilder
+            ->andWhere(sprintf('n.identifier = :%s', $_identifier))
+            ->setParameter($_identifier, $this->nodeIdentifier);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeLastPublicationDateTimeFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeLastPublicationDateTimeFilter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+class NodeLastPublicationDateTimeFilter extends AbstractNodeDateTimeFilter
+{
+    protected function getFieldName(): string
+    {
+        return 'lastPublicationDateTime';
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeLastPublicationDateTimeOrder.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeLastPublicationDateTimeOrder.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+class NodeLastPublicationDateTimeOrder extends AbstractNodeDataOrder
+{
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyOrder(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->orderBy('n.lastPublicationDateTime', $this->order);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeNameFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeNameFilter.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+class NodeNameFilter implements NodeDataFilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $nodeName;
+
+    /**
+     * @param string $nodeName
+     */
+    public function __construct(string $nodeName)
+    {
+        $this->nodeName = $nodeName;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $_nodeName = 'nodeName_' . md5($this->nodeName);
+
+        $queryBuilder
+            ->andWhere(sprintf('n.path LIKE :%s', $_nodeName))
+            ->setParameter($_nodeName, '%/' . $this->nodeName);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeParentFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeParentFilter.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+
+use Doctrine\ORM\QueryBuilder;
+use Neos\ContentRepository\Domain\Model\NodeData;
+
+class NodeParentFilter implements NodeDataFilterInterface
+{
+    /**
+     * @var NodeData
+     */
+    protected $parentNode;
+
+    /**
+     * @var bool
+     */
+    protected $recursive;
+
+    /**
+     * NodeParentFilter constructor.
+     * @param NodeData $parentNode
+     * @param bool $recursive
+     */
+    public function __construct(NodeData $parentNode, $recursive = false)
+    {
+        $this->parentNode = $parentNode;
+        $this->recursive = $recursive;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $parentPath = rtrim($this->parentNode->getPath(), '/');
+        $parentPathHash = md5($parentPath);
+        $_parentPathHash = 'parentPathHash_' . md5($parentPathHash);
+
+        if ($this->recursive === true) {
+            $parentPathRecursive = $parentPath . '/%';
+            $_parentPathRecursive = 'parentPathRecursive_' . md5($parentPathRecursive);
+
+            $queryBuilder
+                ->andWhere(sprintf('(n.parentPathHash = :%s OR n.parentPath LIKE :%s)', $_parentPathHash, $_parentPathRecursive))
+                ->setParameter($_parentPathHash, $parentPathHash)
+                ->setParameter($_parentPathRecursive, $parentPathRecursive);
+        } else {
+            $queryBuilder
+                ->andWhere(sprintf('n.parentPathHash = :%s', $_parentPathHash))
+                ->setParameter($_parentPathHash, $parentPathHash);
+        }
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePathOrder.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePathOrder.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+
+class NodePathOrder extends AbstractNodeDataOrder
+{
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyOrder(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->orderBy('n.path', $this->order);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePropertyFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePropertyFilter.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\QueryBuilder;
+
+class NodePropertyFilter implements NodeDataFilterInterface
+{
+    const OPERATORS = ['=', '!=', '>', '>=', '<=', '<'];
+
+    /**
+     * @var string
+     */
+    protected $key;
+
+    protected $value;
+
+    /**
+     * @var string
+     */
+    protected $operator;
+
+    /**
+     * NodePropertyFilter constructor.
+     * @param string $key
+     * @param $value
+     * @param string $operator
+     */
+    public function __construct(string $key, $value, $operator = '=')
+    {
+        $this->key = $key;
+        $this->value = $value;
+        if (in_array($operator, self::OPERATORS) === false) {
+            throw new \InvalidArgumentException(sprintf('Invalid operator: %s', $operator), 1541606716);
+        }
+        $this->operator = $operator;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $dbPlatform = $queryBuilder->getEntityManager()->getConnection()->getDatabasePlatform();
+
+        if ($dbPlatform instanceof PostgreSqlPlatform) {
+            $key = $this->key;
+        } elseif ($dbPlatform instanceof MySqlPlatform || $dbPlatform instanceof SqlitePlatform) {
+            $key = '$.' . $this->key;
+        } else {
+            throw DBALException::notSupported('JSON_EXTRACT');
+        }
+
+        $_key = 'key_' . md5($key);
+        $_value = 'value_' . md5((string)$this->value);
+
+        $queryBuilder
+            ->andWhere(sprintf('JSON_EXTRACT(n.properties, :%s) %s :%s', $_key, $this->operator, $_value))
+            ->setParameter($_key, $key)
+            ->setParameter($_value, $this->value);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePropertyFulltextFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodePropertyFulltextFilter.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Utility\Unicode\Functions as UnicodeFunctions;
+use Doctrine\ORM\QueryBuilder;
+
+class NodePropertyFulltextFilter implements NodeDataFilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $search;
+
+    /**
+     * NodePropertyFilter constructor.
+     * @param string $search
+     */
+    public function __construct(string $search)
+    {
+        $this->search = $search;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $_search = 'search_' . md5($this->search);
+
+        $search = '%' . trim(json_encode(UnicodeFunctions::strtolower($this->search), JSON_UNESCAPED_UNICODE), '"') . '%';
+
+        $queryBuilder
+            ->andWhere(sprintf('LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :%s', $_search))
+            ->setParameter($_search, $search);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeTypeFilter.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/Query/NodeTypeFilter.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+use Neos\ContentRepository\Domain\Model\NodeType;
+
+class NodeTypeFilter implements NodeDataFilterInterface
+{
+    const OPERATORS = ['=', '!='];
+
+    /**
+     * @var NodeType
+     */
+    protected $nodeType;
+
+    /**
+     * @var string
+     */
+    protected $operator;
+
+    /**
+     * @param NodeType $nodeType
+     * @param string $operator
+     */
+    public function __construct(NodeType $nodeType, string $operator = '=')
+    {
+        $this->nodeType = $nodeType;
+        if (in_array($operator, self::OPERATORS) === false) {
+            throw new \InvalidArgumentException(sprintf('Invalid operator: %s', $operator), 1541606720);
+        }
+        $this->operator = $operator;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @return void
+     */
+    public function applyFilter(QueryBuilder $queryBuilder): void
+    {
+        $nodeTypeName = $this->nodeType->getName();
+        $_nodeTypeName = 'nodeTypeName_' . md5($nodeTypeName);
+
+        $queryBuilder
+            ->andWhere(sprintf('n.nodeType %s :%s', $this->operator, $_nodeTypeName))
+            ->setParameter($_nodeTypeName, $nodeTypeName);
+    }
+}

--- a/Neos.ContentRepository/Classes/Domain/Utility/NodeDataUtility.php
+++ b/Neos.ContentRepository/Classes/Domain/Utility/NodeDataUtility.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Neos\ContentRepository\Domain\Utility;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\QueryBuilder;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Exception;
+
+class NodeDataUtility
+{
+    /**
+     * Returns a subset of $nodes which are not flagged as removed.
+     *
+     * @param array $nodes NodeData including removed entries
+     * @return array Only those NodeData instances which are not flagged as removed
+     */
+    public static function withoutRemovedNodes(array $nodes)
+    {
+        return array_filter($nodes, function (NodeData $node) {
+            return !$node->isRemoved();
+        });
+    }
+
+    /**
+     * If $dimensions is not empty, adds join constraints to the given $queryBuilder
+     * limiting the query result to matching hits.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param array $dimensions
+     * @return void
+     */
+    public static function addDimensionJoinConstraintsToQueryBuilder(QueryBuilder $queryBuilder, array $dimensions)
+    {
+        $count = 0;
+        foreach ($dimensions as $dimensionName => $dimensionValues) {
+            $dimensionAlias = 'd' . $count;
+            $queryBuilder->andWhere(
+                'EXISTS (SELECT ' . $dimensionAlias . ' FROM Neos\ContentRepository\Domain\Model\NodeDimension ' . $dimensionAlias . ' WHERE ' . $dimensionAlias . '.nodeData = n AND ' . $dimensionAlias . '.name = \'' . $dimensionName . '\' AND ' . $dimensionAlias . '.value IN (:' . $dimensionAlias . ')) ' .
+                'OR NOT EXISTS (SELECT ' . $dimensionAlias . '_c FROM Neos\ContentRepository\Domain\Model\NodeDimension ' . $dimensionAlias . '_c WHERE ' . $dimensionAlias . '_c.nodeData = n AND ' . $dimensionAlias . '_c.name = \'' . $dimensionName . '\')'
+            );
+            $queryBuilder->setParameter($dimensionAlias, $dimensionValues);
+            $count++;
+        }
+    }
+
+    /**
+     * Given an array with duplicate nodes (from different workspaces and dimensions) those are reduced to uniqueness (by node identifier)
+     *
+     * @param array $nodes NodeData result with multiple and duplicate identifiers (different nodes and redundant results for node variants with different dimensions)
+     * @param array $workspaces
+     * @param array $dimensions
+     * @return array Array of unique node results indexed by identifier
+     * @throws Exception\NodeException
+     */
+    public static function reduceNodeVariantsByWorkspacesAndDimensions(array $nodes, array $workspaces, array $dimensions)
+    {
+        $reducedNodes = [];
+
+        $minimalDimensionPositionsByIdentifier = [];
+        foreach ($nodes as $node) {
+            /** @var NodeData $node */
+            $nodeDimensions = $node->getDimensionValues();
+
+            // Find the position of the workspace, a smaller value means more priority
+            $workspaceNames = array_map(
+                function (Workspace $workspace) {
+                    return $workspace->getName();
+                },
+                $workspaces
+            );
+            $workspacePosition = array_search($node->getWorkspace()->getName(), $workspaceNames);
+            if ($workspacePosition === false) {
+                throw new Exception\NodeException(sprintf('Node workspace "%s" not found in allowed workspaces (%s), this could result from a detached workspace entity in the context.', $node->getWorkspace()->getName(), implode($workspaceNames, ', ')), 1413902143);
+            }
+
+            // Find positions in dimensions, add workspace in front for highest priority
+            $dimensionPositions = [];
+
+            // Special case for no dimensions
+            if ($dimensions === []) {
+                // We can just decide if the given node has no dimensions.
+                $dimensionPositions[] = ($nodeDimensions === []) ? 0 : 1;
+            }
+
+            foreach ($dimensions as $dimensionName => $dimensionValues) {
+                if (isset($nodeDimensions[$dimensionName])) {
+                    foreach ($nodeDimensions[$dimensionName] as $nodeDimensionValue) {
+                        $position = array_search($nodeDimensionValue, $dimensionValues);
+                        $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min($dimensionPositions[$dimensionName],
+                            $position) : $position;
+                    }
+                } else {
+                    $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min($dimensionPositions[$dimensionName],
+                        PHP_INT_MAX) : PHP_INT_MAX;
+                }
+            }
+            $dimensionPositions[] = $workspacePosition;
+
+            $identifier = $node->getIdentifier();
+            // Yes, it seems to work comparing arrays that way!
+            if (!isset($minimalDimensionPositionsByIdentifier[$identifier]) || $dimensionPositions < $minimalDimensionPositionsByIdentifier[$identifier]) {
+                $reducedNodes[$identifier] = $node;
+                $minimalDimensionPositionsByIdentifier[$identifier] = $dimensionPositions;
+            }
+        }
+
+        return $reducedNodes;
+    }
+
+    /**
+     * Returns an array that contains the given workspace and all base (parent) workspaces of it.
+     *
+     * @param Workspace $workspace
+     * @return array
+     */
+    public static function collectWorkspaceAndAllBaseWorkspaces(Workspace $workspace)
+    {
+        $workspaces = [];
+        while ($workspace !== null) {
+            $workspaces[] = $workspace;
+            $workspace = $workspace->getBaseWorkspace();
+        }
+
+        return $workspaces;
+    }
+}

--- a/Neos.ContentRepository/Classes/Persistence/Ast/JsonExtractFunction.php
+++ b/Neos.ContentRepository/Classes/Persistence/Ast/JsonExtractFunction.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Persistence\Ast;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class JsonExtractFunction extends FunctionNode
+{
+    /**
+     * @var Node
+     */
+    public $jsonData;
+
+    /**
+     * @var Node[]
+     */
+    public $jsonPaths = [];
+
+    /**
+     * @param SqlWalker $sqlWalker
+     * @return string
+     * @throws DBALException
+     * @throws \Doctrine\ORM\Query\AST\ASTException
+     */
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        $dbPlatform = $sqlWalker->getConnection()->getDatabasePlatform();
+
+        if (!$dbPlatform instanceof PostgreSqlPlatform && !$dbPlatform instanceof MySqlPlatform && !$dbPlatform instanceof SqlitePlatform) {
+            throw DBALException::notSupported('JSON_EXTRACT');
+        }
+
+        $jsonData = $sqlWalker->walkStringPrimary($this->jsonData);
+        $jsonPaths = [];
+
+        foreach ($this->jsonPaths as $path) {
+            if ($dbPlatform instanceof MySqlPlatform || $dbPlatform instanceof SqlitePlatform) {
+                $jsonPaths[] = $sqlWalker->walkStringPrimary($path);
+            } elseif ($dbPlatform instanceof PostgreSqlPlatform) {
+                $jsonPaths[] = $path->dispatch($sqlWalker);
+            }
+        }
+
+        if ($dbPlatform instanceof MySqlPlatform || $dbPlatform instanceof SqlitePlatform) {
+            return sprintf('json_extract(%s, %s)', $jsonData, join(', ', $jsonPaths));
+        } elseif ($dbPlatform instanceof PostgreSqlPlatform) {
+            return sprintf('%s->>%s', $jsonData, join(', ', $jsonPaths));
+        }
+    }
+
+    /**
+     * @param Parser $parser
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->jsonData = $parser->StringPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->jsonPaths[] = $parser->StringPrimary();
+        while ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
+            $parser->match(Lexer::T_COMMA);
+            $this->jsonPaths[] = $parser->StringPrimary();
+        }
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/Neos.ContentRepository/Configuration/Settings.yaml
+++ b/Neos.ContentRepository/Configuration/Settings.yaml
@@ -12,7 +12,7 @@ Neos:
         dql:
           customStringFunctions:
             NEOSCR_TOSTRING: Neos\ContentRepository\Persistence\Ast\ToStringFunction
-
+            JSON_EXTRACT: Neos\ContentRepository\Persistence\Ast\JsonExtractFunction
     # Improve debug output for node objects by ignoring large classes
     error:
       debugger:

--- a/Neos.ContentRepository/Tests/Functional/Domain/Repository/Query/NodeDataQueryTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/Repository/Query/NodeDataQueryTest.php
@@ -1,0 +1,273 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Tests\Functional\Domain\Repository\Query;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Repository\Query\NodeCreationDateTimeFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodeIdentifierFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodeLastPublicationDateTimeFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodeLastPublicationDateTimeOrder;
+use Neos\ContentRepository\Domain\Repository\Query\NodeNameFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodeDataQuery;
+use Neos\ContentRepository\Domain\Repository\Query\NodeParentFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodePathOrder;
+use Neos\ContentRepository\Domain\Repository\Query\NodeTypeFilter;
+use Neos\ContentRepository\Domain\Repository\Query\NodePropertyFilter;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+
+/**
+ * Functional test case.
+ */
+class NodeDataQueryTest extends FunctionalTestCase
+{
+    /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var Workspace
+     */
+    protected $liveWorkspace;
+
+    /**
+     * @return void
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $this->liveWorkspace = new Workspace('live');
+        $this->workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $this->workspaceRepository->add($this->liveWorkspace);
+        $this->persistenceManager->persistAll();
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
+        $this->context = $this->contextFactory->create(['workspaceName' => 'live']);
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+    }
+
+    protected function setUpNodes()
+    {
+        $rootNode = $this->context->getRootNode();
+        $rootNode
+            ->createNode('node-1')
+            ->createNode('node-1-1')
+            ->setProperty('property-x-x', '1-1');
+        $rootNode
+            ->createNode('node-2')
+            ->createNode('node-2-1')
+            ->setProperty('property-x-x', '2-1');
+        $node_3 = $rootNode
+            ->createNode('node-3', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'), '554f9350-f02b-fec4-e1bf-e1bcaf9ebc77');
+        $node_3->setProperty('foo', ['bar' => ['baz' => 123]]);
+        $node_4 = $rootNode
+            ->createNode('node-4', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'), 'e9b1a63b-9c8b-fce7-eeab-59d76a255881');
+        $node_4->setProperty('foo', ['bar' => ['baz' => 456]]);
+        $rootNode
+            ->createNode('node-5')
+            ->createNode('node-5-1')
+            ->createNode('node-5-1-1')
+            ->createNode('node-5-1-1-1');
+
+        $node_6 = $rootNode->createNode('node-6');
+
+        /** @var Node $node_6_1 */
+        $node_6_1 = $node_6->createNode('node-6-1');
+        $node_6_1->setProperty('foo', 1);
+        $node_6_1->setProperty('bar', 1);
+        $node_6_1->setLastPublicationDateTime(new \DateTime('2000-06-01T01:00:00+00:00'));
+
+        /** @var Node $node_6_2 */
+        $node_6_2 = $node_6->createNode('node-6-2');
+        $node_6_2->setProperty('foo', 1);
+        $node_6_2->setProperty('bar', 2);
+        $node_6_2->setLastPublicationDateTime(new \DateTime('2000-06-01T02:00:00+00:00'));
+
+        /** @var Node $node_6_3 */
+        $node_6_3 = $node_6->createNode('node-6-3');
+        $node_6_3->setProperty('foo', 1);
+        $node_6_3->setProperty('bar', 3);
+        $node_6_3->setLastPublicationDateTime(new \DateTime('2000-06-01T03:00:00+00:00'));
+
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @return array
+     */
+    public function filterDataProvider()
+    {
+        return [
+            'nodeType' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeTypeFilter($nodeTypeManager->getNodeType('Neos.NodeTypes:Page')));
+                $query->order(new NodePathOrder());
+            }, ['node-3', 'node-4'], null],
+            'nodeTypeAndLimit' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeTypeFilter($nodeTypeManager->getNodeType('Neos.NodeTypes:Page')));
+                $query->order(new NodePathOrder());
+            }, ['node-3'], 1],
+            'nodeName' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeNameFilter('node-2-1'));
+            }, ['node-2-1'], null],
+            'property' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('property-x-x', '1-1'));
+            }, ['node-1-1'], null],
+            /*subproperty search does not yet work on PostgreSQL
+            'subproperty' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo.bar.baz', 123));
+            }, ['node-3'], null],*/
+            'property>=' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo', 1));
+                $query->filter(new NodePropertyFilter('bar', 2, '>='));
+                $query->order(new NodePathOrder());
+            }, ['node-6-2', 'node-6-3'], null],
+            'property!=' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo', 1));
+                $query->filter(new NodePropertyFilter('bar', 2, '!='));
+                $query->order(new NodePathOrder());
+            }, ['node-6-1', 'node-6-3'], null],
+            'property<=' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo', 1));
+                $query->filter(new NodePropertyFilter('bar', 2, '<='));
+                $query->order(new NodePathOrder());
+            }, ['node-6-1', 'node-6-2'], null],
+            'property>' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo', 1));
+                $query->filter(new NodePropertyFilter('bar', 2, '>'));
+            }, ['node-6-3'], null],
+            'property<' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodePropertyFilter('foo', 1));
+                $query->filter(new NodePropertyFilter('bar', 2, '<'));
+            }, ['node-6-1'], null],
+            'identifier' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeIdentifierFilter('554f9350-f02b-fec4-e1bf-e1bcaf9ebc77'));
+            }, ['node-3'], null],
+            'parent' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeParentFilter(new NodeData('/node-2', $workspace)));
+            }, ['node-2-1'], null],
+            'parentrecursive' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeParentFilter(new NodeData('/node-5/node-5-1', $workspace), true));
+                $query->order(new NodePathOrder());
+            }, ['node-5-1-1', 'node-5-1-1-1'], null],
+            'lastPublicationDateTime' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $query->filter(new NodeParentFilter(new NodeData('/node-6', $workspace), true));
+                $query->filter(new NodeLastPublicationDateTimeFilter(new \DateTime('2000-06-01T03:00:00+00:00'), '<'));
+                $query->order(new NodeLastPublicationDateTimeOrder());
+            }, ['node-6-1', 'node-6-2'], null],
+            'creationDateTime' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $tenSecondsAgo = new \DateTime('now');
+                $tenSecondsAgo->sub(new \DateInterval('PT10S'));
+
+                $inTenSeconds = new \DateTime('now');
+                $inTenSeconds->add(new \DateInterval('PT10S'));
+
+                $query->filter(new NodeParentFilter(new NodeData('/node-6', $workspace), true));
+                $query->filter(new NodeCreationDateTimeFilter($tenSecondsAgo, '>='));
+                $query->filter(new NodeCreationDateTimeFilter($inTenSeconds, '<='));
+
+                $query->order(new NodeLastPublicationDateTimeOrder());
+            }, ['node-6-1', 'node-6-2', 'node-6-3'], null],
+            'creationDateTime2' => [function (NodeDataQuery $query, NodeTypeManager $nodeTypeManager, Workspace $workspace) {
+                $tenSecondsAgo = new \DateTime('now');
+                $tenSecondsAgo->sub(new \DateInterval('PT10S'));
+
+                $inTenSeconds = new \DateTime('now');
+                $inTenSeconds->add(new \DateInterval('PT10S'));
+
+                $query->filter(new NodeParentFilter(new NodeData('/node-6', $workspace), true));
+                $query->filter(new NodeCreationDateTimeFilter($tenSecondsAgo, '<='));
+                $query->filter(new NodeCreationDateTimeFilter($inTenSeconds, '>='));
+
+                $query->order(new NodeLastPublicationDateTimeOrder());
+            }, [], null],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider filterDataProvider
+     */
+    public function queryGet($queryBuilderFunc, $expectedNodes, $limit)
+    {
+        $this->setUpNodes();
+
+        $query = new NodeDataQuery($this->context->getWorkspace());
+        $this->inject($query, 'nodeDataRepository', $this->nodeDataRepository);
+        $queryBuilderFunc($query, $this->nodeTypeManager, $this->liveWorkspace);
+
+        $actualNodes = [];
+        /** @var NodeData $node */
+        foreach ($query->get($limit) as $node) {
+            $actualNodes[] = $node->getName();
+        }
+        $this->assertEquals($expectedNodes, $actualNodes);
+    }
+
+    /**
+     * @test
+     * @dataProvider filterDataProvider
+     */
+    public function queryCount($queryBuilderFunc, $expectedNodes, $limit)
+    {
+        $this->setUpNodes();
+
+        $query = new NodeDataQuery($this->context->getWorkspace());
+        $this->inject($query, 'nodeDataRepository', $this->nodeDataRepository);
+        $queryBuilderFunc($query, $this->nodeTypeManager, $this->liveWorkspace);
+
+        $this->assertEquals(count($expectedNodes), $query->count($limit));
+    }
+}


### PR DESCRIPTION
I wrote a set of classes that let you easily query the node data table.

- The NodeDataQuery class holds your current query.
- Classes that implement NodeDataFilterInterface can provide custom filters for NodeDataQuery.
- Classes that implement NodeDataOrderInterface can provide custom ordering for NodeDataQuery.
- JsonExtractFunction provides access to the JSON querying capabilities of MySQL/SQLite/PostgreSQL when using DQL. It appears that Doctrine does not support that by default.

This is a non exhaustive example of how the NodeDataQuery class can be used.

```php
(new NodeDataQuery($workspace))  // Create query object, set workspace
    ->filter(new NodeTypeFilter($nodeTypeManager->getNodeType('My.Site:Book')));  // Query for nodes of type My.Site:Book
    ->filter(new NodePropertyFilter('category', 'manual'))  // ... with property 'category' set to 'manual'
    ->filter(new NodePropertyFilter('price', 100, '>='))  // ... and property 'price' equal or greater than 100
    ->order(new NodePathOrder(NodePathOrder::ORDER_DESC))  // Order results by node path, descending
    ->get(10)  // Only return first 10 results
;
```

---

## Todo

- [x] NodeDataQuery
  - [x] get
    - [x] limit (works but not sure if it works correctly with reduceNodeVariantsByWorkspacesAndDimensions/withoutRemovedNodes
  - [x] count
- [x] NodeDataFilterInterface
  - [x] NodeTypeFilter
  - [x] NodePropertyFilter
    - [x] Operators: greater than [or qeuals], less than [or qeuals], equal, not equal
    - [ ] ~Operators: contains @>, IN~ (implement later)
    - [ ] ~Nested properties (works for MySQL and SQLite but not yet for PostgreSQL)~ (implement later)
  - [x] NodeParentFilter
    - [x] recursive
  - [x] NodeNameFilter
  - [x] NodeIdentifierFilter
  - [ ] ~NodeHiddenBeforeDateTimeFilter~ (implement later)
  - [ ] ~NodeHiddenAfterDateTimeFilter~ (implement later)
  - [ ] ~NodeHiddenFilter~ (implement later)
- [x] NodeDataOrderInterface
  - [x] NodePathOrder
  - [x] NodeCreationDateTimeOrder
  - [x] NodeLastPublicationDateTimeOrder
- Logical operations
  - [ ] ~OR~ (implement later)
  - [x] ~NOT~ (solved on a per-filter basis)
- [ ] ~Subqueries ((new NodeDataQuery(...)->filter(new NodeDataQuery(...)->filter))~ (implement later)
- [ ] (Option to)? return Node instead of NodeData (take context in NodeDataQuery constructor, convert NodeData to Node using NodeFactory.createFromNodeData (will return null if node is not accessible in given context))
- Adapt NodeDataRepository to use NodeDataQuery
  - [x] findByProperties