### PR TITLE
TASK: Involve existing contraints

### DIFF
--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
@@ -208,7 +208,12 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
     {
         $query = $this->assetRepository->createQuery();
         try {
-            $query->matching($query->isEmpty('tags'));
+            $constraints = $query->getConstraint();
+            if (!is_null($constraints)) {
+                $query->matching($query->logicalAnd($constraints, $query->isEmpty('tags')));
+            } else {
+                $query->matching($query->isEmpty('tags'));
+            }
         } catch (InvalidQueryException $e) {
         }
 


### PR DESCRIPTION
**What I did**
Adding some lines to query the existing constraints and mixing them with the empty tag constraint.
This ensures that all constraints which may have been until this usage are involved.
I implemented it because the current implementation causes an error, if the createQuery-Method already adds constraints.
 
**How I did it**
1. Get the currently existing constraints
2. Check if they really exist
3. If the existing add require existing constraints and the empty tag constraint. Otherwise, use only the empty tag constraints.


**How to verify it**
Use the existing tests