### PR TITLE
BUGFIX: media:removeunused only works with limit flag

### DIFF
--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -152,7 +152,7 @@ class MediaCommandController extends CommandController
      * @param int $limit Limit the result of unused assets displayed and removed for this run.
      * @return void
      */
-    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '', int $limit = 0)
+    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '', int $limit = null)
     {
         $iterator = $this->assetRepository->findAllIterator();
         $assetCount = $this->assetRepository->countAll();
@@ -163,7 +163,7 @@ class MediaCommandController extends CommandController
 
         $filterByAssetSourceIdentifier = $assetSource;
         if ($filterByAssetSourceIdentifier === '') {
-            !$quiet && $this->outputLine('<b>Searching for unused assets:</b>');
+            !$quiet && $this->outputLine('<b>Searching for unused assets in all asset sources:</b>');
         } else {
             !$quiet && $this->outputLine('<b>Searching for unused assets of asset source "%s":</b>', [$filterByAssetSourceIdentifier]);
         }
@@ -183,7 +183,7 @@ class MediaCommandController extends CommandController
         foreach ($this->assetRepository->iterate($iterator) as $asset) {
             !$quiet && $this->output->progressAdvance(1);
 
-            if ($unusedAssetCount === $limit) {
+            if ($limit !== null && $unusedAssetCount === $limit) {
                 break;
             }
 


### PR DESCRIPTION
This change fixes a regression introduced in 1804dc8e6edf79045fb318edf3e78c6e17232658 where a new command line flag "--limit" was introduced. The command did not detect any unused assets unless the --limit flag was specified, because the iteration would stop right away.