### PR TITLE
BUGFIX: Neos.NodeTypes:Menu has no default class attribute

### DIFF
--- a/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
@@ -12,6 +12,8 @@ prototype(Neos.NodeTypes.Navigation:Navigation) < prototype(Neos.Neos:Menu) {
   maximumLevels = ${q(node).property('maximumLevels')}
   maximumLevels.@process.1 = ${String.toInteger(value)}
 
+  attributes.class.@process < prototype(Neos.Neos:Content).attributes.class.@process
+
   active.attributes = Neos.Fusion:Attributes {
     class = 'active'
   }


### PR DESCRIPTION
This fixes a previous breaking change where "Menu" node-type is not
getting a default class attribute rendered for instance 'neos-nodetypes-menu'
where a website's stylesheet is relying on this CSS class

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
In fusion prototype Neos.NodeTypes.Navigation:Navigation loaded fusion  path 'attributes.class.@process' from Neos.Neos:Content.
**How I did it**

**How to verify it**
Add the Menu node type on the page and check in the console/page source it should have css class 'neos-nodetypes-menu'
**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
