### PR TITLE
BUGFIX: Remove coupling of functional tests to `Neos:Demo` and `Neos.NodeTypes`

### DIFF
--- a/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
@@ -53,28 +53,28 @@ class NodeTypeTest extends FunctionalTestCase
     {
         return [
             'nodeTypeOnly' => [
-                'nodeType' => 'Neos.NodeTypes:Page',
+                'nodeType' => 'Neos.ContentRepository.Testing:Page',
                 'withSubTypes' => false,
                 'exclude' => false,
-                'expected' => 'n0_.nodetype IN (\'Neos.NodeTypes:Page\')',
+                'expected' => 'n0_.nodetype IN (\'Neos.ContentRepository.Testing:Page\')',
             ],
             'nodeTypeAndSubTypes' => [
-                'nodeType' => 'Neos.NodeTypes:Page',
+                'nodeType' => 'Neos.ContentRepository.Testing:Page',
                 'withSubTypes' => true,
                 'exclude' => false,
-                'expected' => 'n0_.nodetype IN (\'Neos.NodeTypes:Page\', \'Neos.Demo:Homepage\')',
+                'expected' => 'n0_.nodetype IN (\'Neos.ContentRepository.Testing:Page\', \'Neos.ContentRepository.Testing:Chapter\', \'Neos.ContentRepository.Testing:PageWithConfiguredLabel\')',
             ],
             'nodeTypeExclude' => [
-                'nodeType' => 'Neos.NodeTypes:Page',
+                'nodeType' => 'Neos.ContentRepository.Testing:Page',
                 'withSubTypes' => false,
                 'exclude' => true,
-                'expected' => 'NOT (n0_.nodetype IN (\'Neos.NodeTypes:Page\'))',
+                'expected' => 'NOT (n0_.nodetype IN (\'Neos.ContentRepository.Testing:Page\'))',
             ],
             'nodeTypeExcludeAndSubTypes' => [
-                'nodeType' => 'Neos.NodeTypes:Page',
+                'nodeType' => 'Neos.ContentRepository.Testing:Page',
                 'withSubTypes' => true,
                 'exclude' => true,
-                'expected' => 'NOT (n0_.nodetype IN (\'Neos.NodeTypes:Page\', \'Neos.Demo:Homepage\'))',
+                'expected' => 'NOT (n0_.nodetype IN (\'Neos.ContentRepository.Testing:Page\', \'Neos.ContentRepository.Testing:Chapter\', \'Neos.ContentRepository.Testing:PageWithConfiguredLabel\'))',
             ],
         ];
     }

--- a/Neos.Neos/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/Testing/NodeTypes.yaml
@@ -1,3 +1,10 @@
+'Acme.Demo:Page':
+  superTypes:
+    'Neos.Neos:Document': true
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'
+
 'Acme.Demo:ThreeColumn':
   superTypes:
     'Neos.NodeTypes:Column': true
@@ -28,6 +35,52 @@
   properties:
     text:
       type: 'string'
+
+'Acme.Demo:Headline':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    label: 'Headline content'
+  properties:
+    title:
+      type: string
+      ui:
+        inlineEditable: true
+
+'Acme.Demo:Text':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    label: 'Text content'
+    group: 'default'
+  properties:
+    text:
+      type: string
+      ui:
+        inlineEditable: true
+
+'Acme.Demo:Html':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    label: 'Html content'
+    group: 'default'
+  properties:
+    source:
+      type: string
+      ui:
+        inspector:
+          editor: 'Neos.Neos/Inspector/Editors/CodeEditor'
+
+'Acme.Demo:AssetList':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    label: 'Asset List content'
+    group: 'default'
+  properties:
+    assets:
+      type: array<Neos\Media\Domain\Model\Asset>
 
 'Neos.Neos.BackendSchemaControllerTest:Node':
   abstract: true

--- a/Neos.Neos/Tests/Functional/AbstractNodeTest.php
+++ b/Neos.Neos/Tests/Functional/AbstractNodeTest.php
@@ -10,7 +10,6 @@ namespace Neos\Neos\Tests\Functional;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Media\TypeConverter\AssetInterfaceConverter;
@@ -57,7 +56,6 @@ abstract class AbstractNodeTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->markSkippedIfNodeTypesPackageIsNotInstalled();
 
         $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contentContext = $this->contextFactory->create(['workspaceName' => 'live']);
@@ -91,13 +89,5 @@ abstract class AbstractNodeTest extends FunctionalTestCase
 
         $this->inject($this->contextFactory, 'contextInstances', []);
         $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', []);
-    }
-
-    protected function markSkippedIfNodeTypesPackageIsNotInstalled()
-    {
-        $packageManager = $this->objectManager->get(PackageManagerInterface::class);
-        if (!$packageManager->isPackageAvailable('Neos.NodeTypes')) {
-            $this->markTestSkipped('This test needs the Neos.NodeTypes package.');
-        }
     }
 }

--- a/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -49,6 +49,6 @@ class ConfigurationValidationTest extends FlowConfigurationValidationTest
     protected $configurationPackageKeys = [
         'Neos.Flow', 'Neos.FluidAdaptor', 'Neos.Eel', 'Neos.Kickstart',
         'Neos.ContentRepository', 'Neos.Neos', 'Neos.Fusion', 'Neos.Media',
-        'Neos.Media.Browser', 'Neos.NodeTypes'
+        'Neos.Media.Browser'
     ];
 }

