### PR TITLE
BUGFIX: Improve performance in findOneByResourceSha1

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -246,7 +246,7 @@ class AssetRepository extends Repository
     public function findOneByResourceSha1($sha1)
     {
         $query = $this->createQuery();
-        $query->matching($query->equals('resource.sha1', $sha1, false))->setLimit(1);
+        $query->matching($query->equals('resource.sha1', $sha1))->setLimit(1);
         return $query->execute()->getFirst();
     }
 


### PR DESCRIPTION
AssetRepository::findOneByResourceSha1 forced case innsensitivity on the
SHA1 hash of the resource, so the query builder uses MySQL "LOWER"
function in its generated query, and as such the index cannot be used
in the intended way. Now we are just relying on sha1 to create lower
cased hash values.
