### PR TITLE
FEATURE: Add ``format`` option for image-prototypes, viewHelpers and presets

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -57,6 +57,11 @@ class ThumbnailConfiguration
     protected $async;
 
     /**
+     * @var string
+     */
+    protected $format;
+
+    /**
      * @var boolean
      */
     protected static $loggedDeprecation = false;
@@ -71,7 +76,7 @@ class ThumbnailConfiguration
      * @param integer $quality Quality of the processed image
      * @param boolean $async Whether the thumbnail can be generated asynchronously
      */
-    public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $quality = null)
+    public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $quality = null, $format = null)
     {
         $this->width = $width ? (integer)$width : null;
         $this->maximumWidth = $maximumWidth ? (integer)$maximumWidth : null;
@@ -81,6 +86,7 @@ class ThumbnailConfiguration
         $this->allowUpScaling = $allowUpScaling ? (boolean)$allowUpScaling : false;
         $this->quality = $quality ? (integer)$quality : null;
         $this->async = $async ? (boolean)$async : false;
+        $this->format = $format ?: null;
     }
 
     /**
@@ -164,6 +170,14 @@ class ThumbnailConfiguration
     }
 
     /**
+     * @return string|null
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -175,7 +189,8 @@ class ThumbnailConfiguration
             'maximumHeight' => $this->getMaximumHeight(),
             'ratioMode' => $this->getRatioMode(),
             'allowUpScaling' => $this->isUpScalingAllowed(),
-            'quality' => $this->getQuality()
+            'quality' => $this->getQuality(),
+            'format' => $this->getFormat()
         ], function ($value) {
             return $value !== null;
         });

--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -66,8 +66,6 @@ class ThumbnailConfiguration
      */
     protected static $loggedDeprecation = false;
 
-
-
     /**
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
@@ -175,7 +173,7 @@ class ThumbnailConfiguration
     /**
      * @return string|null
      */
-    public function getFormat()
+    public function getFormat(): ?string
     {
         return $this->format;
     }

--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -66,10 +66,7 @@ class ThumbnailConfiguration
      */
     protected static $loggedDeprecation = false;
 
-    /**
-     * @var array<string>
-     */
-    protected static $allowedFormats = ['jpg', 'jpeg', 'gif', 'png', 'wbmp', 'xbm', 'webp', 'bmp'];
+
 
     /**
      * @param integer $width Desired width of the image
@@ -92,7 +89,7 @@ class ThumbnailConfiguration
         $this->allowUpScaling = $allowUpScaling ? (boolean)$allowUpScaling : false;
         $this->quality = $quality ? (integer)$quality : null;
         $this->async = $async ? (boolean)$async : false;
-        $this->format = in_array($format, self::$allowedFormats) ? $format : null;
+        $this->format = $format ? (string)$format : null;
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -67,6 +67,11 @@ class ThumbnailConfiguration
     protected static $loggedDeprecation = false;
 
     /**
+     * @var array<string>
+     */
+    protected static $allowedFormats = ['jpg', 'jpeg', 'gif', 'png', 'wbmp', 'xbm', 'webp', 'bmp'];
+
+    /**
      * @param integer $width Desired width of the image
      * @param integer $maximumWidth Desired maximum width of the image
      * @param integer $height Desired height of the image
@@ -74,6 +79,7 @@ class ThumbnailConfiguration
      * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
      * @param integer $quality Quality of the processed image
+     * @param string $format Format for the image, only jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported.
      * @param boolean $async Whether the thumbnail can be generated asynchronously
      */
     public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $quality = null, $format = null)
@@ -86,7 +92,7 @@ class ThumbnailConfiguration
         $this->allowUpScaling = $allowUpScaling ? (boolean)$allowUpScaling : false;
         $this->quality = $quality ? (integer)$quality : null;
         $this->async = $async ? (boolean)$async : false;
