### PR TITLE
BUGFIX: Lowercase Node Names upon creation

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/ValueObject/NodeName.php
+++ b/Neos.ContentRepository/Classes/Domain/ValueObject/NodeName.php
@@ -52,7 +52,7 @@ final class NodeName implements \JsonSerializable
 
     public static function fromString(string $value): self
     {
-        return new static($value);
+        return new static(strtolower($value));
     }
 
     /**


### PR DESCRIPTION
This adjusts the `NodeName` Value Object to always convert the given
value to lower case when created via the `fromString()` constructor.

Background:
Node names are considered to be case insensitive. Internally they are
stored lower case but the `NodeInterface::MATCH_PATTERN_NAME` does not
allow for camel case names.

Fixes: #2418