### PR TITLE
BUGFIX: Nullable return type in Neos\ContentRepository\Domain\Model\Node

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -303,10 +303,10 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Create a node for the given NodeData, given that it is a variant of the current node
      *
      * @param NodeData $nodeData
-     * @return NodeInterface
+     * @return NodeInterface|null
      * @throws NodeConfigurationException
      */
-    protected function createNodeForVariant(NodeData $nodeData): NodeInterface
+    protected function createNodeForVariant(NodeData $nodeData): ?NodeInterface
     {
         $contextProperties = $this->context->getProperties();
         $contextProperties['dimensions'] = $nodeData->getDimensionValues();


### PR DESCRIPTION
The return type in createNodeForVariant must be nullable because 
`$this->nodeFactory->createFromNodeData()` can return null when 
moving a node, even if only an edge case that occurs every
once in a while.

This bug only refers to version 4.3 since all previous versions do not contain a strict return type. 