-        $this->format = $format ?: null;
+        $this->format = in_array($format, self::$allowedFormats) ? $format : null;
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Media\Domain\Model\ThumbnailGenerator;
 
 /*

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
@@ -1,0 +1,60 @@
+<?php
+namespace Neos\Media\Domain\Model\ThumbnailGenerator;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Media\Domain\Model\Thumbnail;
+
+/**
+ * A system-generated preview version of an Image
+ */
+class ConvertImageThumbnailGenerator extends ImageThumbnailGenerator
+{
+    /**
+     * The priority for this thumbnail generator.
+     *
+     * @var integer
+     * @api
+     */
+    protected static $priority = 50;
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean true if this ThumbnailGenerator can convert the given thumbnail, false otherwise.
+     */
+    public function canRefresh(Thumbnail $thumbnail)
+    {
+        return (
+            $thumbnail->getOriginalAsset() instanceof ImageInterface &&
+            $this->isExtensionSupported($thumbnail)
+        );
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return string|null
+     */
+    protected function getTargetFormat(Thumbnail $thumbnail): ?string
+    {
+        return $thumbnail->getConfigurationValue('format') ?: $this->getOption('targetExtension');
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return boolean
+     */
+    protected function isExtensionSupported(Thumbnail $thumbnail)
+    {
+        $extension = $thumbnail->getOriginalAsset()->getResource()->getFileExtension();
+        return in_array($extension, $this->getOption('supportedExtensions'));
+    }
+}

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ConvertImageThumbnailGenerator.php
@@ -17,7 +17,8 @@ use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\Thumbnail;
 
 /**
- * A system-generated preview version of an Image
+ * A system-generated preview version of an Image with enforced format conversion
+ * to a configured targetFormat
  */
 class ConvertImageThumbnailGenerator extends ImageThumbnailGenerator
 {
@@ -42,8 +43,11 @@ class ConvertImageThumbnailGenerator extends ImageThumbnailGenerator
     }
 
     /**
+     * Determine whether a specific target format is required, returns the expected file extension
+     * as string or null if the same format as source should be used.
+     *
      * @param Thumbnail $thumbnail
-     * @return string|null
+     * @return string|null The file extension the generated image shall recieve
      */
     protected function getTargetFormat(Thumbnail $thumbnail): ?string
     {

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -75,7 +75,8 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
                 )
             ];
 
-            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments, $this->getTargetFormat($thumbnail));
+            $targetFormat = $this->getTargetFormat($thumbnail);
+            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments, $targetFormat);
 
             $thumbnail->setResource($processedImageInfo['resource']);
             $thumbnail->setWidth($processedImageInfo['width']);
@@ -88,8 +89,11 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
     }
 
     /**
+     * Determine whether a specific target format is required, returns the expected file extension
+     * as string or null if the same format as source should be used.
+     *
      * @param Thumbnail $thumbnail
-     * @return string|null
+     * @return string|null The file extension the generated image shall recieve
      */
     protected function getTargetFormat(Thumbnail $thumbnail): ?string
     {

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -75,7 +75,7 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
                 )
             ];
 
-            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments);
+            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments, $thumbnail->getConfigurationValue('format'));
 
             $thumbnail->setResource($processedImageInfo['resource']);
             $thumbnail->setWidth($processedImageInfo['width']);

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/ImageThumbnailGenerator.php
@@ -75,7 +75,7 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
                 )
             ];
 
-            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments, $thumbnail->getConfigurationValue('format'));
+            $processedImageInfo = $this->imageService->processImage($thumbnail->getOriginalAsset()->getResource(), $adjustments, $this->getTargetFormat($thumbnail));
 
             $thumbnail->setResource($processedImageInfo['resource']);
             $thumbnail->setWidth($processedImageInfo['width']);
@@ -85,5 +85,14 @@ class ImageThumbnailGenerator extends AbstractThumbnailGenerator
             $message = sprintf('Unable to generate thumbnail for the given image (filename: %s, SHA1: %s)', $thumbnail->getOriginalAsset()->getResource()->getFilename(), $thumbnail->getOriginalAsset()->getResource()->getSha1());
             throw new Exception\NoThumbnailAvailableException($message, 1433109654, $exception);
         }
+    }
+
+    /**
+     * @param Thumbnail $thumbnail
+     * @return string|null
+     */
+    protected function getTargetFormat(Thumbnail $thumbnail): ?string
+    {
+        return $thumbnail->getConfigurationValue('format');
     }
 }

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -220,6 +220,7 @@ class ImageService
             );
         }
         $defaultOptions['jpeg_quality'] = $quality;
+        $defaultOptions['webp_quality'] = $quality;
         // png_compression_level should be an integer between 0 and 9 and inverse to the quality level given. So quality 100 should result in compression 0.
         $defaultOptions['png_compression_level'] = (9 - ceil($quality * 9 / 100));
 

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -118,7 +118,7 @@ class ImageService
 
         $resourceUri = $originalResource->createTemporaryLocalCopy();
 
