### PR TITLE
BUGFIX: Adjust warning text in setup

### DIFF
--- a/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
+++ b/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
@@ -97,7 +97,7 @@ class NeosSpecificRequirementsStep extends AbstractStep
 
         if ($foundImageHandler === false) {
             $formElement = $imageSection->createElement('noImageLibrary', 'Neos.Form:StaticText');
-            $formElement->setProperty('text', 'No suitable PHP extension for image manipulation was found. Please install one of the required PHP extensions and restart the server respectively the php process. Then try the setup again.');
+            $formElement->setProperty('text', 'No suitable PHP extension for image manipulation was found. Please install one of the required PHP extensions and restart the php process. Then proceed with the setup.');
             $formElement->setProperty('elementClassAttribute', 'alert alert-error');
         } else {
             $formElement = $imageSection->createElement('configuredImageLibrary', 'Neos.Form:StaticText');

--- a/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
+++ b/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
@@ -97,7 +97,7 @@ class NeosSpecificRequirementsStep extends AbstractStep
 
         if ($foundImageHandler === false) {
             $formElement = $imageSection->createElement('noImageLibrary', 'Neos.Form:StaticText');
-            $formElement->setProperty('text', 'No suitable PHP extension for image manipulation was found. You can continue the setup but be aware that Neos might not work correctly without one of these extensions.');
+            $formElement->setProperty('text', 'No suitable PHP extension for image manipulation was found. Please install one of the required PHP extensions and restart the server respectively the php process. Then try the setup again.');
             $formElement->setProperty('elementClassAttribute', 'alert alert-error');
         } else {
             $formElement = $imageSection->createElement('configuredImageLibrary', 'Neos.Form:StaticText');


### PR DESCRIPTION
Fixes Issue #2488
In this PR I adjusted the somewhat missleading warning text, which is displayed in the image driver setup step, if none of the requiered drivers is installed. Additionaly I added some javascript to the image driver and the database configuration step in the setup package to disable the next button, if an error message is shown. See the PR https://github.com/neos/setup/pull/53
