### PR TITLE
BUGFIX: Use countAll of AssetRepository to get count of all assets

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -247,6 +247,12 @@ class AssetController extends ActionController
      */
     public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null)
     {
+        $allCollectionsCount = 0;
+        // Calculating the asset-count of all collections before applying filters.
+        foreach ($this->assetSources as $assetSource) {
+            $allCollectionsCount += $assetSource->getAssetProxyRepository()->countAll();
+        }
+
         // First, apply all options given to indexAction() and save them in the BrowserState object.
         // Note that the order of these apply*() method calls plays a role, because they may depend on previous results:
         $this->applyActiveAssetSourceToBrowserState($assetSourceIdentifier);
@@ -268,7 +274,6 @@ class AssetController extends ActionController
         $tags = [];
         $assetProxies = [];
 
-        $allCollectionsCount = 0;
         $allCount = 0;
         $searchResultCount = 0;
         $untaggedCount = 0;
@@ -293,7 +298,6 @@ class AssetController extends ActionController
                 $assetProxies = $assetProxyRepository->findAll();
             }
 
-            $allCollectionsCount = $this->assetRepository->countAll();
             $allCount = ($activeAssetCollection ? $this->assetRepository->countByAssetCollection($activeAssetCollection) : $allCollectionsCount);
             $searchResultCount = isset($assetProxies) ? $assetProxies->count() : 0;
             $untaggedCount = ($assetProxyRepository instanceof SupportsTaggingInterface ? $assetProxyRepository->countUntagged() : 0);

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -293,7 +293,7 @@ class AssetController extends ActionController
                 $assetProxies = $assetProxyRepository->findAll();
             }
 
-            $allCollectionsCount = $assetProxyRepository->countAll();
+            $allCollectionsCount = $this->assetRepository->countAll();
             $allCount = ($activeAssetCollection ? $this->assetRepository->countByAssetCollection($activeAssetCollection) : $allCollectionsCount);
             $searchResultCount = isset($assetProxies) ? $assetProxies->count() : 0;
             $untaggedCount = ($assetProxyRepository instanceof SupportsTaggingInterface ? $assetProxyRepository->countUntagged() : 0);


### PR DESCRIPTION
To get count of all assets, we should use the AssetRepository.
Solves #2358 