--- a/Neos.Neos/Tests/Functional/Domain/Fixtures/NodeUriTestStructure.xml
+++ b/Neos.Neos/Tests/Functional/Domain/Fixtures/NodeUriTestStructure.xml
@@ -28,7 +28,7 @@
 					</properties>
 				</variant>
 				<node nodeName="home">
-					<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+					<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 						<dimensions>
 							<language>en_US</language>
 						</dimensions>
@@ -39,7 +39,7 @@
 							<uriPathSegment __type="string">home</uriPathSegment>
 						</properties>
 					</variant>
-					<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+					<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 						<dimensions>
 							<language>de</language>
 						</dimensions>
@@ -51,7 +51,7 @@
 						</properties>
 					</variant>
 					<node nodeName="about-us">
-						<variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Page" version="3" removed="" hidden="" hiddenInIndex="">
+						<variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Page" version="3" removed="" hidden="" hiddenInIndex="">
 							<dimensions>
 								<language>en_US</language>
 							</dimensions>
@@ -61,7 +61,7 @@
 								<uriPathSegment __type="string">about-us</uriPathSegment>
 							</properties>
 						</variant>
-						<variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Page" version="3" removed="" hidden="" hiddenInIndex="">
+						<variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Page" version="3" removed="" hidden="" hiddenInIndex="">
 							<dimensions>
 								<language>de</language>
 							</dimensions>
@@ -72,7 +72,7 @@
 							</properties>
 						</variant>
 						<node nodeName="history">
-							<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>en_US</language>
 								</dimensions>
@@ -82,7 +82,7 @@
 									<uriPathSegment __type="string">history</uriPathSegment>
 								</properties>
 							</variant>
-							<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>de</language>
 								</dimensions>
@@ -94,7 +94,7 @@
 							</variant>
 						</node>
 						<node nodeName="mission">
-							<variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>en_US</language>
 								</dimensions>
@@ -104,7 +104,7 @@
 									<uriPathSegment __type="string">our-mission</uriPathSegment>
 								</properties>
 							</variant>
-							<variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>de</language>
 								</dimensions>
@@ -117,7 +117,7 @@
 						</node>
 					</node>
 					<node nodeName="products">
-						<variant sortingIndex="500" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+						<variant sortingIndex="500" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 							<dimensions>
 								<language>en_US</language>
 							</dimensions>
@@ -127,7 +127,7 @@
 								<uriPathSegment __type="string">products</uriPathSegment>
 							</properties>
 						</variant>
-						<variant sortingIndex="500" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+						<variant sortingIndex="500" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 							<dimensions>
 								<language>de</language>
 							</dimensions>
@@ -138,7 +138,7 @@
 							</properties>
 						</variant>
 						<node nodeName="neos">
-							<variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>en_US</language>
 								</dimensions>
@@ -148,7 +148,7 @@
 									<uriPathSegment __type="string">neos</uriPathSegment>
 								</properties>
 							</variant>
-							<variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>de</language>
 								</dimensions>
@@ -160,7 +160,7 @@
 							</variant>
 						</node>
 						<node nodeName="flow">
-							<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>en_US</language>
 								</dimensions>
@@ -170,7 +170,7 @@
 									<uriPathSegment __type="string">flow</uriPathSegment>
 								</properties>
 							</variant>
-							<variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+							<variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
 								<dimensions>
 									<language>de</language>
 								</dimensions>

--- a/Neos.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
+++ b/Neos.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
@@ -15,7 +15,7 @@
      </properties>
     </variant>
     <node identifier="b2e1b29c-0b33-455a-862b-88bbd09e5310" nodeName="home">
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+     <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
       <dimensions>
        <language>en_US</language>
       </dimensions>
@@ -28,7 +28,7 @@
       </properties>
      </variant>
      <node identifier="94165d9e-1c0d-43ca-b172-7b867524f349" nodeName="protected">
-      <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Page" version="3" removed="" hidden="" hiddenInIndex="">
+      <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Page" version="3" removed="" hidden="" hiddenInIndex="">
        <dimensions>
         <language>en_US</language>
        </dimensions>

--- a/Neos.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
@@ -11,7 +11,6 @@ namespace Neos\Neos\Tests\Functional\Domain\Service;
  * source code.
  */
 
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteExportService;
@@ -61,7 +60,6 @@ class SiteImportExportServiceTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->markSkippedIfNodeTypesPackageIsNotInstalled();
         $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $contentContext = $this->contextFactory->create(['workspaceName' => 'live']);
 
@@ -88,16 +86,5 @@ class SiteImportExportServiceTest extends FunctionalTestCase
         $expectedResult = file_get_contents(__DIR__ . '/Fixtures/Sites.xml');
         $actualResult = $this->siteExportService->export([$this->importedSite], true);
         $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @return void
-     */
-    protected function markSkippedIfNodeTypesPackageIsNotInstalled()
-    {
-        $packageManager = $this->objectManager->get(PackageManagerInterface::class);
-        if (!$packageManager->isPackageAvailable('Neos.NodeTypes')) {
-            $this->markTestSkipped('This test needs the Neos.NodeTypes package.');
-        }
     }
 }

