### PR TITLE
BUGFIX: Fix parameters of internal method call

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -1305,7 +1305,7 @@ HELPTEXT;
         }
 
         $this->output->outputLine('Checking for nodes with missing shadow nodes ...');
-        $fixedShadowNodes = $this->fixShadowNodesInWorkspace($workspace, $nodeType);
+        $fixedShadowNodes = $this->fixShadowNodesInWorkspace($workspace, $dryRun, $nodeType);
 
         $this->output->outputLine('%s %s node%s with missing shadow nodes.', [
             $dryRun ? 'Would repair' : 'Repaired',
@@ -1322,7 +1322,7 @@ HELPTEXT;
      * @param Workspace $workspace
      * @param boolean $dryRun
      * @param NodeType $nodeType
-     * @return array
+     * @return int
      */
     protected function fixShadowNodesInWorkspace(Workspace $workspace, $dryRun, NodeType $nodeType = null)
     {


### PR DESCRIPTION
The method `repairShadowNodes` calls `fixShadowNodesInWorkspace`
in turn. The call passes the `$nodeType` parameter in place of the
`$dryRun`.

This changes fixes that and corrects the return type annotation of
`fixShadowNodesInWorkspace` as well.