### PR TITLE
BUGFIX: The caption of assets is lost when exporting to Sites.xml

### DIFF
--- a/Neos.Media/Classes/TypeConverter/ArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ArrayConverter.php
@@ -135,6 +135,7 @@ class ArrayConverter extends AbstractTypeConverter
                     '__identity' => $identity,
                     '__type' => \Neos\Utility\TypeHandling::getTypeForValue($source),
                     'title' => $source->getTitle(),
+                    'caption' => $source->getCaption(),
                     'resource' => $convertedChildProperties['resource']
                 );
         }


### PR DESCRIPTION
Notes:
1. I could not find tests covering this part of the code. If you point me to it, I will also add a test case for `caption`.
2. The copyright notice is also missing from the export, but afaik this was added in Neos 4.2, so I will open a separate PR.
3. Relations to tags and collections are also missing from the export, but they seem more complicated, so I will open separate PRs.

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

Included the caption of assets in exports to `Sites.xml`.

**How I did it**

Added `caption` in `ArrayConverter.php` the same way as `title`.

**How to verify it**

1. Add a caption to an asset.
2. Export to `Sites.xml`.
3. Do a clean import.
4. Check that the caption is preserved.


