### PR TITLE
BUGFIX: Don't render exception message in Production Context

### DIFF
--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
@@ -50,9 +50,9 @@ class HtmlMessageHandler extends AbstractRenderingExceptionHandler
      */
     protected function handle($fusionPath, \Exception $exception, $referenceCode)
     {
-        $messageBody = sprintf('<p class="neos-message-content">%s</p>', htmlspecialchars($exception->getMessage()));
-
+        $messageBody = '';
         if ($this->renderTechnicalDetails) {
+            $messageBody .= sprintf('<p class="neos-message-content">%s</p>', htmlspecialchars($exception->getMessage()));
             $messageBody .= sprintf('<p class="neos-message-stacktrace"><code>%s</code></p>', $this->formatFusionPath($fusionPath));
         }
 


### PR DESCRIPTION
Synchronizes the behavior of the Fusion rendering exception handing with the one
from Flow to only render the exception *message* in `Development` Context.

Fixes: #2602