### PR TITLE
BUGFIX: Fix wrong Fusion Prototype name

### DIFF
--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -36,7 +36,7 @@ prototype(Neos.Fusion:Loop) {
   itemKey = 'itemKey'
   iterationName = 'iterator'
 }
-prototype(Neos.Fusion:Maping) {
+prototype(Neos.Fusion:Map) {
   @class = 'Neos\\Fusion\\FusionObjects\\MapImplementation'
   itemName = 'item'
   itemKey = 'itemKey'


### PR DESCRIPTION
This changes the wrong prototype name from `Neos.Fusion:Maping` to `Neos.Fusion:Map`

Fixes #2313