### PR TITLE
TASK: Translate Site Management

### DIFF
--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/DomainForm.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/DomainForm.html
@@ -2,7 +2,7 @@
 <div class="neos-row neos-module-container">
 	<fieldset class="neos-span12">
 		<f:form.hidden property="site" value="{f:if(condition: domain.site, then: domain.site, else: site)}" />
-		<legend>{neos:backend.translate(id: 'domainform.domainData', value: 'Domain data')}</legend>
+		<legend>{neos:backend.translate(id: 'domainform.domainData', value: 'Domain data', source: 'Modules')}</legend>
 
 		<div class="neos-row">
 			<div class="neos-span2">
@@ -21,7 +21,7 @@
 							<div class="neos-control-group neos-error">
 								<label class="neos-control-label" for="host">{neos:backend.translate(id: 'host', value: 'Host')}</label>
 								<div class="neos-controls">
-									<f:form.textfield property="hostname" value="{domain.hostname}" id="host" class="neos-span6" placeholder="{neos:backend.translate(id: 'domainform.hostPlaceholder', value: 'e.g. www.neos.io')}" />
+									<f:form.textfield property="hostname" value="{domain.hostname}" id="host" class="neos-span6" placeholder="{neos:backend.translate(id: 'domainform.hostPlaceholder', value: 'e.g. www.neos.io', source: 'Modules')}" />
 									<ul class="errors">
 										<f:for each="{validationResults.errors}" as="error">
 											<li><span class="neos-help-block">{error}</span></li>
@@ -34,7 +34,7 @@
 							<div class="neos-control-group{f:validation.ifHasErrors(for: 'domain.hostname', then: ' neos-error')}">
 								<label class="neos-control-label" for="host">{neos:backend.translate(id: 'host', value: 'Host')}</label>
 								<div class="neos-controls">
-									<f:form.textfield property="hostname" value="{domain.hostname}" id="host" class="neos-span6" placeholder="{neos:backend.translate(id: 'domainform.hostPlaceholder', value: 'e.g. www.neos.io')}" />
+									<f:form.textfield property="hostname" value="{domain.hostname}" id="host" class="neos-span6" placeholder="{neos:backend.translate(id: 'domainform.hostPlaceholder', value: 'e.g. www.neos.io', source: 'Modules')}" />
 									<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'domain.hostname'}"/>
 								</div>
 							</div>
@@ -53,7 +53,7 @@
 			</div>
 		</div>
 		<div class="neos-control-group">
-			<label class="neos-control-label" for="active">{neos:backend.translate(id: 'domainform.state', value: 'State')}</label>
+			<label class="neos-control-label" for="active">{neos:backend.translate(id: 'domainform.state', value: 'State', source: 'Modules')}</label>
 			<div class="neos-controls">
 				<label class="neos-radio neos-inline">
 					<f:if condition="{domain}">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
@@ -19,14 +19,14 @@
 						</div>
 					</div>
 					<div class="neos-control-group{f:validation.ifHasErrors(for: 'newSiteNodeName', then: ' neos-error')}">
-						<label class="neos-control-label" for="node-name">{neos:backend.translate(id: 'sites.rootNodeName', value: 'Root node name')}</label>
+						<label class="neos-control-label" for="node-name">{neos:backend.translate(id: 'sites.rootNodeName', value: 'Root node name', source: 'Modules')}</label>
 						<div class="neos-controls">
 							<f:form.textfield name="newSiteNodeName" id="node-name" value="{site.nodeName}" additionalAttributes="{pattern: '^[a-z0-9\-]+$'}" class="neos-span12" required="true" />
 							<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'newSiteNodeName'}"/>
 						</div>
 					</div>
 					<div class="neos-control-group">
-						<label class="neos-control-label" for="asset-collection">{neos:backend.translate(id: 'sites.defaultAssetCollection', value: 'Default asset collection')}</label>
+						<label class="neos-control-label" for="asset-collection">{neos:backend.translate(id: 'sites.defaultAssetCollection', value: 'Default asset collection', source: 'Modules')}</label>
 						<div class="neos-controls">
 							<f:form.select property="assetCollection" id="asset-collection" options="{assetCollections}" optionLabelField="title" prependOptionLabel="None" prependOptionValue="" class="neos-span12" />
 						</div>
