### PR TITLE
TASK: Remove arguments from VH render methods

### DIFF
--- a/Neos.ContentRepository/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Neos.ContentRepository/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -50,16 +50,30 @@ class PaginateViewHelper extends AbstractWidgetViewHelper
     protected $controller;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('as', 'string', 'Variable name for the result set', true);
+        $this->registerArgument('parentNode', NodeInterface::class, 'The parent node of the child nodes to show (instead of specifying the specific node set)');
+        $this->registerArgument('nodes', 'array', 'The specific collection of nodes to use for this paginator (instead of specifying the parentNode)', false, []);
+        $this->registerArgument('nodeTypeFilter', 'string', 'A node type (or more complex filter) to filter for in the results');
+        $this->registerArgument('configuration', 'array', 'Widget configuration', false, ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99, 'maximumNumberOfNodes' => 0]);
+    }
+
+    /**
      * Render this view helper
      *
-     * @param string $as Variable name for the result set
-     * @param \Neos\ContentRepository\Domain\Model\NodeInterface $parentNode The parent node of the child nodes to show (instead of specifying the specific node set)
-     * @param array $nodes The specific collection of nodes to use for this paginator (instead of specifying the parentNode)
-     * @param string $nodeTypeFilter A node type (or more complex filter) to filter for in the results
-     * @param array $configuration Additional configuration
      * @return string
+     * @throws \Neos\Flow\Mvc\Exception\InfiniteLoopException
+     * @throws \Neos\FluidAdaptor\Core\Widget\Exception\InvalidControllerException
+     * @throws \Neos\FluidAdaptor\Core\Widget\Exception\MissingControllerException
      */
