### PR TITLE
BUGFIX: add missing and new copyright field to the edit and new dialog in the media manager

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -30,6 +30,8 @@
                                     <input id="title" readonly="readonly" value="{assetProxy.iptcProperties.Title}"/>
                                     <label for="caption">{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}</label>
                                     <textarea id="caption" rows="3" readonly="readonly">{assetProxy.iptcProperties.CaptionAbstract}</textarea>
+                                    <label for="copyrightnotice">{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}</label>
+                                    <textarea id="copyrightnotice" rows="2" readonly="readonly">{assetProxy.iptcProperties.CopyrightNotice}</textarea>
                                 </f:then>
                                 <f:else>
                                     <legend>{neos:backend.translate(id: 'basics', package: 'Neos.Media.Browser')}</legend>
@@ -37,6 +39,8 @@
                                     <f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'field.title', package: 'Neos.Media.Browser')}"/>
                                     <label for="caption">{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}</label>
                                     <f:form.textarea property="caption" id="caption" rows="3" placeholder="{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}"/>
+                                    <label for="copyrightnotice">{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}</label>
+                                    <f:form.textarea property="copyrightNotice" id="copyrightnotice" rows="2" placeholder="{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}"/>
                                 </f:else>
                             </f:if>
                             <f:if condition="{tags}">

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -17,6 +17,8 @@
                 <f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'field.title', package: 'Neos.Media.Browser')}"/>
                 <label for="caption">{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}</label>
                 <f:form.textarea property="caption" rows="3" id="caption" placeholder="{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}"/>
+                <label for="copyrightnotice">{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}</label>
+                <f:form.textarea property="copyrightNotice" id="copyrightnotice" rows="2" placeholder="{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}"/>
                 <f:if condition="{tags}">
                     <label>{neos:backend.translate(id: 'field.tags', package: 'Neos.Media.Browser')}</label>
                     <f:for each="{tags}" as="tag">

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -18,7 +18,7 @@
                 <label for="caption">{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}</label>
                 <f:form.textarea property="caption" rows="3" id="caption" placeholder="{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}"/>
                 <label for="copyrightnotice">{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}</label>
-                <f:form.textarea property="copyrightNotice" id="copyrightnotice" rows="2" placeholder="{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}"/>
+                <f:form.textarea property="copyrightNotice" id="copyrightnotice" rows="4" placeholder="{neos:backend.translate(id: 'field.copyrightnotice', package: 'Neos.Media.Browser')}"/>
                 <f:if condition="{tags}">
                     <label>{neos:backend.translate(id: 'field.tags', package: 'Neos.Media.Browser')}</label>
                     <f:for each="{tags}" as="tag">


### PR DESCRIPTION
**What I did**
I add the missing copyright field again and also added a new on for the "new" dialog

**How I did it**
I updated the edit.html and the new.html of the asset controller actions 

**How to verify it**
I test with example data based on the demo package