### PR TITLE
BUGFIX: Deletion of backend users

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -310,7 +310,10 @@ class UserService
     public function deleteUser(User $user)
     {
         foreach ($user->getAccounts() as $account) {
-            $this->deletePersonalWorkspace($account->getAccountIdentifier());
+            $this->securityContext->withoutAuthorizationChecks(function () use ($account) {
+                $this->deletePersonalWorkspace($account->getAccountIdentifier());
+            });
+
             $this->accountRepository->remove($account);
         }
 


### PR DESCRIPTION
**What I did**
Backend users can now be deleted, even if they have a private workspace.

**How I did it**
Wrap deletePersonalWorkspace() in withoutAuthorizationChecks.

**How to verify it**
Create a backend user, log in and edit something. Log in as administrator and delete this user.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed.
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Fixes #926 
@nezaniel