### PR TITLE
BUGFIX: change aside bar in media browser for many tags

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Styles/Media/_Media.scss
+++ b/Neos.Media.Browser/Resources/Private/Styles/Media/_Media.scss
@@ -1,8 +1,9 @@
 @mixin neos-media-aside-condensed {
-	flex-direction: column;
+	flex-direction: row-reverse;
 
 	.neos-media-aside {
-		margin-top: $wideMargin;
+		flex: 1;
+		margin-right: $wideMargin;
 		@include clearfix;
 
 		.neos-media-aside-group {
@@ -146,6 +147,10 @@
 				}
 			}
 		}
+	}
+
+	.neos-media-assets {
+		flex: 3;
 	}
 }
 


### PR DESCRIPTION
It's unfortunate, that the interactive fields are below the gallery, if the editors use too many tags in the media browser. It results in the odd behavior that the search bar is at the bottom of the page and limits the usability:

![aside-bar-at-bottom](https://user-images.githubusercontent.com/6552092/51618692-063b8a00-1f2f-11e9-8477-68e7da329749.png)



I understand that it quickly turns unsightly, if there are too many tags in the side bar, but I've noticed that if we use the button-style tags, rather than the tag list in the aside-bar, it works out quite nicely:

![aside-bar-to-the-left](https://user-images.githubusercontent.com/6552092/51618693-063b8a00-1f2f-11e9-8f96-cac9f0b82e5e.png)
