### PR TITLE
BUGFIX: Flush affected document node on asset change

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -280,10 +280,8 @@ class ContentCacheFlusher
             $this->registerNodeChange($node);
 
             $workspaceHash = $cachingHelper->renderWorkspaceTagForContextNode($reference->getWorkspaceName());
-            $this->registerChangeOnNodeType($reference->getNodeTypeName(), $reference->getNodeIdentifier(), $workspaceHash);
-
             $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
-
+            // @see RuntimeContentCache.addTag
             $tagName = 'AssetDynamicTag_' . $workspaceHash . '_' . $assetIdentifier;
             $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because asset "%s" has changed.', $tagName, $assetIdentifier);
         }

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -78,7 +78,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flushingANodeWillResolveAllWorkspacesToFlush()
+    public function flushingANodeWillResolveAllWorkspacesToFlush(): void
     {
         // Add more workspaces
         $workspaceFirstLevel = new Workspace('first-level');
@@ -124,7 +124,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flushingANodeWithAnAdditionalTargetWorkspaceWillAlsoResolveThatWorkspace()
+    public function flushingANodeWithAnAdditionalTargetWorkspaceWillAlsoResolveThatWorkspace(): void
     {
         // Add more workspaces
         $workspaceFirstLevel = new Workspace('first-level');
@@ -169,7 +169,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aNodeChangeWillRegisterNodeIdentifierTagsForAllWorkspaces()
+    public function aNodeChangeWillRegisterNodeIdentifierTagsForAllWorkspaces(): void
     {
         $workspaceFirstLevel = new Workspace('first-level');
 
@@ -206,7 +206,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aNodeChangeWillRegisterNodeTypeTagsForAllWorkspaces()
+    public function aNodeChangeWillRegisterNodeTypeTagsForAllWorkspaces(): void
     {
         $workspaceFirstLevel = new Workspace('first-level');
 
@@ -246,7 +246,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aNodeChangeWillRegisterAllDescendantOfTagsForAllWorkspaces()
+    public function aNodeChangeWillRegisterAllDescendantOfTagsForAllWorkspaces(): void
     {
         $workspaceFirstLevel = new Workspace('first-level');
 

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -16,7 +16,7 @@ use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
-use Neos\Neos\Fusion\Helper\CachingHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Tests the CachingHelper
@@ -26,8 +26,9 @@ class ContentCacheFlusherTest extends UnitTestCase
     /**
      * @test
      */
-    public function theWorkspaceChainWillOnlyEvaluatedIfNeeded()
+    public function theWorkspaceChainWillOnlyEvaluatedIfNeeded(): void
     {
+        /** @var MockObject|ContentCacheFlusher $contentCacheFlusher */
         $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
         $contentCacheFlusher->expects($this->never())->method('resolveWorkspaceChain');
 
@@ -41,6 +42,7 @@ class ContentCacheFlusherTest extends UnitTestCase
 
         $nodeType = new NodeType('Some.Node:Type', [], []);
 
+        /** @var MockObject|NodeInterface $nodeMock */
         $nodeMock = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
         $nodeMock->expects($this->any())->method('getWorkspace')->willReturn($workspace);
         $nodeMock->expects($this->any())->method('getNodeType')->willReturn($nodeType);


### PR DESCRIPTION
When an asset is replaced, the content cache is flushed, but in most
cases this does not have an effect. As most content nodes do not have
a cache entry, the cache entry higher in the chain needs to be
flushed.

This is now done by fetching the affected node for an asset usage and
passing that to `registerNodeChange(…)` in the `ContentCacheFlusher`.

Fixes #2061