### PR TITLE
TASK: PHP 7.3 - Use break instead of continue within a switch case

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Utility/NodePaths.php
+++ b/Neos.ContentRepository/Classes/Domain/Utility/NodePaths.php
@@ -178,7 +178,7 @@ abstract class NodePaths
         foreach ($pathSegments as $pathSegment) {
             switch ($pathSegment) {
                 case '.':
-                    continue;
+                    break;
                 break;
                 case '..':
                     $absolutePath = NodePaths::getParentPath($absolutePath);


### PR DESCRIPTION
Starting in PHP 7.3, PHP will throw a warning when using `continue`
within a `switch` to confirm intent. In PHP, within `switch`, `break`
and `continue` do the same thing.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
