### PR TITLE
!!! FEATURE Improve standalone FusionView

### DIFF
--- a/Neos.Fusion/Classes/Aspects/FusionCachingAspect.php
+++ b/Neos.Fusion/Classes/Aspects/FusionCachingAspect.php
@@ -1,0 +1,49 @@
+<?php
+namespace Neos\Fusion\Aspects;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Cache\Frontend\VariableFrontend;
+
+/**
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class FusionCachingAspect
+{
+    /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $fusionCache;
+
+    /**
+     * @Flow\Around("setting(Neos.Fusion.enableObjectTreeCache) && method(Neos\Fusion\View\FusionView->getMergedFusionObjectTree())")
+     * @param JoinPointInterface $joinPoint The current join point
+     * @return mixed
+     */
+    public function cacheGetMergedFusionObjectTree(JoinPointInterface $joinPoint)
+    {
+        $fusionPathPatterns = $joinPoint->getProxy()->getOption('fusionPathPatterns');
+        $cacheIdentifier = md5(serialize($fusionPathPatterns));
+
+        if ($this->fusionCache->has($cacheIdentifier)) {
+            $fusionObjectTree = $this->fusionCache->get($cacheIdentifier);
+        } else {
+            $fusionObjectTree = $joinPoint->getAdviceChain()->proceed($joinPoint);
+            $this->fusionCache->set($cacheIdentifier, $fusionObjectTree);
+        }
+
+        return $fusionObjectTree;
+    }
+}

--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -14,7 +14,6 @@ namespace Neos\Fusion\View;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\View\AbstractView;
-use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Utility\Files;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Runtime;
@@ -28,7 +27,7 @@ use Neos\Fusion\Exception\RuntimeException;
  *
  * If the controller class name is Foo\Bar\Baz\Controller\BlahController and the action is "index",
  * it checks for the Fusion path Foo.Bar.Baz.BlahController.index.
