### PR TITLE
TASK: Adjust behavior of NodePropertyConverterServiceTest

### DIFF
--- a/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
@@ -149,10 +149,10 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
     public function complexTypesWithGivenTypeConverterAreConvertedByTypeConverter()
     {
         $propertyValue = $this->getMockForAbstractClass(ImageInterface::class);
-        $expected = json_encode([
+        $expected = [
             '__identity' => null,
             '__type' => get_class($propertyValue)
-        ]);
+        ];
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)


### PR DESCRIPTION
This adjusts the complexTypesWithGivenTypeConverterAreConvertedByTypeConverter
of NodePropertyConverterServiceTest to behave as if the new UI is installed
which is insalled when test are run on CI and probably the case in all
other installations.