### PR TITLE
BUGFIX: Recover inheritance path for all super type mixins of Neos.NodeTypes:ContentImageMixin

### DIFF
--- a/Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
+++ b/Neos.NodeTypes/Configuration/NodeTypes.Mixins.yaml
@@ -4,6 +4,10 @@
   abstract: true
   superTypes:
     'Neos.NodeTypes.BaseMixins:ContentImageMixin': true
+    'Neos.NodeTypes:ImageMixin': true
+    'Neos.NodeTypes:LinkMixin': true
+    'Neos.NodeTypes:ImageCaptionMixin': true
+    'Neos.NodeTypes:ImageAlignmentMixin': true
 
 'Neos.NodeTypes:ImageMixin':
   abstract: true


### PR DESCRIPTION
The inheritance path has changed, because of the new BaseMixins. This is a breaking change beginning with Neos 3.3.

The broken inheritance path causes issues if you extend or query based on superTypes of former `Neos.NodeTypes:ContentImageMixin`:

Broken NodeType Mixins:
* 'Neos.NodeTypes:ImageMixin'
* 'Neos.NodeTypes:LinkMixin'
*  'Neos.NodeTypes:ImageCaptionMixin'
* 'Neos.NodeTypes:ImageAlignmentMixin'

Following example FlowQuery found `Neos.NodeTypes:Image` up to version 3.2. and returns null beginning version 3.3
``` 
${q(node).find('[instanceof Neos.NodeTypes:ImageMixin]')}
```
To fix this issue I re-added the NodeType mixins to `Neos.NodeTypes:ContentImageMixin` as superTypes. As all of their configurations are added anyway by there replacements (`Neos.NodeTypes.BaseMixins:*`) in `Neos.NodeTypes.BaseMixins:ContentImageMixin` this has no effect to the configuration.