### PR TITLE
BUGFIX: Assigned asset collections cannot be unassigned

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -399,7 +399,9 @@ class Asset implements AssetInterface
     {
         $this->lastModified = new \DateTime();
         foreach ($this->assetCollections as $existingAssetCollection) {
-            $existingAssetCollection->removeAsset($this);
+            if (!$assetCollections->contains($existingAssetCollection)) {
+                $existingAssetCollection->removeAsset($this);
+            }
         }
         foreach ($assetCollections as $newAssetCollection) {
             $newAssetCollection->addAsset($this);

--- a/Neos.Media/Classes/Domain/Model/AssetCollection.php
+++ b/Neos.Media/Classes/Domain/Model/AssetCollection.php
@@ -120,7 +120,7 @@ class AssetCollection
      */
     public function removeAsset(Asset $asset): bool
     {
-        if ($asset->getAssetCollections()->contains($this) === false) {
+        if ($asset->getAssetCollections()->contains($this) === true) {
             $this->assets->removeElement($asset);
             return true;
         }


### PR DESCRIPTION
Fix the behaviour when the asset can't be unassigned from collections

Fixes #2473