### PR TITLE
BUGFIX: Backend login plays nicely with other authentications

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/BackendController.php
+++ b/Neos.Neos/Classes/Controller/Backend/BackendController.php
@@ -16,6 +16,7 @@ use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Http\Component\SetHeaderComponent;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Utility\Algorithms;
 use Neos\Neos\Domain\Model\Site;
@@ -62,6 +63,12 @@ class BackendController extends ActionController
     protected $currentSession;
 
     /**
+     * @Flow\Inject
+     * @var PrivilegeManagerInterface
+     */
+    protected $privilegeManager;
+
+    /**
      * Default action of the backend controller.
      *
      * @return void
@@ -72,7 +79,7 @@ class BackendController extends ActionController
     public function indexAction()
     {
         $redirectionUri = $this->backendRedirectionService->getAfterLoginRedirectionUri($this->request);
-        if ($redirectionUri === null) {
+        if (!$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess') || $redirectionUri === null) {
             $redirectionUri = $this->uriBuilder->uriFor('index', [], 'Login', 'Neos.Neos');
         }
         $this->redirectToUri($redirectionUri);

--- a/Neos.Neos/Classes/Controller/Backend/BackendController.php
+++ b/Neos.Neos/Classes/Controller/Backend/BackendController.php
@@ -80,7 +80,7 @@ class BackendController extends ActionController
     {
         $redirectionUri = $this->backendRedirectionService->getAfterLoginRedirectionUri($this->request);
         if (!$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess') || $redirectionUri === null) {
-            $redirectionUri = $this->uriBuilder->uriFor('index', [], 'Login', 'Neos.Neos');
+            $redirectionUri = $this->uriBuilder->reset()->setCreateAbsoluteUri(true)->uriFor('index', [], 'Login', 'Neos.Neos');
         }
         $this->redirectToUri($redirectionUri);
     }

--- a/Neos.Neos/Classes/Controller/LoginController.php
+++ b/Neos.Neos/Classes/Controller/LoginController.php
@@ -21,6 +21,7 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
+use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Session\SessionManagerInterface;
@@ -77,6 +78,12 @@ class LoginController extends AbstractAuthenticationController
     protected $loginTokenCache;
 
     /**
+     * @Flow\Inject
+     * @var PrivilegeManagerInterface
+     */
+    protected $privilegeManager;
+
+    /**
      * @Flow\InjectConfiguration(package="Neos.Flow", path="session.name")
      * @var string
      */
@@ -129,7 +136,7 @@ class LoginController extends AbstractAuthenticationController
         if ($unauthorized || $this->securityContext->getInterceptedRequest()) {
             $this->response->setComponentParameter(SetHeaderComponent::class, 'X-Authentication-Required', '1');
         }
-        if ($this->authenticationManager->isAuthenticated()) {
+        if ($this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {
             $this->redirect('index', 'Backend\Backend');
         }
         $currentDomain = $this->domainRepository->findOneByActiveRequest();

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -27,7 +27,10 @@ privilegeTargets:
       matcher: 'method(Neos\Neos\Controller\LoginController->(index|tokenLogin|authenticate)Action()) || method(Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController->authenticateAction())'
 
     'Neos.Neos:Backend.GeneralAccess':
-      matcher: 'method(Neos\Neos\Controller\Backend\BackendController->(index|switchSite|xliffAsJson)Action()) || method(Neos\Neos\Controller\Backend\ModuleController->indexAction()) || method(Neos\Neos\Controller\LoginController->logoutAction()) || method(Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController->logoutAction()) || method(Neos\Neos\Controller\Module\AbstractModuleController->indexAction()) || method(Neos\Neos\Service\Controller\AbstractServiceController->errorAction())'
+      matcher: 'method(Neos\Neos\Controller\Backend\BackendController->(switchSite|xliffAsJson)Action()) || method(Neos\Neos\Controller\Backend\ModuleController->indexAction()) || method(Neos\Neos\Controller\LoginController->logoutAction()) || method(Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController->logoutAction()) || method(Neos\Neos\Controller\Module\AbstractModuleController->indexAction()) || method(Neos\Neos\Service\Controller\AbstractServiceController->errorAction())'
+
+    'Neos.Neos:Backend.Redirect':
+      matcher: 'method(Neos\Neos\Controller\Backend\BackendController->indexAction())'
 
     #
     # Content access and publishing
@@ -154,7 +157,9 @@ roles:
       -
         privilegeTarget: 'Neos.Neos:WidgetControllers'
         permission: GRANT
-
+      -
+        privilegeTarget: 'Neos.Neos:Backend.Redirect'
+        permission: GRANT
 
   'Neos.Neos:LivePublisher':
     privileges:

--- a/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
+++ b/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
@@ -43,15 +43,32 @@ class BackendControllerSecurityTest extends FunctionalTestCase
 
         $account = $this->authenticateRoles(['Neos.Neos:Administrator']);
         $account->setAccountIdentifier('admin');
-        $this->browser->request('http://localhost/neos/login');
+        $this->browser->request('http://localhost/neos');
+
+        $this->assertSame(200, $this->browser->getLastResponse()->getStatusCode());
     }
 
     /**
      * @test
      */
-    public function indexActionIsDeniedForEverybody()
+    public function indexActionIsRedirectsToLoginIfNotAuthenticated()
     {
+        $this->browser->setFollowRedirects(false);
         $this->browser->request('http://localhost/neos/');
-        self::assertSame(403, $this->browser->getLastResponse()->getStatusCode());
+        $this->assertSame(303, $this->browser->getLastResponse()->getStatusCode());
+        $this->assertSame('http://localhost/neos/login', $this->browser->getLastResponse()->getHeader('Location'));
+    }
+
+    /**
+     * @test
+     */
+    public function indexActionIsRedirectsToLoginIfNoBackendAccess()
+    {
+        $account = $this->authenticateRoles(['Neos.Flow:Customer']);
+        $account->setAccountIdentifier('customer');
+        $this->browser->setFollowRedirects(false);
+        $this->browser->request('http://localhost/neos/');
+        $this->assertSame(303, $this->browser->getLastResponse()->getStatusCode());
+        $this->assertSame('http://localhost/neos/login', $this->browser->getLastResponse()->getHeader('Location'));
     }
 }


### PR DESCRIPTION
This slightly modifies the backend login and redirections so that:

The `LoginController` at `/neos/login` now specifically checks if
access to the Neos backend is currently granted and not only if any
account is authenticated before trying to redirect to the backend.

The `BackendController` at `/neos` is no longer protected by
Policy but checks internally for access to the Neos backend.
Before with policy protection in case you had no active account you
would be redirected to the login due to the provider entry point, but
if you were authenticated and couldn't access the `indexAction` or
weren't authenticated with a Neos user you would end up
with a 403 error, while now you will get redirected to the login.

These behavior changes make it much easier to have the Neos backend
login co-exist with another login and be authenticated to both.
