### PR TITLE
BUGFIX: Add missing controller to edit forms

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
@@ -5,7 +5,7 @@
 <f:section name="Title">Edit asset collection</f:section>
 
 <f:section name="Content">
-    <f:form method="post" action="updateAssetCollection" object="{assetCollection}" objectName="assetCollection">
+    <f:form method="post" action="updateAssetCollection" controller="Asset" object="{assetCollection}" objectName="assetCollection">
         <legend>{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}</legend>
         <div class="neos-row-fluid">
             <div class="neos-span6 neos-image-inputs">

--- a/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
@@ -46,7 +46,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', arguments: {assetCollection: assetCollection})}" class="neos-button neos-button-mini neos-button-danger">
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', controller: 'Asset', arguments: {assetCollection: assetCollection})}" class="neos-button neos-button-mini neos-button-danger">
                                 {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                             </button>
                         </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
@@ -47,7 +47,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', arguments: {tag: tag})}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', controller: 'Asset', arguments: {tag: tag})}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
                         </div>
                     </div>
                 </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
@@ -5,7 +5,7 @@
 <f:section name="Title">Edit tag</f:section>
 
 <f:section name="Content">
-    <f:form method="post" action="updateTag" object="{tag}" objectName="tag">
+    <f:form method="post" action="updateTag" controller="Asset" object="{tag}" objectName="tag">
         <legend>{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}</legend>
         <div class="neos-row-fluid">
             <div class="neos-span6 neos-image-inputs">


### PR DESCRIPTION
The Media Browser has at the moment the issue that you get an exception when you change the tag name or the collection name.

**What I did**
I just added the correct controllers to the fluid forms.

**How I did it**
1. Go to media browser module
2. click the pencil for tags for instance
3. Choose a tag and click the edit button
4. Change the name and click save

**How to verify it**
![Bildschirmfoto 2019-09-02 um 16 19 52](https://user-images.githubusercontent.com/1014126/64121136-405eeb00-cd9e-11e9-8c76-fe2c3ae3e55a.png)


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
