### PR TITLE
BUGFIX: Allow translation of the textareaeditor placeholder

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -238,6 +238,11 @@ class NodeTypeConfigurationEnrichmentAspect
                     $editorOptions['placeholder'] = $translationIdGenerator('textFieldEditor.placeholder');
                 }
                 break;
+            case 'Neos.Neos/Inspector/Editors/TextAreaEditor':
+                if (isset($editorOptions) && $this->shouldFetchTranslation($editorOptions, 'placeholder')) {
+                    $editorOptions['placeholder'] = $translationIdGenerator('textAreaEditor.placeholder');
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
This additionally requires a fix in the ui which will be done in the neos-ui package.

**What I did**

Add the textarea editor for configuration enrichment.

**How to verify it**

When using i18n in the placeholder it should show the full translation path in the textarea editor instead of just i18n.