### PR TITLE
FEATURE: Trigger signal when Thumbnail is persisted

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Thumbnail.php
+++ b/Neos.Media/Classes/Domain/Model/Thumbnail.php
@@ -108,6 +108,16 @@ class Thumbnail implements ImageInterface
     }
 
     /**
+     * Post persistence lifecycle callback
+     *
+     * @ORM\PostPersist
+     */
+    public function onPostPersist()
+    {
+        $this->emitThumbnailPersisted($this);
+    }
+
+    /**
      * Returns the Asset this thumbnail is derived from
      *
      * @return ImageInterface
@@ -219,6 +229,17 @@ class Thumbnail implements ImageInterface
      * @return void
      */
     protected function emitThumbnailCreated(Thumbnail $thumbnail)
+    {
+    }
+
+    /**
+     * Signals that a thumbnail was persisted.
+     *
+     * @Flow\Signal
+     * @param Thumbnail $thumbnail
+     * @return void
+     */
+    protected function emitThumbnailPersisted(Thumbnail $thumbnail)
     {
     }
 }

--- a/Neos.Media/Classes/Domain/Model/Thumbnail.php
+++ b/Neos.Media/Classes/Domain/Model/Thumbnail.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Utility\Arrays;
 use Neos\Media\Domain\Strategy\ThumbnailGeneratorStrategy;
 
@@ -38,6 +39,12 @@ class Thumbnail implements ImageInterface
      * @Flow\Inject
      */
     protected $generatorStrategy;
+
+    /**
+     * @var ThumbnailService
+     * @Flow\Inject
+     */
+    protected $thumbnailService;
 
     /**
      * @var Asset
@@ -114,7 +121,7 @@ class Thumbnail implements ImageInterface
      */
     public function onPostPersist()
     {
-        $this->emitThumbnailPersisted($this);
+        $this->thumbnailService->emitThumbnailPersisted($this);
     }
 
     /**
@@ -229,17 +236,6 @@ class Thumbnail implements ImageInterface
      * @return void
      */
     protected function emitThumbnailCreated(Thumbnail $thumbnail)
-    {
-    }
-
-    /**
-     * Signals that a thumbnail was persisted.
-     *
-     * @Flow\Signal
-     * @param Thumbnail $thumbnail
-     * @return void
-     */
-    protected function emitThumbnailPersisted(Thumbnail $thumbnail)
     {
     }
 }

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -248,6 +248,17 @@ class ThumbnailService
     }
 
     /**
+     * Signals that a thumbnail was persisted.
+     *
+     * @Flow\Signal
+     * @param Thumbnail $thumbnail
+     * @return void
+     */
+    public function emitThumbnailPersisted(Thumbnail $thumbnail)
+    {
+    }
+
+    /**
      * Signals that a thumbnail was created.
      *
      * @Flow\Signal


### PR DESCRIPTION
PR for issue #2387 

**What I did**
Added a signal `thumbnailPersisted` and an ORM lifecycle callback that triggers the signal once the thumbnail is persisted.

**How I did it**
Added two methods in Neos\Media\Domain\Model\Thumbnail: one for the signal and one for the lifecycle callback that triggers the signal.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
