### PR TITLE
BUGFIX: node label sanitizing regex strips characters

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -1,6 +1,6 @@
 # Base node, which just configures the "removed" property of the node.
 'Neos.Neos:Node':
-  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[[^:print:]]|\\s+/u', ' '))), 100, '...')}"
+  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' '))), 100, '...')}"
   abstract: true
   options:
     fusion:


### PR DESCRIPTION
**What I did**
`[[^:print:]]` resulted in the characters `print:` followed by `]` being removed from the node label. Non-printable characters should be matched with `[^[:print:]]`.

Resolves https://github.com/neos/neos-ui/issues/2496

**How to verify it**
Output node labels normally including `n]`, `i]` etc. e.g. in the document tree.