### PR TITLE
BUGFIX: Add missing Eel FileHelper registration

### DIFF
--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -38,3 +38,4 @@ Neos:
       Translation: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       Type: 'Neos\Eel\Helper\TypeHelper'
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
+      File: 'Neos\Eel\Helper\FileHelper'


### PR DESCRIPTION
Register the file helper by default so that they can be used in Fusion, without the need of separate registration.

Solves Issue: #2405 
