### PR TITLE
BUGFIX: Allow pinnedDimension argument on itemLabel to be null

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuImplementation.php
@@ -148,7 +148,7 @@ class DimensionsMenuImplementation extends AbstractMenuImplementation
      * @param array $targetDimensions
      * @return string
      */
-    protected function itemLabel(string $pinnedDimensionName, NodeInterface $nodeInDimensions = null, array $targetDimensions = null): string
+    protected function itemLabel(string $pinnedDimensionName = null, NodeInterface $nodeInDimensions = null, array $targetDimensions = null): string
     {
         if ($nodeInDimensions === null && $pinnedDimensionName === null) {
             $itemLabel = '';


### PR DESCRIPTION
This fixes a regression not caught by https://github.com/neos/neos-development-collection/pull/2092
