### PR TITLE
FEATURE: Hide property "target" of Neos.Neos.ShortCut depending on targetMode

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -240,6 +240,7 @@
         label: i18n
         reloadPageIfChanged: true
         inspector:
+          hidden: 'ClientEval:node.properties.targetMode === "selectedTarget" ? false : true'
           group: 'document'
           editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
           editorListeners:

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -128,6 +128,8 @@ additionalProperties:
                         additionalProperties: false
                         properties:
 
+                          'hidden': { type: ['string', 'null'], description: 'Option to hide a property.' }
+
                           'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
 
                           'position': { type: ['integer', 'null'], description: 'Position inside the inspector group, small numbers are sorted on top' }


### PR DESCRIPTION
*What I did/How I did it*
I added configuration to the shortcut nodetype definition to hide the target-property in the UI when targetMode is not "selectedTarget"

*How to verify it*
Insert a shortcut node. You should not see the target-property untill you change the targetMode to "selectedTarget"