@@ -93,12 +93,12 @@
 												<div class="neos-modal-content">
 													<div class="neos-modal-header">
 														<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-														<div class="neos-header">{neos:backend.translate(id: 'domain.deleteConfirmQuestion', arguments: {0: domain}, value: 'Do you really want to delete "{domain}"? This action cannot be undone.')}</div>
+														<div class="neos-header">{neos:backend.translate(id: 'domain.deleteConfirmQuestion', arguments: {0: domain}, source: 'Modules', value: 'Do you really want to delete "{domain}"? This action cannot be undone.')}</div>
 													</div>
 													<div class="neos-modal-footer">
 														<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>
-														<button form="postHelper" formaction="{f:uri.action(action: 'deleteDomain', arguments: {site: site, domain: domain})}" type="submit" class="neos-button-danger neos-button" title="{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!')}">
-															{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!')}
+														<button form="postHelper" formaction="{f:uri.action(action: 'deleteDomain', arguments: {site: site, domain: domain})}" type="submit" class="neos-button-danger neos-button" title="{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!', source: 'Modules')}">
+															{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!', source: 'Modules')}
 														</button>
 													</div>
 												</div>
@@ -112,14 +112,14 @@
 						</tbody>
 					</table>
 					<div class="neos-pull-right">
-						<f:link.action action="newDomain" arguments="{site: site}" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}" >{neos:backend.translate(id: 'domain.add', value: 'Add Domain')}</f:link.action>
+						<f:link.action action="newDomain" arguments="{site: site}" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}" >{neos:backend.translate(id: 'domain.add', value: 'Add Domain', source: 'Modules')}</f:link.action>
 					</div>
 				</fieldset>
 			</div>
 
 			<div class="neos-row-fluid">
 				<fieldset class="neos-span5">
-					<legend>{neos:backend.translate(id: 'sites.sitePackage', value: 'Site package')}</legend>
+					<legend>{neos:backend.translate(id: 'sites.sitePackage', value: 'Site package', source: 'Modules')}</legend>
 					<table class="neos-info-table">
 						<tbody>
 							<tr>
@@ -147,17 +147,17 @@
 		<div class="neos-footer">
 			<f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</f:link.action>
 			<button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'clickToDelete', value: 'Click here to delete this site')}" data-toggle="modal" href="#{site.nodeName}">
-				{neos:backend.translate(id: 'sites.delete', value: 'Delete this site')}
+				{neos:backend.translate(id: 'sites.delete', value: 'Delete this site', source: 'Modules')}
 			</button>
 			<f:if condition="{site.online}">
 				<f:then>
 					<button form="postHelper" formaction="{f:uri.action(action: 'deactivateSite', arguments: {site: site})}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}">
-						{neos:backend.translate(id: 'sites.deactivate', value: 'Deactivate site')}
+						{neos:backend.translate(id: 'sites.deactivate', value: 'Deactivate site', source: 'Modules')}
 					</button>
 				</f:then>
 				<f:else>
 					<button form="postHelper" formaction="{f:uri.action(action: 'activateSite', arguments: {site: site})}" type="submit" class="neos-button neos-button-success" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}">
-						{neos:backend.translate(id: 'sites.activate', value: 'Activate site')}
+						{neos:backend.translate(id: 'sites.activate', value: 'Activate site', source: 'Modules')}
 					</button>
 				</f:else>
 			</f:if>
@@ -167,12 +167,12 @@
 			<div class="neos-modal">
 				<div class="neos-modal-header">
 					<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-					<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', arguments: {0: site.name}, value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
+					<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', source: 'Modules', arguments: {0: site.name}, value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
 				</div>
 				<div class="neos-modal-footer">
 					<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>
 					<button form="postHelper" formaction="{f:uri.action(action: 'deleteSite', arguments: {site: site, domain: domain})}" type="submit" class="neos-button neos-button-danger" title="Yes, delete the site">
-						{neos:backend.translate(id: 'sites.confirmDelete', value: 'Yes, delete the site')}
+						{neos:backend.translate(id: 'sites.confirmDelete', value: 'Yes, delete the site', source: 'Modules', source: 'Modules')}
 					</button>
 				</div>
 			</div>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/EditDomain.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/EditDomain.html
