### PR TITLE
BUGFIX: Improve performance in assetCollection operations

### DIFF
--- a/Neos.Media/Classes/Domain/Model/AssetCollection.php
+++ b/Neos.Media/Classes/Domain/Model/AssetCollection.php
@@ -100,14 +100,15 @@ class AssetCollection
      * Add one asset to the asset collection
      *
      * @param Asset $asset
-     * @return boolean
+     * @return bool
      */
-    public function addAsset(Asset $asset)
+    public function addAsset(Asset $asset): bool
     {
-        if ($this->assets->contains($asset) === false) {
+        if ($asset->getAssetCollections()->contains($this) === false) {
             $this->assets->add($asset);
             return true;
         }
+
         return false;
     }
 
@@ -115,11 +116,11 @@ class AssetCollection
      * Remove one asset from the asset collection
      *
      * @param Asset $asset
-     * @return boolean
+     * @return bool
      */
-    public function removeAsset(Asset $asset)
+    public function removeAsset(Asset $asset): bool
     {
-        if ($this->assets->contains($asset) === true) {
+        if ($asset->getAssetCollections()->contains($this) === false) {
             $this->assets->removeElement($asset);
             return true;
         }


### PR DESCRIPTION
This changes how it is checked if an asset is contained
in an asset collection in order to improve performance.

It changes the complexity of O(n) while n is the amount of assets in an asset collection to O(n) where n is the amount of collections of an asset with the assumption that an asset has far less collections than a collection has assets.

close #2375 
