### PR TITLE
TASK: Use PackageManager, not PackageManagerInterface

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepository/Classes/Migration/Configuration/YamlConfiguration.php
@@ -14,7 +14,7 @@ namespace Neos\ContentRepository\Migration\Configuration;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Package\PackageInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\Files as Files;
 use Neos\ContentRepository\Migration\Exception\MigrationException;
 
@@ -31,7 +31,7 @@ class YamlConfiguration extends Configuration
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.ContentRepository/Classes/Package.php
+++ b/Neos.ContentRepository/Classes/Package.php
@@ -17,7 +17,6 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -58,7 +57,7 @@ class Package extends BasePackage
                 if ($step->getIdentifier() === 'neos.flow:systemfilemonitor') {
                     $nodeTypeConfigurationFileMonitor = FileMonitor::createFileMonitorAtBoot('ContentRepository_NodeTypesConfiguration', $bootstrap);
                     /** @var PackageManager $packageManager */
-                    $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
+                    $packageManager = $bootstrap->getEarlyInstance(PackageManager::class);
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;

--- a/Neos.ContentRepository/Tests/Functional/AbstractNodeTest.php
+++ b/Neos.ContentRepository/Tests/Functional/AbstractNodeTest.php
@@ -11,7 +11,7 @@ namespace Neos\ContentRepository\Tests\Functional;
  * source code.
  */
 
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Domain\Service\SiteImportService;
@@ -132,7 +132,7 @@ abstract class AbstractNodeTest extends FunctionalTestCase
 
     protected function markSkippedIfNodeTypesPackageIsNotInstalled()
     {
-        $packageManager = $this->objectManager->get(PackageManagerInterface::class);
+        $packageManager = $this->objectManager->get(PackageManager::class);
         if (!$packageManager->isPackageAvailable('Neos.NodeTypes')) {
             $this->markTestSkipped('This test needs the Neos.NodeTypes package.');
         }

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -17,7 +17,6 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Fusion\Core\Cache\FileMonitorListener;
 
 /**
@@ -41,7 +40,7 @@ class Package extends BasePackage
                 if ($step->getIdentifier() === 'neos.flow:systemfilemonitor') {
                     $fusionFileMonitor = FileMonitor::createFileMonitorAtBoot('Fusion_Files', $bootstrap);
                     /** @var PackageManager $packageManager */
-                    $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
+                    $packageManager = $bootstrap->getEarlyInstance(PackageManager::class);
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -25,7 +25,7 @@ use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Mvc\View\ViewInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -120,7 +120,7 @@ class AssetController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -17,7 +17,7 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\RepositoryInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -80,7 +80,7 @@ class AssetService
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -15,7 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\SiteExportService;
@@ -61,7 +61,7 @@ class SiteCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/PackagesController.php
@@ -13,7 +13,7 @@ namespace Neos\Neos\Controller\Module\Administration;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 
 /**
@@ -23,7 +23,7 @@ class PackagesController extends AbstractModuleController
 {
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -16,7 +16,7 @@ use Neos\Error\Messages\Message;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Package\PackageInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Neos\Controller\Module\AbstractModuleController;
@@ -90,7 +90,7 @@ class SitesController extends AbstractModuleController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -105,7 +105,7 @@ class FusionService
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var \Neos\Flow\Package\PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Domain/Service/SiteExportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteExportService.php
@@ -12,7 +12,7 @@ namespace Neos\Neos\Domain\Service;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\Files;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Exception as NeosException;
@@ -41,7 +41,7 @@ class SiteExportService
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Domain/Service/SiteImportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteImportService.php
@@ -15,7 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\Exception\InvalidPackageStateException;
 use Neos\Flow\Package\Exception\UnknownPackageException;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Media\Domain\Model\AssetInterface;
@@ -40,7 +40,7 @@ class SiteImportService
 {
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
+++ b/Neos.Neos/Classes/Setup/Step/NeosSpecificRequirementsStep.php
@@ -14,7 +14,7 @@ namespace Neos\Neos\Setup\Step;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Configuration\Source\YamlSource;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Utility\Arrays;
@@ -48,7 +48,7 @@ class NeosSpecificRequirementsStep extends AbstractStep
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Neos/Classes/Setup/Step/SiteImportStep.php
+++ b/Neos.Neos/Classes/Setup/Step/SiteImportStep.php
@@ -17,7 +17,7 @@ use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Mvc\FlashMessageContainer;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Validation\Validator\NotEmptyValidator;
 use Neos\Form\Core\Model\FinisherContext;
@@ -49,7 +49,7 @@ class SiteImportStep extends AbstractStep
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
@@ -13,7 +13,7 @@ namespace Neos\SiteKickstarter\Command;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\SiteKickstarter\Service\GeneratorService;
 
 /**
@@ -22,7 +22,7 @@ use Neos\SiteKickstarter\Service\GeneratorService;
 class KickstartCommandController extends CommandController
 {
     /**
-     * @var PackageManagerInterface
+     * @var PackageManager
      * @Flow\Inject
      */
     protected $packageManager;

--- a/Neos.SiteKickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.SiteKickstarter/Classes/Service/GeneratorService.php
@@ -12,7 +12,7 @@ namespace Neos\SiteKickstarter\Service;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\Files;
 use Neos\ContentRepository\Domain\Repository\ContentDimensionRepository;
 use Neos\ContentRepository\Utility;
@@ -24,7 +24,7 @@ class GeneratorService extends \Neos\Kickstarter\Service\GeneratorService
 {
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 


### PR DESCRIPTION
The `PackageManagerInterface` is deprecated and will be removed with
Flow 6.0, so avoid it and use `PackageManager` directly.
