### PR TITLE
FEATURE: Add fallback from `itemRenderer` to `content` for `Neos.Fusion:Map` and derived prototypes

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
@@ -84,6 +84,13 @@ class MapImplementation extends AbstractFusionObject
         $itemKey = $this->getItemKey();
         $iterationName = $this->getIterationName();
         $collectionTotalCount = count($collection);
+
+        $itemRenderPath = $this->path . '/itemRenderer';
+        $fallbackRenderPath =  $this->path . '/content';
+        if ($this->runtime->canRender($itemRenderPath) === false && $this->runtime->canRender($fallbackRenderPath)) {
+            $itemRenderPath = $fallbackRenderPath;
+        }
+
         foreach ($collection as $collectionKey => $collectionElement) {
             $context = $this->runtime->getCurrentContext();
             $context[$itemName] = $collectionElement;
@@ -95,7 +102,7 @@ class MapImplementation extends AbstractFusionObject
             }
 
             $this->runtime->pushContextArray($context);
-            $result[$collectionKey] =  $this->runtime->render($this->path . '/itemRenderer');
+            $result[$collectionKey] =  $this->runtime->render($itemRenderPath);
             $this->runtime->popContext();
             $this->numberOfRenderedNodes++;
         }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
@@ -9,6 +9,14 @@ map.basicLoop = Neos.Fusion:Map {
 	}
 }
 
+map.basicLoopWithContentRenderer = Neos.Fusion:Map {
+  items = ${items}
+  itemName = 'element'
+  content = Neos.Fusion:TestRenderer {
+    test = ${element}
+  }
+}
+
 map.basicLoopOtherContextVariables = Neos.Fusion:Map {
   items = ${items}
 	itemName = 'element'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -31,6 +31,17 @@ class MapTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function basicCollectionWorksWithContentRenderer()
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['element1', 'element2']);
+        $view->setFusionPath('map/basicLoopWithContentRenderer');
+        $this->assertEquals(['Xelement1','Xelement2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function basicCollectionWorksAndPreservesKeys()
     {
         $view = $this->buildView();

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -116,7 +116,7 @@ Render each item in ``collection`` using ``itemRenderer``.
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
+:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
 
 .. note:: The Neos.Fusion:Collection object is DEPRECATED use Neos.Fusion:Loop instead.
 
@@ -151,7 +151,7 @@ Render each item in ``collection`` using ``itemRenderer`` and return the result 
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
+:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
 
 .. note:: The Neos.Fusion:RawCollection object is DEPRECATED use Neos.Fusion:Map instead.**
 
@@ -166,7 +166,7 @@ Render each item in ``items`` using ``itemRenderer``.
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated
+:itemRenderer: (string, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element, and its results will be concatenated (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
 :@glue: (string) The glue used to join the items together (default = '').
 
 Example using an object ``itemRenderer``::
@@ -200,7 +200,7 @@ Render each item in ``items`` using ``itemRenderer`` and return the result as an
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element
+:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
 
 .. _Neos_Fusion__Reduce:
 


### PR DESCRIPTION
This allows to declare the itemRenderers in `afx` without `@children` annotation and avoids a 
common error in afx code.

Affected prototypes:
-  `Neos.Fusion:Map`
-  `Neos.Fusion:RawCollection`
-  `Neos.Fusion:Loop`
-  `Neos.Fusion:Collection`