### PR TITLE
TASK: Remove useless ternary operator use

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -290,7 +290,7 @@ class AssetController extends ActionController
             } elseif ($this->browserState->get('activeTag') !== null) {
                 $assetProxies = $assetProxyRepository->findByTag($this->browserState->get('activeTag'));
             } else {
-                $assetProxies = $activeAssetCollection === null ? $assetProxyRepository->findAll() : $assetProxyRepository->findAll();
+                $assetProxies = $assetProxyRepository->findAll();
             }
 
             $allCollectionsCount = $assetProxyRepository->countAll();


### PR DESCRIPTION
The issue described in #2337 is not as bad as it seems. In fact, the
ternary operation is useless *and* no longer needed. The filtering is
applied via `applyAssetCollectionFilterFromBrowserState()` already.

Resolves #2337
