### PR TITLE
FEATURE: Health status and proper exit code for node:repair

### DIFF
--- a/Neos.ContentRepository/Classes/Command/EventDispatchingNodeCommandControllerPluginInterface.php
+++ b/Neos.ContentRepository/Classes/Command/EventDispatchingNodeCommandControllerPluginInterface.php
@@ -1,0 +1,48 @@
+<?php
+namespace Neos\ContentRepository\Command;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * An interface for plugins for the NodeCommandController that dispatches events
+ */
+interface EventDispatchingNodeCommandControllerPluginInterface extends NodeCommandControllerPluginInterface
+{
+
+    /**
+     * Entering a task. Event arguments are $taskDescription, $taskClosure (only executed if not in dry-run) and (optionally)  a $requiresConfirmation flag
+     */
+    const EVENT_TASK = 'task';
+
+    /**
+     * A notice is printed to the console
+     */
+    const EVENT_NOTICE = 'notice';
+
+    /**
+     * A warning is printed to the console but does not quit the execution
+     */
+    const EVENT_WARNING = 'warning';
+
+    /**
+     * An error is printed to the console and stops the execution with an error exit code
+     */
+    const EVENT_ERROR = 'error';
+
+    /**
+     * Attaches a new event handler
+     *
+     * @param string $eventIdentifier one of the EVENT_* constants
+     * @param \Closure $callback a closure to be invoked when the corresponding event was triggered
+     * @return void
+     */
+    public function on($eventIdentifier, \Closure $callback);
+}

--- a/Neos.ContentRepository/Classes/Command/EventDispatchingNodeCommandControllerPluginInterface.php
+++ b/Neos.ContentRepository/Classes/Command/EventDispatchingNodeCommandControllerPluginInterface.php
@@ -44,5 +44,5 @@ interface EventDispatchingNodeCommandControllerPluginInterface extends NodeComma
      * @param \Closure $callback a closure to be invoked when the corresponding event was triggered
      * @return void
      */
-    public function on($eventIdentifier, \Closure $callback);
+    public function on(string $eventIdentifier, \Closure $callback): void;
 }

