### PR TITLE
BUGFIX: Skip nodes if they cannot be resolved in ContentCacheFlusher

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -164,6 +164,12 @@ class ContentCacheFlusher
             }
 
             $node = $this->getContextForReference($reference)->getNodeByIdentifier($reference->getNodeIdentifier());
+
+            if (!$node instanceof NodeInterface) {
+                $this->systemLogger->log(sprintf('Found a node reference from node with identifier %s in workspace %s to asset %s, but the node could not be fetched.', $reference->getNodeIdentifier(), $reference->getWorkspaceName(), $this->persistenceManager->getIdentifierByObject($asset), LOG_WARNING));
+                continue;
+            }
+
             $this->registerNodeChange($node);
 
             $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);


### PR DESCRIPTION
If a node cannot be resolved in the content cache flusher
skip this node instead of throwing an exception.

Resolves: #2594