--- a/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
+++ b/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
@@ -16,7 +16,7 @@
      </properties>
     </variant>
     <node identifier="3239baee-3e7f-785c-0853-f4302ef32570" nodeName="home">
-     <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+     <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
       <dimensions>
        <language>en_US</language>
       </dimensions>
@@ -28,7 +28,7 @@
       </properties>
      </variant>
      <node identifier="30e893c1-caef-0ca5-b53d-e5699bb8e506" nodeName="about-us">
-      <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Page" version="3" removed="" hidden="" hiddenInIndex="">
+      <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Page" version="3" removed="" hidden="" hiddenInIndex="">
        <dimensions>
         <language>en_US</language>
        </dimensions>
@@ -39,7 +39,7 @@
        </properties>
       </variant>
       <node identifier="9abf48a7-b8a2-0896-7b42-754c23074a7b" nodeName="history">
-       <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -51,7 +51,7 @@
        </variant>
       </node>
       <node identifier="63b28f4d-8831-ecb0-f9a6-466d97ffe2c2" nodeName="mission">
-       <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -72,7 +72,7 @@
        <properties/>
       </variant>
       <node identifier="1477a6e2-fc22-2caa-442c-328a86939559" nodeName="dummy42">
-       <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -83,7 +83,7 @@
        </variant>
       </node>
       <node identifier="b1e0e78d-04f3-8fc3-e3d1-e2399f831312" nodeName="dummy42a">
-       <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Headline" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -94,7 +94,7 @@
        </variant>
       </node>
       <node identifier="b24222b5-9098-a800-043b-06cb42190300" nodeName="dummy43">
-       <variant sortingIndex="300" workspace="live" nodeType="Neos.NodeTypes:Html" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="300" workspace="live" nodeType="Acme.Demo:Html" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -121,7 +121,7 @@
          <properties/>
         </variant>
         <node identifier="049b2a7c-2c5c-0765-3573-caa64bfb2cfc" nodeName="dummy42">
-         <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+         <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
           <dimensions>
            <language>en_US</language>
           </dimensions>
@@ -132,7 +132,7 @@
          </variant>
         </node>
         <node identifier="d1d78bfa-4440-761f-2e2c-88f7075a79b4" nodeName="dummy42a">
-         <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Headline" version="2" removed="" hidden="" hiddenInIndex="">
+         <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
           <dimensions>
            <language>en_US</language>
           </dimensions>
@@ -143,7 +143,7 @@
          </variant>
         </node>
         <node identifier="73595b61-edc3-1eef-9de6-3df5ff9c30d1" nodeName="dummy43">
-         <variant sortingIndex="300" workspace="live" nodeType="Neos.NodeTypes:Html" version="2" removed="" hidden="" hiddenInIndex="">
+         <variant sortingIndex="300" workspace="live" nodeType="Acme.Demo:Html" version="2" removed="" hidden="" hiddenInIndex="">
           <dimensions>
            <language>en_US</language>
           </dimensions>
@@ -163,7 +163,7 @@
          <properties/>
         </variant>
         <node identifier="59c0e9ff-99ae-17fe-8f5f-ec4697bc20cd" nodeName="dummy42">
-         <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+         <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
           <dimensions>
            <language>en_US</language>
           </dimensions>
@@ -174,7 +174,7 @@
          </variant>
         </node>
         <node identifier="1694f221-dd36-03bd-843b-2b928a5eb079" nodeName="dummy42a">
-         <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Headline" version="2" removed="" hidden="" hiddenInIndex="">
+         <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
           <dimensions>
            <language>en_US</language>
           </dimensions>
@@ -248,7 +248,7 @@
       </node>
      </node>
      <node identifier="25eaba22-b8ed-11e3-a8b5-c82a1441d728" nodeName="products">
-      <variant sortingIndex="500" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+      <variant sortingIndex="500" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
        <dimensions>
         <language>en_US</language>
        </dimensions>
@@ -259,20 +259,20 @@
        </properties>
       </variant>
       <node identifier="68c57ffd-955e-7a67-d28c-7b3bf32805be" nodeName="assetlist">
-       <variant sortingIndex="300" workspace="live" nodeType="Neos.NodeTypes:AssetList" version="2" removed="" hidden="" hiddenInIndex="">
-        <dimensions>
-         <language>en_US</language>
-        </dimensions>
-        <accessRoles __type="array"/>
-        <properties>
-         <assets __type="array">
-          <entry0 __type="object" __identifier="1af89e5c-9e23-9a9d-ae15-1d77160cfb57" __classname="Neos\Media\Domain\Model\Asset" __encoding="json">{&quot;__identity&quot;:&quot;1af89e5c-9e23-9a9d-ae15-1d77160cfb57&quot;,&quot;title&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;Neos-logo_sRGB_color.pdf&quot;,&quot;hash&quot;:&quot;bed9a3e45070e97b921877e2bd9c35ba368beca0&quot;,&quot;__identity&quot;:&quot;8a4496e4-fa0d-8550-0995-01fd869728bf&quot;}}</entry0>
-         </assets>
-        </properties>
-       </variant>
+        <variant sortingIndex="300" workspace="live" nodeType="Acme.Demo:AssetList" version="2" removed="" hidden="" hiddenInIndex="">
+          <dimensions>
+            <language>en_US</language>
+          </dimensions>
+          <accessRoles __type="array"/>
+          <properties>
+            <assets __type="array">
+              <entry0 __type="object" __identifier="1af89e5c-9e23-9a9d-ae15-1d77160cfb57" __classname="Neos\Media\Domain\Model\Asset" __encoding="json">{&quot;__identity&quot;:&quot;1af89e5c-9e23-9a9d-ae15-1d77160cfb57&quot;,&quot;title&quot;:&quot;&quot;,&quot;resource&quot;:{&quot;filename&quot;:&quot;Neos-logo_sRGB_color.pdf&quot;,&quot;hash&quot;:&quot;bed9a3e45070e97b921877e2bd9c35ba368beca0&quot;,&quot;__identity&quot;:&quot;8a4496e4-fa0d-8550-0995-01fd869728bf&quot;}}</entry0>
+            </assets>
+          </properties>
+        </variant>
       </node>
       <node identifier="bc488ff2-92ba-f2c5-f063-9a0fcbb90510" nodeName="cms">
