### PR TITLE
BUGFIX: Don't wrap content element if not allowed to edit property

### DIFF
--- a/Neos.Neos/Classes/Service/ContentElementEditableService.php
+++ b/Neos.Neos/Classes/Service/ContentElementEditableService.php
@@ -58,11 +58,11 @@ class ContentElementEditableService
     {
         /** @var $contentContext ContentContext */
         $contentContext = $node->getContext();
-        if ($contentContext->getWorkspaceName() === 'live' || !$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {
-            return $content;
-        }
-
-        if (!$this->nodeAuthorizationService->isGrantedToEditNode($node)) {
+        if ($contentContext->getWorkspaceName() === 'live'
+            || !$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
+            || !$this->nodeAuthorizationService->isGrantedToEditNode($node)
+            || !$this->nodeAuthorizationService->isGrantedToEditNodeProperty($node, $property)
+        ) {
             return $content;
         }
 


### PR DESCRIPTION
The content element should not get augmented if the node property it is assigned to is not allowed to be edited.

Loosely relates to https://github.com/neos/neos-ui/pull/2165.