### PR TITLE
TASK: Contain dimension changes in tests to test case only

### DIFF
--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeServiceTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * source code.
  */
 
+use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\ContentDimensionRepository;
@@ -88,7 +89,8 @@ class NodeServiceTest extends FunctionalTestCase
     {
         parent::tearDown();
         $this->inject($this->contextFactory, 'contextInstances', array());
-        $this->contentDimensionRepository->setDimensionsConfiguration(array());
+        $configuredDimensions = $this->objectManager->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.ContentRepository.contentDimensions');
+        $this->contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * source code.
  */
 
+use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -103,7 +104,8 @@ class NodesTest extends FunctionalTestCase
     {
         parent::tearDown();
         $this->inject($this->contextFactory, 'contextInstances', []);
-        $this->contentDimensionRepository->setDimensionsConfiguration([]);
+        $configuredDimensions = $this->objectManager->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.ContentRepository.contentDimensions');
+        $this->contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
+++ b/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
@@ -12,6 +12,7 @@ namespace Neos\ContentRepository\Tests\Functional\TypeConverter;
  */
 
 use Neos\Error\Messages\Error;
+use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -113,8 +114,9 @@ class NodeConverterTest extends FunctionalTestCase
 
     public function tearDown()
     {
+        $configuredDimensions = $this->objectManager->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.ContentRepository.contentDimensions');
         $contentDimensionRepository = $this->objectManager->get(ContentDimensionRepository::class);
-        $contentDimensionRepository->setDimensionsConfiguration(array());
+        $contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
         parent::tearDown();
     }
 

--- a/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
+++ b/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
@@ -12,7 +12,9 @@ namespace Neos\Neos\Tests\Functional\Controller\Backend;
  */
 
 use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Neos\Controller\Backend\BackendController;
 use Neos\Neos\Domain\Model\User;
+use Neos\Neos\Service\BackendRedirectionService;
 
 /**
  * Testcase for method security of the backend controller
@@ -31,6 +33,15 @@ class BackendControllerSecurityTest extends FunctionalTestCase
      */
     public function indexActionIsGrantedForAdministrator()
     {
+        $backendRedirectionServiceMock = $this->getMockBuilder(BackendRedirectionService::class)->getMock();
+        $backendRedirectionServiceMock
+            ->expects(self::any())
+            ->method('getAfterLoginRedirectionUri')
+            ->willReturn('http://localhost/');
+
+        $backendController = $this->objectManager->get(BackendController::class);
+        $this->inject($backendController, 'backendRedirectionService', $backendRedirectionServiceMock);
+
         $account = $this->authenticateRoles(array('Neos.Neos:Administrator'));
         $account->setAccountIdentifier('admin');
         $this->browser->request('http://localhost/neos/login');


### PR DESCRIPTION
The reset to empty array was technically wrong because dimensions were
configured. While this is not an issue at this time, it can be one
when other tests rely on the integrity of configured dimensions and
the repository.
