### PR TITLE
!!!TASK: Remove static robots.txt file for fresh installations

### DIFF
--- a/Neos.Neos/Resources/Private/Installer/Distribution/Defaults/Web/robots.txt
+++ b/Neos.Neos/Resources/Private/Installer/Distribution/Defaults/Web/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /neos/

--- a/Neos.Neos/Resources/Private/Templates/Login/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Login/Index.html
@@ -2,6 +2,7 @@
 <f:layout name="Default" />
 
 <f:section name="head">
+	<meta name="robots" content="noindex">
 	<title><neos:backend.translate id="login.index.title">Login to</neos:backend.translate> {site.name}</title>
 	<f:for each="{styles}" as="style">
 		<link rel="stylesheet" href="{f:uri.resource(path: style)}" />

--- a/Neos.Neos/Resources/Private/Templates/Login/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Login/Index.html
@@ -2,7 +2,7 @@
 <f:layout name="Default" />
 
 <f:section name="head">
-	<meta name="robots" content="noindex">
+	<meta name="robots" content="noindex" />
 	<title><neos:backend.translate id="login.index.title">Login to</neos:backend.translate> {site.name}</title>
 	<f:for each="{styles}" as="style">
 		<link rel="stylesheet" href="{f:uri.resource(path: style)}" />


### PR DESCRIPTION
Since the base distribution contains ´´neos/seo´´ 3.x which does a much
better job at providing a more valuable and accurate ``robots.txt`` file.

When the default ``robots.txt`` still remains in the projects Web
folder, this can cause a lot of confusion. To make matters worse, it's
recreated whenever the composer install scripts are executed.

In case a custom distribution does not install the ``neos/seo`` package,
we now have the meta tag within the Neos login page as a fallback, so
even then status quo remains without the standard ``robots.txt`` from a SEO perspective.