### PR TITLE
BUGFIX: Continue in switch targets surrounding foreach

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Utility/NodePaths.php
+++ b/Neos.ContentRepository/Classes/Domain/Utility/NodePaths.php
@@ -178,7 +178,7 @@ abstract class NodePaths
         foreach ($pathSegments as $pathSegment) {
             switch ($pathSegment) {
                 case '.':
-                    continue;
+                    continue 2;
                 break;
                 case '..':
                     $absolutePath = NodePaths::getParentPath($absolutePath);


### PR DESCRIPTION
```
Exception #1355480641 in line 406 of .../Packages/Framework/Neos.Flow/Classes/Core/Booting/Scripts.php: Warning: "continue" targeting switch is equivalent to "break".
Did you mean to use "continue 2"? in
.../Packages/Application/Neos.ContentRepository/Classes/Domain/Utility/NodePaths.php
line 181

  Type: Neos\Flow\Error\Exception
  Code: 1
  File: Packages/Framework/Neos.Flow/Classes/Error/ErrorHandler.php
  Line: 81

Open Data/Logs/Exceptions/20181207114820edf26f.txt for a full stack trace.

12 Neos\Flow\Core\Booting\Scripts::executeCommand("neos.flow:core:compile", array|16|)
11 Neos\Flow\Core\Booting\Scripts::initializeProxyClasses(Neos\Flow\Core\Bootstrap)
10 call_user_func(array|2|, Neos\Flow\Core\Bootstrap)
9 Neos\Flow\Core\Booting\Step::__invoke(Neos\Flow\Core\Bootstrap)
8 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
7 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
6 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
5 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
4 Neos\Flow\Core\Booting\Sequence::invoke(Neos\Flow\Core\Bootstrap)
3 Neos\Flow\Http\RequestHandler::boot()
2 Neos\Flow\Http\RequestHandler::handleRequest()
1 Neos\Flow\Core\Bootstrap::run()
```