### PR TITLE
BUGFIX: No redirect with status 201

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -434,6 +434,7 @@ class AssetController extends ActionController
      *
      * @param Asset $asset
      * @return void
+     * @throws \Neos\Flow\Mvc\Exception\StopActionException
      */
     public function createAction(Asset $asset)
     {
@@ -441,7 +442,7 @@ class AssetController extends ActionController
             $this->assetRepository->add($asset);
         }
         $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
-        $this->redirect('index', null, null, [], 0, 201);
+        $this->redirect('index');
     }
 
     /**


### PR DESCRIPTION
Sending a redirect code of 201 does not cause the browser to redirect
and leads to a blank page.

Fixes: #2414