### PR TITLE
BUGFIX: change regex for selecting `<a href="">` Tag

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -116,7 +116,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         }, $text);
 
         if ($unresolvedUris !== array()) {
-            $processedContent = preg_replace('/<a[^>]* href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
+            $processedContent = preg_replace('/<a(?: [^>]*)? href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
             $processedContent = preg_replace(LinkingService::PATTERN_SUPPORTED_URIS, '', $processedContent);
         }
 
@@ -142,7 +142,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
         $processedContent = preg_replace_callback(
-            '~<a.*?href="(.*?)".*?>~i',
+            '~<a(?: [^>]*)? href="(.*?)".*?>~i',
             function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host) {
                 list($linkText, $linkHref) = $matches;
                 $uriHost = parse_url($linkHref, PHP_URL_HOST);

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -305,4 +305,32 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }
+
+    /**
+     * This test checks that targets for resource links are correctly replaced if the a Tag is inside a tag with the name beginning wit a
+     *
+     * @test
+     */
+    public function evaluateReplaceResourceLinkTargetsInsideTag()
+    {
+        $assetIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff8';
+        $resourceLinkTarget = '_blank';
+
+        $value = 'and an external link inside another tag beginning with a <article> test <a href="asset://' . $assetIdentifier . '">example1</a></article>';
+        $this->addValueExpectation($value, null, false, null, $resourceLinkTarget);
+
+        $this->mockWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
+
+        $self = $this;
+        $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveAssetUri')->will($this->returnCallback(function ($assetUri) use ($self, $assetIdentifier) {
+            if ($assetUri !== 'asset://' . $assetIdentifier) {
+                $self->fail('Unexpected asset URI "' . $assetUri . '"');
+            }
+            return 'http://localhost/_Resources/01';
+        }));
+
+        $expectedResult = 'and an external link inside another tag beginning with a <article> test <a target="' . $resourceLinkTarget . '" href="http://localhost/_Resources/01">example1</a></article>';
+        $actualResult = $this->convertUrisImplementation->evaluate();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 }


### PR DESCRIPTION
fixe the behaviour when the a Tag is inside a Tag with the name beginning with a

Example: `<article> test <a target="_blank" href="http://localhost/_Resources/01">example1</a></article>`

the function replaceLinkTargets returned  `<a target="_blank"rticle> test <a target="_blank" href="http://localhost/_Resources/01">example1</a></article>`

create new test evaluateReplaceResourceLinkTargetsInsideTag

this issue was already fixed in 4.2 release on 5 Nov 2018

Fixes #2395