### PR TITLE
!!! BUGFIX: Neos\Eel\Utility::evaluateEelExpression may contain null

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
@@ -72,9 +72,8 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
      * @return string
      * @throws \Neos\Eel\Exception
      */
-    public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node)
+    public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node): string
     {
-        $label = Utility::evaluateEelExpression($this->getExpression(), $this->eelEvaluator, ['node' => $node], $this->defaultContextConfiguration);
-        return $label;
+        return (string)Utility::evaluateEelExpression($this->getExpression(), $this->eelEvaluator, ['node' => $node], $this->defaultContextConfiguration);
     }
 }

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
@@ -93,7 +93,7 @@ interface NodeInterface
      * @return string
      * @api
      */
-    public function getLabel();
+    public function getLabel(): string;
 
     /**
      * Sets the specified property.

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeLabelGeneratorInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeLabelGeneratorInterface.php
@@ -25,5 +25,5 @@ interface NodeLabelGeneratorInterface
      * @return string
      * @api
      */
-    public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node);
+    public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node): string;
 }


### PR DESCRIPTION
`Node::getLabel()` has a return type set to `string` while the interface hasn’t.
The label is built by the ExpressionBasedNodeLabelGenerator which may return null.
Added an explicit string cast to get an empty string in that case.