### PR TITLE
BUGFIX: Handle maximum cache lifetime of 0

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
@@ -211,11 +211,16 @@ class RuntimeContentCache
 
 
             if (isset($evaluateContext['configuration']['maximumLifetime'])) {
-                $maximumLifetime = $this->runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/maximumLifetime', $fusionObject);
+                $maximumLifetime = (int)$this->runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/maximumLifetime', $fusionObject);
 
                 if ($maximumLifetime !== null && $this->cacheMetadata !== []) {
-                    $cacheMetadata = &$this->cacheMetadata[count($this->cacheMetadata) - 1];
-                    $cacheMetadata['lifetime'] = $cacheMetadata['lifetime'] !== null ? min($cacheMetadata['lifetime'], $maximumLifetime) : $maximumLifetime;
+                    $parentCacheMetadata = &$this->cacheMetadata[count($this->cacheMetadata) - 1];
+
+                    if ($parentCacheMetadata['lifetime'] === null) {
+                        $parentCacheMetadata['lifetime'] = $maximumLifetime;
+                    } elseif ($maximumLifetime > 0) {
+                        $parentCacheMetadata['lifetime'] = min($parentCacheMetadata['lifetime'], $maximumLifetime);
+                    }
                 }
             }
         }

--- a/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
@@ -211,15 +211,15 @@ class RuntimeContentCache
 
 
             if (isset($evaluateContext['configuration']['maximumLifetime'])) {
-                $maximumLifetime = (int)$this->runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/maximumLifetime', $fusionObject);
+                $maximumLifetime = $this->runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/maximumLifetime', $fusionObject);
 
                 if ($maximumLifetime !== null && $this->cacheMetadata !== []) {
                     $parentCacheMetadata = &$this->cacheMetadata[count($this->cacheMetadata) - 1];
 
                     if ($parentCacheMetadata['lifetime'] === null) {
-                        $parentCacheMetadata['lifetime'] = $maximumLifetime;
+                        $parentCacheMetadata['lifetime'] = (int)$maximumLifetime;
                     } elseif ($maximumLifetime > 0) {
-                        $parentCacheMetadata['lifetime'] = min($parentCacheMetadata['lifetime'], $maximumLifetime);
+                        $parentCacheMetadata['lifetime'] = min((int)$parentCacheMetadata['lifetime'], (int)$maximumLifetime);
                     }
                 }
             }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -417,9 +417,9 @@ class ContentCacheTest extends AbstractFusionObjectTest
         }));
 
         $firstRenderResult = $view->render();
-        $this->assertEquals('Foo|Bar|Baz', $firstRenderResult);
+        $this->assertEquals('Foo|Bar|Baz|Qux', $firstRenderResult);
 
-        $this->assertCount(3, $entriesWritten);
+        $this->assertCount(4, $entriesWritten);
         $this->assertEquals(array(
             // contentCache.maximumLifetimeInNestedEmbedAndCachedSegments.5
             '7075cb501854d7d8b25926b8c7f79c3e' => array(
@@ -429,6 +429,10 @@ class ContentCacheTest extends AbstractFusionObjectTest
             '007836f2658952a45cfd706c300e208f' => array(
                 'lifetime' => null
             ),
+            // contentCache.maximumLifetimeInNestedEmbedAndCachedSegments.35
+            'd27ee4bbdef0fe0a4611e8f7bb34472b' => [
+                'lifetime' => 0
+            ],
             // contentCache.maximumLifetimeInNestedEmbedAndCachedSegments
             'a604a8f56ba95f256b3df4769b42bc6a' => array(
                 'lifetime' => 5

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
@@ -432,6 +432,24 @@ contentCache.maximumLifetimeInNestedEmbedAndCachedSegments = Neos.Fusion:Array {
 		}
 	}
 
+	30 = '|'
+
+	35 = Neos.Fusion:Value {
+		value = 'Qux'
+
+		@cache {
+			mode = 'cached'
+
+			entryIdentifier {
+				static = 35
+			}
+
+			maximumLifetime = 0
+
+			# A maximum lifetime of 0 means infinity caching for this segment. Infinity must not be propagated upwards
+		}
+	}
+
 	@cache {
 		mode = 'cached'
 


### PR DESCRIPTION
If a cached prototype had a `maximumLifetime` of 0
configured, which is meant as infinite cache
lifetime, this value is propagated upwards to all
surrounding prototypes as it is the selected
as minimum value