### PR TITLE
TASK: Fix Plugin reference regarding additional arguments, add example

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -837,7 +837,7 @@ arbitrary logic.
 :controller: (array) The controller name (e.g. 'Registration')
 :action: (string) The action name, defaults to `'index'`
 :argumentNamespace: (string) Namespace for action arguments, will be resolved from node type by default
-:[key]: (mixed) Pass an internal argument to the controller action (access with argument name ``_key``)
+:[key]: (mixed) Pass an internal argument to the controller action (access with argument name ``__key``)
 
 Example::
 
@@ -845,6 +845,23 @@ Example::
 		package = 'My.Site'
 		controller = 'Registration'
 	}
+  
+Example with argument passed to controller action::
+
+  prototype(My.Site:Registration) < prototype(Neos.Neos:Plugin) {
+    package = 'My.Site'
+    controller = 'Registration'
+    action = 'register'
+    additionalArgument = 'foo'
+  }
+  
+Get argument in controller action::
+
+  public function registerAction()
+  {
+    $additionalArgument = $this->request->getInternalArgument('__additionalArgument');
+    [...]
+  }
 
 .. _Neos_Neos__Menu:
 


### PR DESCRIPTION
**What I did**

The documentation regarding internal arguments for controller-based plugins mentions that internal arguments can be accessed by using `_key`, while `__key` is correct. Besides fixing this, I added an example on how to access it in the controller.