@@ -2,7 +2,7 @@
 <f:layout name="BackendSubModule" />
 
 <f:section name="subtitle">
-	<h2>{neos:backend.translate(id: 'domain.edit', value: 'Edit domain')}</h2>
+	<h2>{neos:backend.translate(id: 'domain.edit', value: 'Edit domain', source: 'Modules')}</h2>
 </f:section>
 
 <f:section name="content">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
@@ -6,8 +6,8 @@
 		<thead>
 			<tr>
 				<th>{neos:backend.translate(id: 'name', value: 'Name')}</th>
-				<th>{neos:backend.translate(id: 'sites.rootNodeName', value: 'Rootnode name')}</th>
-				<th>{neos:backend.translate(id: 'sites.domains', value: 'Domains')}</th>
+				<th>{neos:backend.translate(id: 'sites.rootNodeName', value: 'Rootnode name', source: 'Modules')}</th>
+				<th>{neos:backend.translate(id: 'sites.domains', value: 'Domains', source: 'Modules')}</th>
 				<th></th>
 			</tr>
 		</thead>
@@ -71,13 +71,14 @@
 												<div class="neos-modal-content">
 													<div class="neos-modal-header">
 														<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-														<div class="neos-header">Do you really want to delete "{site.name}"? This action cannot be undone.</div>
+														<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', arguments: {0: site.name}, source: 'Modules', value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
 													</div>
 													<div class="neos-modal-footer">
 														<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>
 														<f:form action="deleteSite" arguments="{site: site}" class="neos-inline">
-															<button class="neos-button neos-button-danger" title="Delete this site">
-																{neos:backend.translate(id: 'sites.confirmDelete', value: 'Yes, delete this site')}
+															<button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'sites.delete', value: 'Delete this site', source: 'Modules')}">
+
+																{neos:backend.translate(id: 'sites.confirmDelete', value: 'Yes, delete this site', source: 'Modules')}
 															</button>
 														</f:form>
 													</div>
@@ -92,7 +93,7 @@
 					</f:then>
 					<f:else>
 						<tr class="fold-{sitePackageKey}">
-							<td colspan="4"><i>No sites available</i></td>
+							<td colspan="4"><i>{neos:backend.translate(id: 'sites.noSitesAvailable', value: 'No sites available', source: 'Modules')}</i></td>
 						</tr>
 					</f:else>
 				</f:if>
@@ -100,7 +101,7 @@
 		</tbody>
 	</table>
 	<div class="neos-footer">
-		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site')}</f:link.action>
+		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site', source: 'Modules')}</f:link.action>
 	</div>
 
 	<script>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewDomain.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewDomain.html
@@ -2,11 +2,11 @@
 <f:layout name="BackendSubModule" />
 
 <f:section name="subtitle">
-	<h2>{neos:backend.translate(id: 'domain.new', value: 'New domain')}</h2>
+	<h2>{neos:backend.translate(id: 'domain.new', value: 'New domain', source: 'Modules')}</h2>
 </f:section>
 
 <f:section name="content">
 	<f:form action="createDomain" name="domain" object="{domain}">
-		<f:render partial="Module/Shared/DomainForm" arguments="{domain: domain, site: site, schemes: schemes, saveText: 'Create'}" />
+		<f:render partial="Module/Shared/DomainForm" arguments="{domain: domain, site: site, schemes: schemes, saveText: '{neos:backend.translate(id: \'domainform.create\', value: \'Create\', source: \'Modules\')}'}" />
 	</f:form>
 </f:section>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -2,24 +2,24 @@
 <f:layout name="BackendSubModule" />
 
 <f:section name="content">
-	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site')}</h2>
+	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')}</h2>
 
   <div class="neos-row-fluid">
     <f:form action="importSite">
       <fieldset class="neos-span3">
-        <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site')}</legend>
+        <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site', source: 'Modules')}</legend>
         <f:if condition="{sitePackages -> f:count()} > 0">
           <f:then>
             <div class="neos-control-group">
-              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
+              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
               <div class="neos-controls neos-select">
                 <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
-            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
+            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}
             </p>
           </f:else>
         </f:if>
