### PR TITLE
TASK: Remove deprecated signals

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -166,9 +166,10 @@ class Asset implements AssetInterface
     }
 
     /**
+     * @param $initializationCause
      * @return void
      */
-    public function initializeObject()
+    public function initializeObject($initializationCause)
     {
         // FIXME: This is a workaround for after the resource management changes that introduced the property.
         if ($this->thumbnails === null) {

--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\PsrSystemLoggerInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -155,6 +154,7 @@ class Asset implements AssetInterface
      * is called.
      *
      * @param PersistentResource $resource
+     * @throws \Exception
      */
     public function __construct(PersistentResource $resource)
     {
@@ -166,17 +166,13 @@ class Asset implements AssetInterface
     }
 
     /**
-     * @param integer $initializationCause
      * @return void
      */
-    public function initializeObject($initializationCause)
+    public function initializeObject()
     {
         // FIXME: This is a workaround for after the resource management changes that introduced the property.
         if ($this->thumbnails === null) {
             $this->thumbnails = new ArrayCollection();
-        }
-        if ($initializationCause === ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
-            $this->emitAssetCreated($this);
         }
     }
 
@@ -515,19 +511,6 @@ class Asset implements AssetInterface
             $this->systemLogger->notice(sprintf('Asset %s: Failed connecting to asset source %s (%s): %s', $this->getIdentifier(), $assetSource->getIdentifier(), $assetSource->getLabel(), $e->getMessage()), LogEnvironment::fromMethodName(__METHOD__));
             return null;
         }
-    }
-
-    /**
-     * Signals that an asset was created.
-     * @deprecated Will be removed with next major version of Neos.Media.
-     * Use AssetService::emitAssetCreated signal instead.
-     *
-     * @Flow\Signal
-     * @param AssetInterface $asset
-     * @return void
-     */
-    protected function emitAssetCreated(AssetInterface $asset)
-    {
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -166,7 +166,7 @@ class Asset implements AssetInterface
     }
 
     /**
-     * @param $initializationCause
+     * @param integer $initializationCause
      * @return void
      */
     public function initializeObject($initializationCause)

--- a/Neos.Media/Classes/Domain/Model/Image.php
+++ b/Neos.Media/Classes/Domain/Model/Image.php
@@ -45,6 +45,7 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
      * Constructor
      *
      * @param PersistentResource $resource
+     * @throws \Exception
      */
     public function __construct(PersistentResource $resource)
     {
@@ -66,6 +67,7 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
         if ($initializationCause === ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
             $this->calculateDimensionsFromResource($this->resource);
         }
+
         parent::initializeObject($initializationCause);
     }
 

--- a/Neos.Media/Classes/Domain/Model/Thumbnail.php
+++ b/Neos.Media/Classes/Domain/Model/Thumbnail.php
@@ -110,7 +110,6 @@ class Thumbnail implements ImageInterface
             if ($this->async === false) {
                 $this->refresh();
             }
-            $this->emitThumbnailCreated($this);
         }
     }
 
@@ -224,18 +223,5 @@ class Thumbnail implements ImageInterface
     public function refresh()
     {
         $this->generatorStrategy->refresh($this);
-    }
-
-    /**
-     * Signals that a thumbnail was created.
-     * @deprecated Will be removed with next major version of Neos.Media.
-     * Use ThumbnailService::emitThumbnailCreated signal instead.
-     *
-     * @Flow\Signal
-     * @param Thumbnail $thumbnail
-     * @return void
-     */
-    protected function emitThumbnailCreated(Thumbnail $thumbnail)
-    {
     }
 }

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Media\Tests\Functional\Domain\Model;
 
 /*


### PR DESCRIPTION
Remove deprecated signals `Asset::emitAssetCreated` and `Thumbnail:: emitThumbnailCreated` which were moved to the according service classes.