### PR TITLE
BUGFIX: Changed Domains by UriConstraints will not no longer get destroyed by the LinkingService

### DIFF
--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -309,7 +309,9 @@ class LinkingService
                 $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
             }
         } elseif ($absolute === true) {
-            $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
+            if (substr($uri, 0, 7) !== 'http://' && substr($uri, 0, 8) !== 'https://') {
+                $uri = $request->getHttpRequest()->getBaseUri() . ltrim($uri, '/');
+            }
         }
 
         return $uri;


### PR DESCRIPTION
With `UriConstraints` we have the ability to modify the Host but there is a problem with the `LinkingService` in combination with `UriConstraints`. If you ask the `LinkingService` for a absolut Uri then it add the current base to the Url.

Fixes #2398
