### PR TITLE
BUGFIX: Respect settings for quality and format even if images are smaller that target dimensions

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -117,9 +117,15 @@ class ImageService
         }
 
         $resourceUri = $originalResource->createTemporaryLocalCopy();
-
-        $resultingFileExtension = ($format !== null && in_array($format, self::$allowedFormats, true)) ? $format : $originalResource->getFileExtension();
-        $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $resultingFileExtension;
+        $fileExtension = $originalResource->getFileExtension();
+        if ($format !== null
+            && $originalResource->getFileExtension() !== $format
+            && in_array($format, self::$allowedFormats, true)
+        ) {
+            $adjustmentsApplied = true;
+            $fileExtension = $format;
+        }
+        $transformedImageTemporaryPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ProcessedImage-' . Algorithms::generateRandomString(13) . '.' . $fileExtension;
 
         if (!file_exists($resourceUri)) {
             throw new ImageFileException(sprintf('An error occurred while transforming an image: the resource data of the original image does not exist (%s, %s).', $originalResource->getSha1(), $resourceUri), 1374848224);
@@ -182,7 +188,7 @@ class ImageService
             unlink($transformedImageTemporaryPathAndFilename);
 
             $pathInfo = UnicodeFunctions::pathinfo($originalResource->getFilename());
-            $resource->setFilename(sprintf('%s-%ux%u.%s', $pathInfo['filename'], $imageSize->getWidth(), $imageSize->getHeight(), $resultingFileExtension));
+            $resource->setFilename(sprintf('%s-%ux%u.%s', $pathInfo['filename'], $imageSize->getWidth(), $imageSize->getHeight(), $fileExtension));
         } else {
             $originalResourceStream = $originalResource->getStream();
             $resource = $this->resourceManager->importResource($originalResourceStream, $originalResource->getCollectionName());

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -117,7 +117,8 @@ class ThumbnailService
             $maximumWidth = ($configuration->getMaximumWidth() > $asset->getWidth()) ? $asset->getWidth() : $configuration->getMaximumWidth();
             $maximumHeight = ($configuration->getMaximumHeight() > $asset->getHeight()) ? $asset->getHeight() : $configuration->getMaximumHeight();
             if ($configuration->isUpScalingAllowed() === false
-                && $configuration->getQuality() !== null
+                && $configuration->getQuality() === null
+                && $configuration->getFormat() === null
                 && $maximumWidth === $asset->getWidth()
                 && $maximumHeight === $asset->getHeight()
             ) {


### PR DESCRIPTION
Thumbnail images always returned the original source if allowUpscaling is false and the target size is smaller than the original image. This is unexpected when quality and format are defined.

This change makes sure the new assets are rendered when quality and format is defined.
The dimension calculation of the target images respects the allowUpscaling if the source is smaller that the target dimension.

Resolves: #2416