### PR TITLE
Bugfix: Do access objects by key 0 in canEvaluate() of sort-operation

### DIFF
--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -41,7 +41,7 @@ class SortOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof NodeInterface));
+	return count($context) === 0 || (is_array($context) === true && (current($context) instanceof NodeInterface));
     }
 
     /**

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -41,7 +41,7 @@ class SortOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-	return count($context) === 0 || (is_array($context) === true && (current($context) instanceof NodeInterface));
+        return count($context) === 0 || (is_array($context) === true && (current($context) instanceof NodeInterface));
     }
 
     /**


### PR DESCRIPTION
For the current use of the sort operation, the element with key 0 must be present in $context. But this is not necessary for the sort itself. Consequently, the sort operation does not work using arrays without key 0. 

Access via pointer avoids this problem in this PR.