### PR TITLE
BUGFIX: Allow using font awesome brand icons in backend modules

### DIFF
--- a/Neos.Neos/Resources/Private/Styles/_Mixins.scss
+++ b/Neos.Neos/Resources/Private/Styles/_Mixins.scss
@@ -22,6 +22,6 @@
 
 	&:before,
 	&:after {
-		font-family: $fontFamily;
+		font-family: inherit;
 	}
 }

--- a/Neos.Neos/Resources/Public/Styles/Includes-built.css
+++ b/Neos.Neos/Resources/Public/Styles/Includes-built.css
@@ -7872,7 +7872,7 @@ readers do not read off random characters that represent icons */
   text-align: center;
 }
 .neos [class^="fa-"]:before, .neos [class^="fa-"]:after, .neos [class*=" fa-"]:before, .neos [class*=" fa-"]:after {
-  font-family: FontAwesome;
+  font-family: inherit;
 }
 .neos .neos-clear {
   clear: both;

--- a/Neos.Neos/Resources/Public/Styles/Neos.css
+++ b/Neos.Neos/Resources/Public/Styles/Neos.css
@@ -7872,7 +7872,7 @@ readers do not read off random characters that represent icons */
   text-align: center;
 }
 .neos [class^="fa-"]:before, .neos [class^="fa-"]:after, .neos [class*=" fa-"]:before, .neos [class*=" fa-"]:after {
-  font-family: FontAwesome;
+  font-family: inherit;
 }
 .neos .neos-clear {
   clear: both;


### PR DESCRIPTION
This was broken with 4.0 as fontawesome styling changed.

**What I did**

Inherit the font family for the icon pseudo element from the surrounding fa* class.

**How to verify it**

Use `fab fa-google` as icon for a backend module, f.e. Media Browser.
Instead of an empty square you should see the Google icon.