### PR TITLE
FEATURE: Add native 404 error rendering that can be controlled via Fusion

### DIFF
--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -1,0 +1,169 @@
+<?php
+namespace Neos\Neos\View;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Mvc\View\ViewInterface;
+use Neos\Flow\Mvc\View\AbstractView;
+use Neos\Neos\Domain\Service\FusionService;
+use Neos\Fusion\Core\Runtime as FusionRuntime;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Domain\Repository\DomainRepository;
+use Neos\Neos\Domain\Service\ContentContextFactory;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Service;
+use Neos\Flow\Security\Context;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Http\Response;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\Controller\Arguments;
+
+class FusionExceptionView extends AbstractView implements ViewInterface
+{
+
+    /**
+     * @Flow\Inject
+     * @var Bootstrap
+     */
+    protected $bootstrap;
+
+    /**
+     * @var ObjectManagerInterface
+     * @Flow\Inject
+     */
+    protected $objectManager;
+
+    /**
+     * @Flow\Inject
+     * @var Service
+     */
+    protected $i18nService;
+
+    /**
+     * @var FusionService
+     * @Flow\Inject
+     */
+    protected $fusionService;
+
+    /**
+     * @var FusionRuntime
+     */
+    protected $fusionRuntime;
+
+    /**
+     * @var SiteRepository
+     * @Flow\Inject
+     */
+    protected $siteRepository;
+
+    /**
+     * @var DomainRepository
+     * @Flow\Inject
+     */
+    protected $domainRepository;
+
+    /**
+     * @var ContentContextFactory
+     * @Flow\Inject
+     */
+    protected $contentContextFactory;
+
+    /**
+     * @return string
+     * @throws \Neos\Flow\Security\Exception
+     * @throws \Neos\Neos\Domain\Exception
+     */
+    public function render()
+    {
+        $domain = $this->domainRepository->findOneByActiveRequest();
+
+        if ($domain) {
+            $site = $domain->getSite();
+        } else {
+            $site = $this->siteRepository->findDefault();
+        }
+
+        $httpRequest = $this->bootstrap->getActiveRequestHandler()->getHttpRequest();
+        $request = new ActionRequest($httpRequest);
+        $request->setControllerPackageKey('Neos.Neos');
+        $request->setFormat('html');
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($request);
+        $controllerContext = new ControllerContext(
+            $request,
+            new Response(),
+            new Arguments([]),
+            $uriBuilder
+        );
+
+        $securityContext = $this->objectManager->get(Context::class);
+        $securityContext->setRequest($request);
+
+        $contentContext = $this->contentContextFactory->create(['currentSite' => $site]);
+        $currentSiteNode = $contentContext->getCurrentSiteNode();
+
+        $fusionRuntime = $this->getFusionRuntime($currentSiteNode, $controllerContext);
+
+        $dimensions = $currentSiteNode->getContext()->getDimensions();
+        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== array()) {
+            $currentLocale = new Locale($dimensions['language'][0]);
+            $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
+            $this->i18nService->getConfiguration()->setFallbackRule(array('strict' => false, 'order' => array_reverse($dimensions['language'])));
+        }
+
+        $fusionRuntime->pushContextArray(array_merge(
+            $this->variables,
+            [
+                'node' => $currentSiteNode,
+                'documentNode' => $currentSiteNode,
+                'site' => $currentSiteNode,
+                'editPreviewMode' => null
+            ]
+        ));
+
+        try {
+            $output = $fusionRuntime->render('error');
+            $output = $this->extractBodyFromOutput($output);
+        } catch (RuntimeException $exception) {
+            throw $exception->getPrevious();
+        }
+        $fusionRuntime->popContext();
+
+        return $output;
+    }
+
+    /**
+     * @param string $output
+     * @return string The message body without the message head
+     */
+    protected function extractBodyFromOutput($output)
+    {
+        if (substr($output, 0, 5) === 'HTTP/') {
+            $endOfHeader = strpos($output, "\r\n\r\n");
+            if ($endOfHeader !== false) {
+                $output = substr($output, $endOfHeader + 4);
+            }
+        }
+        return $output;
+    }
+
+    /**
+     * @param NodeInterface $currentSiteNode
+     * @param ControllerContext $controllerContext
+     * @return \Neos\Fusion\Core\Runtime
+     */
+    protected function getFusionRuntime(NodeInterface $currentSiteNode, $controllerContext)
+    {
+        if ($this->fusionRuntime === null) {
+            $this->fusionRuntime = $this->fusionService->createRuntime($currentSiteNode, $controllerContext);
+
+            if (isset($this->options['enableContentCache']) && $this->options['enableContentCache'] !== null) {
+                $this->fusionRuntime->setEnableContentCache($this->options['enableContentCache']);
+            }
+        }
+        return $this->fusionRuntime;
+    }
+}

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -1,6 +1,16 @@
 <?php