- * If this path is found, then it is used for rendering. Otherwise, the $fallbackView is used.
+ * If this path is found, then it is used for rendering.
  */
 class FusionView extends AbstractView
 {
@@ -38,7 +37,7 @@ class FusionView extends AbstractView
      * @var array
      */
     protected $supportedOptions = [
-        'fusionPathPatterns' => [['resource://@package/Private/Fusion'], 'Fusion files will be recursively loaded from this paths.', 'array'],
+        'fusionPathPatterns' => [['resource://@package/Private/Fusion/Root.fusion'], 'Fusion files will be recursively loaded from this paths.', 'array'],
         'fusionPath' => [null, 'The Fusion path which should be rendered; derived from the controller and action names or set by the user.', 'string'],
         'packageKey' => [null, 'The package key where the Fusion should be loaded from. If not given, is automatically derived from the current request.', 'string'],
         'debugMode' => [false, 'Flag to enable debug mode of the Fusion runtime explicitly (overriding the global setting).', 'boolean'],
@@ -50,12 +49,6 @@ class FusionView extends AbstractView
      * @var Parser
      */
     protected $fusionParser;
-
-    /**
-     * @Flow\Inject
-     * @var ViewInterface
-     */
-    protected $fallbackView;
 
     /**
      * The parsed Fusion array in its internal representation
@@ -71,13 +64,6 @@ class FusionView extends AbstractView
      * @var string
      */
     protected $fusionPath = null;
-
-    /**
-     * if false, the fallback view will never be used.
-     *
-     * @var boolean
-     */
-    protected $fallbackViewEnabled = true;
 
     /**
      * The Fusion Runtime
@@ -142,28 +128,6 @@ class FusionView extends AbstractView
     }
 
     /**
-     * Disable the use of the Fallback View
-     *
-     * @return void
-     */
-    public function disableFallbackView()
-    {
-        $this->fallbackViewEnabled = false;
-    }
-
-    /**
-     * Re-Enable the use of the Fallback View. By default, it is enabled,
-     * so calling this method only makes sense if disableFallbackView() has
-     * been called before.
-     *
-     * @return void
-     */
-    public function enableFallbackView()
-    {
-        $this->fallbackViewEnabled = true;
-    }
-
-    /**
      * Render the view
      *
      * @return string The rendered view
@@ -172,11 +136,7 @@ class FusionView extends AbstractView
     public function render()
     {
         $this->initializeFusionRuntime();
-        if ($this->fusionRuntime->canRender($this->getFusionPathForCurrentRequest()) || $this->fallbackViewEnabled === false) {
-            return $this->renderFusion();
-        } else {
-            return $this->renderFallbackView();
-        }
+        return $this->renderFusion();
     }
 
     /**
@@ -207,18 +167,25 @@ class FusionView extends AbstractView
      */
     protected function loadFusion()
     {
-        $mergedFusionCode = '';
+        $this->parsedFusion = $this->getMergedFusionObjectTree();
+    }
+
+    /**
+     * Parse all the fusion files the are in the current fusionPathPatterns
+     *
+     * @return array
+     */
+    protected function getMergedFusionObjectTree(): array
+    {
+        $parsedFusion = [];
         $fusionPathPatterns = $this->getOption('fusionPathPatterns');
-        ksort($fusionPathPatterns);
         foreach ($fusionPathPatterns as $fusionPathPattern) {
             $fusionPathPattern = str_replace('@package', $this->getPackageKey(), $fusionPathPattern);
-            $filePaths = array_merge(Files::readDirectoryRecursively($fusionPathPattern, '.fusion'), Files::readDirectoryRecursively($fusionPathPattern, '.ts2'));
-            sort($filePaths);
-            foreach ($filePaths as $filePath) {
-                $mergedFusionCode .= PHP_EOL . file_get_contents($filePath) . PHP_EOL;
+            if (file_exists($fusionPathPattern)) {
+                $parsedFusion = $this->fusionParser->parse(file_get_contents($fusionPathPattern), $fusionPathPattern, $parsedFusion);
             }
         }
-        $this->parsedFusion = $this->fusionParser->parse($mergedFusionCode);
+        return $parsedFusion;
     }
 
     /**
@@ -281,17 +248,5 @@ class FusionView extends AbstractView
         }
         $this->fusionRuntime->popContext();
         return $output;
-    }
-
-    /**
-     * Initialize and render the fallback view
-     *
-     * @return string
-     */
-    public function renderFallbackView()
-    {
-        $this->fallbackView->setControllerContext($this->controllerContext);
-        $this->fallbackView->assignMultiple($this->variables);
-        return $this->fallbackView->render();
     }
 }

--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -37,7 +37,7 @@ class FusionView extends AbstractView
      * @var array
      */
     protected $supportedOptions = [
-        'fusionPathPatterns' => [['resource://@package/Private/Fusion/Root.fusion'], 'Fusion files will be recursively loaded from this paths.', 'array'],
+        'fusionPathPatterns' => [['resource://@package/Private/Fusion'], 'Fusion files that will be loaded if directories are given the Root.fusion is used.', 'array'],
         'fusionPath' => [null, 'The Fusion path which should be rendered; derived from the controller and action names or set by the user.', 'string'],
         'packageKey' => [null, 'The package key where the Fusion should be loaded from. If not given, is automatically derived from the current request.', 'string'],
         'debugMode' => [false, 'Flag to enable debug mode of the Fusion runtime explicitly (overriding the global setting).', 'boolean'],
@@ -181,6 +181,9 @@ class FusionView extends AbstractView
         $fusionPathPatterns = $this->getOption('fusionPathPatterns');
         foreach ($fusionPathPatterns as $fusionPathPattern) {
             $fusionPathPattern = str_replace('@package', $this->getPackageKey(), $fusionPathPattern);
+            if (is_dir($fusionPathPattern)) {
+                $fusionPathPattern .= '/Root.fusion';
+            }
             if (file_exists($fusionPathPattern)) {
                 $parsedFusion = $this->fusionParser->parse(file_get_contents($fusionPathPattern), $fusionPathPattern, $parsedFusion);
             }

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -130,7 +130,6 @@ class RenderViewHelper extends AbstractViewHelper
     {
         $this->fusionView = new FusionView();
         $this->fusionView->setControllerContext($this->controllerContext);
-        $this->fusionView->disableFallbackView();
         if ($this->hasArgument('fusionFilePathPattern')) {
             $this->fusionView->setFusionPathPattern($this->arguments['fusionFilePathPattern']);
         }

--- a/Neos.Fusion/Configuration/Caches.yaml
+++ b/Neos.Fusion/Configuration/Caches.yaml
@@ -1,3 +1,7 @@
 Neos_Fusion_Content:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\FileBackend
+
+Neos_Fusion_ObjectTree:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -1,8 +1,3 @@
-Neos\Fusion\View\FusionView:
-  properties:
-    fallbackView:
-      object: Neos\FluidAdaptor\View\TemplateView
-
 Neos\Fusion\Core\Cache\ContentCache:
   properties:
     cache:
@@ -12,3 +7,13 @@ Neos\Fusion\Core\Cache\ContentCache:
         arguments:
           1:
             value: Neos_Fusion_Content
+
+Neos\Fusion\Aspects\FusionCachingAspect:
+  properties:
+    fusionCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Neos_Fusion_ObjectTree

--- a/Neos.Fusion/Configuration/Production/Settings.yaml
+++ b/Neos.Fusion/Configuration/Production/Settings.yaml
@@ -1,0 +1,7 @@
+#                                                                        #
+# Settings for the Production context                                    #
+#                                                                        #
+
+Neos:
+  Fusion:
+    enableObjectTreeCache: true

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -20,6 +20,13 @@ Neos:
     debugMode: false
     enableContentCache: true
 
+    # if set to true, Fusion is cached for each set of fusionPathPatterns.
+    # Depending on the size of your Fusion, will improve rendering times 20-100+ ms.
+    # HOWEVER, the cache is NOT FLUSHED automatically (yet), so that's why we suggest that
+    # you enable this setting only if you are sure not to change Fusion in this context.
+    # This is case if you use automatic deployment and is also assumed in Production context
+    enableObjectTreeCache: false
+
     # Default context objects that are available in Eel expressions
     #
     # New variables should be added with a package key prefix. Example:

--- a/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
+++ b/Neos.Fusion/Resources/Private/Schema/Settings.schema.yaml
@@ -19,6 +19,8 @@ properties:
                 format: class-name
           debugMode:
             type: boolean
+          enableObjectTreeCache:
+            type: boolean
           enableContentCache:
             type: boolean
           defaultContext:

--- a/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTest.php
@@ -54,7 +54,6 @@ abstract class AbstractFusionObjectTest extends FunctionalTestCase
         );
 
         $view->setControllerContext($this->controllerContext);
-        $view->disableFallbackView();
         $view->setPackageKey('Neos.Fusion');
         $view->setFusionPathPattern(__DIR__ . '/Fixtures/Fusion');
         $view->assign('fixtureDirectory', __DIR__ . '/Fixtures/');

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Root.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Root.fusion
@@ -1,0 +1,1 @@
+include: ./**/*.fusion

--- a/Neos.Fusion/Tests/Functional/View/Fixtures/Fusion/Root.fusion
+++ b/Neos.Fusion/Tests/Functional/View/Fixtures/Fusion/Root.fusion
@@ -1,0 +1,1 @@
+include: ./**/*.fusion

--- a/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
+++ b/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
@@ -13,7 +13,6 @@ namespace Neos\Fusion\Tests\Functional\View;
 
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Fusion\View\FusionView;
 
@@ -24,11 +23,6 @@ use Neos\Fusion\View\FusionView;
 class FusionViewTest extends FunctionalTestCase
 {
     /**
-     * @var ViewInterface
-     */
-    protected $mockFallbackView;
-
-    /**
      * @var ControllerContext
      */
     protected $mockControllerContext;
@@ -38,7 +32,6 @@ class FusionViewTest extends FunctionalTestCase
      */
     public function setUp(): void
     {
-        $this->mockFallbackView = $this->createMock(ViewInterface::class);
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
     }
 
@@ -59,18 +52,6 @@ class FusionViewTest extends FunctionalTestCase
         $view = $this->buildView('Foo\Bar\Controller\TestController', 'index');
         $view->setFusionPath('foo/bar');
         $this->assertEquals('Xfoobar', $view->render());
-    }
-
-    /**
-     * @test
-     */
-    public function ifNoFusionViewIsFoundThenFallbackViewIsExecuted()
-    {
-        $view = $this->buildView('Foo\Bar\Controller\TestController', 'nonExisting');
-        $this->mockFallbackView->expects($this->once())->method('render')->will($this->returnValue('FallbackView called'));
-        $this->mockFallbackView->expects($this->once())->method('setControllerContext')->with($this->mockControllerContext);
-
-        $this->assertEquals('FallbackView called', $view->render());
     }
 
     /**
@@ -99,7 +80,6 @@ class FusionViewTest extends FunctionalTestCase
 
         $view = new FusionView();
         $view->setControllerContext($this->mockControllerContext);
-        $this->inject($view, 'fallbackView', $this->mockFallbackView);
         $view->setFusionPathPattern(__DIR__ . '/Fixtures/Fusion');
 
         return $view;

--- a/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
@@ -85,6 +85,6 @@ class HistoryController extends AbstractModuleController
     {
         parent::initializeView($view);
         /** @var FusionView $view */
-        $view->setFusionPathPattern('resource://Neos.Neos/Private/Fusion/Backend');
+        $view->setFusionPathPattern('resource://Neos.Neos/Private/Fusion/Backend/History');
     }
 }


### PR DESCRIPTION
- The `fallbackView` and related options are removed as it only caused confusion and made debugging harder
- The `fusionPathPatterns` are now expected to point to a single fusion file instead of parsing all files in the while directory. If the path points to a directory the `Root.fusion` is loaded as starting point. 
- Below the Root.fusion all other fusion files have to be included explicitly!
- The cache `Neos_Fusion_ObjectTree` is added and connected to the FusionView via aspect. The cache is enabled only for production via Setting `Neos.Fusion.enableObjectTreeCache`

Upgrade Instructions: If you use the standalone FusionView make sure that a `Root.fusion` exist in your `fusionPathPatterns` and that all other fusion files are included from there.