@@ -28,32 +28,32 @@
 
     <f:form action="createSiteNode">
       <fieldset class="neos-span3 neos-offset1">
-        <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site')}</legend>
+        <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site', source: 'Modules')}</legend>
         <f:if condition="{sitePackages -> f:count()} > 0">
           <f:then>
             <div class="neos-control-group">
-              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package')}</label>
+              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
               <div class="neos-controls neos-select">
                 <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'nodeType', then: ' neos-error')}">
-              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType')}</label>
+              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType', source: 'Modules')}</label>
               <div class="neos-controls neos-select">
                 <f:form.select name="nodeType" options="{documentNodeTypes}" optionLabelField="name" optionValueField="name" id="node-type" class="neos-span12" />
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
-              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name')}</label>
+              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name', source: 'Modules')}</label>
               <div class="neos-controls">
                 <f:form.textfield name="siteName" value="{siteName}" id="site-name" />
                 <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.createNode', value: 'Create empty Site')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.createNode', value: 'Create empty Site', source: 'Modules')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
-            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.')}
+            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}
             </p>
           </f:else>
         </f:if>
@@ -62,27 +62,27 @@
 
     <f:form action="createSitePackage">
       <fieldset class="neos-span3 neos-offset1">
-        <legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package')}</legend>
+        <legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package', source: 'Modules')}</legend>
         <f:if condition="{generatorServiceIsAvailable}">
           <f:then>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'packageKey', then: ' neos-error')}">
-              <label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key')}</label>
+              <label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key', source: 'Modules')}</label>
               <div class="neos-controls">
                 <f:form.textfield name="packageKey" value="{packageKey}" id="package-key" class="neos-span12" placeholder="{neos:backend.translate(id: 'sites.validPackageKeyInfo', value: 'VendorName.MyPackageKey')}" />
                 <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'packageKey'}"/>
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
-              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name')}</label>
+              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name', source: 'Modules')}</label>
               <div class="neos-controls">
                 <f:form.textfield name="siteName" value="{siteName}" id="site-name" />
                 <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.createPackage', value: 'Create Site-Package')}" class="neos-button neos-button-primary" />
+            <f:form.submit value="{neos:backend.translate(id: 'sites.createPackage', value: 'Create Site-Package', source: 'Modules')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
-            <p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.') -> f:format.raw()}</p>
+            <p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.', source: 'Modules') -> f:format.raw()}</p>
           </f:else>
         </f:if>
       </fieldset>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -598,8 +598,14 @@
 			<trans-unit id="sites.validPackageKeyInfo" xml:space="preserve">
 				<source>VendorName.MyPackageKey</source>
 			</trans-unit>
+			<trans-unit id="sites.noSitesAvailable" xml:space="preserve">
+				<source>No sites available</source>
+			</trans-unit>
 			<trans-unit id="sites.noNeosKickstarterInfo" xml:space="preserve">
 				<source>The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.</source>
+			</trans-unit>
+			<trans-unit id="sites.new" xml:space="preserve">
+				<source>New site</source>
 			</trans-unit>
 
 			<trans-unit id="domain.deleteConfirmQuestion" xml:space="preserve">
@@ -610,6 +616,19 @@
 			</trans-unit>
 			<trans-unit id="domain.edit" xml:space="preserve">
 				<source>Edit domain</source>
+			</trans-unit>
+
+			<trans-unit id="domainform.domainData" xml:space="preserve">
+				<source>Domain data</source>
+			</trans-unit>
+			<trans-unit id="domainform.hostPlaceholder" xml:space="preserve">
+				<source>e.g. www.neos.io</source>
+			</trans-unit>
+			<trans-unit id="domainform.state" xml:space="preserve">
+				<source>State</source>
+			</trans-unit>
+			<trans-unit id="domainform.create" xml:space="preserve">
+				<source>Create</source>
 			</trans-unit>
 
 			<trans-unit id="configuration.label" xml:space="preserve">


### PR DESCRIPTION
The Site Management uses labels both from `Main.xlf` and `Modules.xlf`. For the labels from `Module.xlf`, the `source` attribute must be set. Apart from that, some labels didn't have a translation at all. This change makes the Site Management fully localizable.

Fixes #2394 