-        $resultingFileExtension = ($format && in_array($format, self::$allowedFormats)) ? $format : $originalResource->getFileExtension();
+        $resultingFileExtension = ($format !== null && in_array($format, self::$allowedFormats, true)) ? $format : $originalResource->getFileExtension();
         $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $resultingFileExtension;
 
         if (!file_exists($resourceUri)) {

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -76,6 +76,11 @@ class ImageService
     protected $settings;
 
     /**
+     * @var array<string>
+     */
+    protected static $allowedFormats = ['jpg', 'jpeg', 'gif', 'png', 'wbmp', 'xbm', 'webp', 'bmp'];
+
+    /**
      * @param array $settings
      * @return void
      */
@@ -113,7 +118,7 @@ class ImageService
 
         $resourceUri = $originalResource->createTemporaryLocalCopy();
 
-        $resultingFileExtension = $format ?: $originalResource->getFileExtension();
+        $resultingFileExtension = ($format && in_array($format, self::$allowedFormats)) ? $format : $originalResource->getFileExtension();
         $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $resultingFileExtension;
 
         if (!file_exists($resourceUri)) {

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -87,12 +87,13 @@ class ImageService
     /**
      * @param PersistentResource $originalResource
      * @param array $adjustments
+     * @param string $format
      * @return array resource, width, height as keys
      * @throws ImageFileException
      * @throws InvalidConfigurationException
      * @throws Exception
      */
-    public function processImage(PersistentResource $originalResource, array $adjustments)
+    public function processImage(PersistentResource $originalResource, array $adjustments, string $format = null)
     {
         $additionalOptions = [];
         $adjustmentsApplied = false;
@@ -112,7 +113,7 @@ class ImageService
 
         $resourceUri = $originalResource->createTemporaryLocalCopy();
 
-        $resultingFileExtension = $originalResource->getFileExtension();
+        $resultingFileExtension = $format ?: $originalResource->getFileExtension();
         $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $resultingFileExtension;
 
         if (!file_exists($resourceUri)) {
@@ -176,7 +177,7 @@ class ImageService
             unlink($transformedImageTemporaryPathAndFilename);
 
             $pathInfo = UnicodeFunctions::pathinfo($originalResource->getFilename());
-            $resource->setFilename(sprintf('%s-%ux%u.%s', $pathInfo['filename'], $imageSize->getWidth(), $imageSize->getHeight(), $pathInfo['extension']));
+            $resource->setFilename(sprintf('%s-%ux%u.%s', $pathInfo['filename'], $imageSize->getWidth(), $imageSize->getHeight(), $resultingFileExtension));
         } else {
             $originalResourceStream = $originalResource->getStream();
             $resource = $this->resourceManager->importResource($originalResourceStream, $originalResource->getCollectionName());

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -204,7 +204,8 @@ class ThumbnailService
             isset($presetConfiguration['allowCropping']) ? $presetConfiguration['allowCropping'] : false,
             isset($presetConfiguration['allowUpScaling']) ? $presetConfiguration['allowUpScaling'] : false,
             $async,
-            isset($presetConfiguration['quality']) ? $presetConfiguration['quality'] : null
+            isset($presetConfiguration['quality']) ? $presetConfiguration['quality'] : null,
+            isset($presetConfiguration['format']) ? $presetConfiguration['format'] : null
         );
         return $thumbnailConfiguration;
     }

--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -111,9 +111,10 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
      * @param integer $quality Quality of the image
+     * @param string $format Format for the image, if not specified same as source
      * @return string an <img...> html tag
      */
-    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null, $format = null)
     {
         if ($image === null) {
             return '';
@@ -122,7 +123,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality, $format);
         }
         $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $this->controllerContext->getRequest());
 

--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -110,8 +110,8 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
-     * @param integer $quality Quality of the image
-     * @param string $format Format for the image, if not specified same as source
+     * @param integer $quality Image quality, from 0 to 100
+     * @param string $format Format for the image, jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported
      * @return string an <img...> html tag
      */
     public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null, $format = null)

--- a/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -74,8 +74,8 @@ class ImageViewHelper extends AbstractViewHelper
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
-     * @param integer $quality Quality of the image
-     * @param string $format Format for the image, if not specified same as source
+     * @param integer $quality Image quality, from 0 to 100
+     * @param string $format Format for the image, jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported
      * @return string the relative image path, to be used as src attribute for <img /> tags
      */
     public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null, $format = null)

--- a/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -75,9 +75,10 @@ class ImageViewHelper extends AbstractViewHelper
      * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
      * @param string $preset Preset used to determine image configuration
      * @param integer $quality Quality of the image
+     * @param string $format Format for the image, if not specified same as source
      * @return string the relative image path, to be used as src attribute for <img /> tags
      */
-    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null)
+    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null, $format = null)
     {
         if ($image === null) {
             return '';
@@ -86,7 +87,7 @@ class ImageViewHelper extends AbstractViewHelper
         if ($preset) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality);
+            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality, $format);
         }
         return $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $this->controllerContext->getRequest())['src'];
     }

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -56,6 +56,10 @@ Neos:
 
     thumbnailGenerators:
 
