### PR TITLE
BUGFIX: Avoid server-error when invalid/deleted identifiers are passed to the node service

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -111,9 +111,11 @@ class NodesController extends ActionController
         if ($nodeIdentifiers === array()) {
             $nodes = $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode);
         } else {
-            $nodes = array_map(function ($identifier) use ($contentContext) {
-                return $contentContext->getNodeByIdentifier($identifier);
-            }, $nodeIdentifiers);
+            $nodes = array_filter(
+                array_map(function ($identifier) use ($contentContext) {
+                    return $contentContext->getNodeByIdentifier($identifier);
+                }, $nodeIdentifiers)
+            );
         }
 
         $this->view->assign('nodes', $nodes);


### PR DESCRIPTION
When invalid node-identifiers, are passed to the node-service it mapped the list of identifier to the getNodeByIdentifier call, which rightly returned null. This is triggered especially in the LinkEditor when nodes are referenced that have been deleted in the meantime.

Since the result was not filtered the list containing a mix of null-values and nodeInterfaces is passed to the template of the nodeService where an error is triggered inside the `neos:node.closestDocument` view helper. 

This error in turn triggers the ui showing a red error box with the html content of the server-error that confused editors and is not helpful at all. 

The fix applies array_filter to the nodes array to avoid passing `null` nodes to the template.