### PR TITLE
BUGFIX: The copyright notice of assets is lost when exporting to Sites.xml

### DIFF
--- a/Neos.Media/Classes/TypeConverter/ArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ArrayConverter.php
@@ -135,6 +135,7 @@ class ArrayConverter extends AbstractTypeConverter
                     '__identity' => $identity,
                     '__type' => \Neos\Utility\TypeHandling::getTypeForValue($source),
                     'title' => $source->getTitle(),
+                    'copyrightNotice' => $source->getCopyrightNotice(),
                     'resource' => $convertedChildProperties['resource']
                 ];
         }


### PR DESCRIPTION
see also #2503

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

Included the copyright notice of assets in exports to `Sites.xml`.

**How I did it**

Added `copyrightNotice` in `ArrayConverter.php` the same way as `title`.

**How to verify it**

1. Add a copyright notice to an asset.
2. Export to `Sites.xml`.
3. Do a clean import.
4. Check that the copyright notice is preserved.