-namespace Neos\Neos\View;
+declare(strict_types=1);
 
+namespace Neos\Neos\View;
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\View\ViewInterface;
@@ -139,7 +149,7 @@ class FusionExceptionView extends AbstractView implements ViewInterface
      * @param string $output
      * @return string The message body without the message head
      */
-    protected function extractBodyFromOutput($output)
+    protected function extractBodyFromOutput(string $output): string
     {
         if (substr($output, 0, 5) === 'HTTP/') {
             $endOfHeader = strpos($output, "\r\n\r\n");
@@ -155,7 +165,7 @@ class FusionExceptionView extends AbstractView implements ViewInterface
      * @param ControllerContext $controllerContext
      * @return \Neos\Fusion\Core\Runtime
      */
-    protected function getFusionRuntime(NodeInterface $currentSiteNode, $controllerContext)
+    protected function getFusionRuntime(NodeInterface $currentSiteNode, ControllerContext  $controllerContext): \Neos\Fusion\Core\Runtime
     {
         if ($this->fusionRuntime === null) {
             $this->fusionRuntime = $this->fusionService->createRuntime($currentSiteNode, $controllerContext);

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 namespace Neos\Neos\View;
+
 /*
  * This file is part of the Neos.Neos package.
  *
@@ -11,6 +12,7 @@ namespace Neos\Neos\View;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\View\ViewInterface;
@@ -33,6 +35,14 @@ use Neos\Flow\Mvc\Controller\Arguments;
 
 class FusionExceptionView extends AbstractView implements ViewInterface
 {
+
+    /**
+     * This contains the supported options, their default values, descriptions and types.
+     * @var array
+     */
+    protected $supportedOptions = [
+        'enableContentCache' => ['defaultValue', true, 'boolean'],
+    ];
 
     /**
      * @Flow\Inject
@@ -118,10 +128,10 @@ class FusionExceptionView extends AbstractView implements ViewInterface
         $fusionRuntime = $this->getFusionRuntime($currentSiteNode, $controllerContext);
 
         $dimensions = $currentSiteNode->getContext()->getDimensions();
-        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== array()) {
+        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== []) {
             $currentLocale = new Locale($dimensions['language'][0]);
             $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
-            $this->i18nService->getConfiguration()->setFallbackRule(array('strict' => false, 'order' => array_reverse($dimensions['language'])));
+            $this->i18nService->getConfiguration()->setFallbackRule(['strict' => false, 'order' => array_reverse($dimensions['language'])]);
         }
 
         $fusionRuntime->pushContextArray(array_merge(

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -17,6 +17,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Mvc\View\AbstractView;
+use Neos\Fusion\Exception\RuntimeException;
 use Neos\Neos\Domain\Service\FusionService;
 use Neos\Fusion\Core\Runtime as FusionRuntime;
 use Neos\Neos\Domain\Repository\SiteRepository;
@@ -35,7 +36,6 @@ use Neos\Flow\Mvc\Controller\Arguments;
 
 class FusionExceptionView extends AbstractView implements ViewInterface
 {
-
     /**
      * This contains the supported options, their default values, descriptions and types.
      * @var array
@@ -93,7 +93,8 @@ class FusionExceptionView extends AbstractView implements ViewInterface
 
     /**
      * @return string
-     * @throws \Neos\Flow\Security\Exception
+     * @throws \Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException
+     * @throws \Neos\Fusion\Exception
      * @throws \Neos\Neos\Domain\Exception
      */
     public function render()
@@ -173,7 +174,9 @@ class FusionExceptionView extends AbstractView implements ViewInterface
     /**
      * @param NodeInterface $currentSiteNode
      * @param ControllerContext $controllerContext
-     * @return \Neos\Fusion\Core\Runtime
+     * @return FusionRuntime
+     * @throws \Neos\Fusion\Exception
+     * @throws \Neos\Neos\Domain\Exception
      */
     protected function getFusionRuntime(NodeInterface $currentSiteNode, ControllerContext  $controllerContext): \Neos\Fusion\Core\Runtime
     {

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -458,11 +458,11 @@ Neos:
         renderingGroups:
           notFoundExceptions:
             matchingStatusCodes:
+              - 403
               - 404
+              - 410
             options:
-              templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Index.html'
-              layoutRootPath: 'resource://Neos.Neos/Private/Layouts/'
-              format: html
+              viewClassName: \Neos\Neos\View\FusionExceptionView
           databaseConnectionExceptions:
             matchingExceptionClassNames:
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseException

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -89,27 +89,27 @@ root {
 
 # The error matcher used to render errors that are configured for fusion rendering
 #
-# The matcher recieves the context values `exception`, `renderingOptions`, `statusCode`,
+# The matcher receives the context values `exception`, `renderingOptions`, `statusCode`,
 # `statusMessage` and `referenceCode`.
 #
-# By default the existing template is rendered but by extending the matcher
+# By default the standard error template is rendered, but by extending the matcher
 # custom rendering can be implemented
 #
 error = Neos.Fusion:Case {
-  default {
-    @position = 'end 9999'
-    condition = true
-    renderer = Neos.Fusion:Template {
-      templatePath = 'resource://Neos.Neos/Private/Templates/Error/Index.html'
-      layoutRootPath = 'resource://Neos.Neos/Private/Layouts/'
+	default {
+	@position = 'end 9999'
+	condition = true
+	renderer = Neos.Fusion:Template {
+		templatePath = 'resource://Neos.Neos/Private/Templates/Error/Index.html'
+		layoutRootPath = 'resource://Neos.Neos/Private/Layouts/'
 
-      exception = ${exception}
-      renderingOptions = ${renderingOptions}
-      statusCode = ${statusCode}
-      statusMessage = ${statusMessage}
-      referenceCode = ${referenceCode}
-    }
-  }
+		exception = ${exception}
+		renderingOptions = ${renderingOptions}
+		statusCode = ${statusCode}
+		statusMessage = ${statusMessage}
+		referenceCode = ${referenceCode}
+	}
+	}
 }
 
 

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -92,7 +92,7 @@ root {
 # The matcher recieves the context values `exception`, `renderingOptions`, `statusCode`,
 # `statusMessage` and `referenceCode`.
 #
-# By default a the existing template is rendered but by extending the matcher
+# By default the existing template is rendered but by extending the matcher
 # custom rendering can be implemented
 #
 error = Neos.Fusion:Case {

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -87,6 +87,32 @@ root {
 	@exceptionHandler = 'Neos\\Neos\\Fusion\\ExceptionHandlers\\PageHandler'
 }
 
+# The error matcher used to render errors that are configured for fusion rendering
+#
+# The matcher recieves the context values `exception`, `renderingOptions`, `statusCode`,
+# `statusMessage` and `referenceCode`.
+#
+# By default a the existing template is rendered but by extending the matcher
+# custom rendering can be implemented
+#
+error = Neos.Fusion:Case {
+  default {
+    @position = 'end 9999'
+    condition = true
+    renderer = Neos.Fusion:Template {
+      templatePath = 'resource://Neos.Neos/Private/Templates/Error/Index.html'
+      layoutRootPath = 'resource://Neos.Neos/Private/Layouts/'
+
+      exception = ${exception}
+      renderingOptions = ${renderingOptions}
+      statusCode = ${statusCode}
+      statusMessage = ${statusMessage}
+      referenceCode = ${referenceCode}
+    }
+  }
+}
+
+
 # Extension of the GlobalCacheIdentifiers prototype
 #
 # We add the names of workspaces of the current workspace chain (for example, "user-john,some-workspace,live") to the list


### PR DESCRIPTION
This change adds the default fusion path `error` that is used to render status messages
for the status codes 403, 404 and 410.

The matcher receives the context values `exception`, `renderingOptions`, `statusCode`,
 `statusMessage` and `referenceCode` and will by default render the previous template.

By extending the `error` Case you can add custom 404 rendering like in the example below.

```
#
# Extend error matcher to render the document with uriPathSegment `notfound`
# for exceptions with 4xx status code
#
error {
	@context.notfoundDocument = ${q(site).children('[instanceof Neos.Neos:Document]').filter('[uriPathSegment="notfound"]').get(0)}

	4xx {
		@position = 'start'
		condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
		renderer = Neos.Fusion:Renderer {
			@context.node = ${notfoundDocument}
			renderPath = '/root'
		}
	}
}
```

Resolves: #2325