### PR TITLE
BUGFIX: HtmlAugmenter xPATH Change: ignore <script>tags when searching root element

### DIFF
--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -71,7 +71,7 @@ class HtmlAugmenter
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
         $domDocument->loadHTML($html);
         $xPath = new \DOMXPath($domDocument);
-        $rootElement = $xPath->query('//html/body/*[not(self::script)]');
+        $rootElement = $xPath->query('//html/body/*[not(self::script and @data-neos-nodedata)]');
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }

--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -71,7 +71,7 @@ class HtmlAugmenter
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
         $domDocument->loadHTML($html);
         $xPath = new \DOMXPath($domDocument);
-        $rootElement = $xPath->query('//html/body/*');
+        $rootElement = $xPath->query('//html/body/*[not(self::script)]');
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }


### PR DESCRIPTION
**Reason for the change:**

When passing wrapped content elements to a fusion renderer via @props, a script tag gets added when evaluating:

  $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
  $wrappedContent .= "<script data-neos-nodedata>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$node->getContextPath()}'] = {$serializedNode}})()</script>";

This leads to the query not detecting a root element since the html is of structure `<div></div><script></script>`. It will break functionality for the Neos.Fusion:Augmenter since it will wrap the actual root element one more time.

**What I did**

The change filters script tags in the XPATH query, leading to the correct behavior.

**How I did it**
**How to verify it**

Have a Neos.Fusion:Component and pass a Neos.Neos:ContentCollection via props. Augment the ContentCollection inside the component and the Augmenter will wrap an extra time. With the fix, the augmentation gets applied to the actual _neos-contentcollection_ div.


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