-       <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -283,7 +283,7 @@
         </properties>
        </variant>
        <node identifier="1bc783f6-81e9-b9af-6835-d14ed91324f5" nodeName="neos-neos">
-        <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -296,7 +296,7 @@
        </node>
       </node>
       <node identifier="1b2060e3-2e30-1ad0-83fd-7dcdd1e2d5fc" nodeName="frameworks">
-       <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -307,7 +307,7 @@
         </properties>
        </variant>
        <node identifier="51a2fe86-32d2-02fb-4020-38cfb1c5ac73" nodeName="who-cares-about-nodenames">
-        <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -321,7 +321,7 @@
       </node>
      </node>
      <node identifier="bbf90c0a-a9f8-1bf3-1d6b-2eac028bd104" nodeName="shortcuts">
-      <variant sortingIndex="600" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+      <variant sortingIndex="600" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
        <dimensions>
         <language>en_US</language>
        </dimensions>
@@ -340,7 +340,7 @@
         <properties/>
        </variant>
        <node identifier="cd373cee-7e67-816d-ff81-01b20ab10888" nodeName="asset-link">
-        <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -351,7 +351,7 @@
         </variant>
        </node>
        <node identifier="a8240758-ed13-a38c-ade0-77ac0d557cfc" nodeName="broken-asset-link">
-        <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -362,7 +362,7 @@
         </variant>
        </node>
        <node identifier="774fe387-a772-ac5a-222e-15663ddac0c6" nodeName="broken-node-link">
-        <variant sortingIndex="300" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="300" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -373,7 +373,7 @@
         </variant>
        </node>
        <node identifier="2a1bf251-7a57-ceda-2f56-90cc32d1c158" nodeName="empty-asset-link">
-        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -384,7 +384,7 @@
         </variant>
        </node>
        <node identifier="7ca679e4-593d-29d1-00d2-8c124b38c2a3" nodeName="empty-node-link">
-        <variant sortingIndex="500" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="500" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -395,7 +395,7 @@
         </variant>
        </node>
        <node identifier="ad58c465-2790-a675-dbbe-80c8ec3a80bf" nodeName="shortcut-to-child-node-link">
-        <variant sortingIndex="600" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="600" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -406,7 +406,7 @@
         </variant>
        </node>
        <node identifier="f19e5c84-26da-3239-34df-19e3328eb784" nodeName="shortcut-to-parent-node-link">
-        <variant sortingIndex="700" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="700" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -417,7 +417,7 @@
         </variant>
        </node>
        <node identifier="7a982455-768c-d750-5d2b-7f7b7390baa6" nodeName="shortcut-to-target-node-link">
-        <variant sortingIndex="800" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="800" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -428,7 +428,7 @@
         </variant>
        </node>
        <node identifier="ba178461-f13a-2355-3902-f2f7c7266dd5" nodeName="shortcut-to-target-uri-link">
-        <variant sortingIndex="900" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="900" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -452,7 +452,7 @@
         </properties>
        </variant>
        <node identifier="fce12ede-b404-abc7-9820-ff6b45858713" nodeName="child-node">
-        <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -464,7 +464,7 @@
         </variant>
        </node>
        <node identifier="f1d0332e-8032-7e41-704e-860c65849fca" nodeName="target-node">
-        <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Page" version="2" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Page" version="2" removed="" hidden="" hiddenInIndex="">
          <dimensions>
           <language>en_US</language>
          </dimensions>
@@ -527,7 +527,7 @@
        <properties/>
       </variant>
       <node identifier="4acf5fba-33f0-9185-6f71-0c58ed5e7b87" nodeName="dummy42">
-       <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -538,7 +538,7 @@
        </variant>
       </node>
       <node identifier="a8b05e98-2842-5a95-7a86-f61dfb729c29" nodeName="dummy42a">
-       <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Headline" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -549,7 +549,7 @@
        </variant>
       </node>
       <node identifier="85341be3-1cb0-650b-6cb6-20872142c138" nodeName="dummy43">
-       <variant sortingIndex="300" workspace="live" nodeType="Neos.NodeTypes:Html" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="300" workspace="live" nodeType="Acme.Demo:Html" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -571,7 +571,7 @@
        </properties>
       </variant>
       <node identifier="7b443d48-56f1-85a4-8f82-8d4f7342331f" nodeName="dummy42">
