### PR TITLE
BUGFIX: Asynchronous and presets for media browser thumbnails

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -180,6 +180,12 @@ class AssetController extends ActionController
     protected $translator;
 
     /**
+     * @Flow\InjectConfiguration(path="asyncThumbnails", package="Neos.Media")
+     * @var array
+     */
+    protected $asyncThumbnails;
+
+    /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
      * @var array
      */
@@ -314,7 +320,8 @@ class AssetController extends ActionController
             'maximumFileUploadSize' => $this->getMaximumFileUploadSize(),
             'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($this->getMaximumFileUploadSize()),
             'activeAssetSource' => $activeAssetSource,
-            'activeAssetSourceSupportsSorting' => ($assetProxyRepository instanceof SupportsSortingInterface)
+            'activeAssetSourceSupportsSorting' => ($assetProxyRepository instanceof SupportsSortingInterface),
+            'asyncThumbnails' => $this->asyncThumbnails
         ]);
     }
 
@@ -345,7 +352,8 @@ class AssetController extends ActionController
             'asset' => $asset,
             'maximumFileUploadSize' => $maximumFileUploadSize,
             'redirectPackageEnabled' => $this->packageManager->isPackageAvailable('Neos.RedirectHandler'),
-            'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($maximumFileUploadSize)
+            'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($maximumFileUploadSize),
+            'asyncThumbnails' => $this->asyncThumbnails
         ]);
     }
 
@@ -370,7 +378,8 @@ class AssetController extends ActionController
 
             $this->view->assignMultiple([
                 'assetProxy' => $assetProxy,
-                'assetCollections' => $this->assetCollectionRepository->findAll()
+                'assetCollections' => $this->assetCollectionRepository->findAll(),
+                'asyncThumbnails' => $this->asyncThumbnails
             ]);
         } catch (AssetNotFoundExceptionInterface $e) {
             $this->throwStatus(404, 'Asset not found');
@@ -418,7 +427,8 @@ class AssetController extends ActionController
                 'tags' => $tags,
                 'assetProxy' => $assetProxy,
                 'assetCollections' => $this->assetCollectionRepository->findAll(),
-                'assetSource' => $assetSource
+                'assetSource' => $assetSource,
+                'asyncThumbnails' => $this->asyncThumbnails
             ]);
         } catch (AssetNotFoundExceptionInterface $e) {
             $this->throwStatus(404, 'Asset not found');

--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -97,11 +97,11 @@
                              data-trigger="hover"
                              data-title="{f:if(condition: assetProxy.widthInPixels, then: '{assetProxy.widthInPixels} x {assetProxy.heightInPixels}')}"
                              data-html="true"
-                             data-content="{mediaBrowser:thumbnail(assetProxy: assetProxy, alt: '') -> f:format.htmlentities()}"
+                             data-content="{m:thumbnail(asset: assetProxy.asset, alt: assetProxy.label, preset: 'Neos.Media.Browser:Thumbnail', async: asyncThumbnails) -> f:format.htmlentities()}"
                              alt=""
                              width="250"
                              height="250">
-                            <img src="{assetProxy.thumbnailUri}" alt="{assetProxy.label}" width="250" height="250"/>
+                            <m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Thumbnail" alt="{assetProxy.label}" async="{asyncThumbnails}" />
                         </div>
                     </td>
                     <td class="asset-label"><span data-neos-toggle="tooltip" title="{assetProxy.label}"><f:format.crop maxCharacters="50">{assetProxy.label}</f:format.crop></span></td>

--- a/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
@@ -18,7 +18,7 @@
                             <f:link.action action="edit" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container draggable-asset {f:if(condition: '{assetProxy.asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}">
                                     <f:if condition="{assetProxy.thumbnailUri}">
-                                        <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
+                                        <f:then><m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Thumbnail" alt="{assetProxy.label}" async="{asyncThumbnails}" /></f:then>
                                         <f:else><img src="{f:uri.resource(path:'Images/dummy-image.svg', package:'Neos.Neos')}" alt="" width="250" height="250"/></f:else>
                                     </f:if>
                                 </div>
@@ -28,7 +28,7 @@
                             <f:link.action action="show" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container">
                                     <f:if condition="{assetProxy.thumbnailUri}">
-                                        <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
+                                        <f:then><m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Thumbnail" alt="{assetProxy.label}" async="{asyncThumbnails}" /></f:then>
                                         <f:else><img src="{f:uri.resource(path:'Images/dummy-image.svg', package:'Neos.Neos')}" alt="" width="250" height="250"/></f:else>
                                     </f:if>
                                 </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -149,7 +149,7 @@
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
         <a href="{assetProxy.importStream}" target="_blank">
-            <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+            <m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Preview" alt="{assetProxy.label}" async="{asyncThumbnails}" class="img-polaroid" />
         </a>
     </div>
 </f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -279,7 +279,7 @@
                 <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package: 'Neos.Media.Browser')}
             </div>
                     </f:if>
-                    <f:render partial="{view}View" arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}" />
+                    <f:render partial="{view}View" arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection, asyncThumbnails: asyncThumbnails}" />
 
             <div class="neos-hide" id="delete-asset-modal">
                 <div class="neos-modal-centered">

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -67,7 +67,7 @@
     <label>{neos:backend.translate(id: 'replace.previewFile', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
         <a href="{f:uri.resource(resource: asset.resource)}" target="_blank">
-            <m:thumbnail asset="{asset}" maximumWidth="1000" maximumHeight="1000" alt="{asset.label}" class="img-polaroid"/>
+            <m:thumbnail asset="{asset}" preset="Neos.Media.Browser:Preview" alt="{asset.label}" async="{asyncThumbnails}" class="img-polaroid" />
         </a>
     </div>
 </f:section>
@@ -78,5 +78,3 @@
     </script>
     <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/new.js')}"></script>
 </f:section>
-
-

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -73,7 +73,7 @@
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
         <a href="{assetProxy.importStream}" target="_blank">
-            <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+            <m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Preview" alt="{assetProxy.label}" async="{asyncThumbnails}" class="img-polaroid" />
         </a>
     </div>
 </f:section>


### PR DESCRIPTION
Fixes the usage of the `asyncThumbnails` option in the media browser
along with using the thumbnail preset to improve performance of the
media browser and avoid additional thumbnails being generated.

Fixes: #2330