### PR TITLE
TASK: Fix documentation example for toggling visibility of properties in inspector

### DIFF
--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
@@ -37,7 +37,7 @@ by changing its group name to a non-existant value:
         type: string
         ui:
           inspector:
-            hidden: 'ClientEval:node.properties.borderWidth ? "style" : "invalid-group"'
+            hidden: 'ClientEval:node.properties.borderWidth ? true : false
 
 Dependent SelectBoxes
 ---------------------

--- a/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
+++ b/Neos.Neos/Documentation/CreatingASite/NodeTypes/DynamicConfigurationProcessing.rst
@@ -37,7 +37,7 @@ by changing its group name to a non-existant value:
         type: string
         ui:
           inspector:
-            group: 'ClientEval:node.properties.borderWidth ? "style" : "invalid-group"'
+            hidden: 'ClientEval:node.properties.borderWidth ? "style" : "invalid-group"'
 
 Dependent SelectBoxes
 ---------------------


### PR DESCRIPTION
I updated the example for *"Hiding one property when the other one is not set"* in the *"Dynamic Client-side Configuration Processing"* docs (https://neos.readthedocs.io/en/stable/CreatingASite/NodeTypes/DynamicConfigurationProcessing.html). The example didn't work, as stated here (https://github.com/neos/neos-ui/pull/2118#issuecomment-441986052), but the "hidden" property has been introduced with https://github.com/neos/neos-ui/pull/2118.