### PR TITLE
 FEATURE: Set crop image adjustment by aspect ratio

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -663,7 +663,7 @@ class AssetController extends ActionController
      * @Flow\Validate(argumentName="label", type="Label")
      * @throws ForwardException
      */
-    public function createTagAction($label): void
+    public function createTagAction(string $label): void
     {
         $this->forward('create', 'Tag', 'Neos.Media.Browser', ['label' => $label]);
     }

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -20,7 +20,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\ForwardException;
-use Neos\Flow\Mvc\Exception\InvalidArgumentValueException;
 use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -19,12 +19,15 @@ use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\InvalidArgumentValueException;
+use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\FluidAdaptor\View\TemplateView;
@@ -47,11 +50,13 @@ use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
 use Neos\Media\Domain\Service\AssetService;
+use Neos\Media\Exception\AssetServiceException;
 use Neos\Media\TypeConverter\AssetInterfaceConverter;
 use Neos\Neos\Controller\BackendUserTranslationTrait;
 use Neos\Neos\Controller\CreateContentContextTrait;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Utility\Exception\FilesException;
 use Neos\Utility\Files;
 use Neos\Utility\MediaTypes;
 
@@ -65,12 +70,12 @@ class AssetController extends ActionController
     use CreateContentContextTrait;
     use BackendUserTranslationTrait;
 
-    const TAG_GIVEN = 0;
-    const TAG_ALL = 1;
-    const TAG_NONE = 2;
+    protected const TAG_GIVEN = 0;
+    protected const TAG_ALL = 1;
+    protected const TAG_NONE = 2;
 
-    const COLLECTION_GIVEN = 0;
-    const COLLECTION_ALL = 1;
+    protected const COLLECTION_GIVEN = 0;
+    protected const COLLECTION_ALL = 1;
 
     /**
      * @var array
@@ -154,7 +159,7 @@ class AssetController extends ActionController
     /**
      * @return void
      */