+      Neos\Media\Domain\Model\ThumbnailGenerator\ConvertImageThumbnailGenerator:
+        supportedExtensions:
+          - tiff
+        targetExtension: jpg
       Neos\Media\Domain\Model\ThumbnailGenerator\DocumentThumbnailGenerator:
         resolution: 120
         supportedExtensions:

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -6,7 +6,7 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/imagine": "dev-dependabot/composer/imagine/Imagine-tw-1.1.0 as 4.0.0",
+        "neos/imagine": "^3.1.0",
         "neos/flow": "*",
         "neos/cache": "*",
         "neos/fluid-adaptor": "*",

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -6,7 +6,7 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/imagine": "^3.0.2",
+        "neos/imagine": "dev-dependabot/composer/imagine/Imagine-tw-1.1.0 as 4.0.0",
         "neos/flow": "*",
         "neos/cache": "*",
         "neos/fluid-adaptor": "*",

--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -130,6 +130,16 @@ class ImageUriImplementation extends AbstractFusionObject
     }
 
     /**
+     * Async
+     *
+     * @return string|null
+     */
+    public function getFormat()
+    {
+        return $this->fusionValue('format');
+    }
+
+    /**
      * Preset
      *
      * @return string
@@ -156,7 +166,7 @@ class ImageUriImplementation extends AbstractFusionObject
         if (!empty($preset)) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getAsync(), $this->getQuality());
+            $thumbnailConfiguration = new ThumbnailConfiguration($this->getWidth(), $this->getMaximumWidth(), $this->getHeight(), $this->getMaximumHeight(), $this->getAllowCropping(), $this->getAllowUpScaling(), $this->getAsync(), $this->getQuality(), $this->getFormat());
         }
         $request = $this->getRuntime()->getControllerContext()->getRequest();
         $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $request);

--- a/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ImageUriImplementation.php
@@ -134,7 +134,7 @@ class ImageUriImplementation extends AbstractFusionObject
      *
      * @return string|null
      */
-    public function getFormat()
+    public function getFormat(): ?string
     {
         return $this->fusionValue('format');
     }

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1037,7 +1037,9 @@ Get a URI to a (thumbnail) image for an asset.
 :maximumHeight: (integer) Desired maximum width of the image
 :allowCropping: (boolean) Whether the image should be cropped if the given sizes would hurt the aspect ratio, defaults to ``FALSE``
 :allowUpScaling: (boolean) Whether the resulting image size might exceed the size of the original image, defaults to ``FALSE``
-:async (boolean): Return asynchronous image URI in case the requested image does not exist already, defaults to ``FALSE``
+:async: (boolean) Return asynchronous image URI in case the requested image does not exist already, defaults to ``FALSE``
+:quality: (integer) Image quality, from 0 to 100
+:format: (string) Format for the image, jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported
 :preset: (string) Preset used to determine image configuration, if set all other resize attributes will be ignored
 
 Example::

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
@@ -8,6 +8,8 @@ prototype(Neos.Neos:ImageUri) {
 	allowCropping = false
 	allowUpScaling = false
 	async = false
+	quality = NULL
+	format = NULL
 	preset = NULL
 	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
@@ -31,6 +33,8 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 	@context.allowCropping = ${this.allowCropping}
 	@context.allowUpScaling = ${this.allowUpScaling}
 	@context.async = ${this.async}
+	@context.quality = ${this.quality}
+	@context.format = ${this.format}
 	@context.preset = ${this.preset}
 
 	tagName = 'img'
@@ -44,6 +48,8 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 			allowCropping = ${allowCropping}
 			allowUpScaling = ${allowUpScaling}
 			async = ${async}
+			quality = ${quality}
+			format = ${format}
 			preset = ${preset}
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "neos/utility-mediatypes": "*",
         "neos/error-messages": "*",
         "doctrine/common": "^2.7",
-        "neos/imagine": "^3.0.2",
+        "neos/imagine": "^3.1.0",
         "imagine/imagine": "*",
         "doctrine/dbal": "^2.8",
         "neos/party": "*",


### PR DESCRIPTION
The option ``format`` is added to imagePresets, viewHelpers and FusionPrototypes.
The format is passed as string "jpg", "jpeg", "gif", "png", "wbmp", "xbm", "webp" and "bmp" are supported. If no format is given the crops will use the format of the original image.

This allows to to enforce rendering of crops in jpeg or png but also adds support for rendering 
of webp-images as alternate sources.

Additionally this pr adds the ConvertImageThumbnailGenerator that allows to specify images that should be converted for online-presentation to an optimized target format. While the default imageFormat is specified in the settings this can still be overridden via `format` option on
the thumbnail-configurations.

The ConvertImageThumbnailGenerator is configured via settings:

```
Neos:
  Media:
    thumbnailGenerators:
      Neos\Media\Domain\Model\ThumbnailGenerator\ConvertImageThumbnailGenerator:
        supportedExtensions:
          - tiff
        targetExtension: jpg
```


Resolves. #2320