### PR TITLE
BUGFIX: Image previews should be rendered for asset proxies as well

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
@@ -2,6 +2,6 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <div class="neos-preview-image" id="neos-preview-image">
     <a href="{assetProxy.importStream}" target="_blank">
-        <m:thumbnail asset="{assetProxy.asset}" preset="Neos.Media.Browser:Preview" alt="{assetProxy.label}" async="{asyncThumbnails}" class="img-polaroid" />
+        <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
     </a>
 </div>


### PR DESCRIPTION
The previous code must be a leftover from an upmerge and it results in
fatal errors when trying to open the details of an asset coming from a
proxy source.
