### PR TITLE
TASK: Add flowQuery `q` helper to the Eel configuration

### DIFF
--- a/Neos.ContentRepository/Configuration/Settings.yaml
+++ b/Neos.ContentRepository/Configuration/Settings.yaml
@@ -56,6 +56,7 @@ Neos:
           Math: Neos\Eel\Helper\MathHelper
           Json: Neos\Eel\Helper\JsonHelper
           I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
+          q: Neos\Eel\FlowQuery\FlowQuery::q
 
     # the fallback NodeType can be used as a replacement for unknown NodeTypes
     #

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -39,3 +39,4 @@ Neos:
       Type: 'Neos\Eel\Helper\TypeHelper'
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       File: 'Neos\Eel\Helper\FileHelper'
+      q: 'Neos\Eel\FlowQuery\FlowQuery::q'

--- a/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
+++ b/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
@@ -24,8 +24,11 @@ properties:
           defaultContext:
             type: dictionary
             additionalProperties:
-              type: string
-              format: class-name
+              type:
+                - type: string
+                  format: class-name
+                - type: string
+                  pattern: '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\\]*::[a-zA-Z_\x7f-\xff]*$/u'
           dsl:
             type: dictionary
             additionalProperties:


### PR DESCRIPTION
Once the magic `q` method is removed FlowQuery has to be registered in the configuration to have `q` in the defaultContext for Fusion and CR label generation. This makes FlowQuery work as before from an integration perspective.