-    public function initializeObject()
+    public function initializeObject(): void
     {
         $domain = $this->domainRepository->findOneByActiveRequest();
 
@@ -173,7 +178,7 @@ class AssetController extends ActionController
      * @param ViewInterface $view
      * @return void
      */
-    protected function initializeView(ViewInterface $view)
+    protected function initializeView(ViewInterface $view): void
     {
         $view->assignMultiple([
             'view' => $this->browserState->get('view'),
@@ -201,9 +206,9 @@ class AssetController extends ActionController
      * @param AssetCollection $assetCollection
      * @param string $assetSourceIdentifier
      * @return void
-     * @throws \Neos\Utility\Exception\FilesException
+     * @throws FilesException
      */
-    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null)
+    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
         // First, apply all options given to indexAction() and save them in the BrowserState object.
         // Note that the order of these apply*() method calls plays a role, because they may depend on previous results:
@@ -232,12 +237,14 @@ class AssetController extends ActionController
         $untaggedCount = 0;
 
         try {
-            foreach ($this->assetCollectionRepository->findAll() as $assetCollection) {
-                $assetCollections[] = ['object' => $assetCollection, 'count' => $this->assetRepository->countByAssetCollection($assetCollection)];
+            foreach ($this->assetCollectionRepository->findAll()->toArray() as $retrievedAssetCollection) {
+                assert($retrievedAssetCollection instanceof AssetCollection);
+                $assetCollections[] = ['object' => $retrievedAssetCollection, 'count' => $this->assetRepository->countByAssetCollection($retrievedAssetCollection)];
             }
 
-            foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $tag) {
-                $tags[] = ['object' => $tag, 'count' => $this->assetRepository->countByTag($tag, $activeAssetCollection)];
+            foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $retrievedTag) {
+                assert($retrievedTag instanceof Tag);
+                $tags[] = ['object' => $tag, 'count' => $this->assetRepository->countByTag($retrievedTag, $activeAssetCollection)];
             }
 
             if ($searchTerm !== null) {
@@ -272,7 +279,7 @@ class AssetController extends ActionController
             'maximumFileUploadSize' => $this->getMaximumFileUploadSize(),
             'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($this->getMaximumFileUploadSize()),
             'activeAssetSource' => $activeAssetSource,
-            'activeAssetSourceSupportsSorting' => ($assetProxyRepository instanceof SupportsSortingInterface)
+            'activeAssetSourceSupportsSorting' => $assetProxyRepository instanceof SupportsSortingInterface
         ]);
     }
 
@@ -281,9 +288,14 @@ class AssetController extends ActionController
      *
      * @return void
      */
-    public function newAction()
+    public function newAction(): void
     {
-        $maximumFileUploadSize = $this->getMaximumFileUploadSize();
+        try {
+            $maximumFileUploadSize = $this->getMaximumFileUploadSize();
+        } catch (FilesException $e) {
+            $maximumFileUploadSize = null;
+        }
+
         $this->view->assignMultiple([
             'tags' => $this->tagRepository->findAll(),
             'assetCollections' => $this->assetCollectionRepository->findAll(),
@@ -296,9 +308,14 @@ class AssetController extends ActionController
      * @param Asset $asset
      * @return void
      */
-    public function replaceAssetResourceAction(Asset $asset)
+    public function replaceAssetResourceAction(Asset $asset): void
     {
-        $maximumFileUploadSize = $this->getMaximumFileUploadSize();
+        try {
+            $maximumFileUploadSize = $this->getMaximumFileUploadSize();
+        } catch (FilesException $e) {
+            $maximumFileUploadSize = null;
+        }
+
         $this->view->assignMultiple([
             'asset' => $asset,
             'maximumFileUploadSize' => $maximumFileUploadSize,
@@ -316,7 +333,7 @@ class AssetController extends ActionController
      * @throws StopActionException
      * @throws UnsupportedRequestTypeException
      */
-    public function showAction(string $assetSourceIdentifier, string $assetProxyIdentifier)
+    public function showAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {
         if (!isset($this->assetSources[$assetSourceIdentifier])) {
             throw new \RuntimeException('Given asset source is not configured.', 1509702178);
@@ -346,7 +363,7 @@ class AssetController extends ActionController
      * @throws StopActionException
      * @throws UnsupportedRequestTypeException
      */
-    public function editAction(string $assetSourceIdentifier, string $assetProxyIdentifier)
+    public function editAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {
         if (!isset($this->assetSources[$assetSourceIdentifier])) {
             throw new \RuntimeException('Given asset source is not configured.', 1509632166);
@@ -392,6 +409,8 @@ class AssetController extends ActionController
     }
 
     /**
+     * Display variants of an asset
+     *
      * @param string $assetSourceIdentifier
      * @param string $assetProxyIdentifier
      * @param string $overviewAction
@@ -429,9 +448,9 @@ class AssetController extends ActionController
 
     /**
      * @return void
-     * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
+     * @throws NoSuchArgumentException
      */
-    protected function initializeUpdateAction()
+    protected function initializeUpdateAction(): void
     {
         $assetMappingConfiguration = $this->arguments->getArgument('asset')->getPropertyMappingConfiguration();
         $assetMappingConfiguration->allowProperties('title', 'resource', 'tags', 'assetCollections');
@@ -444,8 +463,9 @@ class AssetController extends ActionController
      * @param Asset $asset
      * @return void
      * @throws StopActionException
+     * @throws IllegalObjectTypeException
      */
-    public function updateAction(Asset $asset)
+    public function updateAction(Asset $asset): void
     {
         $this->assetRepository->update($asset);
         $this->addFlashMessage('assetHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
@@ -456,9 +476,9 @@ class AssetController extends ActionController
      * Initialization for createAction
      *
      * @return void
-     * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
+     * @throws NoSuchArgumentException
      */
-    protected function initializeCreateAction()
+    protected function initializeCreateAction(): void
     {
         $assetMappingConfiguration = $this->arguments->getArgument('asset')->getPropertyMappingConfiguration();
         $assetMappingConfiguration->allowProperties('title', 'resource', 'tags', 'assetCollections');
@@ -472,8 +492,9 @@ class AssetController extends ActionController
      * @param Asset $asset
      * @return void
      * @throws StopActionException
+     * @throws IllegalObjectTypeException
      */
-    public function createAction(Asset $asset)
+    public function createAction(Asset $asset): void
     {
         if ($this->persistenceManager->isNewObject($asset)) {
             $this->assetRepository->add($asset);
@@ -486,9 +507,9 @@ class AssetController extends ActionController
      * Initialization for uploadAction
      *
      * @return void
-     * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
+     * @throws NoSuchArgumentException
      */
-    protected function initializeUploadAction()
+    protected function initializeUploadAction(): void
     {
         $assetMappingConfiguration = $this->arguments->getArgument('asset')->getPropertyMappingConfiguration();
         $assetMappingConfiguration->allowProperties('title', 'resource');
@@ -501,9 +522,9 @@ class AssetController extends ActionController
      *
      * @param Asset $asset
      * @return string
-     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws IllegalObjectTypeException
      */
-    public function uploadAction(Asset $asset)
+    public function uploadAction(Asset $asset): string
     {
         if (($tag = $this->browserState->get('activeTag')) !== null) {
             $asset->addTag($tag);
@@ -532,8 +553,9 @@ class AssetController extends ActionController
      * @param Asset $asset
      * @param Tag $tag
      * @return void
+     * @throws IllegalObjectTypeException
      */
-    public function tagAssetAction(Asset $asset, Tag $tag)
+    public function tagAssetAction(Asset $asset, Tag $tag): void
     {
         $success = false;
         if ($asset->addTag($tag)) {
@@ -549,8 +571,9 @@ class AssetController extends ActionController
      * @param Asset $asset
      * @param AssetCollection $assetCollection
      * @return void
+     * @throws IllegalObjectTypeException
      */
-    public function addAssetToCollectionAction(Asset $asset, AssetCollection $assetCollection)
+    public function addAssetToCollectionAction(Asset $asset, AssetCollection $assetCollection): void
     {
         $success = false;
         if ($assetCollection->addAsset($asset)) {
@@ -565,8 +588,11 @@ class AssetController extends ActionController
      *
      * @param Asset $asset
      * @return void
+     * @throws IllegalObjectTypeException
+     * @throws StopActionException
+     * @throws AssetServiceException
      */
-    public function deleteAction(Asset $asset)
+    public function deleteAction(Asset $asset): void
     {
         $usageReferences = $this->assetService->getUsageReferences($asset);
         if (count($usageReferences) > 0) {
@@ -585,16 +611,17 @@ class AssetController extends ActionController
      * @param AssetInterface $asset
      * @param PersistentResource $resource
      * @param array $options
-     * @throws InvalidArgumentValueException
      * @return void
+     * @throws StopActionException
+     * @throws ForwardException
      */
-    public function updateAssetResourceAction(AssetInterface $asset, PersistentResource $resource, array $options = [])
+    public function updateAssetResourceAction(AssetInterface $asset, PersistentResource $resource, array $options = []): void
     {
         $sourceMediaType = MediaTypes::parseMediaType($asset->getMediaType());
         $replacementMediaType = MediaTypes::parseMediaType($resource->getMediaType());
 
         // Prevent replacement of image, audio and video by a different mimetype because of possible rendering issues.
-        if (in_array($sourceMediaType['type'], ['image', 'audio', 'video']) && $sourceMediaType['type'] !== $replacementMediaType['type']) {
+        if ($sourceMediaType['type'] !== $replacementMediaType['type'] && in_array($sourceMediaType['type'], ['image', 'audio', 'video'])) {
             $this->addFlashMessage(
                 'resourceCanOnlyBeReplacedBySimilarResource',
                 '',
@@ -606,7 +633,6 @@ class AssetController extends ActionController
         }
 
         try {
-            $originalFilename = $asset->getLabel();
             $this->assetService->replaceAssetResource($asset, $resource, $options);
         } catch (\Exception $exception) {
             $this->addFlashMessage('couldNotReplaceAsset', '', Message::SEVERITY_OK, [], 1463472606);
@@ -614,7 +640,8 @@ class AssetController extends ActionController
             return;
         }
 
-        $this->addFlashMessage('assetHasBeenReplaced', '', Message::SEVERITY_OK, [htmlspecialchars($originalFilename)]);
+        $assetLabel = (method_exists($asset, 'getLabel') ? $asset->getLabel() : $resource->getFilename());
+        $this->addFlashMessage('assetHasBeenReplaced', '', Message::SEVERITY_OK, [htmlspecialchars($assetLabel)]);
         $this->redirect('index');
     }
 
@@ -623,8 +650,9 @@ class AssetController extends ActionController
      *
      * @param AssetInterface $asset
      * @return void
+     * @throws ForwardException
      */
-    public function relatedNodesAction(AssetInterface $asset)
+    public function relatedNodesAction(AssetInterface $asset): void
     {
         $this->forward('relatedNodes', 'Usage', 'Neos.Media.Browser', ['asset' => $asset]);
     }
@@ -634,8 +662,9 @@ class AssetController extends ActionController
      * @return void
      * @Flow\Validate(argumentName="label", type="NotEmpty")
      * @Flow\Validate(argumentName="label", type="Label")
+     * @throws ForwardException
      */
-    public function createTagAction($label)
+    public function createTagAction($label): void
     {
         $this->forward('create', 'Tag', 'Neos.Media.Browser', ['label' => $label]);
     }
@@ -643,8 +672,9 @@ class AssetController extends ActionController
     /**
      * @param Tag $tag
      * @return void
+     * @throws ForwardException
      */
-    public function editTagAction(Tag $tag)
+    public function editTagAction(Tag $tag): void
     {
         $this->forward('edit', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
     }
@@ -652,8 +682,9 @@ class AssetController extends ActionController
     /**
      * @param Tag $tag
      * @return void
+     * @throws ForwardException
      */
-    public function updateTagAction(Tag $tag)
+    public function updateTagAction(Tag $tag): void
     {
         $this->forward('update', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
     }
@@ -661,8 +692,9 @@ class AssetController extends ActionController
     /**
      * @param Tag $tag
      * @return void
+     * @throws ForwardException
      */
-    public function deleteTagAction(Tag $tag)
+    public function deleteTagAction(Tag $tag): void
     {
         $this->forward('delete', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
     }
@@ -672,8 +704,9 @@ class AssetController extends ActionController
      * @return void
      * @Flow\Validate(argumentName="title", type="NotEmpty")
      * @Flow\Validate(argumentName="title", type="Label")
+     * @throws ForwardException
      */
-    public function createAssetCollectionAction($title)
+    public function createAssetCollectionAction($title): void
     {
         $this->forward('create', 'AssetCollection', 'Neos.Media.Browser', ['title' => $title]);
     }
@@ -681,8 +714,9 @@ class AssetController extends ActionController
     /**
      * @param AssetCollection $assetCollection
      * @return void
+     * @throws ForwardException
      */
-    public function editAssetCollectionAction(AssetCollection $assetCollection)
+    public function editAssetCollectionAction(AssetCollection $assetCollection): void
     {
         $this->forward('edit', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
     }
@@ -690,8 +724,9 @@ class AssetController extends ActionController
     /**
      * @param AssetCollection $assetCollection
      * @return void
+     * @throws ForwardException
      */
-    public function updateAssetCollectionAction(AssetCollection $assetCollection)
+    public function updateAssetCollectionAction(AssetCollection $assetCollection): void
     {
         $this->forward('update', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
     }
@@ -699,8 +734,9 @@ class AssetController extends ActionController
     /**
      * @param AssetCollection $assetCollection
      * @return void
+     * @throws ForwardException
      */
-    public function deleteAssetCollectionAction(AssetCollection $assetCollection)
+    public function deleteAssetCollectionAction(AssetCollection $assetCollection): void
     {
         $this->forward('delete', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
     }
@@ -710,7 +746,7 @@ class AssetController extends ActionController
      *
      * @return string
      */
-    protected function errorAction()
+    protected function errorAction(): string
     {
         foreach ($this->arguments->getValidationResults()->getFlattenedErrors() as $propertyPath => $errors) {
             foreach ($errors as $error) {
@@ -749,7 +785,7 @@ class AssetController extends ActionController
      * @param integer $messageCode
      * @return void
      */
-    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null)
+    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null): void
     {
         if (is_string($messageBody)) {
             $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'Neos.Media.Browser') ?: $messageBody;
@@ -762,10 +798,10 @@ class AssetController extends ActionController
     /**
      * Returns the lowest configured maximum upload file size
      *
-     * @return integer
-     * @throws \Neos\Utility\Exception\FilesException
+     * @return int
+     * @throws FilesException
      */
-    private function getMaximumFileUploadSize()
+    private function getMaximumFileUploadSize(): int
     {
         return min(Files::sizeStringToBytes(ini_get('post_max_size')), Files::sizeStringToBytes(ini_get('upload_max_filesize')));
     }
@@ -799,7 +835,7 @@ class AssetController extends ActionController
     /**
      * @param $assetSourceIdentifier
      */
-    private function applyActiveAssetSourceToBrowserState($assetSourceIdentifier)
+    private function applyActiveAssetSourceToBrowserState($assetSourceIdentifier): void
     {
         if ($assetSourceIdentifier !== null && isset($this->assetSources[$assetSourceIdentifier])) {
             $this->browserState->setActiveAssetSourceIdentifier($assetSourceIdentifier);
@@ -823,7 +859,7 @@ class AssetController extends ActionController
         $this->browserState->set('tagMode', $tagMode);
 
         // Unset active tag if it isn't available in the active asset collection
-        if ($this->browserState->get('activeTag') && $activeAssetCollection !== null && !$activeAssetCollection->getTags()->contains($this->browserState->get('activeTag'))) {
+        if ($activeAssetCollection !== null && $this->browserState->get('activeTag') && !$activeAssetCollection->getTags()->contains($this->browserState->get('activeTag'))) {
             $this->browserState->set('activeTag', null);
             $this->view->assign('activeTag', null);
         }

--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -52,7 +52,7 @@ class ImageController extends AssetController
      * @return void
      * @throws \Neos\Utility\Exception\FilesException
      */
-    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null)
+    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
         $this->view->assign('disableFilter', true);
         parent::indexAction($view, $sortBy, $sortDirection, 'Image', $tagMode, $tag, $searchTerm, $collectionMode, $assetCollection, $assetSourceIdentifier);
@@ -66,12 +66,14 @@ class ImageController extends AssetController
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
-    public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, Asset $asset = null)
+    public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, Asset $asset = null): void
     {
         if ($assetSourceIdentifier !== null && $assetProxyIdentifier !== null) {
             parent::editAction($assetSourceIdentifier, $assetProxyIdentifier);
             return;
-        } elseif ($asset instanceof AssetSourceAwareInterface) {
+        }
+
+        if ($asset instanceof AssetSourceAwareInterface) {
             /** @var ImportedAsset $importedAsset */
             $importedAsset = $this->importedAssetRepository->findOneByLocalAssetIdentifier($asset->getIdentifier());
             parent::editAction($asset->getAssetSourceIdentifier(), $importedAsset ? $importedAsset->getRemoteAssetIdentifier() : $asset->getIdentifier());

--- a/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -60,7 +60,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setHeight($height)
+    public function setHeight($height): void
     {
         $this->height = $height;
     }
@@ -68,10 +68,10 @@ class CropImageAdjustment extends AbstractImageAdjustment
     /**
      * Returns height
      *
-     * @return integer
+     * @return integer|null
      * @api
      */
-    public function getHeight()
+    public function getHeight(): ?int
     {
         return $this->height;
     }
@@ -83,7 +83,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setWidth($width)
+    public function setWidth($width): void
     {
         $this->width = $width;
     }
@@ -94,7 +94,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return integer
      * @api
      */
-    public function getWidth()
+    public function getWidth(): ?int
     {
         return $this->width;
     }
@@ -106,7 +106,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setX($x)
+    public function setX($x): void
     {
         $this->x = $x;
     }
@@ -117,7 +117,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return integer
      * @api
      */
-    public function getX()
+    public function getX(): ?int
     {
         return $this->x;
     }
@@ -129,7 +129,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setY($y)
+    public function setY($y): void
     {
         $this->y = $y;
     }
@@ -140,7 +140,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return integer
      * @api
      */
-    public function getY()
+    public function getY(): ?int
     {
         return $this->y;
     }
@@ -149,16 +149,16 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * Check if this Adjustment can or should be applied to its ImageVariant.
      *
      * @param ImagineImageInterface $image
-     * @return boolean
+     * @return bool
      */
-    public function canBeApplied(ImagineImageInterface $image)
+    public function canBeApplied(ImagineImageInterface $image): bool
     {
         if (
             $this->x === 0 &&
             $this->y === 0 &&
             $image->getSize()->getWidth() === $this->width &&
             $image->getSize()->getHeight() === $this->height
-            ) {
+        ) {
             return false;
         }
 
@@ -172,7 +172,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return ImagineImageInterface
      * @internal Should never be used outside of the media package. Rely on the ImageService to apply your adjustments.
      */
-    public function applyToImage(ImagineImageInterface $image)
+    public function applyToImage(ImagineImageInterface $image): ImagineImageInterface
     {
         $point = new Point($this->x, $this->y);
         $box = new Box($this->width, $this->height);
@@ -185,7 +185,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @param ImageInterface $image
      * @return void
      */
-    public function refit(ImageInterface $image)
+    public function refit(ImageInterface $image): void
     {
         $this->x = 0;
         $this->y = 0;

--- a/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -17,6 +17,7 @@ use Imagine\Image\Box;
 use Imagine\Image\Point;
 use Imagine\Image\ImageInterface as ImagineImageInterface;
 use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Media\Domain\ValueObject\Configuration\AspectRatio;
 
 /**
  * An adjustment for cropping an image
@@ -54,15 +55,22 @@ class CropImageAdjustment extends AbstractImageAdjustment
     protected $height;
 
     /**
+     * @var string
+     * @ORM\Column(nullable = true)
+     */
+    protected $aspectRatioAsString;
+
+    /**
      * Sets height
      *
      * @param integer $height
      * @return void
      * @api
      */
-    public function setHeight($height): void
+    public function setHeight(int $height = null): void
     {
         $this->height = $height;
+        $this->aspectRatioAsString = null;
     }
 
     /**
@@ -83,9 +91,10 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setWidth($width): void
+    public function setWidth(int $width = null): void
     {
         $this->width = $width;
+        $this->aspectRatioAsString = null;
     }
 
     /**
@@ -106,9 +115,10 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setX($x): void
+    public function setX(int $x = null): void
     {
         $this->x = $x;
+        $this->aspectRatioAsString = null;
     }
 
     /**
@@ -129,9 +139,10 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setY($y): void
+    public function setY(int $y = null): void
     {
         $this->y = $y;
+        $this->aspectRatioAsString = null;
     }
 
     /**
@@ -146,6 +157,65 @@ class CropImageAdjustment extends AbstractImageAdjustment
     }
 
     /**
+     * This setter accepts strings in order to make configuration / mapping of settings easier.
+     *
+     * @param AspectRatio | string | null $aspectRatio
+     */
+    public function setAspectRatio($aspectRatio = null): void
+    {
+        if ($aspectRatio === null) {
+            $this->aspectRatioAsString = null;
+            return;
+        }
+        if (!$aspectRatio instanceof AspectRatio && !is_string($aspectRatio)) {
+            throw new \InvalidArgumentException(sprintf('Aspect ratio must be either AspectRatio or string, %s given.', gettype($aspectRatio)), 1552652570);
+        }
+        if (is_string($aspectRatio)) {
+            $aspectRatio = AspectRatio::fromString($aspectRatio);
+        }
+
+        $this->aspectRatioAsString = (string)$aspectRatio;
+        $this->x = null;
+        $this->y = null;
+        $this->width = null;
+        $this->height = null;
+    }
+
+    /**
+     * @return AspectRatio|null
+     */
+    public function getAspectRatio(): ?AspectRatio
+    {
+        return $this->aspectRatioAsString ? AspectRatio::fromString($this->aspectRatioAsString) : null;
+    }
+
+    /**
+     * Calculates the actual position and dimensions of the cropping area based on the given image
+     * dimensions and desired aspect ratio.
+     *
+     * @param int $originalWidth Width of the original image
+     * @param int $originalHeight Height of the original image
+     * @param AspectRatio $desiredAspectRatio The desired aspect ratio
+     * @return array Returns an array containing x, y, width and height
+     */
+    public static function calculateDimensionsByAspectRatio(int $originalWidth, int $originalHeight, AspectRatio $desiredAspectRatio): array
+    {
+        $newWidth = $originalWidth;
+        $newHeight = round($originalWidth / $desiredAspectRatio->getRatio());
+        $newX = 0;
+        $newY = round(($originalHeight - $newHeight) / 2);
+
+        if ($newHeight > $originalHeight) {
+            $newHeight = $originalHeight;
+            $newY = 0;
+            $newWidth = round($originalHeight * $desiredAspectRatio->getRatio());
+            $newX = round(($originalWidth - $newWidth) / 2);
+        }
+
+        return [$newX, $newY, $newWidth, $newHeight];
+    }
+
+    /**
      * Check if this Adjustment can or should be applied to its ImageVariant.
      *
      * @param ImagineImageInterface $image
@@ -153,16 +223,18 @@ class CropImageAdjustment extends AbstractImageAdjustment
      */
     public function canBeApplied(ImagineImageInterface $image): bool
     {
-        if (
+        if ($this->aspectRatioAsString !== null) {
+            $desiredAspectRatio = AspectRatio::fromString($this->aspectRatioAsString);
+            $originalAspectRatio = new AspectRatio($image->getSize()->getWidth(), $image->getSize()->getHeight());
+            return $originalAspectRatio->getRatio() !== $desiredAspectRatio->getRatio();
+        }
+
+        return !(
             $this->x === 0 &&
             $this->y === 0 &&
             $image->getSize()->getWidth() === $this->width &&
             $image->getSize()->getHeight() === $this->height
-        ) {
-            return false;
-        }
-
-        return true;
+        );
     }
 
     /**
@@ -174,8 +246,19 @@ class CropImageAdjustment extends AbstractImageAdjustment
      */
     public function applyToImage(ImagineImageInterface $image): ImagineImageInterface
     {
-        $point = new Point($this->x, $this->y);
-        $box = new Box($this->width, $this->height);
+        $desiredAspectRatio = $this->getAspectRatio();
+        if ($desiredAspectRatio !== null) {
+            $originalWidth = $image->getSize()->getWidth();
+            $originalHeight = $image->getSize()->getHeight();
+
+            [$newX, $newY, $newWidth, $newHeight] = self::calculateDimensionsByAspectRatio($originalWidth, $originalHeight, $desiredAspectRatio);
+
+            $point = new Point($newX, $newY);
+            $box = new Box($newWidth, $newHeight);
+        } else {
+            $point = new Point($this->x, $this->y);
+            $box = new Box($this->width, $this->height);
+        }
         return $image->crop($point, $box);
     }
 

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -103,7 +103,6 @@ class AssetRepository extends Repository
      * @param Tag $tag
      * @param AssetCollection $assetCollection
      * @return integer
-     * @throws NonUniqueResultException
      */
     public function countByTag(Tag $tag, AssetCollection $assetCollection = null)
     {
@@ -121,7 +120,11 @@ class AssetRepository extends Repository
         if ($assetCollection !== null) {
             $query->setParameter(2, $assetCollection);
         }
-        return $query->getSingleScalarResult();
+        try {
+            return $query->getSingleScalarResult();
+        } catch (NonUniqueResultException $e) {
+            return 0;
+        }
     }
 
     /**
@@ -210,7 +213,6 @@ class AssetRepository extends Repository
      *
      * @param AssetCollection $assetCollection
      * @return integer
-     * @throws NonUniqueResultException
      */
     public function countByAssetCollection(AssetCollection $assetCollection)
     {
@@ -221,7 +223,11 @@ class AssetRepository extends Repository
 
         $query = $this->entityManager->createNativeQuery($queryString, $rsm);
         $query->setParameter(1, $assetCollection);
-        return $query->getSingleScalarResult();
+        try {
+            return $query->getSingleScalarResult();
+        } catch (NonUniqueResultException $e) {
+            return 0;
+        }
     }
 
     /**

--- a/Neos.Media/Migrations/Mysql/Version20190315122900.php
+++ b/Neos.Media/Migrations/Mysql/Version20190315122900.php
@@ -1,0 +1,44 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Introduce aspect ratio field for image adjustments
+ */
+class Version20190315122900 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Introduce aspect ratio field for image adjustments';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment ADD aspectratioasstring VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment DROP aspectratioasstring');
+    }
+}

--- a/Neos.Media/Migrations/Postgresql/Version20190315122901.php
+++ b/Neos.Media/Migrations/Postgresql/Version20190315122901.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Migrations\AbortMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Introduce aspect ratio field for image adjustments
+ */
+class Version20190315122901 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Introduce aspect ratio field for image adjustments';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment ADD aspectratioasstring VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment DROP aspectratioasstring');
+    }
+}
+

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
@@ -13,8 +13,13 @@ namespace Neos\Media\Tests\Unit\Domain\Model\Adjustment;
 
 use Imagine\Gd\Imagine;
 use Imagine\Image\Box;
+use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\Palette\Color\RGB as RGBColor;
+use Imagine\Image\Palette\RGB as RGBPalette;
+use Imagine\Image\Point;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
+use Neos\Media\Domain\ValueObject\Configuration\AspectRatio;
 
 /**
  * Test case for the Crop Image Adjustment
@@ -24,10 +29,129 @@ class CropImageAdjustmentTest extends UnitTestCase
     /**
      * @test
      */
+    public function aspectRatioCanBeSetInsteadOfAbsoluteDimensions(): void
+    {
+        $imagine = new Imagine();
+        $size = new Box(1600, 1000);
+        $image = $imagine->create($size);
+
+        $cropImageAdjustment = new CropImageAdjustment();
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+
+        self::assertTrue($cropImageAdjustment->canBeApplied($image));
+    }
+
+    /**
+     * @test
+     */
+    public function settingAnAspectRatioRemovesValuesForManualDimensions(): void
+    {
+        $cropImageAdjustment = new CropImageAdjustment();
+        $cropImageAdjustment->setX(10);
+        $cropImageAdjustment->setY(20);
+        $cropImageAdjustment->setWidth(100);
+        $cropImageAdjustment->setHeight(100);
+
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+
+        self::assertNull($cropImageAdjustment->getX());
+        self::assertNull($cropImageAdjustment->getY());
+        self::assertNull($cropImageAdjustment->getWidth());
+        self::assertNull($cropImageAdjustment->getHeight());
+
+        self::assertSame((string)$cropImageAdjustment->getAspectRatio(), '16:9');
+    }
+
+    /**
+     * @test
+     */
+    public function settingManualDimensionsRemovesAspectRatio(): void
+    {
+        $cropImageAdjustment = new CropImageAdjustment();
+
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+        $cropImageAdjustment->setX(10);
+        self::assertNull($cropImageAdjustment->getAspectRatio());
+
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+        $cropImageAdjustment->setY(20);
+        self::assertNull($cropImageAdjustment->getAspectRatio());
+
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+        $cropImageAdjustment->setWidth(100);
+        self::assertNull($cropImageAdjustment->getAspectRatio());
+
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+        $cropImageAdjustment->setHeight(100);
+        self::assertNull($cropImageAdjustment->getAspectRatio());
+    }
+
+    /**
+     * @test
+     */
+    public function canBeAppliedReturnsFalseIfAspectRatioEqualsOriginalAspectRatio(): void
+    {
+        $imagine = new Imagine();
+        $size = new Box(1600, 900);
+        $image = $imagine->create($size);
+
+        $cropImageAdjustment = new CropImageAdjustment();
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString('16:9'));
+
+        self::assertFalse($cropImageAdjustment->canBeApplied($image));
+    }
+
+    /**
+     * @return array
+     */
+    public function imageCropByAspectRatioDataProvider(): array
+    {
+        return [
+            ['16:9', 1600, 1000, 0, 50, 1600, 900],
+            ['16:9', 1000, 1000, 0, 219, 1000, 563],
+            ['4:3', 1000, 1000, 0, 125, 1000, 750]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider imageCropByAspectRatioDataProvider
+     * @param string $aspectRatio
+     * @param int $originalWidth
+     * @param int $originalHeight
+     * @param int $expectedX
+     * @param int $expectedY
+     * @param int $expectedWidth
+     * @param int $expectedHeight
+     */
+    public function aspectRatioIsAppliedWithMaximumPossibleClipping(string $aspectRatio, int $originalWidth, int $originalHeight, int $expectedX, int $expectedY, int $expectedWidth, int $expectedHeight): void
+    {
+        $imagine = new Imagine();
+        $size = new Box($originalWidth, $originalHeight);
+        $image = $imagine->create($size);
+
+        $color = new RGBColor(new RGBPalette(), [100, 100, 100], 100);
+        $point = new Point($expectedX, $expectedY);
+        $image->draw()->dot($point, $color);
+
+        $cropImageAdjustment = new CropImageAdjustment();
+        $cropImageAdjustment->setAspectRatio(AspectRatio::fromString($aspectRatio));
+
+        $cropImageAdjustment->applyToImage($image);
+
+        $imageSize = $image->getSize();
+        self::assertSame($expectedWidth, $imageSize->getWidth());
+        self::assertSame($expectedHeight, $imageSize->getHeight());
+        self::assertSame(100, $image->getColorAt(new Point(0, 0))->getValue(ColorInterface::COLOR_RED));
+    }
+
+    /**
+     * @test
+     */
     public function canBeAppliedReturnsTrueIfCropClippingIsSmallerThanTheImage(): void
     {
         $imagine = new Imagine();
-        $size  = new Box(1600, 900);
+        $size = new Box(1600, 900);
         $image = $imagine->create($size);
 
         $cropImageAdjustment = new CropImageAdjustment();
@@ -45,7 +169,7 @@ class CropImageAdjustmentTest extends UnitTestCase
     public function canBeAppliedReturnsFalseIfCropClippingIsTheFullImage(): void
     {
         $imagine = new Imagine();
-        $size  = new Box(1600, 900);
+        $size = new Box(1600, 900);
         $image = $imagine->create($size);
 
         $cropImageAdjustment = new CropImageAdjustment();
@@ -64,39 +188,88 @@ class CropImageAdjustmentTest extends UnitTestCase
     {
         return [
             [
-                0, 0, 100, 100,
-                1000, 1000,
-                0, 0, 1000, 1000
+                0,
+                0,
+                100,
+                100,
+                1000,
+                1000,
+                0,
+                0,
+                1000,
+                1000
             ],
             [
-                10, 10, 100, 100,
-                1000, 1000,
-                0, 0, 1000, 1000
+                10,
+                10,
+                100,
+                100,
+                1000,
+                1000,
+                0,
+                0,
+                1000,
+                1000
             ],
             [
-                50, 40, 300, 400,
-                3000, 4000,
-                0, 0, 3000, 4000
+                50,
+                40,
+                300,
+                400,
+                3000,
+                4000,
+                0,
+                0,
+                3000,
+                4000
             ],
             [
-                0, 0, 300, 400,
-                3000, 8000,
-                0, 0, 3000, 4000
+                0,
+                0,
+                300,
+                400,
+                3000,
+                8000,
+                0,
+                0,
+                3000,
+                4000
             ],
             [
-                0, 0, 400, 300,
-                8000, 3000,
-                0, 0, 4000, 3000
+                0,
+                0,
+                400,
+                300,
+                8000,
+                3000,
+                0,
+                0,
+                4000,
+                3000
             ],
             [
-                0, 0, 300, 400,
-                8000, 3000,
-                0, 0, 2250, 3000
+                0,
+                0,
+                300,
+                400,
+                8000,
+                3000,
+                0,
+                0,
+                2250,
+                3000
             ],
             [
-                0, 0, 400, 300,
-                3000, 8000,
-                0, 0, 3000, 2250
+                0,
+                0,
+                400,
+                300,
+                3000,
+                8000,
+                0,
+                0,
+                3000,
+                2250
             ]
         ];
     }
@@ -116,7 +289,7 @@ class CropImageAdjustmentTest extends UnitTestCase
     public function refitFitsCropPropertyWithinImageSizeConstraints(int $cropX, int $cropY, int $cropWidth, int $cropHeight, int $newImageWidth, int $newImageHeight, int $expectedX, int $expectedY, int $expectedWidth, int $expectedHeight): void
     {
         $imagine = new Imagine();
-        $size  = new Box($newImageWidth, $newImageHeight);
+        $size = new Box($newImageWidth, $newImageHeight);
         $image = $imagine->create($size);
 
         $cropImageAdjustment = new CropImageAdjustment();


### PR DESCRIPTION
This change introduces a new property "aspectRatio" for the crop image
adjustment. It allows users to set a cropping area simply by providing
an aspect ratio, instead of x, y, width and height.

If an aspect ratio is specified, the x, y, width, and height parameters
are automatically deactivated. Likewise, if x, y, width or height are
specified, a potentially defined aspect ratio value will be reset.