### PR TITLE
BUGFIX: Add return types to viewhelper

### DIFF
--- a/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.Media/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -77,7 +77,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
      * @return string
      * @api
      */
-    public function render($checked = null, $multiple = null)
+    public function render($checked = null, $multiple = null): string
     {
         $this->tag->addAttribute('type', 'checkbox');
 
@@ -126,7 +126,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
      *
      * @return string name
      */
-    protected function getNameWithoutPrefix()
+    protected function getNameWithoutPrefix(): string
     {
         $name = parent::getNameWithoutPrefix();
         return str_replace('[__identity]', '', $name);

--- a/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/JavascriptConfigurationViewHelper.php
@@ -86,7 +86,7 @@ class JavascriptConfigurationViewHelper extends AbstractViewHelper
     /**
      * @param LoggerInterface $logger
      */
-    public function injectLogger(LoggerInterface $logger)
+    public function injectLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
The Media CheckboxViewHelper and the
JavascriptConfigurationViewHelper is not compatible
with the relevant abstract view helper and lead to errors.

**What I did**

Tried to execute a flow command and this lead to the fatal error.
<img width="1103" alt="Bildschirmfoto 2019-05-20 um 20 21 06" src="https://user-images.githubusercontent.com/1014126/58043213-e282fc00-7b3c-11e9-9cb5-4b14c5f481d1.png">

```./flow doctrine:migrate```

**How I did it**
Adjusted the return types in the viewhelpers that lead to a fatal error.

**How to verify it**
Install latest development version of neos and excecute flow commands.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
