### PR TITLE
Show hidden in index nodes in dimensions menu

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
@@ -7,6 +7,9 @@ prototype(Neos.Neos:DimensionsMenu) < prototype(Neos.Neos:Menu) {
 		class = 'normal'
 	}
 
+  # if documents which are hidden in index should be rendered or not
+  renderHiddenInIndex = true
+
 	# name of the dimension to use (optional)
 	dimension = null
 


### PR DESCRIPTION
Re-add `renderHiddenInIndex` with default `true`, to show also hidden in index nodes in dimensions menu as before.