### PR TITLE
BUGFIX: Fix `parents` flowQuery operation accidentally returning the `/sites` and `/` node

### DIFF
--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/ParentsOperation.php
@@ -70,8 +70,8 @@ class ParentsOperation extends AbstractOperation
                     break;
                 }
                 // stop at sites
-                if ($node->findNodePath() === SiteService::SITES_ROOT_PATH) {
-                    continue;
+                if ($node->findNodePath() == SiteService::SITES_ROOT_PATH) {
+                    break;
                 }
                 $parents[] = $node;
             } while (true);

--- a/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -30,12 +30,18 @@ class ParentsOperationTest extends UnitTestCase
      */
     public function parentsWillReturnTheSiteNodeAsRootLevelParent()
     {
+        $rootNode = $this->createMock(TraversableNodeInterface::class);
+        $sitesNode = $this->createMock(TraversableNodeInterface::class);
         $siteNode = $this->createMock(TraversableNodeInterface::class);
         $firstLevelNode = $this->createMock(TraversableNodeInterface::class);
         $secondLevelNode = $this->createMock(TraversableNodeInterface::class);
 
+        $rootNode->expects($this->any())->method('findNodePath')->will($this->returnValue(NodePath::fromString('/')));
+        $rootNode->expects($this->any())->method('findParentNode')->will($this->throwException(new NodeException('No parent')));
+        $sitesNode->expects($this->any())->method('findNodePath')->will($this->returnValue(NodePath::fromString('/sites')));
+        $sitesNode->expects($this->any())->method('findParentNode')->will($this->returnValue($rootNode));
         $siteNode->expects($this->any())->method('findNodePath')->will($this->returnValue(NodePath::fromString('/sites/site')));
-        $siteNode->expects($this->any())->method('findParentNode')->will($this->throwException(new NodeException('No parent')));
+        $siteNode->expects($this->any())->method('findParentNode')->will($this->returnValue($sitesNode));
         $firstLevelNode->expects($this->any())->method('findParentNode')->will($this->returnValue($siteNode));
         $firstLevelNode->expects($this->any())->method('findNodePath')->will($this->returnValue(NodePath::fromString('/sites/site/first')));
         $secondLevelNode->expects($this->any())->method('findParentNode')->will($this->returnValue($firstLevelNode));


### PR DESCRIPTION
The test that should verify this behavior failed to mock the root and sites node and thus the exclusion of `/sites` was not verified correctly.

Resolves: #2459