-       <variant sortingIndex="200" workspace="live" nodeType="Neos.NodeTypes:Text" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>
@@ -582,7 +582,7 @@
        </variant>
       </node>
       <node identifier="9fa376af-a1b8-83ac-bedc-9ad83c8598bc" nodeName="dummy42a">
-       <variant sortingIndex="100" workspace="live" nodeType="Neos.NodeTypes:Headline" version="2" removed="" hidden="" hiddenInIndex="">
+       <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
         </dimensions>

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/Fixtures/SortableNodes.xml
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/Fixtures/SortableNodes.xml
@@ -7,7 +7,7 @@
     <nodes formatVersion="2.0">
 
       <node identifier="c381f64d-4269-429a-9c21-6d846115addf" nodeName="text-1">
-        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
           <dimensions/>
           <accessRoles __type="array"/>
           <creationDateTime __type="object" __classname="DateTime">2016-07-06T13:04:23+02:00</creationDateTime>
@@ -22,7 +22,7 @@
       </node>
 
       <node identifier="c381f64d-4269-429a-9c21-6d846115adde" nodeName="text-2">
-        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
           <dimensions/>
           <accessRoles __type="array"/>
           <creationDateTime __type="object" __classname="DateTime">2016-01-06T13:04:23+02:00</creationDateTime>
@@ -37,7 +37,7 @@
       </node>
 
       <node identifier="c381f64d-4269-429a-9c21-6d846115addd" nodeName="text-3">
-        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
           <dimensions/>
           <accessRoles __type="array"/>
           <creationDateTime __type="object" __classname="DateTime">2016-08-06T13:04:23+02:00</creationDateTime>

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -233,13 +233,13 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         // Check for legacy tags wich are still supported
         $this->assertArrayHasKey('NodeType_Neos.Neos:Content', $tagsToFlush);
         $this->assertArrayHasKey('NodeType_Neos.Neos:Node', $tagsToFlush);
-        $this->assertArrayHasKey('NodeType_Neos.NodeTypes:Text', $tagsToFlush);
+        $this->assertArrayHasKey('NodeType_Acme.Demo:Text', $tagsToFlush);
 
         // Check for tags that respect the workspace hash
         foreach ($workspacesToTest as $name => $workspaceHash) {
             $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.Neos:Content', $tagsToFlush, 'on workspace ' . $name);
             $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.Neos:Node', $tagsToFlush, 'on workspace ' . $name);
-            $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Neos.NodeTypes:Text', $tagsToFlush, 'on workspace ' . $name);
+            $this->assertArrayHasKey('NodeType_'.$workspaceHash.'_Acme.Demo:Text', $tagsToFlush, 'on workspace ' . $name);
         }
     }
 

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/Fixtures/CacheableNodes.xml
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/Fixtures/CacheableNodes.xml
@@ -6,7 +6,7 @@
     <site name="example" state="1" siteResourcesPackageKey="Neos.Neos" siteNodeName="example">
         <nodes formatVersion="2.0">
             <node identifier="c381f64d-4269-429a-9c21-6d846115addf" nodeName="text-1">
-                <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
                     <dimensions/>
                     <accessRoles __type="array"/>
                     <creationDateTime __type="object" __classname="DateTime">2016-07-06T13:04:23+02:00</creationDateTime>
@@ -17,7 +17,7 @@
                     </properties>
                 </variant>
                 <node identifier="c381f64d-4269-429a-9c21-6d846115adde" nodeName="text-2">
-                    <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                    <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
                         <dimensions/>
                         <accessRoles __type="array"/>
                         <creationDateTime __type="object" __classname="DateTime">2016-01-06T13:04:23+02:00</creationDateTime>
@@ -28,7 +28,7 @@
                         </properties>
                     </variant>
                     <node identifier="c381f64d-4269-429a-9c21-6d846115addd" nodeName="text-3">
-                        <variant sortingIndex="400" workspace="live" nodeType="Neos.NodeTypes:Text" version="1" removed="" hidden="" hiddenInIndex="">
+                        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
                             <dimensions/>
                             <accessRoles __type="array"/>
                             <creationDateTime __type="object" __classname="DateTime">2016-08-06T13:04:23+02:00</creationDateTime>

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/AssetListTemplate.html
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/AssetListTemplate.html
@@ -1,0 +1,19 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<f:if condition="{assets}">
+	<f:then>
+		<ul{attributes -> f:format.raw()}>
+			<f:for each="{assets}" as="asset">
+				<li><a href="{f:uri.resource(resource: asset.resource)}">{asset.resource.filename}</a></li>
+			</f:for>
+		</ul>
+	</f:then>
+	<f:else>
+		<f:if condition="{neos:rendering.inEditMode()}">
+			<ul{attributes -> f:format.raw()}>
+				<li>
+					empty asset List
+				</li>
+			</ul>
+		</f:if>
+	</f:else>
+</f:if>

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Base.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Base.fusion
@@ -3,6 +3,22 @@
 ################################
 
 # Definition of custom Fusion types
