### PR TITLE
FEATURE: add index to column path on nodedata table

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -41,7 +41,8 @@ use Neos\ContentRepository\Utility;
  *      @ORM\Index(name="parentpath_sortingindex",columns={"parentpathhash", "sortingindex"}),
  *      @ORM\Index(name="parentpath",columns={"parentpath"},options={"lengths": {255}}),
  *      @ORM\Index(name="identifierindex",columns={"identifier"}),
- *      @ORM\Index(name="nodetypeindex",columns={"nodetype"})
+ *      @ORM\Index(name="nodetypeindex",columns={"nodetype"}),
+ *      @ORM\Index(name="pathindex",columns={"path"},options={"lengths": {255}})
  *    }
  * )
  */

--- a/Neos.ContentRepository/Migrations/Mysql/Version20190905074145.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20190905074145.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Create index on path for nodedata table
+ */
+class Version20190905074145 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Create index on path for nodedata table';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('CREATE INDEX path ON neos_contentrepository_domain_model_nodedata (path(255))');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('DROP INDEX path ON neos_contentrepository_domain_model_nodedata');
+    }
+}

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20190905074146.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20190905074146.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Create index on path for nodedata table
+ */
+class Version20190905074146 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Create index on path for nodedata table';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('CREATE INDEX path ON neos_contentrepository_domain_model_nodedata (path)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('DROP INDEX path');
+    }
+}


### PR DESCRIPTION
This allows for faster results in case of prefixed path queries on the nodedata table. The
index speeds up queries like in `findNodesByPathPrefixAndRelatedEntities()` (used to
determine the asset usage.)

Resolves: #2684