### PR TITLE
TASK: Continue during create missing child nodes if none defined

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -340,6 +340,9 @@ HELPTEXT;
         /** @var $nodeType NodeType */
         foreach ($nodeTypes as $nodeTypeName => $nodeType) {
             $childNodes = $nodeType->getAutoCreatedChildNodes();
+            if (count($childNodes) === 0) {
+                continue;
+            }
             foreach ($this->getNodeDataByNodeTypeAndWorkspace($nodeTypeName, $workspaceName) as $nodeData) {
                 $context = $this->nodeFactory->createContextMatchingNodeData($nodeData);
                 $node = $this->nodeFactory->createFromNodeData($nodeData, $context);


### PR DESCRIPTION
In `createChildNodesByNodeType` there is no need to iterate nodes of
types that have no child nodes defined in their type.