+prototype(Acme.Demo:Text) < prototype(Neos.Neos:Content) {
+  templatePath = ${fixturesDirectory + '/TextTemplate.html'}
+}
+
+prototype(Acme.Demo:Headline) < prototype(Neos.Neos:Content) {
+  templatePath = ${fixturesDirectory + '/HeadlineTemplate.html'}
+}
+
+prototype(Acme.Demo:Html) < prototype(Neos.Neos:Content) {
+  templatePath = ${fixturesDirectory + '/HtmlTemplate.html'}
+}
+
+prototype(Acme.Demo:AssetList) < prototype(Neos.Neos:Content) {
+  templatePath = ${fixturesDirectory + '/AssetListTemplate.html'}
+}
+
 prototype(Acme.Demo:ThreeColumn) < prototype(Neos.Neos:Content) {
 	templatePath = ${fixturesDirectory + '/ThreeColumnTemplate.html'}
 	left = Neos.Neos:ContentCollection

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/HeadlineTemplate.html
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/HeadlineTemplate.html
@@ -1,0 +1,4 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<div{attributes -> f:format.raw()}>
+	{neos:contentElement.editable(property: 'title')}
+</div>

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/HtmlTemplate.html
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/HtmlTemplate.html
@@ -1,0 +1,3 @@
+<div{attributes -> f:format.raw()}>
+	{source -> f:format.raw()}
+</div>

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AdditionalProcessorInPrototype.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AdditionalProcessorInPrototype.fusion
@@ -1,5 +1,5 @@
 #
 # This example modifies the rendering inside the sidebar section, wrapping the title of the text
 #
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline).title = 'Static Headline'
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline).title.@process.1 = ${'<div class="processor-wrap">BEFORE' + value + 'AFTER</div>'}
+page1.body.content.sidebar.prototype(Acme.Demo:Headline).title = 'Static Headline'
+page1.body.content.sidebar.prototype(Acme.Demo:Headline).title.@process.1 = ${'<div class="processor-wrap">BEFORE' + value + 'AFTER</div>'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AdditionalProcessorInPrototype2.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AdditionalProcessorInPrototype2.fusion
@@ -2,6 +2,6 @@
 # Here, we test that the processor 1 is evaluated FIRST, and then processor 2
 #
 
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline).title = 'Static Headline'
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline).title.@process.1 = ${'<div class="processor-wrap">BEFORE' + value + 'AFTER</div>'}
-prototype(Neos.NodeTypes:Headline).title.@process.2 = ${'<header>' + value + '</header>'}
+page1.body.content.sidebar.prototype(Acme.Demo:Headline).title = 'Static Headline'
+page1.body.content.sidebar.prototype(Acme.Demo:Headline).title.@process.1 = ${'<div class="processor-wrap">BEFORE' + value + 'AFTER</div>'}
+prototype(Acme.Demo:Headline).title.@process.2 = ${'<header>' + value + '</header>'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AppendingClassesToContent.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_AppendingClassesToContent.fusion
@@ -1,11 +1,11 @@
 #
 # This example modifies the rendering inside the teaser and sidebar section, adding a class to headline elements
 #
-page1.body.content.teaser.prototype(Neos.NodeTypes:Headline) {
+page1.body.content.teaser.prototype(Acme.Demo:Headline) {
 	attributes.class = Neos.Fusion:RawArray
 	attributes.class.test = 'test'
 }
 
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline) {
+page1.body.content.sidebar.prototype(Acme.Demo:Headline) {
 	attributes.class = 'test'
 }

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInNestedPrototype.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInNestedPrototype.fusion
@@ -2,5 +2,5 @@
 # This example modifies the rendering pf all texts inside the three column element, setting the title to a static value
 #
 
-prototype(Acme.Demo:ThreeColumn).prototype(Neos.NodeTypes:Headline).title = 'Static Headline'
-prototype(Acme.Demo:ThreeColumn).prototype(Neos.NodeTypes:Headline).title.@process.1 = ${'<header>' + value + '</header>'}
+prototype(Acme.Demo:ThreeColumn).prototype(Acme.Demo:Headline).title = 'Static Headline'
+prototype(Acme.Demo:ThreeColumn).prototype(Acme.Demo:Headline).title.@process.1 = ${'<header>' + value + '</header>'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInNestedPrototype2.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInNestedPrototype2.fusion
@@ -2,5 +2,5 @@
 # This example modifies the rendering pf all texts inside the left column of a three column element, setting the title to a static value
 #
 
-prototype(Acme.Demo:ThreeColumn).left.prototype(Neos.NodeTypes:Headline).title = 'Static Headline'
-prototype(Acme.Demo:ThreeColumn).left.prototype(Neos.NodeTypes:Headline).title.@process.1 = ${'<header>' + value + '</header>'}
+prototype(Acme.Demo:ThreeColumn).left.prototype(Acme.Demo:Headline).title = 'Static Headline'
+prototype(Acme.Demo:ThreeColumn).left.prototype(Acme.Demo:Headline).title.@process.1 = ${'<header>' + value + '</header>'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInPrototype.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_OverriddenValueInPrototype.fusion
@@ -2,4 +2,4 @@
 # This example modifies the rendering inside the sidebar section, setting the title to a static value
 #
 
-page1.body.content.sidebar.prototype(Neos.NodeTypes:Headline).title = 'Static Headline'
+page1.body.content.sidebar.prototype(Acme.Demo:Headline).title = 'Static Headline'

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_PrototypeInheritance.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_PrototypeInheritance.fusion
@@ -3,14 +3,14 @@
 #
 
 page1.body.sections.sidebar.prototype(Neos.Fusion:Case).smallHeadline {
-	condition = ${q(node).is('[instanceof Neos.NodeTypes:Headline]')}
-	type = 'Neos.NodeTypes:SmallHeadline'
+	condition = ${q(node).is('[instanceof Acme.Demo:Headline]')}
+	type = 'Acme.Demo:SmallHeadline'
 	@position = 'start'
 }
 
 # this line should make sure that SmallHeadline's Prototype points to "Headline".
-prototype(Neos.NodeTypes:SmallHeadline) < prototype(Neos.NodeTypes:Headline)
-prototype(Neos.NodeTypes:SmallHeadline).templatePath = ${fixturesDirectory + '/SmallHeadlineTemplate.html'}
+prototype(Acme.Demo:SmallHeadline) < prototype(Acme.Demo:Headline)
+prototype(Acme.Demo:SmallHeadline).templatePath = ${fixturesDirectory + '/SmallHeadlineTemplate.html'}
 
 # thus, any changes in "headline" must be reflected in "SmallHeadline" as well
-prototype(Neos.NodeTypes:Headline).title = '<h1>Static Headline</h1>'
+prototype(Acme.Demo:Headline).title = '<h1>Static Headline</h1>'

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_ReplaceElementRenderingCompletelyBasedOnAdvancedCondition.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_ReplaceElementRenderingCompletelyBasedOnAdvancedCondition.fusion
@@ -8,6 +8,6 @@ prototype(Neos.Neos:ContentCase).override {
 	@position = 'start'
 }
 
-prototype(Neos.Fusion:DocumentationText) < prototype(Neos.NodeTypes:Headline)
+prototype(Neos.Fusion:DocumentationText) < prototype(Acme.Demo:Headline)
 prototype(Neos.Fusion:DocumentationText).title = 'Documentation'
 prototype(Neos.Fusion:DocumentationText).title.@process.1 = ${'<header>DOCS: ' + value + '</header>'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_ReplaceElementRenderingCompletelyInSidebar.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Test_ReplaceElementRenderingCompletelyInSidebar.fusion
@@ -3,9 +3,9 @@
 #
 
 page1.body.content.sidebar.prototype(Neos.Neos:ContentCase).smallHeadline {
-	condition = ${q(node).is('[instanceof Neos.NodeTypes:Headline]')}
-	type = 'Neos.NodeTypes:SmallHeadline'
+	condition = ${q(node).is('[instanceof Acme.Demo:Headline]')}
+	type = 'Acme.Demo:SmallHeadline'
 	@position = 'start'
 }
-prototype(Neos.NodeTypes:SmallHeadline) < prototype(Neos.NodeTypes:Headline)
-prototype(Neos.NodeTypes:SmallHeadline).templatePath = ${fixturesDirectory + '/SmallHeadlineTemplate.html'}
+prototype(Acme.Demo:SmallHeadline) < prototype(Acme.Demo:Headline)
+prototype(Acme.Demo:SmallHeadline).templatePath = ${fixturesDirectory + '/SmallHeadlineTemplate.html'}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/TextTemplate.html
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/TextTemplate.html
@@ -1,0 +1,4 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<div{attributes -> f:format.raw()}>
+	{neos:contentElement.editable(property: 'text')}
+</div>

--- a/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
@@ -65,8 +65,8 @@ class RenderingTest extends AbstractNodeTest
         $this->assertTeaserConformsToBasicRendering($output);
         $this->assertMainContentConformsToBasicRendering($output);
 
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > div', 'Static Headline', true, $output);
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-text > div', 'Below, you\'ll see the most recent activity', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
         $this->assertSelectEquals('.sidebar', '[COMMIT WIDGET]', true, $output);
     }
 
@@ -80,7 +80,7 @@ class RenderingTest extends AbstractNodeTest
         $this->assertTeaserConformsToBasicRendering($output);
         $this->assertMainContentConformsToBasicRendering($output);
 
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > div > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
     }
 
     /**
@@ -90,11 +90,11 @@ class RenderingTest extends AbstractNodeTest
     {
         $output = $this->simulateRendering('Test_AdditionalProcessorInPrototype2.fusion');
 
-        $this->assertSelectEquals('.teaser > .neos-contentcollection > .neos-nodetypes-headline > div > header > h1', 'Welcome to this example', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-headline > div > header > h1', 'Documentation', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .neos-nodetypes-headline > div > header > h1', 'Development Process', true, $output);
+        $this->assertSelectEquals('.teaser > .neos-contentcollection > .acme-demo-headline > div > header > h1', 'Welcome to this example', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > header > h1', 'Documentation', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .acme-demo-headline > div > header > h1', 'Development Process', true, $output);
 
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > div > header > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > header > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
     }
 
     /**
@@ -107,8 +107,8 @@ class RenderingTest extends AbstractNodeTest
         $this->assertMainContentConformsToBasicRendering($output);
 
         // header is now wrapped in h3
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > header > h3', 'Last Commits', true, $output);
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-text > div', 'Below, you\'ll see the most recent activity', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > header > h3', 'Last Commits', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
     }
 
     /**
@@ -117,12 +117,12 @@ class RenderingTest extends AbstractNodeTest
     public function prototypeInheritance()
     {
         $output = $this->simulateRendering('Test_PrototypeInheritance.fusion');
-        $this->assertSelectEquals('.teaser > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Static Headline', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.teaser > .neos-contentcollection > .acme-demo-headline > div > h1', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-headline > div > h1', 'Static Headline', true, $output);
 
         // header is now wrapped in h3 (as set in the concrete template), AND is set to a static headline (as set in the abstract template)
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Static Headline', true, $output);
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-text > div', 'Below, you\'ll see the most recent activity', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > h1', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
     }
 
     /**
@@ -134,7 +134,7 @@ class RenderingTest extends AbstractNodeTest
         $this->assertTeaserConformsToBasicRendering($output);
         $this->assertSidebarConformsToBasicRendering($output);
 
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-headline > div > header', 'DOCS: Documentation', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > header', 'DOCS: Documentation', true, $output);
     }
 
     /**
@@ -145,8 +145,8 @@ class RenderingTest extends AbstractNodeTest
         $output = $this->simulateRendering('Test_OverriddenValueInNestedPrototype.fusion');
         $this->assertTeaserConformsToBasicRendering($output);
 
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-headline > div > header', 'Static Headline', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .neos-nodetypes-headline > div > header', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > header', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .acme-demo-headline > div > header', 'Static Headline', true, $output);
 
         $this->assertSidebarConformsToBasicRendering($output);
     }
@@ -159,8 +159,8 @@ class RenderingTest extends AbstractNodeTest
         $output = $this->simulateRendering('Test_OverriddenValueInNestedPrototype2.fusion');
         $this->assertTeaserConformsToBasicRendering($output);
 
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-headline > div > header', 'Static Headline', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Development Process', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > header', 'Static Headline', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .acme-demo-headline > div > h1', 'Development Process', true, $output);
 
         $this->assertSidebarConformsToBasicRendering($output);
     }
@@ -190,8 +190,8 @@ class RenderingTest extends AbstractNodeTest
     public function classesAreAppendedAsExpected()
     {
         $output = $this->simulateRendering('Test_AppendingClassesToContent.fusion');
-        $this->assertSelectEquals('.teaser > .neos-contentcollection > .neos-nodetypes-headline.test h1', 'Welcome to this example', true, $output);
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline.test h1', 'Last Commits', true, $output);
+        $this->assertSelectEquals('.teaser > .neos-contentcollection > .acme-demo-headline.test h1', 'Welcome to this example', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline.test h1', 'Last Commits', true, $output);
     }
 
     /**
@@ -213,8 +213,8 @@ class RenderingTest extends AbstractNodeTest
         $this->assertContains('This website is powered by Neos, the Open Source Content Application Platform licensed under the GNU/GPL.', $output);
         $this->assertSelectEquals('h1', 'Home', true, $output);
 
-        $this->assertSelectEquals('.teaser > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Welcome to this example', true, $output);
-        $this->assertSelectEquals('.teaser > .neos-contentcollection > .neos-nodetypes-text > div', 'This is our exemplary rendering test.', true, $output);
+        $this->assertSelectEquals('.teaser > .neos-contentcollection > .acme-demo-headline > div > h1', 'Welcome to this example', true, $output);
+        $this->assertSelectEquals('.teaser > .neos-contentcollection > .acme-demo-text > div', 'This is our exemplary rendering test.', true, $output);
     }
 
     /**
@@ -223,16 +223,16 @@ class RenderingTest extends AbstractNodeTest
      */
     protected function assertMainContentConformsToBasicRendering($output)
     {
-        $this->assertSelectEquals('.main > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Do you love Flow?', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .neos-nodetypes-text > div', 'If you do, make sure to post your opinion about it on Twitter!', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-headline > div > h1', 'Do you love Flow?', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-text > div', 'If you do, make sure to post your opinion about it on Twitter!', true, $output);
 
         $this->assertSelectEquals('.main', '[TWITTER WIDGET]', true, $output);
 
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Documentation', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .neos-nodetypes-text > div', 'We\'re still improving our docs, but check them out nevertheless!', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > h1', 'Documentation', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-text > div', 'We\'re still improving our docs, but check them out nevertheless!', true, $output);
         $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left', '[SLIDESHARE]', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Development Process', true, $output);
-        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .neos-nodetypes-text > div', 'We\'re spending lots of thought into our infrastructure, you can profit from that, too!', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .acme-demo-headline > div > h1', 'Development Process', true, $output);
+        $this->assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .center > .neos-contentcollection > .acme-demo-text > div', 'We\'re spending lots of thought into our infrastructure, you can profit from that, too!', true, $output);
     }
 
     /**
@@ -241,8 +241,8 @@ class RenderingTest extends AbstractNodeTest
      */
     protected function assertSidebarConformsToBasicRendering($output)
     {
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-headline > div > h1', 'Last Commits', true, $output);
-        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .neos-nodetypes-text > div', 'Below, you\'ll see the most recent activity', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > h1', 'Last Commits', true, $output);
+        $this->assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
         $this->assertSelectEquals('.sidebar', '[COMMIT WIDGET]', true, $output);
     }
 


### PR DESCRIPTION
The previous tests tested nodetypes from those external packages which lead to testing errors because of changes to the master of Neos.Demo. This change uses nodetypes local to the testing context of the cr itself. 

This is cleaner and a preparation to move Neos.NodeTypes out of the development collection someday. Right now it allows to run the functional tests without Neos.Demo or Neos.NodeTyoes beeing installed.