### PR TITLE
BUGFIX: Flush affected document node on asset change

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -166,9 +166,8 @@ class ContentCacheFlusher
             $node = $this->getContextForReference($reference)->getNodeByIdentifier($reference->getNodeIdentifier());
             $this->registerNodeChange($node);
 
-            $this->registerChangeOnNodeType($reference->getNodeTypeName(), $reference->getNodeIdentifier());
-
             $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
+            // @see RuntimeContentCache.addTag
             $tagName = 'AssetDynamicTag_' . $assetIdentifier;
             $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because asset "%s" has changed.', $tagName, $assetIdentifier);
         }
@@ -195,7 +194,7 @@ class ContentCacheFlusher
      * @param AssetUsageInNodeProperties $assetUsage
      * @return ContentContext
      */
-    protected function getContextForReference(AssetUsageInNodeProperties $assetUsage)
+    protected function getContextForReference(AssetUsageInNodeProperties $assetUsage): ContentContext
     {
         $hash = md5(sprintf('%s-%s', $assetUsage->getWorkspaceName(), json_encode($assetUsage->getDimensionValues())));
         if (!isset($this->contexts[$hash])) {


### PR DESCRIPTION
When an asset is replaced, the content cache is flushed, but in most
cases this does not have an effect. As most content nodes do not have
a cache entry, the cache entry higher in the chain needs to be
flushed.

This is now done by fetching the affected node for an asset usage and
passing that to `registerNodeChange(…)` in the `ContentCacheFlusher`.

Fixes #2061
