### PR TITLE
TASK: Limit parentpath index length through annotation

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -39,14 +39,11 @@ use Neos\ContentRepository\Utility;
  *    },
  *    indexes={
  *      @ORM\Index(name="parentpath_sortingindex",columns={"parentpathhash", "sortingindex"}),
- *      @ORM\Index(name="parentpath",columns={"parentpath"}),
+ *      @ORM\Index(name="parentpath",columns={"parentpath"},options={"lengths": {255}}),
  *      @ORM\Index(name="identifierindex",columns={"identifier"}),
  *      @ORM\Index(name="nodetypeindex",columns={"nodetype"})
  *    }
  * )
- *
- * The parentpath index above is actually limited to a size of 255 characters in the corresponding MySQL migration,
- * something that cannot be expressed through the annotation.
  */
 class NodeData extends AbstractNodeData
 {


### PR DESCRIPTION
As of Doctrine DBAL 2.9.0 this is actually possible, so we can finally
do it right.

See #2475
