### PR TITLE
BUGFIX: node:repair now handles node->getProperties() as ArrayObject

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -734,7 +734,15 @@ HELPTEXT;
                     continue;
                 }
                 $nodeType = $node->getNodeType();
-                $undefinedProperties = array_diff(array_keys($node->getProperties()), array_keys($nodeType->getProperties()));
+
+                $nodeTypePropertyNames = array_keys($nodeType->getProperties());
+                $undefinedProperties = [];
+
+                foreach ($node->getProperties() as $propertyName => $propertyValue) {
+                    if (!in_array($propertyName, $nodeTypePropertyNames)) {
+                        $undefinedProperties[] = $propertyName;
+                    }
+                }
                 if ($undefinedProperties !== []) {
                     $nodesWithUndefinedPropertiesNodes[$node->getIdentifier()] = ['node' => $node, 'undefinedProperties' => $undefinedProperties];
                     foreach ($undefinedProperties as $undefinedProperty) {


### PR DESCRIPTION
**What I did**
I changed the code of the node:repair command to handle the result of node->getProperties() as ArrayObject and not as array, because that recently changed.

**How I did it**
Instead of getting the key via array_keys the properties are now iterated to find undefinded properties.

**How to verify it**
* run the node:repair-command on a content repository that is fine already => it should not complain about anything
* add a undefinded property to a node (by editing a record in the nodedata-table directly) and run node:repair => you should be asked if you want to remove the undefinded property