### PR TITLE
BUGFIX: Filtering by nodeType that has subtypes causes a php_error

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1093,13 +1093,13 @@ class NodeDataRepository extends Repository
             } else {
                 $negate = false;
             }
-            $nodeTypeFilterPartSubTypes = array_merge([$nodeTypeFilterPart], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart));
+            $nodeTypeFilterPartSubTypes = array_merge([$this->nodeTypeManager->getNodeType($nodeTypeFilterPart)], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart));
 
             foreach ($nodeTypeFilterPartSubTypes as $nodeTypeFilterPartSubType) {
                 if ($negate === true) {
-                    $constraints['excludeNodeTypes'][] = $nodeTypeFilterPartSubType;
+                    $constraints['excludeNodeTypes'][] = $nodeTypeFilterPartSubType->getName();
                 } else {
-                    $constraints['includeNodeTypes'][] = $nodeTypeFilterPartSubType;
+                    $constraints['includeNodeTypes'][] = $nodeTypeFilterPartSubType->getName();
                 }
             }
         }
@@ -1125,13 +1125,13 @@ class NodeDataRepository extends Repository
             } else {
                 $negate = false;
             }
-            $nodeTypeFilterPartSubTypes = array_merge([$nodeTypeFilterPart], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart, false));
+            $nodeTypeFilterPartSubTypes = array_merge([$this->nodeTypeManager->getNodeType($nodeTypeFilterPart)], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart, false));
 
             foreach ($nodeTypeFilterPartSubTypes as $nodeTypeFilterPartSubType) {
                 if ($negate === true) {
-                    $excludeNodeTypeConstraints[] = $query->logicalNot($query->equals('nodeType', $nodeTypeFilterPartSubType));
+                    $excludeNodeTypeConstraints[] = $query->logicalNot($query->equals('nodeType', $nodeTypeFilterPartSubType->getName()));
                 } else {
-                    $includeNodeTypeConstraints[] = $query->equals('nodeType', $nodeTypeFilterPartSubType);
+                    $includeNodeTypeConstraints[] = $query->equals('nodeType', $nodeTypeFilterPartSubType->getName());
                 }
             }
         }


### PR DESCRIPTION
When calculating constraints for nodeType filter the nodeDataRepository currently puts the nodeType that was given as filter-argument directly as string to the returned constraint-object but all superTypes as NodeType-objects. This later causes trouble once the types are passed to the isOfType method that expects (but not enforces) strings.

The problem exists since ages but is exposed in Neos 4.2 by the altered handling of removed NodeTypes. Before that `isOfType` implicitly accepted a NodeType as argument. The added checks for declaredSuperTypes that are null (removed by subtype) broke this implication.

Resolves: https://github.com/neos/neos-development-collection/issues/2460