### PR TITLE
BUGFIX: Fix broken JS require implementation in Backend Modules

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -95,7 +95,7 @@
 			$(function() {
 				require(
 					{
-						baseUrl: 'resource://Neos.Neos/Public/JavaScript',
+						baseUrl: /*]]>*/'resource://Neos.Neos/Public/JavaScript'/*<![CDATA[*/,
 						paths: requirePaths,
 						context: 'neos',
 						locale: 'en'


### PR DESCRIPTION
With resolution of #2479 javascript blocks were put into CDATA
sections in order to prevent them to break the Fluid parser.

This introduced a regression that prevents Backend Modules to
work properly when `loadMinifiedJavascript` is disabled.

Background:

The string `resource://...` is replaced by the `ResourceInterceptor`
but that behavior is skipped for CDATA sections.

Related: #2479