### PR TITLE
Replace a few occurrences of TYPO3 with Neos

### DIFF
--- a/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -34,10 +34,10 @@ use Neos\FluidAdaptor\ViewHelpers\Form\AbstractFormFieldViewHelper;
  * </output>
  *
  * <code title="Bind to object property">
- * <neos.media:form.checkbox property="interests" value="TYPO3" />
+ * <neos.media:form.checkbox property="interests" value="Neos" />
  * </code>
  * <output>
- * <input type="checkbox" name="user[interests][]" value="TYPO3" checked="checked" />
+ * <input type="checkbox" name="user[interests][]" value="Neos" checked="checked" />
  * (depending on property "interests")
  * </output>
  *

--- a/Neos.Media/Documentation/ThumbnailGenerator/Code.rst
+++ b/Neos.Media/Documentation/ThumbnailGenerator/Code.rst
@@ -40,7 +40,7 @@ Configuration
 
 In your generator class use the ``AbstractThumbnailGenerator::getOption()`` to access your settings::
 
-    TYPO3:
+    Neos:
       Media:
         thumbnailGenerators:
           'Your\Package\Domain\Model\ThumbnailGenerator\YourOwnThumbnailGenerator':
@@ -53,8 +53,8 @@ Remember to add the Media Package in your package ``composer.json``` to load the
     {
         ...
         "require": {
-            "typo3/flow": "*",
-            "typo3/media": "*"
+            "neos/flow": "*",
+            "neos/media": "*"
         }
         ...
     }

--- a/Neos.Media/Documentation/ThumbnailGenerator/Configuration.rst
+++ b/Neos.Media/Documentation/ThumbnailGenerator/Configuration.rst
@@ -15,7 +15,7 @@ Change the priority of an existing Generator
 
 You can change the priority (higher is better) for an existing Generator, by editing you ``Settings.yaml``::
 
-    TYPO3:
+    Neos:
       Media:
         thumbnailGenerators:
           'Neos\Media\Domain\Model\ThumbnailGenerator\DocumentThumbnailGenerator':
@@ -26,7 +26,7 @@ Disabling an existing Generator
 
 To disable an existing Generator use the ``disable`` configuration option for the desired Generator::
 
-    TYPO3:
+    Neos:
       Media:
         thumbnailGenerators:
           'Neos\Media\Domain\Model\ThumbnailGenerator\IconThumbnailGenerator':

--- a/Neos.Neos/Classes/Command/DomainCommandController.php
+++ b/Neos.Neos/Classes/Command/DomainCommandController.php
@@ -47,7 +47,7 @@ class DomainCommandController extends CommandController
     /**
      * Add a domain record
      *
-     * @param string $siteNodeName The nodeName of the site rootNode, e.g. "neostypo3org"
+     * @param string $siteNodeName The nodeName of the site rootNode, e.g. "flowneosio"
      * @param string $hostname The hostname to match on, e.g. "flow.neos.io"
      * @param string $scheme The scheme for linking (http/https)
      * @param integer $port The port for linking (0-49151)

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
@@ -12,7 +12,7 @@ prototype(Neos.Neos:ImageUri) {
 	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
 
-# ImageTag object works exactly the same way as image ViewHelper in the TYPO3.Media package
+# ImageTag object works exactly the same way as image ViewHelper in the Neos.Media package
 prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 	asset = 'pass-the-media-asset'
 	maximumWidth = 2560

--- a/Neos.Neos/Tests/Unit/Domain/Model/DomainTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Model/DomainTest.php
@@ -27,8 +27,8 @@ class DomainTest extends UnitTestCase
     public function setHostPatternAllowsForSettingTheHostPatternOfTheDomain()
     {
         $domain = new Domain();
-        $domain->setHostname('typo3.com');
-        $this->assertSame('typo3.com', $domain->getHostname());
+        $domain->setHostname('neos.io');
+        $this->assertSame('neos.io', $domain->getHostname());
     }
 
     /**


### PR DESCRIPTION
This change replaces a few occurrences of "TYPO3" with "Neos",
mostly affecting code examples and documentation.