### PR TITLE
BUGFIX: Make exception for non renderable fusion path more helpful

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -949,12 +949,14 @@ class Runtime
         if (isset($fusionConfiguration['__objectType'])) {
             $objectType = $fusionConfiguration['__objectType'];
             throw new Exceptions\MissingFusionImplementationException(sprintf(
-                "The Fusion object at path `%s` could not be rendered:
-					The Fusion object `%s` is not completely defined (missing property `@class`).
-					Most likely you didn't inherit from a basic object.
-					For example you could add the following line to your Fusion:
-					`prototype(%s) < prototype(Neos.Fusion:Template)`",
-                $fusionPath, $objectType, $objectType), 1332493995);
+                "The Fusion object `%s` cannot be rendered:
+					Most likely you misstyped the prototype name or did not define 
+					the fusion prototype with `prototype(%s) < prototype ...` . 
+					Other possible reasons are a missing parent-prototype or 
+					a missing `@class` annotation for prototypes without parent.
+					It is also possible your fusion file ins not read because 
+					of a missing `include:` statement.",
+                $objectType, $objectType), 1332493995);
         }
 
         if ($behaviorIfPathNotFound === self::BEHAVIOR_EXCEPTION) {

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -950,11 +950,11 @@ class Runtime
             $objectType = $fusionConfiguration['__objectType'];
             throw new Exceptions\MissingFusionImplementationException(sprintf(
                 "The Fusion object `%s` cannot be rendered:
-					Most likely you misstyped the prototype name or did not define 
-					the fusion prototype with `prototype(%s) < prototype ...` . 
+					Most likely you mistyped the prototype name or did not define 
+					the Fusion prototype with `prototype(%s) < prototype ...` . 
 					Other possible reasons are a missing parent-prototype or 
 					a missing `@class` annotation for prototypes without parent.
-					It is also possible your fusion file ins not read because 
+					It is also possible your Fusion file is not read because 
 					of a missing `include:` statement.",
                 $objectType, $objectType), 1332493995);
         }


### PR DESCRIPTION
The existing exception for non renderable fusion pathes was not very helpful hard to read and missed mentioning likely reasons like a typo in the prototype name. It also suggested a solution that is unlikely to fix the problem.

With this change the prototype name is moved to the front of the error message
as it is the most important information.

The path is removed from the message-body as the fusion exception handler will render it anyway.

The most likely reasons typo + missing prototype are mentioned first and other possible reasons
like missing parent-protopype, missing `@class` and missing `include:` later.

The proposed solution to inherit from `Neos.Fusion:Template` is removed as it was misleading