### PR TITLE
BUGFIX: Fix site-package generator

### DIFF
--- a/Neos.SiteKickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.SiteKickstarter/Classes/Service/GeneratorService.php
@@ -105,7 +105,7 @@ class GeneratorService extends \Neos\Kickstarter\Service\GeneratorService
             'siteNodeName' => $this->generateSiteNodeName($packageKey)
         ];
 
-        $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);
+        $fileContent = $this->renderSimpleTemplate($templatePathAndFilename, $contextVariables);
 
         $sitesRootFusionPathAndFilename = $this->packageManager->getPackage($packageKey)->getResourcesPath() . 'Private/Fusion/Root.fusion';
         $this->generateFile($sitesRootFusionPathAndFilename, $fileContent);
@@ -128,7 +128,7 @@ class GeneratorService extends \Neos\Kickstarter\Service\GeneratorService
         $packageKeyDomainPart = substr(strrchr($packageKey, '.'), 1) ?: $packageKey;
         $contextVariables['siteNodeName'] = $packageKeyDomainPart;
 
-        $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);
+        $fileContent = $this->renderSimpleTemplate($templatePathAndFilename, $contextVariables);
 
         $sitesPageFusionPathAndFilename = $this->packageManager->getPackage($packageKey)->getResourcesPath() . 'Private/Fusion/NodeTypes/Page.fusion';
         $this->generateFile($sitesPageFusionPathAndFilename, $fileContent);
@@ -183,7 +183,7 @@ class GeneratorService extends \Neos\Kickstarter\Service\GeneratorService
             'packageKey' => $packageKey
         ];
 
-        $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);
+        $fileContent = $this->renderSimpleTemplate($templatePathAndFilename, $contextVariables);
 
         $sitesNodeTypesPathAndFilename = $this->packageManager->getPackage($packageKey)->getConfigurationPath() . 'NodeTypes.Document.Page.yaml';
         $this->generateFile($sitesNodeTypesPathAndFilename, $fileContent);
@@ -202,5 +202,21 @@ class GeneratorService extends \Neos\Kickstarter\Service\GeneratorService
         foreach (['Images', 'JavaScript', 'Styles'] as $publicResourceFolder) {
             Files::createDirectoryRecursively(Files::concatenatePaths([$publicResourcesPath, $publicResourceFolder]));
         }
+    }
+
+    /**
+     * Simplified template rendering
+     *
+     * @param string $templatePathAndFilename
+     * @param array $contextVariables
+     * @return string
+     */
+    protected function renderSimpleTemplate($templatePathAndFilename, array $contextVariables)
+    {
+        $content = file_get_contents($templatePathAndFilename);
+        foreach ($contextVariables as $key => $value) {
+            $content = str_replace('{' . $key . '}', $value, $content);
+        }
+        return $content;
     }
 }


### PR DESCRIPTION
Somehow the classic site generator did not replace the occurrences of the package names
in fusion `reference://{packageKey}/...` strings any more while in other places this still worked.

This works around this by falling back to a very plain search replace based implementation that is only used on the fusion files.

With this change a site package created with the setup tool or the kickstart:site command will not directly welcome the user with fusion-errors which it did before.