### PR TITLE
BUGFIX: Removed super types can be added again regardless of order

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -158,7 +158,7 @@ class NodeType
     protected function buildFullConfiguration()
     {
         $mergedConfiguration = array();
-        $applicableSuperTypes = $this->buildInheritanceChain();
+        $applicableSuperTypes = static::getFlattenedSuperTypes($this);
         foreach ($applicableSuperTypes as $key => $superType) {
             $mergedConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedConfiguration, $superType->getLocalConfiguration());
         }
@@ -173,47 +173,27 @@ class NodeType
     /**
      * Returns a flat list of super types to inherit from.
      *
+     * @param NodeType $nodeType
+     *
      * @return array
      */
-    protected function buildInheritanceChain()
+    protected static function getFlattenedSuperTypes(NodeType $nodeType) : array
     {
-        $superTypes = array();
-        foreach ($this->declaredSuperTypes as $superTypeName => $superType) {
+        $flattenedSuperTypes = [];
+        foreach ($nodeType->declaredSuperTypes as $superTypeName => $superType) {
             if ($superType !== null) {
-                $this->addInheritedSuperTypes($superTypes, $superType);
-                $superTypes[$superTypeName] = $superType;
+                $flattenedSuperTypes += static::getFlattenedSuperTypes($superType);
+                $flattenedSuperTypes[$superTypeName] = $superType;
             }
         }
 
-        foreach ($this->declaredSuperTypes as $superTypeName => $superType) {
+        foreach ($nodeType->declaredSuperTypes as $superTypeName => $superType) {
             if ($superType === null) {
-                unset($superTypes[$superTypeName]);
+                unset($flattenedSuperTypes[$superTypeName]);
             }
         }
 
-        return array_unique($superTypes);
-    }
-
-    /**
-     * Recursively add super types
-     *
-     * @param array $superTypes
-     * @param NodeType $superType
-     * @return void
-     */
-    protected function addInheritedSuperTypes(array &$superTypes, NodeType $superType)
-    {
-        foreach ($superType->getDeclaredSuperTypes() as $inheritedSuperTypeName => $inheritedSuperType) {
-            $this->addInheritedSuperTypes($superTypes, $inheritedSuperType);
-            $superTypes[$inheritedSuperTypeName] = $inheritedSuperType;
-        }
-
-        $superTypesInSuperType = $superType->getConfiguration('superTypes') ?: [];
-        foreach ($superTypesInSuperType as $inheritedSuperTypeName => $inheritedSuperType) {
-            if (!$inheritedSuperType) {
-                unset($superTypes[$inheritedSuperTypeName]);
-            }
-        }
+        return $flattenedSuperTypes;
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -105,8 +105,9 @@ class NodeTypeTest extends UnitTestCase
         ),
         'Neos.ContentRepository.Testing:SubSubShortcut' => array(
             'superTypes' => array(
+                // SomeMixin placed explicitly before SubShortcut
+                'Neos.ContentRepository.Testing:SomeMixin' => true,
                 'Neos.ContentRepository.Testing:SubShortcut' => true,
-                'Neos.ContentRepository.Testing:SomeMixin' => true
             ),
             'ui' => array(
                 'label' => 'Sub-Sub-Shortcut'
@@ -370,13 +371,13 @@ class NodeTypeTest extends UnitTestCase
         $this->assertSame('Sub-Sub-Sub-Shortcut', $nodeType->getLabel());
 
         $expectedProperties = array(
-            'target' => array(
-                'type' => 'string'
-            ),
             'someMixinProperty' => array(
                 'type' => 'string',
                 'label' => 'Important hint'
-            )
+            ),
+            'target' => array(
+                'type' => 'string',
+            ),
         );
         $this->assertSame($expectedProperties, $nodeType->getProperties());
     }


### PR DESCRIPTION
I noticed the order of `superTypes` being of importance in one special case: re-adding a super type removed by a super type.
There already was a test, but it didn't catch one case: the re-addition being positioned **before** the super type where it was removed. Run the same test with only the changes in [NodeTypeTest.php](https://github.com/neos/neos-development-collection/pull/2272/files#diff-960a57534a39e75dc45c37535d2ba971R108) and you'll get a [failed test](https://travis-ci.org/ComiR/neos-development-collection/jobs/454551553).

By making the Method `addInheritedSuperTypes()` `static` and slightly modifying it to not handing over the array, I could get rid of `buildInheritanceChain()` completely and renamed the method to `getFlattenedSuperTypes()`.
The `array_unique()` present before wasn't useful anyway because the array was already indexed by the node type names.

As a reminder: The visibility is determined by class and not by object. You can just call `$nodeType->declaredSuperTypes`, even if it is another object (of the same class of course)!

Since I started working on the `master` branch, there also is a version for that: https://github.com/ComiR/neos-development-collection/commit/a8076ae958676e1309a4e33a51491d3204847239.