--- a/Neos.ContentRepository/Classes/Command/NodeCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandController.php
@@ -138,10 +138,10 @@ class NodeCommandController extends CommandController implements DescriptionAwar
      */
     private function attachPluginEventHandlers(EventDispatchingNodeCommandControllerPluginInterface $plugin, bool $dryRun)
     {
-        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_NOTICE, function(string $text) {
+        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_NOTICE, function (string $text) {
             $this->outputLine($text);
         });
-        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_TASK, function(string $description, \Closure $task, bool $requiresConfirmation = false) use ($dryRun) {
+        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_TASK, function (string $description, \Closure $task, bool $requiresConfirmation = false) use ($dryRun) {
             $text = sprintf(' <b>❱ %s</b> ', $description);
 
             if (!$dryRun && $requiresConfirmation) {
@@ -160,10 +160,10 @@ class NodeCommandController extends CommandController implements DescriptionAwar
                 $this->outputLine('    <success>applied ✔</success>');
             }
         });
-        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_WARNING, function(string $text) {
+        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_WARNING, function (string $text) {
             $this->outputLine('<comment>WARNING: %s</comment>', [$text]);
         });
-        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_ERROR, function($text) {
+        $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_ERROR, function (string $text) {
             $this->outputLine('<error>%s</error>', [$text]);
             $this->quit(1);
         });

--- a/Neos.ContentRepository/Classes/Command/NodeCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandController.php
@@ -136,7 +136,7 @@ class NodeCommandController extends CommandController implements DescriptionAwar
      * @param bool $dryRun
      * @return void
      */
-    private function attachPluginEventHandlers(EventDispatchingNodeCommandControllerPluginInterface $plugin, bool $dryRun)
+    private function attachPluginEventHandlers(EventDispatchingNodeCommandControllerPluginInterface $plugin, bool $dryRun): void
     {
         $plugin->on(EventDispatchingNodeCommandControllerPluginInterface::EVENT_NOTICE, function (string $text) {
             $this->outputLine($text);

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -115,7 +115,7 @@ class NodeCommandControllerPlugin implements EventDispatchingNodeCommandControll
      * Callbacks to be invoked when an event is triggered
      *
      * @see dispatch()
-     * @var array
+     * @var \Closure[]
      */
     protected $eventCallbacks;
 
@@ -1326,7 +1326,7 @@ HELPTEXT;
      * @param \Closure $callback a closure to be invoked when the corresponding event was triggered
      * @return void
      */
-    public function on($eventIdentifier, \Closure $callback)
+    public function on(string $eventIdentifier, \Closure $callback): void
     {
         $this->eventCallbacks[$eventIdentifier][] = $callback;
     }
@@ -1338,10 +1338,10 @@ HELPTEXT;
      * @param array $eventPayload optional arguments to be passed to the handler closure
      * @return void
      */
-    protected function dispatch($eventIdentifier, ...$eventPayload)
+    protected function dispatch(string $eventIdentifier, ...$eventPayload): void
     {
         if (!isset($this->eventCallbacks[$eventIdentifier])) {
-            return null;
+            return;
         }
         /** @var \Closure $callback */
         foreach ($this->eventCallbacks[$eventIdentifier] as $callback) {

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -351,7 +351,7 @@ HELPTEXT;
                     $childNodeIdentifier = Utility::buildAutoCreatedChildNodeIdentifier($childNodeName, $node->getIdentifier());
                     if ($childNode === null) {
                         $taskDescription = sprintf('Add node <i>%s</i> named "<i>%s</i>" in "<i>%s</i>"', $childNodeIdentifier, $childNodeName, $node->getPath());
-                        $taskClosure = function() use ($node, $childNodeName, $childNodeType, $childNodeIdentifier, &$nodeCreationExceptions) {
+                        $taskClosure = function () use ($node, $childNodeName, $childNodeType, $childNodeIdentifier, &$nodeCreationExceptions) {
                             try {
                                 $node->createNode($childNodeName, $childNodeType, $childNodeIdentifier);
                             } catch (\Exception $exception) {
@@ -363,7 +363,7 @@ HELPTEXT;
                         $createdNodesCount++;
                     } elseif ($childNode->isRemoved() === true) {
                         $taskDescription = sprintf('Undelete node <i>%s</i> named "<i>%s</i>" in "<i>%s</i>"', $childNodeIdentifier, $childNodeName, $node->getPath());
-                        $taskClosure = function() use ($node) {
+                        $taskClosure = function () use ($node) {
                             $node->setRemoved(false);
                         };
                         $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
@@ -372,7 +372,7 @@ HELPTEXT;
                         $nodeIdentifiersWhichNeedUpdate[$childNode->getIdentifier()] = $childNodeIdentifier;
                     } elseif ($childNode->getNodeType() !== $childNodeType) {
                         $taskDescription = sprintf('Set node type of node <i>%s</i>: <i>%s</i> => <i>%s</i>', $childNodeIdentifier, $childNode->getNodeType(), $childNodeType);
-                        $taskClosure = function() use ($childNode, $childNodeType) {
+                        $taskClosure = function () use ($childNode, $childNodeType) {
                             $childNode->setNodeType($childNodeType);
                         };
                         $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
@@ -383,7 +383,7 @@ HELPTEXT;
         }
         foreach ($nodeIdentifiersWhichNeedUpdate as $oldNodeIdentifier => $newNodeIdentifier) {
             $taskDescription = sprintf('Update node identifier from <i>%s</i> to <i>%s</i> because it is not a "stable" identifier', $oldNodeIdentifier, $newNodeIdentifier);
-            $taskClosure = function() use ($oldNodeIdentifier, $newNodeIdentifier) {
+            $taskClosure = function () use ($oldNodeIdentifier, $newNodeIdentifier) {
                 $queryBuilder = $this->entityManager->createQueryBuilder();
                 $queryBuilder->update(NodeData::class, 'n')
                     ->set('n.identifier', $queryBuilder->expr()->literal($newNodeIdentifier))
@@ -501,7 +501,7 @@ HELPTEXT;
                     }
 
                     $taskDescription = sprintf('Set default value for property named "<i>%s</i>" in "<i>%s</i>" (<i>%s</i>)', $propertyName, $node->getPath(), $node->getNodeType()->getName());
-                    $taskClosure = function() use ($node, $propertyName ,$defaultValue) {
+                    $taskClosure = function () use ($node, $propertyName ,$defaultValue) {
                         $node->setProperty($propertyName, $defaultValue);
                     };
                     $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
@@ -566,7 +566,7 @@ HELPTEXT;
             $this->dispatch(self::EVENT_NOTICE, sprintf('Found node with %s node type named "<i>%s</i>" (<i>%s</i>) in "<i>%s</i>"', $type, $name, $node['nodeType'], $node['path']));
         }
         $taskDescription = sprintf('Remove <i>%d</i> node%s with abstract or undefined node types', $removableNodesCount, $removableNodesCount > 1 ? 's' : '');
-        $taskClosure = function() use ($nodes) {
+        $taskClosure = function () use ($nodes) {
             foreach ($nodes as $node) {
                 $this->removeNode($node['identifier'], $node['dimensionsHash']);
             }
@@ -619,7 +619,7 @@ HELPTEXT;
         $disallowedChildNodesCount = count($nodes);
         if ($disallowedChildNodesCount > 0) {
             $taskDescription = sprintf('Remove <i>%d</i> disallowed node%s.', $disallowedChildNodesCount, $disallowedChildNodesCount > 1 ? 's' : '');
-            $taskClosure = function() use ($nodes, $workspaceName) {
+            $taskClosure = function () use ($nodes, $workspaceName) {
                 foreach ($nodes as $node) {
                     $this->removeNodeAndChildNodesInWorkspaceByPath($node->getPath(), $workspaceName);
                 }
@@ -689,7 +689,7 @@ HELPTEXT;
         }
 
         $taskDescription = sprintf('Remove <i>%d</i> orphan node%s', $nodesToBeRemoved, $nodesToBeRemoved > 1 ? 's' : '');
-        $taskClosure = function() use ($nodes, $workspaceName) {
+        $taskClosure = function () use ($nodes, $workspaceName) {
             foreach ($nodes as $node) {
                 $this->removeNodeAndChildNodesInWorkspaceByPath($node['path'], $workspaceName);
             }
@@ -743,7 +743,7 @@ HELPTEXT;
 
         if ($undefinedPropertiesCount > 0) {
             $taskDescription = sprintf('Remove <i>%d</i> undefined propert%s.', $undefinedPropertiesCount, $undefinedPropertiesCount > 1 ? 'ies' : 'y');
-            $taskClosure = function() use ($nodesWithUndefinedPropertiesNodes) {
+            $taskClosure = function () use ($nodesWithUndefinedPropertiesNodes) {
                 foreach ($nodesWithUndefinedPropertiesNodes as $nodesWithUndefinedPropertiesNode) {
                     /** @var NodeInterface $node */
                     $node = $nodesWithUndefinedPropertiesNode['node'];
@@ -830,7 +830,7 @@ HELPTEXT;
             return;
         }
         $taskDescription = sprintf('Remove <i>%d</i> broken entity reference%s.', $brokenReferencesCount, $brokenReferencesCount > 1 ? 's' : '');
-        $taskClosure = function() use ($nodesWithBrokenEntityReferences) {
+        $taskClosure = function () use ($nodesWithBrokenEntityReferences) {
             foreach ($nodesWithBrokenEntityReferences as $nodeIdentifier => $properties) {
                 foreach ($properties as $propertyName => $nodeData) {
                     /** @var NodeData $nodeData */
@@ -948,7 +948,7 @@ HELPTEXT;
         }
         $numberOfNodes = count($nodesArray);
         $taskDescription = sprintf('Remove <i>%d</i> node%s with invalid dimension values', $numberOfNodes, $numberOfNodes > 1 ? 's' : '');
-        $taskClosure = function() use ($nodesArray) {
+        $taskClosure = function () use ($nodesArray) {
             foreach ($nodesArray as $nodeArray) {
                 $this->removeNode($nodeArray['identifier'], $nodeArray['dimensionsHash']);
             }
@@ -1021,7 +1021,7 @@ HELPTEXT;
         }
         $numberOfNodes = count($nodesArray);
         $taskDescription = sprintf('Remove <i>%d</i> node%s referring to an invalid workspace.', $numberOfNodes, $numberOfNodes > 1 ? 's' : '');
-        $taskClosure = function() use ($nodesArray) {
+        $taskClosure = function () use ($nodesArray) {
             foreach ($nodesArray as $nodeArray) {
                 $this->removeNode($nodeArray['identifier'], $nodeArray['dimensionsHash']);
             }
@@ -1112,7 +1112,7 @@ HELPTEXT;
 
         $numberOfNodes = count($nodesArray);
         $taskDescription = sprintf('Fix identifier%s of %s node%s', $numberOfNodes > 1 ? 's' : '', $numberOfNodes, $numberOfNodes > 1 ? 's' : '');
-        $taskClosure = function() use ($nodesArray) {
+        $taskClosure = function () use ($nodesArray) {
             foreach ($nodesArray as $nodeArray) {
                 /** @var QueryBuilder $queryBuilder */
                 $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -1206,7 +1206,7 @@ HELPTEXT;
                     if ($childNode) {
                         if ($childNodeBefore && $childNodeBefore->getIndex() >= $childNode->getIndex()) {
                             $taskDescription = sprintf('Move node named "<i>%s</i>" after node named "<i>%s</i>" in "<i>%s</i>"', $childNodeName, $childNodeBefore->getName(), $node->getPath());
-                            $taskClosure = function() use ($childNode, $childNodeBefore) {
+                            $taskClosure = function () use ($childNode, $childNodeBefore) {
                                 $childNode->moveAfter($childNodeBefore);
                             };
                             $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
@@ -1249,7 +1249,7 @@ HELPTEXT;
         $numberOfNewShadowNodes = count($newShadowNodes);
 
         $taskDescription = sprintf('Add <i>%d</i> missing shadow node%s', $numberOfNewShadowNodes, $numberOfNewShadowNodes > 1 ? 's' : '');
-        $taskClosure = function() use ($newShadowNodes) {
+        $taskClosure = function () use ($newShadowNodes) {
             /** @var NodeData $nodeData */
             foreach ($newShadowNodes as list('nodeData' => $nodeData, 'shadowPath' => $shadowPath)) {
                 $nodeData->createShadow($shadowPath);

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -1312,7 +1312,7 @@ HELPTEXT;
         }
 
         $this->output->outputLine('Checking for nodes with missing shadow nodes ...');
-        $fixedShadowNodes = $this->fixShadowNodesInWorkspace($workspace, $nodeType);
+        $fixedShadowNodes = $this->fixShadowNodesInWorkspace($workspace, $dryRun, $nodeType);
 
         $this->output->outputLine('%s %s node%s with missing shadow nodes.', [
             $dryRun ? 'Would repair' : 'Repaired',

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -571,7 +571,8 @@ HELPTEXT;
                 $this->removeNode($node['identifier'], $node['dimensionsHash']);
             }
         };
-        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+        $taskRequiresConfirmation = true;
+        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
     }
 
     /**
@@ -624,7 +625,8 @@ HELPTEXT;
                     $this->removeNodeAndChildNodesInWorkspaceByPath($node->getPath(), $workspaceName);
                 }
             };
-            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+            $taskRequiresConfirmation = true;
+            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
 
             if ($nodeExceptionCount > 0) {
                 $this->dispatch(self::EVENT_NOTICE, '<i>%d</i> error%s occurred during child node traversing.', $nodeExceptionCount, $nodeExceptionCount > 1 ? 's' : '');
@@ -694,7 +696,8 @@ HELPTEXT;
                 $this->removeNodeAndChildNodesInWorkspaceByPath($node['path'], $workspaceName);
             }
         };
-        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+        $taskRequiresConfirmation = true;
+        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
     }
 
     /**
@@ -754,7 +757,8 @@ HELPTEXT;
                     }
                 }
             };
-            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+            $taskRequiresConfirmation = true;
+            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
         }
 
         $this->persistenceManager->persistAll();
@@ -839,7 +843,8 @@ HELPTEXT;
             }
             $this->persistenceManager->persistAll();
         };
-        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+        $taskRequiresConfirmation = true;
+        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
     }
 
     /**
@@ -953,7 +958,8 @@ HELPTEXT;
                 $this->removeNode($nodeArray['identifier'], $nodeArray['dimensionsHash']);
             }
         };
-        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+        $taskRequiresConfirmation = true;
+        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
     }
 
     /**
@@ -1026,7 +1032,8 @@ HELPTEXT;
                 $this->removeNode($nodeArray['identifier'], $nodeArray['dimensionsHash']);
             }
         };
-        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
+        $taskRequiresConfirmation = true;
+        $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure, $taskRequiresConfirmation);
     }
 
     /**

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -206,7 +206,7 @@ HELPTEXT;
         $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
         if ($sitesNode === null) {
             $taskDescription = sprintf('Create missing site node "<i>%s</i>"', SiteService::SITES_ROOT_PATH);
-            $taskClosure = function() use ($rootNode) {
+            $taskClosure = function () use ($rootNode) {
                 $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
                 $this->persistenceManager->persistAll();
             };
@@ -272,7 +272,7 @@ HELPTEXT;
             $name = $node->getLabel() ?: $node->getName();
             $uriPathSegment = $this->nodeUriPathSegmentGenerator->generateUriPathSegment($node);
             $taskDescription = sprintf('Add missing URI path segment for "<i>%s</i>" (<i>%s</i>) => <i>%s</i>', $node->getPath(), $name, $uriPathSegment);
-            $taskClosure = function() use ($node, $uriPathSegment) {
+            $taskClosure = function () use ($node, $uriPathSegment) {
                 $node->setProperty('uriPathSegment', $uriPathSegment);
             };
             $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
@@ -303,7 +303,7 @@ HELPTEXT;
         foreach ($rootNodes as $rootNode) {
             if ($rootNode->getDimensionValues() !== []) {
                 $taskDescription = 'Remove content dimensions from root node';
-                $taskClosure = function() use ($rootNode) {
+                $taskClosure = function () use ($rootNode) {
                     $rootNode->setDimensions([]);
                     $this->nodeDataRepository->update($rootNode);
                 };
@@ -314,7 +314,7 @@ HELPTEXT;
         foreach ($sitesNodes as $sitesNode) {
             if ($sitesNode->getDimensionValues() !== []) {
                 $taskDescription = 'Remove content dimensions from node "/sites"';
-                $taskClosure = function() use ($sitesNode) {
+                $taskClosure = function () use ($sitesNode) {
                     $sitesNode->setDimensions([]);
                     $this->nodeDataRepository->update($sitesNode);
                 };

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -94,7 +94,7 @@ class NodeCommandControllerPlugin implements EventDispatchingNodeCommandControll
      * Callbacks to be invoked when an event is triggered
      *
      * @see dispatch()
-     * @var array
+     * @var \Closure[]
      */
     protected $eventCallbacks;
 
@@ -349,7 +349,7 @@ HELPTEXT;
      * @param \Closure $callback a closure to be invoked when the corresponding event was triggered
      * @return void
      */
-    public function on($eventIdentifier, \Closure $callback)
+    public function on(string $eventIdentifier, \Closure $callback): void
     {
         $this->eventCallbacks[$eventIdentifier][] = $callback;
     }
@@ -361,10 +361,10 @@ HELPTEXT;
      * @param array $eventPayload optional arguments to be passed to the handler closure
      * @return void
      */
-    protected function dispatch($eventIdentifier, ...$eventPayload)
+    protected function dispatch(string $eventIdentifier, ...$eventPayload): void
     {
         if (!isset($this->eventCallbacks[$eventIdentifier])) {
-            return null;
+            return;
         }
         /** @var \Closure $callback */
         foreach ($this->eventCallbacks[$eventIdentifier] as $callback) {

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -11,8 +11,8 @@ namespace Neos\Neos\Command;
  * source code.
  */
 
+use Neos\ContentRepository\Command\EventDispatchingNodeCommandControllerPluginInterface;
 use Neos\ContentRepository\Exception\NodeException;
-use Neos\ContentRepository\Exception\NodeExistsException;
 use Neos\Eel\Exception as EelException;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
@@ -23,7 +23,6 @@ use Neos\Neos\Exception as NeosException;
 use Neos\Utility\Arrays;
 use Neos\Neos\Domain\Service\SiteService;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
-use Neos\ContentRepository\Command\NodeCommandControllerPluginInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Repository\ContentDimensionRepository;
@@ -41,7 +40,7 @@ use Neos\ContentRepository\Domain\Utility\NodePaths;
  *
  * @Flow\Scope("singleton")
  */
-class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterface
+class NodeCommandControllerPlugin implements EventDispatchingNodeCommandControllerPluginInterface
 {
     /**
      * @Flow\Inject
@@ -81,6 +80,7 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
 
     /**
      * @var ConsoleOutput
+     * @deprecated It's discouraged to interact with the console output directly. Instead use the event dispatching. @see dispatch()
      */
     protected $output;
 
@@ -89,6 +89,14 @@ class NodeCommandControllerPlugin implements NodeCommandControllerPluginInterfac
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
+
+    /**
+     * Callbacks to be invoked when an event is triggered
+     *
+     * @see dispatch()
+     * @var array
+     */
+    protected $eventCallbacks;
 
     /**
      * Returns a short description
@@ -142,7 +150,7 @@ HELPTEXT;
      * A method which runs the task implemented by the plugin for the given command
      *
      * @param string $controllerCommandName Name of the command in question, for example "repair"
-     * @param ConsoleOutput $output An instance of ConsoleOutput which can be used for output or dialogues
+     * @param ConsoleOutput $output (unused)
      * @param NodeType $nodeType Only handle this node type (if specified)
      * @param string $workspaceName Only handle this workspace (if specified)
      * @param boolean $dryRun If true, don't do any changes, just simulate what you would do
@@ -153,6 +161,7 @@ HELPTEXT;
      */
     public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
     {
+        /** @noinspection PhpDeprecationInspection This is only set for backwards compatibility */
         $this->output = $output;
         $commandMethods = [
             'generateUriPathSegments' => [ 'cleanup' => false ],
@@ -183,15 +192,12 @@ HELPTEXT;
     /**
      * Creates the /sites node if it is missing.
      *
-     * @param string $workspaceName Name of the workspace to consider (unused)
-     * @param boolean $dryRun Simulate?
      * @return void
-     * @throws NodeExistsException
      * @throws IllegalObjectTypeException
      */
-    protected function createMissingSitesNode($workspaceName, $dryRun)
+    protected function createMissingSitesNode()
     {
-        $this->output->outputLine('Checking for "%s" node ...', [SiteService::SITES_ROOT_PATH]);
+        $this->dispatch(self::EVENT_NOTICE, sprintf('Checking for "%s" node ...', SiteService::SITES_ROOT_PATH));
         $rootNode = $this->contextFactory->create()->getRootNode();
         // We fetch the workspace to be sure it's known to the persistence manager and persist all
         // so the workspace and site node are persisted before we import any nodes to it.
@@ -199,15 +205,13 @@ HELPTEXT;
         $this->persistenceManager->persistAll();
         $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
         if ($sitesNode === null) {
-            if ($dryRun === false) {
+            $taskDescription = sprintf('Create missing site node "<i>%s</i>"', SiteService::SITES_ROOT_PATH);
+            $taskClosure = function() use ($rootNode) {
                 $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
-                $this->output->outputLine('Missing "%s" node was created', [SiteService::SITES_ROOT_PATH]);
-            } else {
-                $this->output->outputLine('"%s" node is missing!', [SiteService::SITES_ROOT_PATH]);
-            }
+                $this->persistenceManager->persistAll();
+            };
+            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
         }
-
-        $this->persistenceManager->persistAll();
     }
 
     /**
@@ -228,12 +232,12 @@ HELPTEXT;
         $baseContext = $this->createContext($workspaceName, []);
         $baseContextSitesNode = $baseContext->getNode(SiteService::SITES_ROOT_PATH);
         if (!$baseContextSitesNode) {
-            $this->output->outputLine('<error>Could not find "' . SiteService::SITES_ROOT_PATH . '" root node</error>');
+            $this->dispatch(self::EVENT_WARNING, sprintf('Could not find "%s" root node', SiteService::SITES_ROOT_PATH));
             return;
         }
         $baseContextSiteNodes = $baseContextSitesNode->getChildNodes();
         if ($baseContextSiteNodes === []) {
-            $this->output->outputLine('<error>Could not find any site nodes in "' . SiteService::SITES_ROOT_PATH . '" root node</error>');
+            $this->dispatch(self::EVENT_WARNING, sprintf('Could not find any site nodes in "%s" root node', SiteService::SITES_ROOT_PATH));
             return;
         }
 
@@ -242,7 +246,7 @@ HELPTEXT;
             /** @noinspection PhpUndefinedMethodInspection */
             $siteNodes = $flowQuery->context(['dimensions' => $dimensionCombination, 'targetDimensions' => []])->get();
             if (count($siteNodes) > 0) {
-                $this->output->outputLine('Checking for nodes with missing URI path segment in dimension "%s"', [trim(NodePaths::generateContextPath('', '', $dimensionCombination), '@;')]);
+                $this->dispatch(self::EVENT_NOTICE, sprintf('Checking for nodes with missing URI path segment in dimension "%s"', trim(NodePaths::generateContextPath('', '', $dimensionCombination), '@;')));
                 foreach ($siteNodes as $siteNode) {
                     $this->generateUriPathSegmentsForNode($siteNode, $dryRun);
                 }
@@ -267,12 +271,11 @@ HELPTEXT;
         if ((string)$node->getProperty('uriPathSegment') === '') {
             $name = $node->getLabel() ?: $node->getName();
             $uriPathSegment = $this->nodeUriPathSegmentGenerator->generateUriPathSegment($node);
-            if ($dryRun === false) {
+            $taskDescription = sprintf('Add missing URI path segment for "<i>%s</i>" (<i>%s</i>) => <i>%s</i>', $node->getPath(), $name, $uriPathSegment);
+            $taskClosure = function() use ($node, $uriPathSegment) {
                 $node->setProperty('uriPathSegment', $uriPathSegment);
-                $this->output->outputLine('Added missing URI path segment for "%s" (%s) => %s', [$node->getPath(), $name, $uriPathSegment]);
-            } else {
-                $this->output->outputLine('Found missing URI path segment for "%s" (%s) => %s', [$node->getPath(), $name, $uriPathSegment]);
-            }
+            };
+            $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
         }
         foreach ($node->getChildNodes('Neos.Neos:Document') as $childNode) {
             $this->generateUriPathSegmentsForNode($childNode, $dryRun);
@@ -286,40 +289,36 @@ HELPTEXT;
      * the nodes below "/sites" are always reachable.
      *
      * @param string $workspaceName
-     * @param boolean $dryRun
      * @return void
-     * @throws IllegalObjectTypeException
      */
-    public function removeContentDimensionsFromRootAndSitesNode($workspaceName, $dryRun)
+    public function removeContentDimensionsFromRootAndSitesNode($workspaceName)
     {
         $workspace = $this->workspaceRepository->findByIdentifier($workspaceName);
         /** @noinspection PhpUndefinedMethodInspection */
         $rootNodes = $this->nodeDataRepository->findByPath('/', $workspace);
         /** @noinspection PhpUndefinedMethodInspection */
         $sitesNodes = $this->nodeDataRepository->findByPath('/sites', $workspace);
-        $this->output->outputLine('Checking for root and site nodes with content dimensions set ...');
+        $this->dispatch(self::EVENT_NOTICE, 'Checking for root and site nodes with content dimensions set ...');
         /** @var \Neos\ContentRepository\Domain\Model\NodeData $rootNode */
         foreach ($rootNodes as $rootNode) {
             if ($rootNode->getDimensionValues() !== []) {
-                if ($dryRun === false) {
+                $taskDescription = 'Remove content dimensions from root node';
+                $taskClosure = function() use ($rootNode) {
                     $rootNode->setDimensions([]);
                     $this->nodeDataRepository->update($rootNode);
-                    $this->output->outputLine('Removed content dimensions from root node');
-                } else {
-                    $this->output->outputLine('Found root node with content dimensions set.');
-                }
+                };
+                $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
             }
         }
         /** @var \Neos\ContentRepository\Domain\Model\NodeData $sitesNode */
         foreach ($sitesNodes as $sitesNode) {
             if ($sitesNode->getDimensionValues() !== []) {
-                if ($dryRun === false) {
+                $taskDescription = 'Remove content dimensions from node "/sites"';
+                $taskClosure = function() use ($sitesNode) {
                     $sitesNode->setDimensions([]);
                     $this->nodeDataRepository->update($sitesNode);
-                    $this->output->outputLine('Removed content dimensions from node "/sites"');
-                } else {
-                    $this->output->outputLine('Found node "/sites"');
-                }
+                };
+                $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);
             }
         }
     }
@@ -341,5 +340,35 @@ HELPTEXT;
         ];
 
         return $this->contextFactory->create($contextProperties);
+    }
+
+    /**
+     * Attaches a new event handler
+     *
+     * @param string $eventIdentifier one of the EVENT_* constants
+     * @param \Closure $callback a closure to be invoked when the corresponding event was triggered
+     * @return void
+     */
+    public function on($eventIdentifier, \Closure $callback)
+    {
+        $this->eventCallbacks[$eventIdentifier][] = $callback;
+    }
+
+    /**
+     * Trigger a custom event
+     *
+     * @param string $eventIdentifier one of the EVENT_* constants
+     * @param array $eventPayload optional arguments to be passed to the handler closure
+     * @return void
+     */
+    protected function dispatch($eventIdentifier, ...$eventPayload)
+    {
+        if (!isset($this->eventCallbacks[$eventIdentifier])) {
+            return null;
+        }
+        /** @var \Closure $callback */
+        foreach ($this->eventCallbacks[$eventIdentifier] as $callback) {
+            call_user_func_array($callback, $eventPayload);
+        }
     }
 }


### PR DESCRIPTION
This is a backwards compatible rework of the `node:repair` command.

This introduces a new `EventDispatchingNodeCommandControllerPluginInterface`
that can be implemented by NodeCommandControllerPlugins in order to
dispatch repair events instead of having to interact with the console
output directly.

The two provided core plugins now implement this interface and dispatch
corresponding events.

Background:
This rework allows the Command Controller to control the execution of tasks
and the rendering of their output which allows for a more streamlined
console output and serves as basis for further improvements (e.g. verbosity
flag).
This also fixes the exit code of the command, that is now 1 if one of the
commands triggered an error.

In the long term (next major version) we should finally clean up the interfaces (see #2279)

Resolves: #1988