### PR TITLE
BUGFIX: Testing Policy has a working expression

### DIFF
--- a/Neos.Neos/Configuration/Testing/Policy.yaml
+++ b/Neos.Neos/Configuration/Testing/Policy.yaml
@@ -5,4 +5,4 @@
 privilegeTargets:
   'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
     'Neos.Neos:AllControllerActions':
-      matcher: 'within(Neos\Flow\Mvc\Controller\AbstractController) && method(public .*->.(?!initialize).*Action()) &&! method(public .*\Tests\.*\Fixtures\.*->.(?!initialize).*Action())'
+      matcher: 'within(Neos\Flow\Mvc\Controller\AbstractController) && method(public .*->(?!initialize).*Action()) &&! method(public .*\Tests\.*\Fixtures\.*->(?!initialize).*Action())'


### PR DESCRIPTION
The policy expression was wrong and leads to initialize*Action functions being included in the AllControllerActions privilege. That is wrong and can lead to errors in tests. Compared to the (non testing) policy the new expression now works as expected.