-    public function render($as, NodeInterface $parentNode = null, array $nodes = [], $nodeTypeFilter = null, array $configuration = ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99, 'maximumNumberOfNodes' => 0])
+    public function render(): string
     {
         $response = $this->initiateSubRequest();
         return $response->getContent();

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -89,19 +89,10 @@ class RenderViewHelper extends AbstractViewHelper
 
         $slashSeparatedPath = str_replace('.', '/', $path);
 
-        if ($this->hasArgument('fusionPackageKey')) {
-            $this->initializeFusionView();
-            $this->fusionView->setPackageKey($this->arguments['fusionPackageKey']);
-            $this->fusionView->setFusionPath($slashSeparatedPath);
-            if ($this->hasArgument('context') !== null) {
-                $this->fusionView->assignMultiple($this->arguments['context']);
-            }
-
-            $output = $this->fusionView->render();
-        } else {
+        if ($this->arguments['fusionPackageKey'] === null) {
             /** @var $fusionObject AbstractFusionObject */
             $fusionObject = $this->viewHelperVariableContainer->getView()->getFusionObject();
-            if ($this->hasArgument('context')) {
+            if ($this->arguments['context'] !== null) {
                 $currentContext = $fusionObject->getRuntime()->getCurrentContext();
                 foreach ($this->arguments['context'] as $key => $value) {
                     $currentContext[$key] = $value;
@@ -112,9 +103,18 @@ class RenderViewHelper extends AbstractViewHelper
 
             $output = $fusionObject->getRuntime()->render($absolutePath);
 
-            if ($this->hasArgument('context')) {
+            if ($this->arguments['context'] !== null) {
                 $fusionObject->getRuntime()->popContext();
             }
+        } else {
+            $this->initializeFusionView();
+            $this->fusionView->setPackageKey($this->arguments['fusionPackageKey']);
+            $this->fusionView->setFusionPath($slashSeparatedPath);
+            if ($this->arguments['context'] !== null) {
+                $this->fusionView->assignMultiple($this->arguments['context']);
+            }
+
+            $output = $this->fusionView->render();
         }
 
         return $output;

--- a/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
+++ b/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
@@ -15,7 +15,6 @@ namespace Neos\Media\Browser\ViewHelpers;
 use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetViewHelper;
 use Neos\Media\Browser\ViewHelpers\Controller\PaginateController;
-use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;
 
 /**
  * This ViewHelper renders a pagination for asset proxy objects

--- a/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
+++ b/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
@@ -44,7 +44,7 @@ class PaginateViewHelper extends AbstractWidgetViewHelper
      */
     public function initializeArguments()
     {
-        $this->registerArgument('queryString', 'string', '', true);
+        $this->registerArgument('queryResult', AssetProxyQueryResultInterface::class, '', true);
         $this->registerArgument('as', 'string', '', true);
         $this->registerArgument('configuration', 'array', '', false, ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99]);
     }

--- a/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
+++ b/Neos.Media.Browser/Classes/ViewHelpers/PaginateViewHelper.php
@@ -38,18 +38,28 @@ class PaginateViewHelper extends AbstractWidgetViewHelper
     protected $controller;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('queryString', 'string', '', true);
+        $this->registerArgument('as', 'string', '', true);
+        $this->registerArgument('configuration', 'array', '', false, ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99]);
+    }
+
+    /**
      * Render this view helper
      *
-     * @param AssetProxyQueryResultInterface $queryResult
-     * @param string $as
-     * @param array $configuration
      * @return string
      * @throws \Neos\Flow\Mvc\Exception\InfiniteLoopException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\FluidAdaptor\Core\Widget\Exception\InvalidControllerException
      * @throws \Neos\FluidAdaptor\Core\Widget\Exception\MissingControllerException
      */
-    public function render(AssetProxyQueryResultInterface $queryResult, $as, array $configuration = ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99])
+    public function render(): string
     {
         $response = $this->initiateSubRequest();
         return $response->getContent();

--- a/Neos.Media.Browser/Classes/ViewHelpers/ThumbnailViewHelper.php
+++ b/Neos.Media.Browser/Classes/ViewHelpers/ThumbnailViewHelper.php
@@ -41,24 +41,31 @@ class ThumbnailViewHelper extends AbstractTagBasedViewHelper
 
     /**
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
         $this->registerTagAttribute('alt', 'string', 'Specifies an alternate text for an asset', true);
+
+        $this->registerArgument('assetProxy', AssetProxyInterface::class, 'The asset to be rendered as a thumbnail', true);
+        $this->registerArgument('width', 'integer', 'Desired width of the thumbnail');
+        $this->registerArgument('height', 'integer', 'Desired height of the thumbnail');
     }
 
     /**
      * Renders an HTML img tag with a thumbnail or preview image, created from a given asset proxy.
      *
-     * @param AssetProxyInterface $assetProxy The asset to be rendered as a thumbnail
-     * @param integer $width Desired width of the thumbnail
-     * @param integer $height Desired height of the thumbnail
      * @return string an <img...> html tag
      */
-    public function render(AssetProxyInterface $assetProxy = null, $width = null, $height = null)
+    public function render(): string
     {
+        /** @var AssetProxyInterface $assetProxy */
+        $assetProxy = $this->arguments['assetProxy'];
+        $width= $this->arguments['width'];
+        $height= $this->arguments['height'];
+
         if ($width === null || $height === null) {
             $width = 250;
             $height = 250;

--- a/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
@@ -56,46 +56,44 @@ class FileTypeIconViewHelper extends AbstractTagBasedViewHelper
 
     /**
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
+
+        $this->registerArgument('asset', AssetInterface::class, 'An Asset object to determine the file type icon for. Alternatively $filename can be specified.');
+        $this->registerArgument('filename', 'string', 'A filename to determine the file type icon for. Alternatively $asset can be specified.');
+        $this->registerArgument('width', 'integer', 'Desired width of the icon');
+        $this->registerArgument('height', 'integer', 'Desired height of the icon');
     }
 
     /**
      * Renders an <img> HTML tag for a file type icon for a given Neos.Media's asset instance
      *
-     * @param AssetInterface|null $file The Asset object. DEPRECATED, use $asset instead!
-     * @param AssetInterface|null $asset An Asset object to determine the file type icon for. Alternatively $filename can be specified.
-     * @param string|null $filename  A filename to determine the file type icon for. Alternatively $asset can be specified.
-     * @param integer|null $width
-     * @param integer|null $height
      * @return string
      */
-    public function render(AssetInterface $file = null, AssetInterface $asset = null, string $filename = null, $width = null, $height = null)
+    public function render(): string
     {
-        if ($asset === null) {
-            $asset = $file;
-        }
-        if ($asset === null && $filename === null) {
+        if (!$this->hasArgument('asset') && !$this->hasArgument('filename')) {
             throw new \InvalidArgumentException('You must either specify "asset" or "filename" for the ' . __CLASS__ . '.', 1524039575);
         }
 
-        if ($asset instanceof AssetInterface) {
-            $filename = $asset->getResource()->getFilename();
+        if ($this->arguments['asset'] instanceof AssetInterface) {
+            $filename = $this->arguments['asset']->getResource()->getFilename();
         }
 
         $icon = FileTypeIconService::getIcon($filename);
         $this->tag->addAttribute('src', $this->resourceManager->getPublicPackageResourceUriByPath($icon['src']));
         $this->tag->addAttribute('alt', $icon['alt']);
 
-        if ($width !== null) {
-            $this->tag->addAttribute('width', $width);
+        if ($this->arguments['width'] !== null) {
+            $this->tag->addAttribute('width', $this->arguments['width']);
         }
 
-        if ($height !== null) {
-            $this->tag->addAttribute('height', $height);
+        if ($this->arguments['height'] !== null) {
+            $this->tag->addAttribute('height', $this->arguments['height']);
         }
 
         return $this->tag->render();

--- a/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/FileTypeIconViewHelper.php
@@ -76,7 +76,7 @@ class FileTypeIconViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(): string
     {
-        if (!$this->hasArgument('asset') && !$this->hasArgument('filename')) {
+        if ($this->arguments['asset'] === null && !$this->arguments['filename'] === null) {
             throw new \InvalidArgumentException('You must either specify "asset" or "filename" for the ' . __CLASS__ . '.', 1524039575);
         }
 

--- a/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -54,6 +54,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
      * Initialize the arguments.
      *
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      * @api
      */
     public function initializeArguments()
@@ -63,6 +64,9 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this view helper', false, 'f3-form-error');
         $this->overrideArgument('value', 'mixed', 'Value of input tag. Required for checkboxes', true);
         $this->registerUniversalTagAttributes();
+
+        $this->registerArgument('checked', 'boolean', 'Specifies that the input element should be preselected');
+        $this->registerArgument('multiple', 'boolean', 'Specifies whether this checkbox belongs to a multivalue (is part of a checkbox group)');
     }
 
     /**
@@ -71,14 +75,12 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
      * This is changed to use the actual provided value of the value attribute
      * to support selecting object values.
      *
-     * @param boolean $checked Specifies that the input element should be preselected
-     * @param boolean $multiple Specifies whether this checkbox belongs to a multivalue (is part of a checkbox group)
-     *
      * @return string
      * @api
      */
-    public function render($checked = null, $multiple = null)
+    public function render(): string
     {
+        $checked = $this->arguments['checked'];
         $this->tag->addAttribute('type', 'checkbox');
 
         $nameAttribute = $this->getName();
@@ -93,12 +95,13 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
             if ($propertyValue instanceof \Traversable) {
                 $propertyValue = iterator_to_array($propertyValue);
             }
+
             if (is_array($propertyValue)) {
                 if ($checked === null) {
                     $checked = in_array($this->arguments['value'], $propertyValue, true);
                 }
                 $nameAttribute .= '[]';
-            } elseif ($multiple === true) {
+            } elseif ($this->arguments['multiple'] === true) {
                 $nameAttribute .= '[]';
             } elseif ($checked === null && $propertyValue !== null) {
                 $checked = (boolean)$propertyValue === (boolean)$valueAttribute;
@@ -126,7 +129,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
      *
      * @return string name
      */
-    protected function getNameWithoutPrefix()
+    protected function getNameWithoutPrefix(): string
     {
         $name = parent::getNameWithoutPrefix();
         return str_replace('[__identity]', '', $name);

--- a/Neos.Media/Classes/ViewHelpers/Format/RelativeDateViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Format/RelativeDateViewHelper.php
@@ -41,7 +41,7 @@ class RelativeDateViewHelper extends AbstractViewHelper
      */
     public function render(): string
     {
-        if ($this->hasArgument('date')) {
+        if ($this->arguments['date'] === null) {
             $date = $this->arguments['date'];
         } else {
             $date = $this->renderChildren();

--- a/Neos.Media/Classes/ViewHelpers/Format/RelativeDateViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Format/RelativeDateViewHelper.php
@@ -20,21 +20,33 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 class RelativeDateViewHelper extends AbstractViewHelper
 {
     /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('date', \DateTimeInterface::class, 'The date to be formatted');
+    }
+
+    /**
      * Renders a DateTime formatted relative to the current date.
      * Shows the time if the date is the current date.
      * Shows the month and date if the date is the current year.
      * Shows the year/month/date if the date is not the current year.
      *
-     * @param \DateTime $date
      * @return string an <img...> html tag
      * @throws \InvalidArgumentException
+     * @throws \Exception
      */
-    public function render(\DateTime $date = null)
+    public function render(): string
     {
-        if ($date === null) {
+        if ($this->hasArgument('date')) {
+            $date = $this->arguments['date'];
+        } else {
             $date = $this->renderChildren();
         }
-        if (!$date instanceof \DateTime) {
+        if (!$date instanceof \DateTimeInterface) {
             throw new \InvalidArgumentException('No valid date given,', 1424647058);
         }
         // More than 11 months ago

--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -15,6 +15,8 @@ use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Media\Domain\Service\AssetService;
+use Neos\Media\Domain\Service\ThumbnailService;
 
 /**
  * Renders an <img> HTML tag from a given Neos.Media's image instance
@@ -69,13 +71,13 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
 {
     /**
      * @Flow\Inject
-     * @var \Neos\Media\Domain\Service\ThumbnailService
+     * @var ThumbnailService
      */
     protected $thumbnailService;
 
     /**
      * @Flow\Inject
-     * @var \Neos\Media\Domain\Service\AssetService
+     * @var AssetService
      */
     protected $assetService;
 
@@ -120,11 +122,11 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(): string
     {
-        if (!$this->hasArgument('image')) {
+        if ($this->arguments['image'] === null) {
             return '';
         }
 
-        if ($this->hasArgument('preset')) {
+        if ($this->arguments['preset'] !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality'], $this->arguments['format']);

--- a/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ImageViewHelper.php
@@ -94,38 +94,42 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
         $this->registerTagAttribute('alt', 'string', 'Specifies an alternate text for an image', true);
-        $this->registerTagAttribute('ismap', 'string', 'Specifies an image as a server-side image-map. Rarely used. Look at usemap instead', false);
-        $this->registerTagAttribute('usemap', 'string', 'Specifies an image as a client-side image-map', false);
+        $this->registerTagAttribute('ismap', 'string', 'Specifies an image as a server-side image-map. Rarely used. Look at usemap instead');
+        $this->registerTagAttribute('usemap', 'string', 'Specifies an image as a client-side image-map');
+
+        $this->registerArgument('image', ImageInterface::class, 'The image to be rendered as an image');
+        $this->registerArgument('width', 'integer', 'Desired width of the image');
+        $this->registerArgument('maximumWidth', 'integer', 'Desired maximum width of the image');
+        $this->registerArgument('height', 'integer', 'Desired height of the image');
+        $this->registerArgument('maximumHeight', 'integer', 'Desired maximum height of the image');
+        $this->registerArgument('allowCropping', 'boolean', 'Whether the image should be cropped if the given sizes would hurt the aspect ratio', false, false);
+        $this->registerArgument('allowUpScaling', 'boolean', 'Whether the resulting image size might exceed the size of the original asset', false, false);
+        $this->registerArgument('async', 'boolean', 'Return asynchronous image URI in case the requested image does not exist already', false, false);
+        $this->registerArgument('preset', 'string', 'Preset used to determine image configuration');
+        $this->registerArgument('quality', 'integer', 'Quality of the image, from 0 to 100');
+        $this->registerArgument('format', 'string', 'Format for the image, jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported');
     }
 
     /**
      * Renders an HTML img tag with a thumbnail image, created from a given image.
      *
-     * @param ImageInterface $image The image to be rendered as an image
-     * @param integer $width Desired width of the image
-     * @param integer $maximumWidth Desired maximum width of the image
-     * @param integer $height Desired height of the image
-     * @param integer $maximumHeight Desired maximum height of the image
-     * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
-     * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
-     * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
-     * @param string $preset Preset used to determine image configuration
-     * @param integer $quality Image quality, from 0 to 100
-     * @param string $format Format for the image, jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported
      * @return string an <img...> html tag
+     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
+     * @throws \Neos\Media\Exception\AssetServiceException
+     * @throws \Neos\Media\Exception\ThumbnailServiceException
      */
-    public function render(ImageInterface $image = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null, $format = null)
+    public function render(): string
     {
-        if ($image === null) {
+        if (!$this->hasArgument('image')) {
             return '';
         }
 
-        if ($preset) {
-            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
+        if ($this->hasArgument('preset')) {
+            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality, $format);
+            $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality'], $this->arguments['format']);
         }
-        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $this->controllerContext->getRequest());
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($this->arguments['image'], $thumbnailConfiguration, $this->controllerContext->getRequest());
 
         if ($thumbnailData === null) {
             return '';

--- a/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
@@ -130,7 +130,7 @@ class ThumbnailViewHelper extends AbstractTagBasedViewHelper
      */
     public function render(): string
     {
-        if ($this->hasArgument('preset')) {
+        if ($this->arguments['preset'] !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality']);

--- a/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
@@ -21,7 +21,6 @@ use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Media\Exception\AssetServiceException;
 use Neos\Media\Exception\ThumbnailServiceException;
-use Webmozart\Assert\Assert;
 
 /**
  * Renders an <img> HTML tag from a given Neos.Media's asset instance

--- a/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/ThumbnailViewHelper.php
@@ -12,12 +12,16 @@ namespace Neos\Media\ViewHelpers;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Service\ThumbnailService;
+use Neos\Media\Exception\AssetServiceException;
+use Neos\Media\Exception\ThumbnailServiceException;
+use Webmozart\Assert\Assert;
 
 /**
  * Renders an <img> HTML tag from a given Neos.Media's asset instance
@@ -97,37 +101,42 @@ class ThumbnailViewHelper extends AbstractTagBasedViewHelper
 
     /**
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
         $this->registerTagAttribute('alt', 'string', 'Specifies an alternate text for an asset', true);
+
+        $this->registerArgument('asset', AssetInterface::class, 'The asset to be rendered as a thumbnail', true);
+        $this->registerArgument('width', 'integer', 'Desired width of the thumbnail');
+        $this->registerArgument('maximumWidth', 'integer', 'Desired maximum width of the thumbnail');
+        $this->registerArgument('height', 'integer', 'Desired height of the thumbnail');
+        $this->registerArgument('maximumHeight', 'integer', 'Desired maximum height of the thumbnail');
+        $this->registerArgument('allowCropping', 'boolean', 'Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio', false, false);
+        $this->registerArgument('allowUpScaling', 'boolean', 'Whether the resulting thumbnail size might exceed the size of the original asset', false, false);
+        $this->registerArgument('async', 'boolean', 'Return asynchronous image URI in case the requested image does not exist already', false, false);
+        $this->registerArgument('preset', 'string', 'Preset used to determine image configuration');
+        $this->registerArgument('quality', 'integer', 'Quality of the image, from 0 to 100');
     }
 
     /**
      * Renders an HTML img tag with a thumbnail image, created from a given asset.
      *
-     * @param AssetInterface $asset The asset to be rendered as a thumbnail
-     * @param integer $width Desired width of the thumbnail
-     * @param integer $maximumWidth Desired maximum width of the thumbnail
-     * @param integer $height Desired height of the thumbnail
-     * @param integer $maximumHeight Desired maximum height of the thumbnail
-     * @param boolean $allowCropping Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio
-     * @param boolean $allowUpScaling Whether the resulting thumbnail size might exceed the size of the original asset
-     * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
-     * @param string $preset Preset used to determine image configuration
-     * @param integer $quality Quality of the image
      * @return string an <img...> html tag
+     * @throws AssetServiceException
+     * @throws MissingActionNameException
+     * @throws ThumbnailServiceException
      */
-    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null)
+    public function render(): string
     {
-        if ($preset) {
-            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
+        if ($this->hasArgument('preset')) {
+            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality);
+            $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality']);
         }
-        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $this->controllerContext->getRequest());
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($this->arguments['asset'], $thumbnailConfiguration, $this->controllerContext->getRequest());
 
         if ($thumbnailData === null) {
             return '';

--- a/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -83,11 +83,11 @@ class ImageViewHelper extends AbstractViewHelper
      */
     public function render(): string
     {
-        if (!$this->hasArgument('image')) {
+        if ($this->arguments['image'] === null) {
             return '';
         }
 
-        if ($this->hasArgument('preset')) {
+        if ($this->arguments['preset'] !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality'], $this->arguments['format']);

--- a/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
@@ -92,7 +92,7 @@ class ThumbnailViewHelper extends AbstractViewHelper
      */
     public function render(): string
     {
-        if ($this->hasArgument('preset')) {
+        if ($this->arguments['preset'] !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
             $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality']);

--- a/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Uri/ThumbnailViewHelper.php
@@ -64,27 +64,45 @@ class ThumbnailViewHelper extends AbstractViewHelper
     protected $assetService;
 
     /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('asset', AssetInterface::class, 'The asset to be rendered as a thumbnail', true);
+        $this->registerArgument('width', 'integer', 'Desired width of the thumbnail');
+        $this->registerArgument('maximumWidth', 'integer', 'Desired maximum width of the thumbnail');
+        $this->registerArgument('height', 'integer', 'Desired height of the thumbnail');
+        $this->registerArgument('maximumHeight', 'integer', 'Desired maximum height of the thumbnail');
+        $this->registerArgument('allowCropping', 'boolean', 'Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio', false, false);
+        $this->registerArgument('allowUpScaling', 'boolean', 'Whether the resulting thumbnail size might exceed the size of the original asset', false, false);
+        $this->registerArgument('async', 'boolean', 'Return asynchronous image URI in case the requested image does not exist already', false, false);
+        $this->registerArgument('preset', 'string', 'Preset used to determine image configuration');
+        $this->registerArgument('quality', 'integer', 'Quality of the image');
+    }
+
+    /**
      * Renders the path to a thumbnail image, created from a given asset.
      *
-     * @param AssetInterface $asset
-     * @param integer $width Desired width of the thumbnail
-     * @param integer $maximumWidth Desired maximum width of the thumbnail
-     * @param integer $height Desired height of the thumbnail
-     * @param integer $maximumHeight Desired maximum height of the thumbnail
-     * @param boolean $allowCropping Whether the thumbnail should be cropped if the given sizes would hurt the aspect ratio
-     * @param boolean $allowUpScaling Whether the resulting thumbnail size might exceed the size of the original asset
-     * @param boolean $async Return asynchronous image URI in case the requested image does not exist already
-     * @param string $preset Preset used to determine image configuration
-     * @param integer $quality Quality of the image
      * @return string the relative thumbnail path, to be used as src attribute for <img /> tags
+     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
+     * @throws \Neos\Media\Exception\AssetServiceException
+     * @throws \Neos\Media\Exception\ThumbnailServiceException
      */
-    public function render(AssetInterface $asset = null, $width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $preset = null, $quality = null)
+    public function render(): string
     {
-        if ($preset) {
-            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset, $async);
+        if ($this->hasArgument('preset')) {
+            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($this->arguments['preset'], $this->arguments['async']);
         } else {
-            $thumbnailConfiguration = new ThumbnailConfiguration($width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $quality);
+            $thumbnailConfiguration = new ThumbnailConfiguration($this->arguments['width'], $this->arguments['maximumWidth'], $this->arguments['height'], $this->arguments['maximumHeight'], $this->arguments['allowCropping'], $this->arguments['allowUpScaling'], $this->arguments['async'], $this->arguments['quality']);
         }
-        return $this->assetService->getThumbnailUriAndSizeForAsset($asset, $thumbnailConfiguration, $this->controllerContext->getRequest())['src'];
+        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($this->arguments['asset'], $thumbnailConfiguration, $this->controllerContext->getRequest());
+
+        if ($thumbnailData === null) {
+            return '';
+        }
+
+        return $thumbnailData['src'];
     }
 }

--- a/Neos.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/Neos.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -28,16 +28,15 @@ class ImageViewHelperTest extends ViewHelperBaseTestcase
         parent::setUp();
         $this->viewHelper = new ImageViewHelper();
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $this->viewHelper->initializeArguments();
     }
 
     /**
      * @test
      */
-    public function doNotThrowExceptionIfImageIsNull()
+    public function doNotThrowExceptionIfImageIsNull(): void
     {
-        $this->viewHelper->initialize();
-        $actualResult = $this->viewHelper->render(null);
+        $this->viewHelper = $this->prepareArguments($this->viewHelper);
+        $actualResult = $this->viewHelper->render();
 
         $this->assertEquals('', $actualResult);
     }

--- a/Neos.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/Neos.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -28,16 +28,15 @@ class ImageViewHelperTest extends ViewHelperBaseTestcase
         parent::setUp();
         $this->viewHelper = new ImageViewHelper();
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $this->viewHelper->initializeArguments();
     }
 
     /**
      * @test
      */
-    public function doNotThrowExceptionIfImageIsNull()
+    public function doNotThrowExceptionIfImageIsNull(): void
     {
-        $this->viewHelper->initialize();
-        $actualResult = $this->viewHelper->render(null);
+        $this->viewHelper = $this->prepareArguments($this->viewHelper);
+        $actualResult = $this->viewHelper->render();
 
         $this->assertEquals('', $actualResult);
     }

--- a/Neos.Neos/Classes/ViewHelpers/Backend/AuthenticationProviderLabelViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/AuthenticationProviderLabelViewHelper.php
@@ -26,14 +26,24 @@ class AuthenticationProviderLabelViewHelper extends AbstractViewHelper
     protected $authenticationProviderSettings;
 
     /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('identifier', 'string', 'The identifier to render the label for', true);
+    }
+
+    /**
      * Outputs a human friendly label for the authentication provider specified by $identifier
      *
-     * @param string $identifier
      * @return string
      * @throws \Exception
      */
-    public function render($identifier)
+    public function render(): string
     {
-        return (isset($this->authenticationProviderSettings[$identifier]['label']) ? $this->authenticationProviderSettings[$identifier]['label'] : $identifier);
+        $identifier = $this->arguments['identifier'];
+        return ($this->authenticationProviderSettings[$identifier]['label'] ?? $identifier);
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Backend/ChangeStatsViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/ChangeStatsViewHelper.php
@@ -24,15 +24,25 @@ class ChangeStatsViewHelper extends AbstractViewHelper
      * @var boolean
      */
     protected $escapeOutput = false;
+    /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('changeCounts', 'array', 'Expected keys: new, changed, removed', true);
+    }
 
     /**
      * Expects an array of change count data and adds calculated ratios to the rendered child view
      *
-     * @param array $changeCounts Expected keys: new, changed, removed
      * @return string
      */
-    public function render(array $changeCounts)
+    public function render(): string
     {
+        $changeCounts = $this->arguments['changeCounts'];
+
         $this->templateVariableContainer->add('newCountRatio', $changeCounts['new'] / $changeCounts['total'] * 100);
         $this->templateVariableContainer->add('changedCountRatio', $changeCounts['changed'] / $changeCounts['total'] * 100);
         $this->templateVariableContainer->add('removedCountRatio', $changeCounts['removed'] / $changeCounts['total'] * 100);

--- a/Neos.Neos/Classes/ViewHelpers/Backend/ColorOfStringViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/ColorOfStringViewHelper.php
@@ -19,20 +19,33 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 class ColorOfStringViewHelper extends AbstractViewHelper
 {
     /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('string', 'string', 'This is hashed (MD%) and then used as base for the resulting color, if not given the children are used');
+        $this->registerArgument('minimalBrightness', 'integer', 'Brightness, from 0 to 255', false, '50');
+    }
+
+    /**
      * Outputs a hex color code (#000000) based on $text
      *
-     * @param string $string
-     * @param integer $minimalBrightness
      * @return string
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
-    public function render($string = null, $minimalBrightness = 50)
+    public function render(): string
     {
+        $minimalBrightness = $this->arguments['minimalBrightness'];
+
         if ($minimalBrightness < 0 or $minimalBrightness > 255) {
-            throw new \Exception('Minimal brightness should be between 0 and 255', 1417553921);
+            throw new \InvalidArgumentException('Minimal brightness should be between 0 and 255', 1417553921);
         }
 
-        if ($string === null) {
+        if ($this->hasArgument('string')) {
+            $string = $this->arguments['string'];
+        } else {
             $string = $this->renderChildren();
         }
 

--- a/Neos.Neos/Classes/ViewHelpers/Backend/ConfigurationTreeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/ConfigurationTreeViewHelper.php
@@ -31,16 +31,25 @@ class ConfigurationTreeViewHelper extends AbstractViewHelper
     protected $output = '';
 
     /**
-     * Render the given $configuration
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('configuration', 'array', 'Configuration to show', true);
+    }
+
+    /**
+     * Render the $configuration
      *
-     * @param array $configuration
      * @return string
      * @throws \Exception
      */
-    public function render(array $configuration)
+    public function render(): string
     {
         $this->output = '';
-        $this->renderSingleLevel($configuration);
+        $this->renderSingleLevel($this->arguments['configuration']);
         return $this->output;
     }
 
@@ -51,7 +60,7 @@ class ConfigurationTreeViewHelper extends AbstractViewHelper
      * @param string $relativePath the path up-to-now
      * @return void
      */
-    protected function renderSingleLevel(array $configuration, $relativePath = null)
+    protected function renderSingleLevel(array $configuration, ?string $relativePath = null): void
     {
         $this->output .= '<ul>';
         foreach ($configuration as $key => $value) {

--- a/Neos.Neos/Classes/ViewHelpers/Backend/ContainerViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/ContainerViewHelper.php
@@ -73,11 +73,23 @@ class ContainerViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param NodeInterface $node
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node', true);
+    }
+
+    /**
      * @return string
      * @throws NeosException
+     * @throws \Neos\FluidAdaptor\Exception
      */
-    public function render(NodeInterface $node)
+    public function render(): string
     {
         if ($this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess') === false) {
             return '';
@@ -93,7 +105,7 @@ class ContainerViewHelper extends AbstractViewHelper
         $user = $this->partyService->getAssignedPartyOfAccount($this->securityContext->getAccount());
 
         $innerView->assignMultiple([
-            'node' => $node,
+            'node' => $this->arguments['node'],
             'modules' => $this->menuHelper->buildModuleList($this->controllerContext),
             'sites' => $this->menuHelper->buildSiteList($this->controllerContext),
             'user' => $user

--- a/Neos.Neos/Classes/ViewHelpers/Backend/DocumentBreadcrumbPathViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/DocumentBreadcrumbPathViewHelper.php
@@ -27,11 +27,25 @@ class DocumentBreadcrumbPathViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
-     * @param NodeInterface $node A node
-     * @return array of document nodes
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node)
+    public function initializeArguments()
     {
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node', true);
+    }
+
+    /**
+     * @return array of document nodes
+     * @throws \Neos\Eel\Exception
+     */
+    public function render(): array
+    {
+        $node = $this->arguments['node]'];
+
         $documentNodes = [];
         $flowQuery = new FlowQuery([$node]);
         $nodes = array_reverse($flowQuery->parents('[instanceof Neos.Neos:Document]')->get());

--- a/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -84,14 +84,6 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
     private $throwableStorage;
 
     /**
-     * @param LoggerInterface $logger
-     */
-    public function injectLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
-    }
-
-    /**
      * @param ThrowableStorageInterface $throwableStorage
      */
     public function injectThrowableStorage(ThrowableStorageInterface $throwableStorage)

--- a/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -24,7 +24,6 @@ use Neos\Utility\PositionalArraySorter;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Utility\BackendAssetsUtility;
-use Psr\Log\LoggerInterface;
 
 /**
  * ViewHelper for the backend JavaScript configuration. Renders the required JS snippet to configure

--- a/Neos.Neos/Classes/ViewHelpers/Backend/UserInitialsViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/UserInitialsViewHelper.php
@@ -45,19 +45,28 @@ class UserInitialsViewHelper extends AbstractViewHelper
     protected $domainUserService;
 
     /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('format', 'string', 'Supported are "fullFirstName", "initials" and "fullName"', false, 'initials');
+    }
+
+    /**
      * Render user initials or an abbreviated name for a given username. If the account was deleted, use the username as fallback.
      *
-     * @param string $format Supported are "fullFirstName", "initials" and "fullName"
      * @return string
      * @throws \Neos\Neos\Domain\Exception
      */
-    public function render($format = 'initials')
+    public function render(): string
     {
-        if (!in_array($format, ['fullFirstName', 'initials', 'fullName'])) {
+        if (!in_array($this->arguments['format'], ['fullFirstName', 'initials', 'fullName'])) {
             throw new \InvalidArgumentException(sprintf('Format "%s" given to backend.userInitials(), only supporting "fullFirstName", "initials" and "fullName".', $format), 1415705861);
         }
 
-        $username = $this->renderChildren();
+        $username = (string)$this->renderChildren();
 
         /* @var $requestedUser Person */
         $requestedUser = $this->domainUserService->getUser($username);
@@ -66,20 +75,18 @@ class UserInitialsViewHelper extends AbstractViewHelper
         }
 
         $currentUser = $this->userService->getBackendUser();
-        if ($currentUser) {
-            if ($currentUser === $requestedUser) {
-                $translationHelper = new TranslationHelper();
-                $you = $translationHelper->translate('you', null, [], 'Main', 'Neos.Neos');
-            }
+        if ($currentUser && $currentUser === $requestedUser) {
+            $translationHelper = new TranslationHelper();
+            $you = $translationHelper->translate('you', null, [], 'Main', 'Neos.Neos');
         }
 
-        switch ($format) {
+        switch ($this->arguments['format']) {
             case 'initials':
                 return mb_substr(preg_replace('/[^[:alnum:][:space:]]/u', '', $requestedUser->getName()->getFirstName()), 0, 1) . mb_substr(preg_replace('/[^[:alnum:][:space:]]/u', '', $requestedUser->getName()->getLastName()), 0, 1);
             case 'fullFirstName':
-                return isset($you) ? $you : trim($requestedUser->getName()->getFirstName() . ' ' . ltrim(mb_substr($requestedUser->getName()->getLastName(), 0, 1) . '.', '.'));
+                return $you ?? trim($requestedUser->getName()->getFirstName() . ' ' . ltrim(mb_substr($requestedUser->getName()->getLastName(), 0, 1) . '.', '.'));
             case 'fullName':
-                return isset($you) ? $you : $requestedUser->getName()->getFullName();
+                return $you ?? $requestedUser->getName()->getFullName();
         }
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -61,25 +61,28 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
+
+        $this->registerArgument('property', 'string', 'Name of the property to render. Note: If this tag has child nodes, they overrule this argument!', true);
+        $this->registerArgument('tag', 'string', 'The name of the tag that should be wrapped around the property. By default this is a <div>', false, 'div');
+        $this->registerArgument('node', NodeInterface::class, 'The node of the content element. Optional, will be resolved from the Fusion context by default');
     }
 
     /**
      * In live workspace this just renders a tag; for logged in users with access to the Backend this also adds required
      * attributes for the editing.
      *
-     * @param string $property Name of the property to render. Note: If this tag has child nodes, they overrule this argument!
-     * @param string $tag The name of the tag that should be wrapped around the property. By default this is a <div>
-     * @param NodeInterface $node The node of the content element. Optional, will be resolved from the Fusion context by default.
      * @return string The rendered property with a wrapping tag. In the user workspace this adds some required attributes for the RTE to work
      * @throws ViewHelperException
      */
-    public function render($property, $tag = 'div', NodeInterface $node = null)
+    public function render(): string
     {
-        $this->tag->setTagName($tag);
+        $this->tag->setTagName($this->arguments['tag']);
         $this->tag->forceClosingTag(true);
         $content = $this->renderChildren();
 
-        if ($node === null) {
+        if ($this->hasArgument('node')) {
+            $node = $this->arguments['node'];
+        } else {
             $node = $this->getNodeFromFusionContext();
         }
 
@@ -87,15 +90,16 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
             throw new ViewHelperException('A node is required, but one was not supplied and could not be found in the Fusion context.', 1408521638);
         }
 
+        $propertyName = $this->arguments['property'];
         if ($content === null) {
-            if (!$this->templateVariableContainer->exists($property)) {
-                throw new ViewHelperException(sprintf('The property "%1$s" was not set as a template variable. If you use this ViewHelper in a partial, make sure to pass the node property "%1$s" as an argument.', $property), 1384507046);
+            if (!$this->templateVariableContainer->exists($propertyName)) {
+                throw new ViewHelperException(sprintf('The property "%1$s" was not set as a template variable. If you use this ViewHelper in a partial, make sure to pass the node property "%1$s" as an argument.', $propertyName), 1384507046);
             }
-            $content = $this->templateVariableContainer->get($property);
+            $content = $this->templateVariableContainer->get($propertyName);
         }
         $this->tag->setContent($content);
 
-        return $this->contentElementEditableService->wrapContentProperty($node, $property, $this->tag->render());
+        return $this->contentElementEditableService->wrapContentProperty($node, $propertyName, $this->tag->render());
     }
 
     /**

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -80,11 +80,7 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
         $this->tag->forceClosingTag(true);
         $content = $this->renderChildren();
 
-        if ($this->hasArgument('node')) {
-            $node = $this->arguments['node'];
-        } else {
-            $node = $this->getNodeFromFusionContext();
-        }
+        $node = $this->arguments['node'] ?? $this->getNodeFromFusionContext();
 
         if ($node === null) {
             throw new ViewHelperException('A node is required, but one was not supplied and could not be found in the Fusion context.', 1408521638);
@@ -106,7 +102,7 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
      * @return NodeInterface
      * @throws ViewHelperException
      */
-    protected function getNodeFromFusionContext()
+    protected function getNodeFromFusionContext(): NodeInterface
     {
         $node = $this->getContextVariable('node');
         if ($node === null) {

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -50,14 +50,25 @@ class WrapViewHelper extends AbstractViewHelper
     protected $contentElementWrappingService;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node');
+    }
+
+    /**
      * In live workspace this just renders a the content.
      * For logged in users with access to the Backend this also adds the attributes for the RTE to work.
      *
-     * @param NodeInterface $node The node of the content element. Optional, will be resolved from the Fusion context by default.
      * @return string The rendered property with a wrapping tag. In the user workspace this adds some required attributes for the RTE to work
      * @throws ViewHelperException
      */
-    public function render(NodeInterface $node = null)
+    public function render(): string
     {
         $view = $this->viewHelperVariableContainer->getView();
         if (!$view instanceof FusionAwareViewInterface) {
@@ -66,7 +77,9 @@ class WrapViewHelper extends AbstractViewHelper
         $fusionObject = $view->getFusionObject();
         $currentContext = $fusionObject->getRuntime()->getCurrentContext();
 
-        if ($node === null) {
+        if ($this->hasArgument('node')) {
+            $node = $this->arguments['node'];
+        } else {
             $node = $currentContext['node'];
         }
         return $this->contentElementWrappingService->wrapContentObject($node, $this->renderChildren(), $fusionObject->getPath());

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -77,11 +77,7 @@ class WrapViewHelper extends AbstractViewHelper
         $fusionObject = $view->getFusionObject();
         $currentContext = $fusionObject->getRuntime()->getCurrentContext();
 
-        if ($this->hasArgument('node')) {
-            $node = $this->arguments['node'];
-        } else {
-            $node = $currentContext['node'];
-        }
+        $node = $this->arguments['node'] ?? $currentContext['node'];
         return $this->contentElementWrappingService->wrapContentObject($node, $this->renderChildren(), $fusionObject->getPath());
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/GetTypeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/GetTypeViewHelper.php
@@ -36,11 +36,20 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 class GetTypeViewHelper extends AbstractViewHelper
 {
     /**
-     * @param mixed $value The value to determine the type of
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('value', 'mixed', 'The value to get the type of');
+    }
+
+    /**
      * @return string
      */
-    public function render($value = null)
+    public function render(): string
     {
-        return gettype($value ?: $this->renderChildren());
+        return gettype($this->arguments['value'] ?: $this->renderChildren());
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
@@ -51,27 +51,28 @@ class ModuleViewHelper extends AbstractTagBasedViewHelper
         $this->registerTagAttribute('rel', 'string', 'Specifies the relationship between the current document and the linked document');
         $this->registerTagAttribute('rev', 'string', 'Specifies the relationship between the linked document and the current document');
         $this->registerTagAttribute('target', 'string', 'Specifies where to open the linked document');
+
+        $this->registerArgument('path', 'string', 'Target module path', true);
+        $this->registerArgument('action', 'string', 'Target module action');
+        $this->registerArgument('arguments', 'array', 'Arguments', false, []);
+        $this->registerArgument('section', 'string', 'The anchor to be added to the URI');
+        $this->registerArgument('format', 'string', 'The requested format, e.g. ".html"');
+        $this->registerArgument('additionalParams', 'array', 'additional query parameters that won\'t be prefixed like $arguments (overrule $arguments)', false, []);
+        $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
     }
 
     /**
      * Render a link to a specific module
      *
-     * @param string $path Target module path
-     * @param string $action Target module action
-     * @param array $arguments Arguments
-     * @param string $section The anchor to be added to the URI
-     * @param string $format The requested format, e.g. ".html"
-     * @param array $additionalParams additional query parameters that won't be prefixed like $arguments (overrule $arguments)
-     * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
-     * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = true
      * @return string The rendered link
      * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render($path, $action = null, $arguments = [], $section = '', $format = '', array $additionalParams = [], $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [])
+    public function render(): string
     {
         $this->uriModuleViewHelper->setRenderingContext($this->renderingContext);
 
-        $uri = $this->uriModuleViewHelper->render($path, $action, $arguments, $section, $format, $additionalParams, $addQueryString, $argumentsToBeExcludedFromQueryString);
+        $uri = $this->uriModuleViewHelper->render($this->arguments['path'], $this->arguments['action'], $this->arguments['arguments'], $this->arguments['section'], $this->arguments['format'], $this->arguments['additionalParams'], $this->arguments['addQueryString'], $this->arguments['argumentsToBeExcludedFromQueryString']);
         if ($uri !== null) {
             $this->tag->addAttribute('href', $uri);
         }

--- a/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
@@ -43,6 +43,7 @@ class ModuleViewHelper extends AbstractTagBasedViewHelper
      * Initialize arguments
      *
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function initializeArguments()
     {
@@ -72,7 +73,17 @@ class ModuleViewHelper extends AbstractTagBasedViewHelper
     {
         $this->uriModuleViewHelper->setRenderingContext($this->renderingContext);
 
-        $uri = $this->uriModuleViewHelper->render($this->arguments['path'], $this->arguments['action'], $this->arguments['arguments'], $this->arguments['section'], $this->arguments['format'], $this->arguments['additionalParams'], $this->arguments['addQueryString'], $this->arguments['argumentsToBeExcludedFromQueryString']);
+        $this->uriModuleViewHelper->setArguments([
+            'path' => $this->arguments['path'],
+            'action' => $this->arguments['action'],
+            'arguments' => $this->arguments['arguments'],
+            'section' => $this->arguments['section'],
+            'format' => $this->arguments['format'],
+            'additionalParams' => $this->arguments['additionalParams'],
+            'addQueryString' => $this->arguments['addQueryString'],
+            'argumentsToBeExcludedFromQueryString' => $this->arguments['argumentsToBeExcludedFromQueryString']
+        ]);
+        $uri = $this->uriModuleViewHelper->render();
         if ($uri !== null) {
             $this->tag->addAttribute('href', $uri);
         }

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\ViewHelpers\Link;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\Neos\Exception as NeosException;
@@ -120,9 +121,16 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
     protected $linkingService;
 
     /**
+     * @Flow\Inject
+     * @var ThrowableStorageInterface
+     */
+    protected $throwableStorage;
+
+    /**
      * Initialize arguments
      *
      * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function initializeArguments()
     {
@@ -178,9 +186,9 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             );
             $this->tag->addAttribute('href', $uri);
         } catch (NeosException $exception) {
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
         } catch (NoMatchingRouteException $exception) {
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
         }
 
         $linkedNode = $this->linkingService->getLastLinkedNode();

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -16,7 +16,6 @@ use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\Neos\Exception as NeosException;
 use Neos\Neos\Service\LinkingService;
-use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Fusion\ViewHelpers\FusionContextTrait;
 

--- a/Neos.Neos/Classes/ViewHelpers/Node/ClosestDocumentViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Node/ClosestDocumentViewHelper.php
@@ -21,12 +21,24 @@ use Neos\Eel\FlowQuery\FlowQuery;
 class ClosestDocumentViewHelper extends AbstractViewHelper
 {
     /**
-     * @param NodeInterface $node
-     * @return NodeInterface
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node)
+    public function initializeArguments()
     {
-        $flowQuery = new FlowQuery([$node]);
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node', true);
+    }
+
+    /**
+     * @return NodeInterface
+     * @throws \Neos\Eel\Exception
+     */
+    public function render()
+    {
+        $flowQuery = new FlowQuery([$this->arguments['node']]);
         return $flowQuery->closest('[instanceof Neos.Neos:Document]')->get(0);
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InBackendViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InBackendViewHelper.php
@@ -37,12 +37,25 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 class InBackendViewHelper extends AbstractRenderingStateViewHelper
 {
     /**
-     * @param NodeInterface $node
-     * @return boolean
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node = null)
+    public function initializeArguments()
     {
-        $context = $this->getNodeContext($node);
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node');
+    }
+
+    /**
+     * @return boolean
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function render(): bool
+    {
+        $context = $this->getNodeContext($this->arguments['node']);
 
         return $context->isInBackend();
     }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InEditModeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InEditModeViewHelper.php
@@ -74,10 +74,9 @@ class InEditModeViewHelper extends AbstractRenderingStateViewHelper
      */
     public function render(): bool
     {
-        $node = $this->hasArgument('node') ? $this->arguments['node'] : null;
-        $context = $this->getNodeContext($node);
+        $context = $this->getNodeContext($this->arguments['node']);
         $renderingMode = $context->getCurrentRenderingMode();
-        if ($this->hasArgument('mode')) {
+        if ($this->arguments['mode'] !== null) {
             $result = ($renderingMode->getName() === $this->arguments['mode']) && $renderingMode->isEdit();
         } else {
             $result = $renderingMode->isEdit();

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InEditModeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InEditModeViewHelper.php
@@ -55,17 +55,30 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 class InEditModeViewHelper extends AbstractRenderingStateViewHelper
 {
     /**
-     * @param NodeInterface $node Optional Node to use context from
-     * @param string $mode Optional rendering mode name to check if this specific mode is active
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Optional Node to use context from');
+        $this->registerArgument('mode', 'string', 'Optional rendering mode name to check if this specific mode is active');
+    }
+
+    /**
      * @return boolean
      * @throws \Neos\Neos\Exception
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node = null, $mode = null)
+    public function render(): bool
     {
+        $node = $this->hasArgument('node') ? $this->arguments['node'] : null;
         $context = $this->getNodeContext($node);
         $renderingMode = $context->getCurrentRenderingMode();
-        if ($mode !== null) {
-            $result = ($renderingMode->getName() === $mode) && $renderingMode->isEdit();
+        if ($this->hasArgument('mode')) {
+            $result = ($renderingMode->getName() === $this->arguments['mode']) && $renderingMode->isEdit();
         } else {
             $result = $renderingMode->isEdit();
         }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
@@ -74,10 +74,9 @@ class InPreviewModeViewHelper extends AbstractRenderingStateViewHelper
      */
     public function render(): bool
     {
-        $node = $this->hasArgument('node') ? $this->arguments['node'] : null;
-        $context = $this->getNodeContext($node);
+        $context = $this->getNodeContext($this->arguments['node']);
         $renderingMode = $context->getCurrentRenderingMode();
-        if ($this->hasArgument('mode')) {
+        if ($this->arguments['mode'] !== null) {
             $result = ($renderingMode->getName() === $this->arguments['mode']) && $renderingMode->isPreview();
         } else {
             $result = $renderingMode->isPreview();

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
@@ -55,17 +55,30 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 class InPreviewModeViewHelper extends AbstractRenderingStateViewHelper
 {
     /**
-     * @param NodeInterface $node Optional Node to use context from
-     * @param string $mode Optional rendering mode name to check if this specific mode is active
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Optional Node to use context from');
+        $this->registerArgument('mode', 'string', 'Optional rendering mode name to check if this specific mode is active');
+    }
+
+    /**
      * @return boolean
      * @throws \Neos\Neos\Exception
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node = null, $mode = null)
+    public function render(): bool
     {
+        $node = $this->hasArgument('node') ? $this->arguments['node'] : null;
         $context = $this->getNodeContext($node);
         $renderingMode = $context->getCurrentRenderingMode();
-        if ($mode !== null) {
-            $result = ($renderingMode->getName() === $mode) && $renderingMode->isPreview();
+        if ($this->hasArgument('mode')) {
+            $result = ($renderingMode->getName() === $this->arguments['mode']) && $renderingMode->isPreview();
         } else {
             $result = $renderingMode->isPreview();
         }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/LiveViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/LiveViewHelper.php
@@ -39,12 +39,25 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 class LiveViewHelper extends AbstractRenderingStateViewHelper
 {
     /**
-     * @param NodeInterface $node
-     * @return boolean
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render(NodeInterface $node = null)
+    public function initializeArguments()
     {
-        $context = $this->getNodeContext($node);
+        parent::initializeArguments();
+        $this->registerArgument('node', NodeInterface::class, 'Node');
+    }
+
+    /**
+     * @return boolean
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function render(): bool
+    {
+        $context = $this->getNodeContext($this->arguments['node']);
 
         return $context->isLive();
     }

--- a/Neos.Neos/Classes/ViewHelpers/StandaloneViewViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/StandaloneViewViewHelper.php
@@ -12,6 +12,8 @@ namespace Neos\Neos\ViewHelpers;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\FluidAdaptor\View\StandaloneView;
 
 /**
  * A View Helper to render a fluid template based on the given template path and filename.
@@ -32,7 +34,7 @@ use Neos\Flow\Annotations as Flow;
  *
  * @Flow\Scope("prototype")
  */
-class StandaloneViewViewHelper extends \Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
+class StandaloneViewViewHelper extends AbstractViewHelper
 {
     /**
      * @var boolean
@@ -40,14 +42,24 @@ class StandaloneViewViewHelper extends \Neos\FluidAdaptor\Core\ViewHelper\Abstra
     protected $escapeOutput = false;
 
     /**
-     * @param string $templatePathAndFilename Path and filename of the template to render
-     * @param array $arguments Arguments to assign to the template before rendering
-     * @return string
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render($templatePathAndFilename, $arguments = [])
+    public function initializeArguments()
     {
-        $standaloneView = new \Neos\FluidAdaptor\View\StandaloneView($this->controllerContext->getRequest());
-        $standaloneView->setTemplatePathAndFilename($templatePathAndFilename);
-        return $standaloneView->assignMultiple($arguments)->render();
+        parent::initializeArguments();
+        $this->registerArgument('templatePathAndFilename', 'string', 'Path and filename of the template to render', true);
+        $this->registerArgument('arguments', 'array', 'Arguments to assign to the template before rendering', false, []);
+    }
+
+    /**
+     * @return string
+     * @throws \Neos\FluidAdaptor\Exception
+     */
+    public function render(): string
+    {
+        $standaloneView = new StandaloneView($this->controllerContext->getRequest());
+        $standaloneView->setTemplatePathAndFilename($this->arguments['templatePathAndFilename']);
+        return $standaloneView->assignMultiple($this->arguments['arguments'])->render();
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
@@ -71,7 +71,7 @@ class ModuleViewHelper extends AbstractViewHelper
         if ($this->arguments['arguments'] !== []) {
             $modifiedArguments['moduleArguments'] = $this->arguments['arguments'];
         }
-        if ($this->hasArgument('action')) {
+        if ($this->arguments['action'] !== null) {
             $modifiedArguments['moduleArguments']['@action'] = $this->arguments['action'];
         }
 

--- a/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\ViewHelpers\Uri;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 
@@ -39,39 +40,50 @@ class ModuleViewHelper extends AbstractViewHelper
     protected $uriBuilder;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('path', 'string', 'Target module path', true);
+        $this->registerArgument('action', 'string', 'Target module action');
+        $this->registerArgument('arguments', 'string', 'Arguments', false, []);
+        $this->registerArgument('section', 'string', 'The anchor to be added to the URI', false, '');
+        $this->registerArgument('format', 'string', 'The requested format, e.g. ".html"', false, '');
+        $this->registerArgument('additionalParams', 'string', 'additional query parameters that won\'t be prefixed like $arguments (overrule $arguments)', false, []);
+        $this->registerArgument('addQueryString', 'string', 'If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'string', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
+    }
+
+    /**
      * Render a link to a specific module
      *
-     * @param string $path Target module path
-     * @param string $action Target module action
-     * @param array $arguments Arguments
-     * @param string $section The anchor to be added to the URI
-     * @param string $format The requested format, e.g. ".html"
-     * @param array $additionalParams additional query parameters that won't be prefixed like $arguments (overrule $arguments)
-     * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
-     * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = true
      * @return string The rendered link
      * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render($path, $action = null, $arguments = [], $section = '', $format = '', array $additionalParams = [], $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [])
+    public function render(): string
     {
         $this->setMainRequestToUriBuilder();
-        $modifiedArguments = ['module' => $path];
-        if ($arguments !== []) {
-            $modifiedArguments['moduleArguments'] = $arguments;
+        $modifiedArguments = ['module' => $this->arguments['path']];
+        if ($this->arguments['arguments'] !== []) {
+            $modifiedArguments['moduleArguments'] = $this->arguments['arguments'];
         }
-        if ($action !== null) {
-            $modifiedArguments['moduleArguments']['@action'] = $action;
+        if ($this->hasArgument('action')) {
+            $modifiedArguments['moduleArguments']['@action'] = $this->arguments['action'];
         }
 
         try {
             return $this->uriBuilder
                 ->reset()
-                ->setSection($section)
+                ->setSection($this->arguments['section'])
                 ->setCreateAbsoluteUri(true)
-                ->setArguments($additionalParams)
-                ->setAddQueryString($addQueryString)
-                ->setArgumentsToBeExcludedFromQueryString($argumentsToBeExcludedFromQueryString)
-                ->setFormat($format)
+                ->setArguments($this->arguments['additionalParams'])
+                ->setAddQueryString($this->arguments['addQueryString'])
+                ->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString'])
+                ->setFormat($this->arguments['format'])
                 ->uriFor('index', $modifiedArguments, 'Backend\Module', 'Neos.Neos');
         } catch (\Neos\Flow\Exception $exception) {
             throw new \Neos\FluidAdaptor\Core\ViewHelper\Exception($exception->getMessage(), $exception->getCode(), $exception);
@@ -83,8 +95,9 @@ class ModuleViewHelper extends AbstractViewHelper
      *
      * @return void
      */
-    protected function setMainRequestToUriBuilder()
+    protected function setMainRequestToUriBuilder(): void
     {
+        /** @var ActionRequest $mainRequest */
         $mainRequest = $this->controllerContext->getRequest()->getMainRequest();
         $this->uriBuilder->setRequest($mainRequest);
     }

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\ViewHelpers\Uri;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Fusion\ViewHelpers\FusionContextTrait;
@@ -99,6 +100,12 @@ class NodeViewHelper extends AbstractViewHelper
     protected $linkingService;
 
     /**
+     * @Flow\Inject
+     * @var ThrowableStorageInterface
+     */
+    protected $throwableStorage;
+
+    /**
      * Initialize the arguments.
      *
      * @return void
@@ -151,9 +158,9 @@ class NodeViewHelper extends AbstractViewHelper
                 $this->arguments['resolveShortcuts']
             );
         } catch (NeosException $exception) {
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
         } catch (NoMatchingRouteException $exception) {
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
         }
         return '';
     }

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -11,14 +11,13 @@ namespace Neos\Neos\ViewHelpers\Uri;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
-use Neos\Neos\Exception as NeosException;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
-use Neos\Neos\Service\LinkingService;
-use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Fusion\ViewHelpers\FusionContextTrait;
+use Neos\Neos\Exception as NeosException;
+use Neos\Neos\Service\LinkingService;
 
 /**
  * A view helper for creating URIs pointing to nodes.
@@ -86,6 +85,7 @@ use Neos\Fusion\ViewHelpers\FusionContextTrait;
  * about/us.html
  * (depending on current workspace, current node, format etc.)
  * </output>
+ *
  * @api
  */
 class NodeViewHelper extends AbstractViewHelper
@@ -99,26 +99,40 @@ class NodeViewHelper extends AbstractViewHelper
     protected $linkingService;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', 'mixed', 'A node object, a string node path (absolute or relative), a string node://-uri or NULL');
+        $this->registerArgument('format', 'string', 'Format to use for the URL, for example "html" or "json"');
+        $this->registerArgument('absolute', 'boolean', 'If set, an absolute URI is rendered', false, false);
+        $this->registerArgument('arguments', 'array', 'Additional arguments to be passed to the UriBuilder (for example pagination parameters)', false, []);
+        $this->registerArgument('section', 'string', 'The anchor to be added to the URI', false, '');
+        $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
+        $this->registerArgument('baseNodeName', 'string', 'The name of the base node inside the Fusion context to use for the ContentContext or resolving relative paths', false, 'documentNode');
+        $this->registerArgument('resolveShortcuts', 'boolean', 'INTERNAL Parameter - if false, shortcuts are not redirected to their target. Only needed on rare backend occasions when we want to link to the shortcut itself.', false, true);
+    }
+
+    /**
      * Renders the URI.
      *
-     * @param mixed $node A node object, a string node path (absolute or relative), a string node://-uri or NULL
-     * @param string $format Format to use for the URL, for example "html" or "json"
-     * @param boolean $absolute If set, an absolute URI is rendered
-     * @param array $arguments Additional arguments to be passed to the UriBuilder (for example pagination parameters)
-     * @param string $section
-     * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
-     * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = true
-     * @param string $baseNodeName The name of the base node inside the Fusion context to use for the ContentContext or resolving relative paths
-     * @param boolean $resolveShortcuts INTERNAL Parameter - if false, shortcuts are not redirected to their target. Only needed on rare backend occasions when we want to link to the shortcut itself.
      * @return string The rendered URI or NULL if no URI could be resolved for the given node
-     * @throws ViewHelperException
+     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
+     * @throws \Neos\Flow\Property\Exception
+     * @throws \Neos\Flow\Security\Exception
      */
-    public function render($node = null, $format = null, $absolute = false, array $arguments = [], $section = '', $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [], $baseNodeName = 'documentNode', $resolveShortcuts = true)
+    public function render(): string
     {
         $baseNode = null;
+        $node = $this->arguments['node'];
         if (!$node instanceof NodeInterface) {
-            $baseNode = $this->getContextVariable($baseNodeName);
-            if (is_string($node) && substr($node, 0, 7) === 'node://') {
+            $baseNode = $this->getContextVariable($this->arguments['baseNodeName']);
+            if (is_string($node) && strpos($node, 'node://') === 0) {
                 $node = $this->linkingService->convertUriToObject($node, $baseNode);
             }
         }
@@ -128,13 +142,13 @@ class NodeViewHelper extends AbstractViewHelper
                 $this->controllerContext,
                 $node,
                 $baseNode,
-                $format,
-                $absolute,
-                $arguments,
-                $section,
-                $addQueryString,
-                $argumentsToBeExcludedFromQueryString,
-                $resolveShortcuts
+                $this->arguments['format'],
+                $this->arguments['absolute'],
+                $this->arguments['arguments'],
+                $this->arguments['section'],
+                $this->arguments['addQueryString'],
+                $this->arguments['argumentsToBeExcludedFromQueryString'],
+                $this->arguments['resolveShortcuts']
             );
         } catch (NeosException $exception) {
             $this->systemLogger->logException($exception);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -11,6 +11,9 @@ namespace Neos\Neos\Tests\Functional\ViewHelpers\Link;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\Arguments;
@@ -20,9 +23,11 @@ use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Tests\FunctionalTestRequestHandler;
 use Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use Neos\FluidAdaptor\View\AbstractTemplateView;
 use Neos\FluidAdaptor\View\TemplateView;
+use Neos\Fusion\Core\Runtime;
+use Neos\Fusion\FusionObjects\Helpers\FluidView;
+use Neos\Fusion\FusionObjects\TemplateImplementation;
 use Neos\Media\TypeConverter\AssetInterfaceConverter;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Repository\DomainRepository;
@@ -30,12 +35,9 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\Neos\ViewHelpers\Link\NodeViewHelper;
-use Neos\ContentRepository\Domain\Model\Node;
-use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
-use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
-use Neos\Fusion\Core\Runtime;
-use Neos\Fusion\FusionObjects\Helpers\FluidView;
-use Neos\Fusion\FusionObjects\TemplateImplementation;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 
 /**
  * Functional test for the NodeViewHelper
@@ -50,11 +52,6 @@ class NodeViewHelperTest extends FunctionalTestCase
      * @var NodeDataRepository
      */
     protected $nodeDataRepository;
-
-    /**
-     * @var PropertyMapper
-     */
-    protected $propertyMapper;
 
     /**
      * @var NodeViewHelper
@@ -76,6 +73,16 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     protected $contextFactory;
 
+    /**
+     * @var ViewHelperInvoker
+     */
+    protected $viewHelperInvoker;
+
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -87,9 +94,8 @@ class NodeViewHelperTest extends FunctionalTestCase
         $contextProperties = [
             'workspaceName' => 'live'
         ];
-        $contentContext = $this->contextFactory->create($contextProperties);
         $siteImportService = $this->objectManager->get(SiteImportService::class);
-        $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml', $contentContext);
+        $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml');
         $this->persistenceManager->persistAll();
 
         /** @var Domain $currentDomain */
@@ -100,13 +106,11 @@ class NodeViewHelperTest extends FunctionalTestCase
         } else {
             $contextProperties['currentSite'] = $siteRepository->findFirst();
         }
-        $contentContext = $this->contextFactory->create($contextProperties);
 
-        $this->contentContext = $contentContext;
-
-        $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);
+        $this->contentContext = $this->contextFactory->create($contextProperties);
 
         $this->viewHelper = new NodeViewHelper();
+
         /** @var $requestHandler FunctionalTestRequestHandler */
         $requestHandler = self::$bootstrap->getActiveRequestHandler();
         $httpRequest = $requestHandler->getHttpRequest();
@@ -123,17 +127,22 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($fusionObject, 'runtime', $this->runtime);
         /** @var AbstractTemplateView|\PHPUnit_Framework_MockObject_MockObject $mockView */
         $mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
-        $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($fusionObject));
+        $mockView->expects($this->any())->method('getFusionObject')->willReturn($fusionObject);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
-        $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
+
         $templateVariableContainer = new TemplateVariableContainer([]);
         $this->inject($this->viewHelper, 'templateVariableContainer', $templateVariableContainer);
-        $this->viewHelper->setRenderChildrenClosure(function () use ($templateVariableContainer) {
+        $this->viewHelper->setRenderChildrenClosure(static function () use ($templateVariableContainer) {
             $linkedNode = $templateVariableContainer->get('linkedNode');
             return $linkedNode !== null ? $linkedNode->getLabel() : '';
         });
         $this->viewHelper->initialize();
+
+        $this->viewHelperInvoker = new ViewHelperInvoker();
+        $this->renderingContext = new RenderingContext($mockView);
+        $this->renderingContext->setVariableProvider($templateVariableContainer);
+        $this->renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
     }
 
     public function tearDown(): void
@@ -144,47 +153,64 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', []);
     }
 
-    /**
-     * @test
-     */
-    public function viewHelperRendersUriViaGivenNodeObject()
+    private function invoke(array $arguments = []): string
     {
-        $targetNode = $this->propertyMapper->convert('/sites/example/home', Node::class);
-
-        $this->assertSame('<a href="/en/home.html">' . $targetNode->getLabel() . '</a>', $this->viewHelper->render($targetNode));
+        return $this->viewHelperInvoker->invoke($this->viewHelper, $arguments, $this->renderingContext);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaAbsoluteNodePathString()
+    public function viewHelperRendersUriViaGivenNodeObject(): void
     {
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home'));
-        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('/sites/example/home/about-us'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('/sites/example/home/about-us/mission'));
+        $propertyMapper = $this->objectManager->get(PropertyMapper::class);
+        $targetNode = $propertyMapper->convert('/sites/example/home', Node::class);
+
+        $result = $this->invoke(['node' => $targetNode]);
+        $this->assertSame('<a href="/en/home.html">' . $targetNode->getLabel() . '</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaStringStartingWithTilde()
+    public function viewHelperRendersUriViaAbsoluteNodePathString(): void
     {
-        $this->assertSame('<a href="/en/home.html">example.org</a>', $this->viewHelper->render('~'));
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('~/home'));
-        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('~/home/about-us'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('~/home/about-us/mission'));
+        $result = $this->invoke(['node' => '/sites/example/home']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us']);
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaStringPointingToSubNodes()
+    public function viewHelperRendersUriViaStringStartingWithTilde(): void
+    {
+        $result = $this->invoke(['node' => '~']);
+        $this->assertSame('<a href="/en/home.html">example.org</a>', $result);
+        $result = $this->invoke(['node' => '~/home']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+        $result = $this->invoke(['node' => '~/home/about-us']);
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $result);
+        $result = $this->invoke(['node' => '~/home/about-us/mission']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function viewHelperRendersUriViaStringPointingToSubNodes(): void
     {
         $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
-        $this->assertSame('<a href="/en/home/about-us/history.html">History</a>', $this->viewHelper->render('../history'));
+        $result = $this->invoke(['node' => '../history']);
+        $this->assertSame('<a href="/en/home/about-us/history.html">History</a>', $result);
         $this->runtime->popContext();
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('about-us/mission'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('./about-us/mission'));
+        $result = $this->invoke(['node' => 'about-us/mission']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
+        $result = $this->invoke(['node' => './about-us/mission']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
     }
 
     /**
@@ -193,119 +219,140 @@ class NodeViewHelperTest extends FunctionalTestCase
      *
      * @test
      */
-    public function viewHelperRendersUriViaContextNodePathString()
+    public function viewHelperRendersUriViaContextNodePathString(): void
     {
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home@live'));
-        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('/sites/example/home/about-us@live'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
+        $result = $this->invoke(['node' => '/sites/example/home@live']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us@live']);
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission@live']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
 
         // The tests should also work in a regular fluid view, so we set that and repeat the tests
         $mockView = $this->getAccessibleMock(TemplateView::class, [], [], '', false);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home@live'));
-        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('/sites/example/home/about-us@live'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
+        $result = $this->invoke(['node' => '/sites/example/home@live']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us@live']);
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission@live']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaNodeUriPathString()
+    public function viewHelperRendersUriViaNodeUriPathString(): void
     {
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('node://3239baee-3e7f-785c-0853-f4302ef32570'));
-        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $this->viewHelper->render('node://30e893c1-caef-0ca5-b53d-e5699bb8e506'));
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render('node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2'));
+        $result = $this->invoke(['node' => 'node://3239baee-3e7f-785c-0853-f4302ef32570']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+        $result = $this->invoke(['node' => 'node://30e893c1-caef-0ca5-b53d-e5699bb8e506']);
+        $this->assertSame('<a href="/en/home/about-us.html">About Us Test</a>', $result);
+        $result = $this->invoke(['node' => 'node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsAbsoluteParameter()
+    public function viewHelperRespectsAbsoluteParameter(): void
     {
-        $this->assertSame('<a href="http://neos.test/en/home.html">Home</a>', $this->viewHelper->render(null, null, true));
+        $result = $this->invoke(['absolute' => true]);
+        $this->assertSame('<a href="http://neos.test/en/home.html">Home</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsBaseNodeNameParameter()
+    public function viewHelperRespectsBaseNodeNameParameter(): void
     {
-        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $this->viewHelper->render(null, null, false, [], '', false, [], 'alternativeDocumentNode'));
+        $result = $this->invoke(['baseNodeName' => 'alternativeDocumentNode']);
+        $this->assertSame('<a href="/en/home/about-us/our-mission.html">Our mission</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsArgumentsParameter()
+    public function viewHelperRespectsArgumentsParameter(): void
     {
-        $this->assertSame('<a href="/en/home.html?foo=bar">Home</a>', $this->viewHelper->render('/sites/example/home@live', null, false, ['foo' => 'bar']));
+        $result = $this->invoke([
+            'node' => '/sites/example/home@live',
+            'arguments' => ['foo' => 'bar']
+        ]);
+        $this->assertSame('<a href="/en/home.html?foo=bar">Home</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperCatchesExceptionExceptionIfTargetNodeDoesNotExist()
+    public function viewHelperCatchesExceptionExceptionIfTargetNodeDoesNotExist(): void
     {
-        $this->assertSame('<a></a>', $this->viewHelper->render('/sites/example/non-existing-node'));
+        $result = $this->invoke(['node' => '/sites/example/non-existing-node']);
+        $this->assertSame('<a></a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperResolvesLinksToChildNodeShortcutPages()
+    public function viewHelperResolvesLinksToChildNodeShortcutPages(): void
     {
-        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/child-node.html">Shortcut to child node</a>', $this->viewHelper->render('/sites/example/home/shortcuts/shortcut-to-child-node'));
+        $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-child-node']);
+        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/child-node.html">Shortcut to child node</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperResolvesLinksToParentNodeShortcutPages()
+    public function viewHelperResolvesLinksToParentNodeShortcutPages(): void
     {
-        $this->assertSame('<a href="/en/home/shortcuts.html">Shortcut to parent node</a>', $this->viewHelper->render('/sites/example/home/shortcuts/shortcut-to-parent-node'));
+        $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-parent-node']);
+        $this->assertSame('<a href="/en/home/shortcuts.html">Shortcut to parent node</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperResolvesLinksToTargetNodeShortcutPages()
+    public function viewHelperResolvesLinksToTargetNodeShortcutPages(): void
     {
-        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node.html">Shortcut to target node</a>', $this->viewHelper->render('/sites/example/home/shortcuts/shortcut-to-target-node'));
+        $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-target-node']);
+        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node.html">Shortcut to target node</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperResolvesLinksToUriShortcutPages()
+    public function viewHelperResolvesLinksToUriShortcutPages(): void
     {
-        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node.html">Shortcut to target node</a>', $this->viewHelper->render('/sites/example/home/shortcuts/shortcut-to-target-node'));
+        $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-target-node']);
+        $this->assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node.html">Shortcut to target node</a>', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperUsesNodeTitleIfEmpty()
+    public function viewHelperUsesNodeTitleIfEmpty(): void
+    {
+        $result = $this->invoke(['node' => '/sites/example/home@live']);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function viewHelperAssignsLinkedNodeToNodeVariableName(): void
     {
         $templateVariableContainer = new TemplateVariableContainer([]);
         $this->inject($this->viewHelper, 'templateVariableContainer', $templateVariableContainer);
-        $this->viewHelper->setRenderChildrenClosure(function () use ($templateVariableContainer) {
-            return null;
-        });
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home@live'));
-    }
-
-    /**
-     * @test
-     */
-    public function viewHelperAssignsLinkedNodeToNodeVariableName()
-    {
-        $templateVariableContainer = new TemplateVariableContainer([]);
-        $this->inject($this->viewHelper, 'templateVariableContainer', $templateVariableContainer);
-        $this->viewHelper->setRenderChildrenClosure(function () use ($templateVariableContainer) {
+        $this->renderingContext->setVariableProvider($templateVariableContainer);
+        $this->viewHelper->setRenderChildrenClosure(static function () use ($templateVariableContainer) {
             return $templateVariableContainer->get('alternativeLinkedNode')->getLabel();
         });
-        $this->assertSame('<a href="/en/home.html">Home</a>', $this->viewHelper->render('/sites/example/home@live', null, false, [], '', false, [], 'documentNode', 'alternativeLinkedNode'));
+        $result = $this->invoke([
+            'node' => '/sites/example/home@live',
+            'nodeVariableName' => 'alternativeLinkedNode'
+        ]);
+        $this->assertSame('<a href="/en/home.html">Home</a>', $result);
     }
 }

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -11,26 +11,28 @@ namespace Neos\Neos\Tests\Functional\ViewHelpers\Uri;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\FunctionalTestCase;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use Neos\FluidAdaptor\View\TemplateView;
+use Neos\Fusion\Core\Runtime;
+use Neos\Fusion\FusionObjects\Helpers\FluidView;
+use Neos\Fusion\FusionObjects\TemplateImplementation;
 use Neos\Media\TypeConverter\AssetInterfaceConverter;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\Neos\ViewHelpers\Uri\NodeViewHelper;
-use Neos\ContentRepository\Domain\Model\Node;
-use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
-use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
-use Neos\Fusion\Core\Runtime;
-use Neos\Fusion\FusionObjects\Helpers\FluidView;
-use Neos\Fusion\FusionObjects\TemplateImplementation;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 
 /**
  * Functional test for the NodeViewHelper
@@ -45,11 +47,6 @@ class NodeViewHelperTest extends FunctionalTestCase
      * @var NodeDataRepository
      */
     protected $nodeDataRepository;
-
-    /**
-     * @var PropertyMapper
-     */
-    protected $propertyMapper;
 
     /**
      * @var NodeViewHelper
@@ -71,6 +68,16 @@ class NodeViewHelperTest extends FunctionalTestCase
      */
     protected $contextFactory;
 
+    /**
+     * @var ViewHelperInvoker
+     */
+    protected $viewHelperInvoker;
+
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -81,9 +88,8 @@ class NodeViewHelperTest extends FunctionalTestCase
         $contextProperties = [
             'workspaceName' => 'live'
         ];
-        $contentContext = $this->contextFactory->create($contextProperties);
         $siteImportService = $this->objectManager->get(SiteImportService::class);
-        $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml', $contentContext);
+        $siteImportService->importFromFile(__DIR__ . '/../../Fixtures/NodeStructure.xml');
         $this->persistenceManager->persistAll();
 
         $currentDomain = $domainRepository->findOneByActiveRequest();
@@ -93,13 +99,10 @@ class NodeViewHelperTest extends FunctionalTestCase
         } else {
             $contextProperties['currentSite'] = $siteRepository->findFirst();
         }
-        $contentContext = $this->contextFactory->create($contextProperties);
-
-        $this->contentContext = $contentContext;
-
-        $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);
+        $this->contentContext = $this->contextFactory->create($contextProperties);
 
         $this->viewHelper = new NodeViewHelper();
+
         /** @var $requestHandler \Neos\Flow\Tests\FunctionalTestRequestHandler */
         $requestHandler = self::$bootstrap->getActiveRequestHandler();
         $httpRequest = $requestHandler->getHttpRequest();
@@ -115,10 +118,13 @@ class NodeViewHelperTest extends FunctionalTestCase
         ]);
         $this->inject($fusionObject, 'runtime', $this->runtime);
         $mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
-        $mockView->expects($this->any())->method('getFusionObject')->will($this->returnValue($fusionObject));
+        $mockView->expects($this->any())->method('getFusionObject')->willReturn($fusionObject);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
-        $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
+
+        $this->viewHelperInvoker = new ViewHelperInvoker();
+        $this->renderingContext = new RenderingContext($mockView);
+        $this->renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
     }
 
     public function tearDown(): void
@@ -129,47 +135,64 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', []);
     }
 
-    /**
-     * @test
-     */
-    public function viewHelperRendersUriViaGivenNodeObject()
+    private function invoke(array $arguments = []): string
     {
-        $targetNode = $this->propertyMapper->convert('/sites/example/home', Node::class);
-
-        $this->assertOutputLinkValid('home.html', $this->viewHelper->render($targetNode));
+        return $this->viewHelperInvoker->invoke($this->viewHelper, $arguments, $this->renderingContext);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaAbsoluteNodePathString()
+    public function viewHelperRendersUriViaGivenNodeObject(): void
     {
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('/sites/example/home'));
-        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('/sites/example/home/about-us'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('/sites/example/home/about-us/mission'));
+        $propertyMapper = $this->objectManager->get(PropertyMapper::class);
+        $targetNode = $propertyMapper->convert('/sites/example/home', Node::class);
+
+        $result = $this->invoke(['node' => $targetNode]);
+        $this->assertOutputLinkValid('home.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaStringStartingWithTilde()
+    public function viewHelperRendersUriViaAbsoluteNodePathString(): void
     {
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('~'));
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('~/home'));
-        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('~/home/about-us'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('~/home/about-us/mission'));
+        $result = $this->invoke(['node' => '/sites/example/home']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us']);
+        $this->assertOutputLinkValid('en/home/about-us.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaStringPointingToSubNodes()
+    public function viewHelperRendersUriViaStringStartingWithTilde(): void
+    {
+        $result = $this->invoke(['node' => '~']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => '~/home']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => '~/home/about-us']);
+        $this->assertOutputLinkValid('en/home/about-us.html', $result);
+        $result = $this->invoke(['node' => '~/home/about-us/mission']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function viewHelperRendersUriViaStringPointingToSubNodes(): void
     {
         $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
-        $this->assertOutputLinkValid('en/home/about-us/history.html', $this->viewHelper->render('../history'));
+        $result = $this->invoke(['node' => '../history']);
+        $this->assertOutputLinkValid('en/home/about-us/history.html', $result);
         $this->runtime->popContext();
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('about-us/mission'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('./about-us/mission'));
+        $result = $this->invoke(['node' => 'about-us/mission']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
+        $result = $this->invoke(['node' => './about-us/mission']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
     }
 
     /**
@@ -178,69 +201,88 @@ class NodeViewHelperTest extends FunctionalTestCase
      *
      * @test
      */
-    public function viewHelperRendersUriViaContextNodePathString()
+    public function viewHelperRendersUriViaContextNodePathString(): void
     {
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('/sites/example/home@live'));
-        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('/sites/example/home/about-us@live'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
+        $result = $this->invoke(['node' => '/sites/example/home@live']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us@live']);
+        $this->assertOutputLinkValid('en/home/about-us.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission@live']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
 
         // The tests should also work in a regular fluid view, so we set that and repeat the tests
         $mockView = $this->getAccessibleMock(TemplateView::class, [], [], '', false);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);
         $this->inject($this->viewHelper, 'viewHelperVariableContainer', $viewHelperVariableContainer);
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('/sites/example/home@live'));
-        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('/sites/example/home/about-us@live'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('/sites/example/home/about-us/mission@live'));
+        $result = $this->invoke(['node' => '/sites/example/home@live']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us@live']);
+        $this->assertOutputLinkValid('en/home/about-us.html', $result);
+        $result = $this->invoke(['node' => '/sites/example/home/about-us/mission@live']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRendersUriViaNodeUriPathString()
+    public function viewHelperRendersUriViaNodeUriPathString(): void
     {
-        $this->assertOutputLinkValid('en/home.html', $this->viewHelper->render('node://3239baee-3e7f-785c-0853-f4302ef32570'));
-        $this->assertOutputLinkValid('en/home/about-us.html', $this->viewHelper->render('node://30e893c1-caef-0ca5-b53d-e5699bb8e506'));
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render('node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2'));
+        $result = $this->invoke(['node' => 'node://3239baee-3e7f-785c-0853-f4302ef32570']);
+        $this->assertOutputLinkValid('en/home.html', $result);
+        $result = $this->invoke(['node' => 'node://30e893c1-caef-0ca5-b53d-e5699bb8e506']);
+        $this->assertOutputLinkValid('en/home/about-us.html', $result);
+        $result = $this->invoke(['node' => 'node://63b28f4d-8831-ecb0-f9a6-466d97ffe2c2']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsAbsoluteParameter()
+    public function viewHelperRespectsAbsoluteParameter(): void
     {
-        $this->assertOutputLinkValid('http://neos.test/en/home.html', $this->viewHelper->render(null, null, true));
+        $result = $this->invoke(['absolute' => true]);
+        $this->assertOutputLinkValid('http://neos.test/en/home.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsBaseNodeNameParameter()
+    public function viewHelperRespectsBaseNodeNameParameter(): void
     {
-        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $this->viewHelper->render(null, null, false, [], '', false, [], 'alternativeDocumentNode'));
+        $result = $this->invoke(['baseNodeName' => 'alternativeDocumentNode']);
+        $this->assertOutputLinkValid('en/home/about-us/our-mission.html', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperRespectsArgumentsParameter()
+    public function viewHelperRespectsArgumentsParameter(): void
     {
-        $this->assertOutputLinkValid('en/home.html?foo=bar', $this->viewHelper->render('/sites/example/home@live', null, false, ['foo' => 'bar']));
+        $result = $this->invoke([
+            'node' => '/sites/example/home@live',
+            'arguments' => ['foo' => 'bar']
+        ]);
+        $this->assertOutputLinkValid('en/home.html?foo=bar', $result);
     }
 
     /**
      * @test
      */
-    public function viewHelperCatchesExceptionIfTargetNodeDoesNotExist()
+    public function viewHelperCatchesExceptionAndReturnsEmptyStringIfTargetNodeDoesNotExist(): void
     {
-        $this->assertSame('', $this->viewHelper->render('/sites/example/non-existing-node'));
+        $result = $this->invoke(['node' => '/sites/example/non-existing-node']);
+        $this->assertSame('', $result);
     }
 
     /**
      * A wrapper function for the appropriate assertion for the Link- and its Uri-ViewHelper derivate.
      * Is overridden in the FunctionalTest for the LinkViewHelper.
+     *
+     * @param string $expected
+     * @param string $actual
      */
-    protected function assertOutputLinkValid($expected, $actual)
+    protected function assertOutputLinkValid(string $expected, string $actual): void
     {
         $this->assertStringEndsWith($expected, $actual);
     }

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
@@ -49,7 +49,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper = $this->getAccessibleMock(ModuleViewHelper::class, ['renderChildren']);
         $this->tagBuilder = $this->createMock(TagBuilder::class);
         $this->tagBuilder->expects($this->once())->method('render')->willReturn('renderingResult');
-        $this->uriModuleViewHelper = $this->getMockBuilder(UriModuleViewHelper::class)->setMethods(['setRenderingContext', 'render'])->getMock();
+        $this->uriModuleViewHelper = $this->getMockBuilder(UriModuleViewHelper::class)->setMethods(['setRenderingContext', 'setArguments', 'render'])->getMock();
 
         $this->dummyRenderingContext = $this->createMock(RenderingContextInterface::class);
         $this->inject($this->viewHelper, 'renderingContext', $this->dummyRenderingContext);
@@ -71,11 +71,18 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
     /**
      * @test
      */
-    public function callingRenderCallsTheUriModuleViewHelpersRenderMethodWithTheCorrectArguments(): void
+    public function callingRenderCallsTheUriModuleViewHelpersSetArgumentsMethodWithTheCorrectArguments(): void
     {
-        $this->uriModuleViewHelper->expects($this->once())->method('render')->with(
-            'path', 'action', ['arguments'], 'section', 'format', ['additionalParams'], true, ['argumentsToBeExcludedFromQueryString']
-        );
+        $this->uriModuleViewHelper->expects($this->once())->method('setArguments')->with([
+            'path' => 'path',
+            'action' => 'action',
+            'arguments' => ['arguments'],
+            'section' => 'section',
+            'format' => 'format',
+            'additionalParams' => ['additionalParams'],
+            'addQueryString' => true,
+            'argumentsToBeExcludedFromQueryString' => ['argumentsToBeExcludedFromQueryString']
+        ]);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, [
             'path' => 'path',
             'action' => 'action',

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Tests\Unit\ViewHelpers\Link;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Neos\ViewHelpers\Link\ModuleViewHelper;
 use Neos\Neos\ViewHelpers\Uri\ModuleViewHelper as UriModuleViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -19,7 +19,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /**
  */
-class ModuleViewHelperTest extends UnitTestCase
+class ModuleViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ModuleViewHelper
@@ -48,7 +48,8 @@ class ModuleViewHelperTest extends UnitTestCase
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(ModuleViewHelper::class, ['renderChildren']);
         $this->tagBuilder = $this->createMock(TagBuilder::class);
-        $this->uriModuleViewHelper = $this->getMockBuilder(\Neos\Neos\ViewHelpers\Uri\ModuleViewHelper::class)->setMethods(['setRenderingContext', 'render'])->getMock();
+        $this->tagBuilder->expects($this->once())->method('render')->willReturn('renderingResult');
+        $this->uriModuleViewHelper = $this->getMockBuilder(UriModuleViewHelper::class)->setMethods(['setRenderingContext', 'render'])->getMock();
 
         $this->dummyRenderingContext = $this->createMock(RenderingContextInterface::class);
         $this->inject($this->viewHelper, 'renderingContext', $this->dummyRenderingContext);
@@ -60,60 +61,72 @@ class ModuleViewHelperTest extends UnitTestCase
     /**
      * @test
      */
-    public function callingRenderSetsTheRenderingContextOnTheUriViewHelper()
+    public function callingRenderSetsTheRenderingContextOnTheUriViewHelper(): void
     {
         $this->uriModuleViewHelper->expects($this->once())->method('setRenderingContext')->with($this->dummyRenderingContext);
-        $this->viewHelper->render('path');
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);
+        $this->viewHelper->render();
     }
 
     /**
      * @test
      */
-    public function callingRenderCallsTheUriModuleViewHelpersRenderMethodWithTheCorrectArguments()
+    public function callingRenderCallsTheUriModuleViewHelpersRenderMethodWithTheCorrectArguments(): void
     {
         $this->uriModuleViewHelper->expects($this->once())->method('render')->with(
-            'path', 'action', ['arguments'], 'section', 'format', ['additionalParams'], 'addQueryString', ['argumentsToBeExcludedFromQueryString']
+            'path', 'action', ['arguments'], 'section', 'format', ['additionalParams'], true, ['argumentsToBeExcludedFromQueryString']
         );
-        $this->viewHelper->render(
-            'path', 'action', ['arguments'], 'section', 'format', ['additionalParams'], 'addQueryString', ['argumentsToBeExcludedFromQueryString']
-        );
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, [
+            'path' => 'path',
+            'action' => 'action',
+            'arguments' => ['arguments'],
+            'section' => 'section',
+            'format' => 'format',
+            'additionalParams' => ['additionalParams'],
+            'addQueryString' => true,
+            'argumentsToBeExcludedFromQueryString' => ['argumentsToBeExcludedFromQueryString']
+        ]);
+        $this->viewHelper->render();
     }
 
     /**
      * @test
      */
-    public function callingRenderAddsUriViewHelpersReturnAsTagHrefAttributeIfItsNotEmpty()
+    public function callingRenderAddsUriViewHelpersReturnAsTagHrefAttributeIfItsNotEmpty(): void
     {
-        $this->uriModuleViewHelper->expects($this->once())->method('render')->will($this->returnValue('SomethingNotNull'));
-        $this->tagBuilder->expects($this->once())->method('addAttribute')->with('href', 'SomethingNotNull');
-        $this->viewHelper->render('path');
+        $this->uriModuleViewHelper->expects($this->once())->method('render')->willReturn('moduleUri');
+        $this->tagBuilder->expects($this->once())->method('addAttribute')->with('href', 'moduleUri');
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);
+        $this->viewHelper->render();
     }
 
     /**
      * @test
      */
-    public function callingRenderSetsTheTagBuildersContentWithRenderChildrenResult()
+    public function callingRenderSetsTheTagBuildersContentWithRenderChildrenResult(): void
     {
-        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('renderChildrenResult'));
+        $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn('renderChildrenResult');
         $this->tagBuilder->expects($this->once())->method('setContent')->with('renderChildrenResult');
-        $this->viewHelper->render('path');
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);
+        $this->viewHelper->render();
     }
 
     /**
      * @test
      */
-    public function callingRenderSetsForceClosingTagOnTagBuilder()
+    public function callingRenderSetsForceClosingTagOnTagBuilder(): void
     {
         $this->tagBuilder->expects($this->once())->method('forceClosingTag')->with(true);
-        $this->viewHelper->render('path');
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);
+        $this->viewHelper->render();
     }
 
     /**
      * @test
      */
-    public function callingRenderReturnsTagBuildersRenderResult()
+    public function callingRenderReturnsTagBuildersRenderResult(): void
     {
-        $this->tagBuilder->expects($this->once())->method('render')->will($this->returnValue('renderingResult'));
-        $this->assertSame('renderingResult', $this->viewHelper->render('path'));
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);
+        $this->assertSame('renderingResult', $this->viewHelper->render());
     }
 }

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
@@ -12,20 +12,21 @@ namespace Neos\Neos\Tests\Unit\ViewHelpers\Uri;
  */
 
 use Neos\Flow\Mvc\Routing\UriBuilder;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Neos\ViewHelpers\Uri\ModuleViewHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  */
-class ModuleViewHelperTest extends UnitTestCase
+class ModuleViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ModuleViewHelper
+     * @var MockObject|ModuleViewHelper
      */
     protected $viewHelper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|UriBuilder
+     * @var MockObject|UriBuilder
      */
     protected $uriBuilder;
 
@@ -54,20 +55,22 @@ class ModuleViewHelperTest extends UnitTestCase
             'moduleArguments' => ['arguments', '@action' => 'action']
         ];
 
-        $this->uriBuilder->expects($this->once())->method('uriFor')->with('index', $expectedModifiedArguments);
+        $this->uriBuilder->expects($this->once())->method('uriFor')->with('index', $expectedModifiedArguments)->willReturn('expectedUri');
 
         // fallback for the method chaining of the URI builder
-        $this->uriBuilder->expects($this->any())->method($this->anything())->will($this->returnValue($this->uriBuilder));
+        $this->uriBuilder->expects($this->any())->method($this->anything())->willReturn($this->uriBuilder);
 
-        $this->viewHelper->render(
-            'the/path',
-            'action',
-            ['arguments'],
-            'section',
-            'format',
-            ['additionalParams'],
-            true, // `addQueryString`,
-            ['argumentsToBeExcludedFromQueryString']
-        );
+        $this->viewHelper = $this->prepareArguments($this->viewHelper, [
+            'path' => 'the/path',
+            'action' => 'action',
+            'arguments' => ['arguments'],
+            'section' => 'section',
+            'format' => 'format',
+            'additionalParams' => ['additionalParams'],
+            'addQueryString' => true,
+            'argumentsToBeExcludedFromQueryString' => ['argumentsToBeExcludedFromQueryString']
+
+        ]);
+        $this->viewHelper->render();
     }
 }


### PR DESCRIPTION
This removes the arguments from `render()` in Fluid ViewHelpers, and
registers them using `registerArgument` instead.

Arguments to `render()` were deprecated as of Flow 4.0 and support
is removed with Flow 6.0.