### PR TITLE
TASK: Add a hint for the user to avoid errors with incomplete site imports

### DIFF
--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -217,6 +217,17 @@ class SiteCommandController extends CommandController
             $this->outputLine('You have to specify either "--package-key" or "--filename"');
             $this->quit(1);
         }
+
+        // Since this command uses a lot of memory when large sites are imported, we warn the user to watch for
+        // the confirmation of a successful import.
+        $this->outputLine('<b>This command can use a lot of memory when importing sites with many resources.</b>');
+        $this->outputLine('If the import is successful, you will see a message saying "Import of site ... finished".');
+        $this->outputLine('If you do not see this message, the import failed, most likely due to insufficient memory.');
+        $this->outputLine('Increase the <b>memory_limit</b> configuration parameter of your php CLI to attempt to fix this.');
+        $this->outputLine('Starting import...');
+        $this->outputLine('---');
+
+
         $site = null;
         if ($filename !== null) {
             try {


### PR DESCRIPTION
Just a little hint that avoids frequent errors with the site import command crashing due to a memory limit, and users being confused about a breaky-looking site:
![image](https://user-images.githubusercontent.com/10347669/49077207-007d3d00-f23b-11e8-8b41-8c9c5120027d.png)
