### PR TITLE
BUGFIX: Fix tag rendering in media module

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -243,7 +243,7 @@ class AssetController extends ActionController
 
             foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $retrievedTag) {
                 assert($retrievedTag instanceof Tag);
-                $tags[] = ['object' => $tag, 'count' => $this->assetRepository->countByTag($retrievedTag, $activeAssetCollection)];
+                $tags[] = ['object' => $retrievedTag, 'count' => $this->assetRepository->countByTag($retrievedTag, $activeAssetCollection)];
             }
 
             if ($searchTerm !== null) {


### PR DESCRIPTION
The names of tags were not rendered in the sidebar of the media module since https://github.com/neos/neos-development-collection/pull/2408 was merged because of an incomplete renaming from `tag` to `retrievedTag`