### PR TITLE
BUGFIX: HTML augmenter preserves multibyte characters in attributes

### DIFF
--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -69,7 +69,7 @@ class HtmlAugmenter
         $domDocument = new \DOMDocument('1.0', 'UTF-8');
         // ignore parsing errors
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
-        $domDocument->loadHTML($html);
+        $domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
         $xPath = new \DOMXPath($domDocument);
         $rootElement = $xPath->query('//html/body/*');
         if ($useInternalErrorsBackup !== true) {

--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -69,7 +69,7 @@ class HtmlAugmenter
         $domDocument = new \DOMDocument('1.0', 'UTF-8');
         // ignore parsing errors
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
-        $domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $domDocument->loadHTML((substr($html, 0, 5) === '<?xml') ? $html : '<?xml encoding="UTF-8"?>' . $html);
         $xPath = new \DOMXPath($domDocument);
         $rootElement = $xPath->query('//html/body/*');
         if ($useInternalErrorsBackup !== true) {

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -190,6 +190,13 @@ class HtmlAugmenterTest extends UnitTestCase
                 'exclusiveAttributes' => null,
                 'expectedResult' => '<p data-bar="öäüß" data-foo="öäüß">valid characters are decoded</p>',
             ),
+            [
+                'html' => '<p data-foo="öäüß🦆">valid characters are untouched</p>',
+                'attributes' => ['data-bar' => 'öäüß🦆'],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<p data-bar="öäüß🦆" data-foo="öäüß🦆">valid characters are untouched</p>',
+            ],
 
             // exclusive attributes
             array(


### PR DESCRIPTION
The html augmenter uses the `loadHml` method of php which assumes the html content being iso encoded. This caused attributes with umlauts being broken once on the outermost tag. The previous declaration of the `UTF-8` charset has no effect on the `loadHtml` behavior.

The change applies the mb_convert_encoding method to the html which allows to properly read unicode characters as suggested on  https://www.php.net/manual/en/domdocument.loadhtml.php

In addition this change adds a duck-emoji to the neos test codebase which is an important improvement.

Fixes: #2677