### PR TITLE
FEATURE: Add NodeLink fusion prototype

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1023,6 +1023,28 @@ Example::
 		node = ${q(node).parent().get(0)}
 	}
 
+
+.. _Neos_Neos__NodeLink:
+
+Neos.Neos:NodeLink
+-----------------
+
+Renders an anchor tag pointing to the node given via the argument. Based on :ref:`Neos_Neos__NodeUri`.
+The link text is the node label, unless overridden.
+
+:\*: All :ref:`Neos_Neos__NodeUri` properties
+:attributes: (:ref:`Neos_Fusion__Attributes`) Link tag attributes
+:content: (string) The label of the link, defaults to ``node.label``.
+
+Example::
+
+	nodeLink = Neos.Neos:NodeLink {
+		node = ${q(node).parent().get(0)}
+	}
+
+.. note::
+   By default no ``title`` is generated. By setting ``attributes.title = ${node.label}`` the label is rendered as title.
+
 .. _Neos_Neos__ImageUri:
 
 Neos.Neos:ImageUri

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -19,6 +19,7 @@ include: Prototypes/ContentElementWrapping.fusion
 include: Prototypes/ContentElementEditable.fusion
 include: Prototypes/NodeUri.fusion
 include: Prototypes/ImageUri.fusion
+include: Prototypes/NodeLink.fusion
 include: Prototypes/FallbackNode.fusion
 
 # The root matcher used to start rendering in Neos

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -1,0 +1,25 @@
+# Renders an <a> tag based on Neos.Neos:NodeUri pointing to a node
+#
+prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
+  node = 'pass-the-node'
+  additionalParams = Neos.Fusion:RawArray
+  arguments = Neos.Fusion:RawArray
+  argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
+
+  @context.node = ${this.node}
+  @context.additionalParams = ${this.additionalParams}
+  @context.arguments = ${this.arguments}
+  @context.argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
+
+  tagName = 'a'
+  attributes {
+    href = Neos.Neos:NodeUri {
+      node = ${node}
+      additionalParams = ${additionalParams}
+      arguments = ${arguments}
+      argumentsToBeExcludedFromQueryString = ${argumentsToBeExcludedFromQueryString}
+    }
+  }
+
+  content = ''
+}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -1,15 +1,24 @@
 # Renders an <a> tag based on Neos.Neos:NodeUri pointing to a node
+# The link text is the node label, unless overridden
 #
 prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
   node = null
   additionalParams = Neos.Fusion:RawArray
   arguments = Neos.Fusion:RawArray
   argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
+  addQueryString = false
+  absolute = false
+  baseNodeName = 'documentNode'
 
-  @context.node = ${this.node}
-  @context.additionalParams = ${this.additionalParams}
-  @context.arguments = ${this.arguments}
-  @context.argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
+  @context {
+    node = ${this.node}
+    additionalParams = ${this.additionalParams}
+    arguments = ${this.arguments}
+    argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
+    addQueryString = ${this.addQueryString}
+    absolute = ${this.absolute}
+    baseNodeName = ${this.baseNodeName}
+  }
 
   tagName = 'a'
   attributes {
@@ -18,8 +27,11 @@ prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
       additionalParams = ${additionalParams}
       arguments = ${arguments}
       argumentsToBeExcludedFromQueryString = ${argumentsToBeExcludedFromQueryString}
+      addQueryString = ${addQueryString}
+      absolute = ${absolute}
+      baseNodeName = ${baseNodeName}
     }
   }
 
-  content = ${q(this.node).property('_label')}
+  content = ${node.label}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -1,7 +1,7 @@
 # Renders an <a> tag based on Neos.Neos:NodeUri pointing to a node
 #
 prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
-  node = 'pass-the-node'
+  node = null
   additionalParams = Neos.Fusion:RawArray
   arguments = Neos.Fusion:RawArray
   argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
@@ -21,5 +21,5 @@ prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
     }
   }
 
-  content = ''
+  content = ${q(this.node).property('_label')}
 }


### PR DESCRIPTION
Add the ``Neos.Neos:NodeLink`` fusion prototype which renders an ``<a>`` tag based on ``Neos.Neos:NodeUri``, similar to ``Neos.Neos:ImageTag`` and ``Neos.Neos:ImageUri``. 

- all properties of ``Neos.Neos:NodeUri`` are supported and passed over
- ``attributes`` (:ref:`Neos_Fusion__Attributes`) Link tag attributes
- ``content`` (string) The label of the link, defaults to the node label ``q(node).property('_label')``.

This helps reducing code lines especially when using fusion-afx, with this prototype you can now directly link nodes in an afx renderer.