### PR TITLE
BUGFIX: Limit image view in media browser to image

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -13,8 +13,10 @@ namespace Neos\Media\Browser\Controller;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceAwareInterface;
 use Neos\Media\Domain\Model\ImportedAsset;
+use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\ImageRepository;
 
 /**
@@ -33,6 +35,28 @@ class ImageController extends AssetController
      * @var \Neos\Media\Domain\Repository\ImportedAssetRepository
      */
     protected $importedAssetRepository;
+
+    /**
+     * List existing immages
+     *
+     * @param string $view
+     * @param string $sortBy
+     * @param string $sortDirection
+     * @param string $filter
+     * @param int $tagMode
+     * @param Tag $tag
+     * @param string $searchTerm
+     * @param int $collectionMode
+     * @param AssetCollection $assetCollection
+     * @param string $assetSourceIdentifier
+     * @return void
+     * @throws \Neos\Utility\Exception\FilesException
+     */
+    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null)
+    {
+        $this->view->assign('disableFilter', true);
+        parent::indexAction($view, $sortBy, $sortDirection, 'Image', $tagMode, $tag, $searchTerm, $collectionMode, $assetCollection, $assetSourceIdentifier);
+    }
 
     /**
      * @param string $assetSourceIdentifier

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -14,30 +14,34 @@
         </f:if>
     </div>
     <div class="neos-view-options">
-        <div class="neos-dropdown" id="neos-filter-menu">
-            <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
-                <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#" data-neos-toggle="dropdown" data-target="#neos-filter-menu">
-                    <i class="fas fa-filter"></i>
-                </a>
-            </span>
-            <ul class="neos-dropdown-menu neos-pull-right" role="menu">
-                <li>
-                    <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
-                </li>
-                <li>
-                    <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
-                </li>
-                <li>
-                    <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
-                </li>
-                <li>
-                    <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
-                </li>
-                <li>
-                    <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
-                </li>
-            </ul>
-        </div>
+        <f:if condition="{disableFilter}">
+            <f:else>
+                <div class="neos-dropdown" id="neos-filter-menu">
+                <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
+                    <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#" data-neos-toggle="dropdown" data-target="#neos-filter-menu">
+                        <i class="fas fa-filter"></i>
+                    </a>
+                </span>
+                    <ul class="neos-dropdown-menu neos-pull-right" role="menu">
+                        <li>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
+                        </li>
+                    </ul>
+                </div>
+            </f:else>
+        </f:if>
         <f:if condition="{activeAssetSourceSupportsSorting}">
             <f:then>
         <div class="neos-dropdown" id="neos-sort-menu">
@@ -333,7 +337,7 @@
         <f:form.hidden name="asset[__identity]" id="link-asset-to-assetcollection-form-asset" />
         <f:form.hidden name="assetCollection[__identity]" id="link-asset-to-assetcollection-form-assetcollection" />
     </f:form>
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.min.js')}"></script>
+    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.js')}"></script>
     <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/upload.js')}"></script>
     <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/collections-and-tagging.js')}"></script>
     </f:if>


### PR DESCRIPTION
The image list view in the media browser list only image assets and
disable the rendering of the filter in the UI. So the asset type can
not changed in the image view.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

<img width="981" alt="bildschirmfoto 2018-11-07 um 13 26 39" src="https://user-images.githubusercontent.com/1014126/48131564-c995b600-e290-11e8-8c89-7377a17f6002.png">
