### PR TITLE
BUGFIX: Flush content cache for assets regardless of the workspace

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -264,20 +264,17 @@ class ContentCacheFlusher
             return;
         }
 
-        $cachingHelper = $this->getCachingHelper();
-
         foreach ($this->assetService->getUsageReferences($asset) as $reference) {
             if (!$reference instanceof AssetUsageInNodeProperties) {
                 continue;
             }
 
-            $workspaceHash = $cachingHelper->renderWorkspaceTagForContextNode($reference->getWorkspaceName());
             $node = $this->getContextForReference($reference)->getNodeByIdentifier($reference->getNodeIdentifier());
             $this->registerNodeChange($node);
 
             $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
             // @see RuntimeContentCache.addTag
-            $tagName = 'AssetDynamicTag_' . $workspaceHash . '_' . $assetIdentifier;
+            $tagName = 'AssetDynamicTag_' . $assetIdentifier;
             $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because asset "%s" has changed.', $tagName, $assetIdentifier);
         }
     }


### PR DESCRIPTION
If you change some meta data on assets it needs to flush all content caches of ALL workspaces, which are referencing to this asset. A newly introduced feature (https://github.com/neos/neos-development-collection/pull/2097) tried to flush the caches more precisley, which leads to unflushed caches where they need to be flushed (usually the live workspace). 

As a workaround you need to change something on the page containing the asset and publish them to trigger a cache flush in live workspace.

See: https://github.com/neos/neos-development-collection/issues/2294

**What I did**
Cache tag is not depending on the workspace anymore.

**How I did it**
I removed the workspace wise cache tag implementation.

**How to verify it**
1. Open frontend (live workspace) with an image to create cache for this page.
2. Change the title of an image (of this cached page) in media browser and save.
3. Check in frontend (live workspace), if the changed title is visible immediately, without publishing any other changes.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
