### PR TITLE
BUGFIX: Synchronize react-ui menu state with vanilla js

### DIFF
--- a/Neos.Neos/Resources/Public/JavaScript/Helper/getCollectionValueByPath.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Helper/getCollectionValueByPath.js
@@ -5,7 +5,7 @@ const getCollectionValueByPath = (collection, path) => {
 		return null;
 	}
 
-	return path.split('.').reduce(function(value, index) {
+	return path.split('.').reduce((value, index) => {
 		return value[index];
 	}, collection);
 };

--- a/Neos.Neos/Resources/Public/JavaScript/Helper/getCollectionValueByPath.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Helper/getCollectionValueByPath.js
@@ -1,0 +1,13 @@
+import { isNil } from '.';
+
+const getCollectionValueByPath = (collection, path) => {
+	if (isNil(collection)) {
+		return null;
+	}
+
+	return path.split('.').reduce(function(value, index) {
+		return value[index];
+	}, collection);
+};
+
+export default getCollectionValueByPath;

--- a/Neos.Neos/Resources/Public/JavaScript/Helper/index.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Helper/index.js
@@ -1,9 +1,11 @@
 import isNil from './isNil';
 import isEmpty from './isEmpty';
 import getItemByKeyValue from './getItemByKeyValue';
+import getCollectionValueByPath from './getCollectionValueByPath';
 
 export {
 	isNil,
 	isEmpty,
-	getItemByKeyValue
+	getItemByKeyValue,
+	getCollectionValueByPath
 };

--- a/Neos.Neos/Resources/Public/JavaScript/Main.min.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Main.min.js
@@ -84,259 +84,138 @@
 /******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/******/ ({
 
-module.exports = __webpack_require__(1);
-
-
-/***/ }),
-/* 1 */
+/***/ "./Resources/Public/JavaScript/Components/TopBar/DropdownMenu.js":
+/*!***********************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Components/TopBar/DropdownMenu.js ***!
+  \***********************************************************************/
+/*! exports provided: default */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-__webpack_require__.r(__webpack_exports__);
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"default\", function() { return DropDownMenu; });\nclass DropDownMenu {\n  constructor(_root) {\n    this._root = _root;\n    this._button = this._root.querySelectorAll('.neos-dropdown-toggle');\n    this._menu = this._root.querySelectorAll('.neos-dropdown-menu');\n\n    this._setupEventListeners();\n  }\n\n  _setupEventListeners() {\n    this._button.forEach(_toggleButton => {\n      _toggleButton.addEventListener('click', this._toggle.bind(this));\n    });\n  }\n\n  _toggle(_event) {\n    this._changeToogleIcon();\n\n    this._root.classList.toggle('neos-dropdown-open');\n  }\n\n  _changeToogleIcon() {\n    const openIcon = this._root.querySelector('.fa-chevron-down');\n\n    const closeIcon = this._root.querySelector('.fa-chevron-up');\n\n    if (openIcon) {\n      openIcon.classList.replace('fa-chevron-down', 'fa-chevron-up');\n    }\n\n    if (closeIcon) {\n      closeIcon.classList.replace('fa-chevron-up', 'fa-chevron-down');\n    }\n  }\n\n}//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvRHJvcGRvd25NZW51LmpzLmpzIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0NvbXBvbmVudHMvVG9wQmFyL0Ryb3Bkb3duTWVudS5qcz9jMzE4Il0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydCBkZWZhdWx0IGNsYXNzIERyb3BEb3duTWVudSB7XG5cdGNvbnN0cnVjdG9yKF9yb290KSB7XG5cdFx0dGhpcy5fcm9vdCA9IF9yb290O1xuXHRcdHRoaXMuX2J1dHRvbiA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvckFsbCgnLm5lb3MtZHJvcGRvd24tdG9nZ2xlJyk7XG5cdFx0dGhpcy5fbWVudSA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvckFsbCgnLm5lb3MtZHJvcGRvd24tbWVudScpO1xuXHRcdHRoaXMuX3NldHVwRXZlbnRMaXN0ZW5lcnMoKTtcblx0fVxuXG5cdF9zZXR1cEV2ZW50TGlzdGVuZXJzKCkge1xuXHRcdHRoaXMuX2J1dHRvbi5mb3JFYWNoKF90b2dnbGVCdXR0b24gPT4ge1xuXHRcdFx0X3RvZ2dsZUJ1dHRvbi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIHRoaXMuX3RvZ2dsZS5iaW5kKHRoaXMpKTtcblx0XHR9KTtcblx0fVxuXG5cdF90b2dnbGUoX2V2ZW50KSB7XG5cdFx0dGhpcy5fY2hhbmdlVG9vZ2xlSWNvbigpO1xuXHRcdHRoaXMuX3Jvb3QuY2xhc3NMaXN0LnRvZ2dsZSgnbmVvcy1kcm9wZG93bi1vcGVuJyk7XG5cdH1cblxuXHRfY2hhbmdlVG9vZ2xlSWNvbigpIHtcblx0XHRjb25zdCBvcGVuSWNvbiA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvcignLmZhLWNoZXZyb24tZG93bicpO1xuXHRcdGNvbnN0IGNsb3NlSWNvbiA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvcignLmZhLWNoZXZyb24tdXAnKTtcblx0XHRpZiAob3Blbkljb24pIHtcblx0XHRcdG9wZW5JY29uLmNsYXNzTGlzdC5yZXBsYWNlKCdmYS1jaGV2cm9uLWRvd24nLCAnZmEtY2hldnJvbi11cCcpO1xuXHRcdH1cblx0XHRpZiAoY2xvc2VJY29uKSB7XG5cdFx0XHRjbG9zZUljb24uY2xhc3NMaXN0LnJlcGxhY2UoJ2ZhLWNoZXZyb24tdXAnLCAnZmEtY2hldnJvbi1kb3duJyk7XG5cdFx0fVxuXHR9XG59XG4iXSwibWFwcGluZ3MiOiJBQUFBO0FBQUE7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBN0JBIiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Components/TopBar/DropdownMenu.js\n");
 
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Components/TopBar/DropdownMenu.js
-class DropDownMenu {
-  constructor(_root) {
-    this._root = _root;
-    this._button = this._root.querySelectorAll('.neos-dropdown-toggle');
-    this._menu = this._root.querySelectorAll('.neos-dropdown-menu');
+/***/ }),
 
-    this._setupEventListeners();
-  }
+/***/ "./Resources/Public/JavaScript/Components/TopBar/Expandable.js":
+/*!*********************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Components/TopBar/Expandable.js ***!
+  \*********************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-  _setupEventListeners() {
-    this._button.forEach(_toggleButton => {
-      _toggleButton.addEventListener('click', this._toggle.bind(this));
-    });
-  }
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"default\", function() { return Expandable; });\nclass Expandable {\n  constructor(_root, _triggerClassName, _onStateChange, initialState) {\n    this._root = _root;\n    this._trigger = this._root.querySelectorAll(_triggerClassName);\n    this._onStateChange = _onStateChange;\n\n    this._setupEventListeners();\n\n    this._initialize(initialState);\n  }\n\n  _setupEventListeners() {\n    this._trigger.forEach(_toggleButton => {\n      _toggleButton.addEventListener('click', this._toggle.bind(this));\n    });\n  }\n\n  _initialize(initialState) {\n    const header = this._root.querySelector('[aria-expanded]');\n\n    header.setAttribute('aria-expanded', String(initialState));\n\n    if (initialState) {\n      // default is closed\n      this._root.classList.add('neos-open');\n\n      this._changeToogleIcon();\n    }\n  }\n\n  _toggle() {\n    this._changeToogleIcon();\n\n    this._root.classList.toggle('neos-open');\n\n    this._toogleAriaExpandable();\n  }\n\n  _toogleAriaExpandable() {\n    const header = this._root.querySelector('[aria-expanded]');\n\n    const expanded = this._root.classList.contains('neos-open');\n\n    header.setAttribute('aria-expanded', String(expanded));\n\n    if (typeof this._onStateChange === 'function') {\n      const sectionName = this._root.getAttribute('data-key');\n\n      this._onStateChange(sectionName, expanded);\n    }\n  }\n\n  _changeToogleIcon() {\n    const openIcon = this._root.querySelector('.fa-chevron-circle-down');\n\n    const closeIcon = this._root.querySelector('.fa-chevron-circle-up');\n\n    if (openIcon) {\n      openIcon.classList.replace('fa-chevron-circle-down', 'fa-chevron-circle-up');\n    }\n\n    if (closeIcon) {\n      closeIcon.classList.replace('fa-chevron-circle-up', 'fa-chevron-circle-down');\n    }\n  }\n\n}//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvRXhwYW5kYWJsZS5qcy5qcyIsInNvdXJjZXMiOlsid2VicGFjazovLy8uL1Jlc291cmNlcy9QdWJsaWMvSmF2YVNjcmlwdC9Db21wb25lbnRzL1RvcEJhci9FeHBhbmRhYmxlLmpzPzk0MjgiXSwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGRlZmF1bHQgY2xhc3MgRXhwYW5kYWJsZSB7XG5cdGNvbnN0cnVjdG9yKF9yb290LCBfdHJpZ2dlckNsYXNzTmFtZSwgX29uU3RhdGVDaGFuZ2UsIGluaXRpYWxTdGF0ZSkge1xuXHRcdHRoaXMuX3Jvb3QgPSBfcm9vdDtcblx0XHR0aGlzLl90cmlnZ2VyID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKF90cmlnZ2VyQ2xhc3NOYW1lKTtcblx0XHR0aGlzLl9vblN0YXRlQ2hhbmdlID0gX29uU3RhdGVDaGFuZ2U7XG5cdFx0dGhpcy5fc2V0dXBFdmVudExpc3RlbmVycygpO1xuXHRcdHRoaXMuX2luaXRpYWxpemUoaW5pdGlhbFN0YXRlKTtcblx0fVxuXG5cdF9zZXR1cEV2ZW50TGlzdGVuZXJzKCkge1xuXHRcdHRoaXMuX3RyaWdnZXIuZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCB0aGlzLl90b2dnbGUuYmluZCh0aGlzKSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfaW5pdGlhbGl6ZShpbml0aWFsU3RhdGUpIHtcblx0XHRjb25zdCBoZWFkZXIgPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3IoJ1thcmlhLWV4cGFuZGVkXScpO1xuXHRcdGhlYWRlci5zZXRBdHRyaWJ1dGUoJ2FyaWEtZXhwYW5kZWQnLCBTdHJpbmcoaW5pdGlhbFN0YXRlKSk7XG5cblx0XHRpZiAoaW5pdGlhbFN0YXRlKSB7XG5cdFx0XHQvLyBkZWZhdWx0IGlzIGNsb3NlZFxuXHRcdFx0dGhpcy5fcm9vdC5jbGFzc0xpc3QuYWRkKCduZW9zLW9wZW4nKTtcblx0XHRcdHRoaXMuX2NoYW5nZVRvb2dsZUljb24oKTtcblx0XHR9XG5cdH1cblxuXHRfdG9nZ2xlKCkge1xuXHRcdHRoaXMuX2NoYW5nZVRvb2dsZUljb24oKTtcblx0XHR0aGlzLl9yb290LmNsYXNzTGlzdC50b2dnbGUoJ25lb3Mtb3BlbicpO1xuXHRcdHRoaXMuX3Rvb2dsZUFyaWFFeHBhbmRhYmxlKCk7XG5cdH1cblxuXHRfdG9vZ2xlQXJpYUV4cGFuZGFibGUoKSB7XG5cdFx0Y29uc3QgaGVhZGVyID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yKCdbYXJpYS1leHBhbmRlZF0nKTtcblx0XHRjb25zdCBleHBhbmRlZCA9IHRoaXMuX3Jvb3QuY2xhc3NMaXN0LmNvbnRhaW5zKCduZW9zLW9wZW4nKTtcblx0XHRoZWFkZXIuc2V0QXR0cmlidXRlKCdhcmlhLWV4cGFuZGVkJywgU3RyaW5nKGV4cGFuZGVkKSk7XG5cdFx0aWYgKHR5cGVvZiB0aGlzLl9vblN0YXRlQ2hhbmdlID09PSAnZnVuY3Rpb24nKSB7XG5cdFx0XHRjb25zdCBzZWN0aW9uTmFtZSA9IHRoaXMuX3Jvb3QuZ2V0QXR0cmlidXRlKCdkYXRhLWtleScpO1xuXHRcdFx0dGhpcy5fb25TdGF0ZUNoYW5nZShzZWN0aW9uTmFtZSwgZXhwYW5kZWQpO1xuXHRcdH1cblx0fVxuXG5cdF9jaGFuZ2VUb29nbGVJY29uKCkge1xuXHRcdGNvbnN0IG9wZW5JY29uID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yKCcuZmEtY2hldnJvbi1jaXJjbGUtZG93bicpO1xuXHRcdGNvbnN0IGNsb3NlSWNvbiA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvcignLmZhLWNoZXZyb24tY2lyY2xlLXVwJyk7XG5cdFx0aWYgKG9wZW5JY29uKSB7XG5cdFx0XHRvcGVuSWNvbi5jbGFzc0xpc3QucmVwbGFjZShcblx0XHRcdFx0J2ZhLWNoZXZyb24tY2lyY2xlLWRvd24nLFxuXHRcdFx0XHQnZmEtY2hldnJvbi1jaXJjbGUtdXAnXG5cdFx0XHQpO1xuXHRcdH1cblx0XHRpZiAoY2xvc2VJY29uKSB7XG5cdFx0XHRjbG9zZUljb24uY2xhc3NMaXN0LnJlcGxhY2UoXG5cdFx0XHRcdCdmYS1jaGV2cm9uLWNpcmNsZS11cCcsXG5cdFx0XHRcdCdmYS1jaGV2cm9uLWNpcmNsZS1kb3duJ1xuXHRcdFx0KTtcblx0XHR9XG5cdH1cbn1cbiJdLCJtYXBwaW5ncyI6IkFBQUE7QUFBQTtBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUFBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUFBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQUE7QUFDQTtBQUFBO0FBQ0E7QUFDQTtBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQUE7QUFDQTtBQUFBO0FBQ0E7QUFJQTtBQUNBO0FBQUE7QUFDQTtBQUlBO0FBQ0E7QUFDQTtBQTFEQSIsInNvdXJjZVJvb3QiOiIifQ==\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Components/TopBar/Expandable.js\n");
 
-  _toggle(_event) {
-    this._changeToogleIcon();
+/***/ }),
 
-    this._root.classList.toggle('neos-dropdown-open');
-  }
+/***/ "./Resources/Public/JavaScript/Components/TopBar/MenuPanel.js":
+/*!********************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Components/TopBar/MenuPanel.js ***!
+  \********************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-  _changeToogleIcon() {
-    const openIcon = this._root.querySelector('.fa-chevron-down');
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"default\", function() { return MenuPanel; });\n/* harmony import */ var _Expandable__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Expandable */ \"./Resources/Public/JavaScript/Components/TopBar/Expandable.js\");\n/* harmony import */ var _Helper__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../Helper */ \"./Resources/Public/JavaScript/Helper/index.js\");\n\n\nconst STORAGE_KEY = 'persistedState';\nconst VALUE_PATH = 'ui.drawer.collapsedMenuGroups';\nclass MenuPanel {\n  constructor(_root) {\n    this._root = _root;\n    this._button = this._root.querySelectorAll('.neos-menu-button');\n    this._panel = this._root.querySelectorAll('.neos-menu-panel');\n    this._menuSectionStates = this._loadMenuSectionStates();\n\n    this._setupEventListeners();\n\n    if (this._panel) {\n      this._initializeMenuSections();\n    }\n  }\n\n  _initializeMenuSections() {\n    this._panel.forEach(_panel => {\n      const menuSectionElements = _panel.querySelectorAll('.neos-menu-section');\n\n      const sections = this._menuSectionStates;\n      menuSectionElements.forEach(menuSectionElement => {\n        const sectionName = menuSectionElement.getAttribute('data-key');\n        const sectionState = !sections.includes(sectionName);\n        new _Expandable__WEBPACK_IMPORTED_MODULE_0__[\"default\"](menuSectionElement, '.neos-menu-panel-toggle', this._onMenuSectionStateChange.bind(this), sectionState);\n      });\n    });\n  }\n\n  _setupEventListeners() {\n    this._button.forEach(_toggleButton => {\n      _toggleButton.addEventListener('click', this._toggle.bind(this));\n    });\n  }\n\n  _loadStorageData() {\n    const storageData = localStorage.getItem(STORAGE_KEY);\n\n    if (Object(_Helper__WEBPACK_IMPORTED_MODULE_1__[\"isNil\"])(storageData)) {\n      const initialStorageData = {\n        ui: {\n          drawer: {\n            collapsedMenuGroups: []\n          }\n        }\n      };\n      localStorage.setItem(STORAGE_KEY, JSON.stringify(initialStorageData));\n      return initialStorageData;\n    }\n\n    return JSON.parse(storageData);\n  }\n\n  _loadMenuSectionStates() {\n    const storageData = this._loadStorageData();\n\n    return Object(_Helper__WEBPACK_IMPORTED_MODULE_1__[\"getCollectionValueByPath\"])(storageData, VALUE_PATH);\n  }\n\n  _saveMenuSectionStates() {\n    const storageData = this._loadStorageData();\n\n    if (!Object(_Helper__WEBPACK_IMPORTED_MODULE_1__[\"isNil\"])(storageData) && Array.isArray(this._menuSectionStates)) {\n      storageData.ui.drawer.collapsedMenuGroups = this._menuSectionStates;\n      localStorage.setItem(STORAGE_KEY, JSON.stringify(storageData));\n    }\n  }\n\n  _onMenuSectionStateChange(sectionName, newValue) {\n    if (this._menuSectionStates.includes(sectionName) && newValue === true) {\n      this._menuSectionStates = this._menuSectionStates.filter(item => item !== sectionName);\n    }\n\n    if (!this._menuSectionStates.includes(sectionName) && newValue === false) {\n      this._menuSectionStates.push(sectionName);\n    }\n\n    this._saveMenuSectionStates();\n  }\n\n  _toggle(_event) {\n    this._button.forEach(_toggleButton => {\n      _toggleButton.classList.toggle('neos-pressed');\n    });\n\n    document.body.classList.toggle('neos-menu-panel-open');\n  }\n\n}//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvTWVudVBhbmVsLmpzLmpzIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0NvbXBvbmVudHMvVG9wQmFyL01lbnVQYW5lbC5qcz9iY2RkIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBFeHBhbmRhYmxlIGZyb20gJy4vRXhwYW5kYWJsZSc7XG5pbXBvcnQgeyBpc05pbCwgZ2V0SXRlbUJ5S2V5VmFsdWUsIGdldENvbGxlY3Rpb25WYWx1ZUJ5UGF0aCB9IGZyb20gJy4uLy4uL0hlbHBlcic7XG5cbmNvbnN0IFNUT1JBR0VfS0VZID0gJ3BlcnNpc3RlZFN0YXRlJztcbmNvbnN0IFZBTFVFX1BBVEggPSAndWkuZHJhd2VyLmNvbGxhcHNlZE1lbnVHcm91cHMnO1xuZXhwb3J0IGRlZmF1bHQgY2xhc3MgTWVudVBhbmVsIHtcblx0Y29uc3RydWN0b3IoX3Jvb3QpIHtcblx0XHR0aGlzLl9yb290ID0gX3Jvb3Q7XG5cdFx0dGhpcy5fYnV0dG9uID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKCcubmVvcy1tZW51LWJ1dHRvbicpO1xuXHRcdHRoaXMuX3BhbmVsID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKCcubmVvcy1tZW51LXBhbmVsJyk7XG5cdFx0dGhpcy5fbWVudVNlY3Rpb25TdGF0ZXMgPSB0aGlzLl9sb2FkTWVudVNlY3Rpb25TdGF0ZXMoKTtcblx0XHR0aGlzLl9zZXR1cEV2ZW50TGlzdGVuZXJzKCk7XG5cblx0XHRpZiAodGhpcy5fcGFuZWwpIHtcblx0XHRcdHRoaXMuX2luaXRpYWxpemVNZW51U2VjdGlvbnMoKTtcblx0XHR9XG5cdH1cblxuXHRfaW5pdGlhbGl6ZU1lbnVTZWN0aW9ucygpIHtcblx0XHR0aGlzLl9wYW5lbC5mb3JFYWNoKF9wYW5lbCA9PiB7XG5cdFx0XHRjb25zdCBtZW51U2VjdGlvbkVsZW1lbnRzID0gX3BhbmVsLnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLW1lbnUtc2VjdGlvbicpO1xuXHRcdFx0Y29uc3Qgc2VjdGlvbnMgPSB0aGlzLl9tZW51U2VjdGlvblN0YXRlcztcblx0XHRcdG1lbnVTZWN0aW9uRWxlbWVudHMuZm9yRWFjaChtZW51U2VjdGlvbkVsZW1lbnQgPT4ge1xuXHRcdFx0XHRjb25zdCBzZWN0aW9uTmFtZSA9IG1lbnVTZWN0aW9uRWxlbWVudC5nZXRBdHRyaWJ1dGUoJ2RhdGEta2V5Jyk7XG5cdFx0XHRcdGNvbnN0IHNlY3Rpb25TdGF0ZSA9ICFzZWN0aW9ucy5pbmNsdWRlcyhzZWN0aW9uTmFtZSk7XG5cdFx0XHRcdG5ldyBFeHBhbmRhYmxlKFxuXHRcdFx0XHRcdG1lbnVTZWN0aW9uRWxlbWVudCxcblx0XHRcdFx0XHQnLm5lb3MtbWVudS1wYW5lbC10b2dnbGUnLFxuXHRcdFx0XHRcdHRoaXMuX29uTWVudVNlY3Rpb25TdGF0ZUNoYW5nZS5iaW5kKHRoaXMpLFxuXHRcdFx0XHRcdHNlY3Rpb25TdGF0ZVxuXHRcdFx0XHQpO1xuXHRcdFx0fSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfc2V0dXBFdmVudExpc3RlbmVycygpIHtcblx0XHR0aGlzLl9idXR0b24uZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCB0aGlzLl90b2dnbGUuYmluZCh0aGlzKSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfbG9hZFN0b3JhZ2VEYXRhKCkge1xuXHRcdGNvbnN0IHN0b3JhZ2VEYXRhID0gbG9jYWxTdG9yYWdlLmdldEl0ZW0oU1RPUkFHRV9LRVkpO1xuXHRcdGlmIChpc05pbChzdG9yYWdlRGF0YSkpIHtcblx0XHRcdGNvbnN0IGluaXRpYWxTdG9yYWdlRGF0YSA9IHtcblx0XHRcdFx0dWk6IHtcblx0XHRcdFx0XHRkcmF3ZXI6IHtcblx0XHRcdFx0XHRcdGNvbGxhcHNlZE1lbnVHcm91cHM6IFtdXG5cdFx0XHRcdFx0fVxuXHRcdFx0XHR9XG5cdFx0XHR9O1xuXHRcdFx0bG9jYWxTdG9yYWdlLnNldEl0ZW0oU1RPUkFHRV9LRVksIEpTT04uc3RyaW5naWZ5KGluaXRpYWxTdG9yYWdlRGF0YSkpO1xuXHRcdFx0cmV0dXJuIGluaXRpYWxTdG9yYWdlRGF0YTtcblx0XHR9XG5cblx0XHRyZXR1cm4gSlNPTi5wYXJzZShzdG9yYWdlRGF0YSk7XG5cdH1cblxuXHRfbG9hZE1lbnVTZWN0aW9uU3RhdGVzKCkge1xuXHRcdGNvbnN0IHN0b3JhZ2VEYXRhID0gdGhpcy5fbG9hZFN0b3JhZ2VEYXRhKCk7XG5cdFx0cmV0dXJuIGdldENvbGxlY3Rpb25WYWx1ZUJ5UGF0aChzdG9yYWdlRGF0YSwgVkFMVUVfUEFUSCk7XG5cdH1cblxuXHRfc2F2ZU1lbnVTZWN0aW9uU3RhdGVzKCkge1xuXHRcdGNvbnN0IHN0b3JhZ2VEYXRhID0gdGhpcy5fbG9hZFN0b3JhZ2VEYXRhKCk7XG5cdFx0aWYgKCFpc05pbChzdG9yYWdlRGF0YSkgJiYgQXJyYXkuaXNBcnJheSh0aGlzLl9tZW51U2VjdGlvblN0YXRlcykpIHtcblx0XHRcdHN0b3JhZ2VEYXRhLnVpLmRyYXdlci5jb2xsYXBzZWRNZW51R3JvdXBzID0gdGhpcy5fbWVudVNlY3Rpb25TdGF0ZXM7XG5cdFx0XHRsb2NhbFN0b3JhZ2Uuc2V0SXRlbShTVE9SQUdFX0tFWSwgSlNPTi5zdHJpbmdpZnkoc3RvcmFnZURhdGEpKTtcblx0XHR9XG5cdH1cblxuXHRfb25NZW51U2VjdGlvblN0YXRlQ2hhbmdlKHNlY3Rpb25OYW1lLCBuZXdWYWx1ZSkge1xuXHRcdGlmICh0aGlzLl9tZW51U2VjdGlvblN0YXRlcy5pbmNsdWRlcyhzZWN0aW9uTmFtZSkgJiYgbmV3VmFsdWUgPT09IHRydWUpIHtcblx0XHRcdHRoaXMuX21lbnVTZWN0aW9uU3RhdGVzID0gdGhpcy5fbWVudVNlY3Rpb25TdGF0ZXMuZmlsdGVyKGl0ZW0gPT4gaXRlbSAhPT0gc2VjdGlvbk5hbWUpXG5cdFx0fVxuXG5cdFx0aWYgKCF0aGlzLl9tZW51U2VjdGlvblN0YXRlcy5pbmNsdWRlcyhzZWN0aW9uTmFtZSkgJiYgbmV3VmFsdWUgPT09IGZhbHNlKSB7XG5cdFx0XHR0aGlzLl9tZW51U2VjdGlvblN0YXRlcy5wdXNoKHNlY3Rpb25OYW1lKTtcblx0XHR9XG5cblx0XHR0aGlzLl9zYXZlTWVudVNlY3Rpb25TdGF0ZXMoKTtcblx0fVxuXG5cdF90b2dnbGUoX2V2ZW50KSB7XG5cdFx0dGhpcy5fYnV0dG9uLmZvckVhY2goX3RvZ2dsZUJ1dHRvbiA9PiB7XG5cdFx0XHRfdG9nZ2xlQnV0dG9uLmNsYXNzTGlzdC50b2dnbGUoJ25lb3MtcHJlc3NlZCcpO1xuXHRcdH0pO1xuXHRcdGRvY3VtZW50LmJvZHkuY2xhc3NMaXN0LnRvZ2dsZSgnbmVvcy1tZW51LXBhbmVsLW9wZW4nKTtcblx0fVxufVxuIl0sIm1hcHBpbmdzIjoiQUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQ0E7QUFFQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQU1BO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQURBO0FBREE7QUFEQTtBQU9BO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUFBO0FBQ0E7QUFDQTtBQXBGQSIsInNvdXJjZVJvb3QiOiIifQ==\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Components/TopBar/MenuPanel.js\n");
 
-    const closeIcon = this._root.querySelector('.fa-chevron-up');
+/***/ }),
 
-    if (openIcon) {
-      openIcon.classList.replace('fa-chevron-down', 'fa-chevron-up');
-    }
+/***/ "./Resources/Public/JavaScript/Components/TopBar/index.js":
+/*!****************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Components/TopBar/index.js ***!
+  \****************************************************************/
+/*! exports provided: DropDownMenu, Expandable, MenuPanel */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-    if (closeIcon) {
-      closeIcon.classList.replace('fa-chevron-up', 'fa-chevron-down');
-    }
-  }
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _DropdownMenu__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./DropdownMenu */ \"./Resources/Public/JavaScript/Components/TopBar/DropdownMenu.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"DropDownMenu\", function() { return _DropdownMenu__WEBPACK_IMPORTED_MODULE_0__[\"default\"]; });\n\n/* harmony import */ var _Expandable__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Expandable */ \"./Resources/Public/JavaScript/Components/TopBar/Expandable.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"Expandable\", function() { return _Expandable__WEBPACK_IMPORTED_MODULE_1__[\"default\"]; });\n\n/* harmony import */ var _MenuPanel__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./MenuPanel */ \"./Resources/Public/JavaScript/Components/TopBar/MenuPanel.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"MenuPanel\", function() { return _MenuPanel__WEBPACK_IMPORTED_MODULE_2__[\"default\"]; });\n\n\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvaW5kZXguanMuanMiLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvaW5kZXguanM/OTU2ZCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgRHJvcERvd25NZW51IGZyb20gJy4vRHJvcGRvd25NZW51J1xuaW1wb3J0IEV4cGFuZGFibGUgZnJvbSAnLi9FeHBhbmRhYmxlJ1xuaW1wb3J0IE1lbnVQYW5lbCBmcm9tICcuL01lbnVQYW5lbCdcblxuZXhwb3J0IHtcblx0RHJvcERvd25NZW51LFxuXHRFeHBhbmRhYmxlLFxuXHRNZW51UGFuZWxcbn1cbiJdLCJtYXBwaW5ncyI6IkFBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUNBO0FBQ0E7Iiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Components/TopBar/index.js\n");
 
-}
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Components/TopBar/Expandable.js
-class Expandable {
-  constructor(_root, _triggerClassName, _onStateChange, initialState) {
-    this._root = _root;
-    this._trigger = this._root.querySelectorAll(_triggerClassName);
-    this._onStateChange = _onStateChange;
+/***/ }),
 
-    this._setupEventListeners();
+/***/ "./Resources/Public/JavaScript/Helper/getCollectionValueByPath.js":
+/*!************************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Helper/getCollectionValueByPath.js ***!
+  \************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-    this._initialize(initialState);
-  }
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var ___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! . */ \"./Resources/Public/JavaScript/Helper/index.js\");\n\n\nconst getCollectionValueByPath = (collection, path) => {\n  if (Object(___WEBPACK_IMPORTED_MODULE_0__[\"isNil\"])(collection)) {\n    return null;\n  }\n\n  return path.split('.').reduce(function (value, index) {\n    return value[index];\n  }, collection);\n};\n\n/* harmony default export */ __webpack_exports__[\"default\"] = (getCollectionValueByPath);//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2dldENvbGxlY3Rpb25WYWx1ZUJ5UGF0aC5qcy5qcyIsInNvdXJjZXMiOlsid2VicGFjazovLy8uL1Jlc291cmNlcy9QdWJsaWMvSmF2YVNjcmlwdC9IZWxwZXIvZ2V0Q29sbGVjdGlvblZhbHVlQnlQYXRoLmpzP2VmNmIiXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgaXNOaWwgfSBmcm9tICcuJztcblxuY29uc3QgZ2V0Q29sbGVjdGlvblZhbHVlQnlQYXRoID0gKGNvbGxlY3Rpb24sIHBhdGgpID0+IHtcblx0aWYgKGlzTmlsKGNvbGxlY3Rpb24pKSB7XG5cdFx0cmV0dXJuIG51bGw7XG5cdH1cblxuXHRyZXR1cm4gcGF0aC5zcGxpdCgnLicpLnJlZHVjZShmdW5jdGlvbih2YWx1ZSwgaW5kZXgpIHtcblx0XHRyZXR1cm4gdmFsdWVbaW5kZXhdO1xuXHR9LCBjb2xsZWN0aW9uKTtcbn07XG5cbmV4cG9ydCBkZWZhdWx0IGdldENvbGxlY3Rpb25WYWx1ZUJ5UGF0aDtcbiJdLCJtYXBwaW5ncyI6IkFBQUE7QUFBQTtBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Helper/getCollectionValueByPath.js\n");
 
-  _setupEventListeners() {
-    this._trigger.forEach(_toggleButton => {
-      _toggleButton.addEventListener('click', this._toggle.bind(this));
-    });
-  }
+/***/ }),
 
-  _initialize(initialState) {
-    const header = this._root.querySelector('[aria-expanded]');
+/***/ "./Resources/Public/JavaScript/Helper/getItemByKeyValue.js":
+/*!*****************************************************************!*\
+  !*** ./Resources/Public/JavaScript/Helper/getItemByKeyValue.js ***!
+  \*****************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-    header.setAttribute('aria-expanded', String(initialState));
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var ___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! . */ \"./Resources/Public/JavaScript/Helper/index.js\");\n\n\nconst getItemByKeyValue = (collection, key, value) => {\n  if (Object(___WEBPACK_IMPORTED_MODULE_0__[\"isNil\"])(collection)) {\n    return null;\n  }\n\n  return collection.find(object => object[key] === value);\n};\n\n/* harmony default export */ __webpack_exports__[\"default\"] = (getItemByKeyValue);//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2dldEl0ZW1CeUtleVZhbHVlLmpzLmpzIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0hlbHBlci9nZXRJdGVtQnlLZXlWYWx1ZS5qcz83ZmE0Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGlzTmlsIH0gZnJvbSAnLic7XG5cbmNvbnN0IGdldEl0ZW1CeUtleVZhbHVlID0gKGNvbGxlY3Rpb24sIGtleSwgdmFsdWUpID0+IHtcblx0aWYgKGlzTmlsKGNvbGxlY3Rpb24pKSB7XG5cdFx0cmV0dXJuIG51bGw7XG5cdH1cblx0cmV0dXJuIGNvbGxlY3Rpb24uZmluZChvYmplY3QgPT4gb2JqZWN0W2tleV0gPT09IHZhbHVlKTtcbn07XG5cbmV4cG9ydCBkZWZhdWx0IGdldEl0ZW1CeUtleVZhbHVlO1xuIl0sIm1hcHBpbmdzIjoiQUFBQTtBQUFBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFBQTtBQUNBO0FBQ0E7QUFDQSIsInNvdXJjZVJvb3QiOiIifQ==\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Helper/getItemByKeyValue.js\n");
 
-    if (initialState) {
-      // default is closed
-      this._root.classList.add('neos-open');
+/***/ }),
 
-      this._changeToogleIcon();
-    }
-  }
+/***/ "./Resources/Public/JavaScript/Helper/index.js":
+/*!*****************************************************!*\
+  !*** ./Resources/Public/JavaScript/Helper/index.js ***!
+  \*****************************************************/
+/*! exports provided: isNil, isEmpty, getItemByKeyValue, getCollectionValueByPath */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-  _toggle() {
-    this._changeToogleIcon();
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _isNil__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./isNil */ \"./Resources/Public/JavaScript/Helper/isNil.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"isNil\", function() { return _isNil__WEBPACK_IMPORTED_MODULE_0__[\"default\"]; });\n\n/* harmony import */ var _isEmpty__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./isEmpty */ \"./Resources/Public/JavaScript/Helper/isEmpty.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"isEmpty\", function() { return _isEmpty__WEBPACK_IMPORTED_MODULE_1__[\"default\"]; });\n\n/* harmony import */ var _getItemByKeyValue__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./getItemByKeyValue */ \"./Resources/Public/JavaScript/Helper/getItemByKeyValue.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"getItemByKeyValue\", function() { return _getItemByKeyValue__WEBPACK_IMPORTED_MODULE_2__[\"default\"]; });\n\n/* harmony import */ var _getCollectionValueByPath__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./getCollectionValueByPath */ \"./Resources/Public/JavaScript/Helper/getCollectionValueByPath.js\");\n/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, \"getCollectionValueByPath\", function() { return _getCollectionValueByPath__WEBPACK_IMPORTED_MODULE_3__[\"default\"]; });\n\n\n\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2luZGV4LmpzLmpzIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0hlbHBlci9pbmRleC5qcz8yOTBlIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBpc05pbCBmcm9tICcuL2lzTmlsJztcbmltcG9ydCBpc0VtcHR5IGZyb20gJy4vaXNFbXB0eSc7XG5pbXBvcnQgZ2V0SXRlbUJ5S2V5VmFsdWUgZnJvbSAnLi9nZXRJdGVtQnlLZXlWYWx1ZSc7XG5pbXBvcnQgZ2V0Q29sbGVjdGlvblZhbHVlQnlQYXRoIGZyb20gJy4vZ2V0Q29sbGVjdGlvblZhbHVlQnlQYXRoJztcblxuZXhwb3J0IHtcblx0aXNOaWwsXG5cdGlzRW1wdHksXG5cdGdldEl0ZW1CeUtleVZhbHVlLFxuXHRnZXRDb2xsZWN0aW9uVmFsdWVCeVBhdGhcbn07XG4iXSwibWFwcGluZ3MiOiJBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFDQTtBQUNBO0FBQ0E7Iiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Helper/index.js\n");
 
-    this._root.classList.toggle('neos-open');
+/***/ }),
 
-    this._toogleAriaExpandable();
-  }
+/***/ "./Resources/Public/JavaScript/Helper/isEmpty.js":
+/*!*******************************************************!*\
+  !*** ./Resources/Public/JavaScript/Helper/isEmpty.js ***!
+  \*******************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-  _toogleAriaExpandable() {
-    const header = this._root.querySelector('[aria-expanded]');
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _isNil__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./isNil */ \"./Resources/Public/JavaScript/Helper/isNil.js\");\n\n\nconst isEmpty = object => {\n  if (Object(_isNil__WEBPACK_IMPORTED_MODULE_0__[\"default\"])(object)) {\n    return false;\n  }\n\n  return !Object.getOwnPropertySymbols(object).length && !Object.getOwnPropertyNames(object).length;\n};\n\n/* harmony default export */ __webpack_exports__[\"default\"] = (isEmpty);//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2lzRW1wdHkuanMuanMiLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2lzRW1wdHkuanM/YTBkZSJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgaXNOaWwgZnJvbSAnLi9pc05pbCc7XG5cbmNvbnN0IGlzRW1wdHkgPSBvYmplY3QgPT4ge1xuXHRpZiAoaXNOaWwob2JqZWN0KSkge1xuXHRcdHJldHVybiBmYWxzZTtcblx0fVxuXG5cdHJldHVybiAoXG5cdFx0IU9iamVjdC5nZXRPd25Qcm9wZXJ0eVN5bWJvbHMob2JqZWN0KS5sZW5ndGggJiZcblx0XHQhT2JqZWN0LmdldE93blByb3BlcnR5TmFtZXMob2JqZWN0KS5sZW5ndGhcblx0KTtcbn07XG5cbmV4cG9ydCBkZWZhdWx0IGlzRW1wdHk7XG4iXSwibWFwcGluZ3MiOiJBQUFBO0FBQUE7QUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBSUE7QUFDQTtBQUNBIiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Helper/isEmpty.js\n");
 
-    const expanded = this._root.classList.contains('neos-open');
+/***/ }),
 
-    header.setAttribute('aria-expanded', String(expanded));
+/***/ "./Resources/Public/JavaScript/Helper/isNil.js":
+/*!*****************************************************!*\
+  !*** ./Resources/Public/JavaScript/Helper/isNil.js ***!
+  \*****************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-    if (typeof this._onStateChange === 'function') {
-      const sectionName = this._root.getAttribute('data-key');
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\nconst isNil = value => value === null || value === undefined;\n\n/* harmony default export */ __webpack_exports__[\"default\"] = (isNil);//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2lzTmlsLmpzLmpzIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0hlbHBlci9pc05pbC5qcz8yOGRlIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGlzTmlsID0gdmFsdWUgPT4gdmFsdWUgPT09IG51bGwgfHwgdmFsdWUgPT09IHVuZGVmaW5lZDtcblxuZXhwb3J0IGRlZmF1bHQgaXNOaWw7XG4iXSwibWFwcGluZ3MiOiJBQUFBO0FBQUE7QUFDQTtBQUNBIiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/Helper/isNil.js\n");
 
-      this._onStateChange(sectionName, expanded);
-    }
-  }
+/***/ }),
 
-  _changeToogleIcon() {
-    const openIcon = this._root.querySelector('.fa-chevron-circle-down');
+/***/ "./Resources/Public/JavaScript/index.js":
+/*!**********************************************!*\
+  !*** ./Resources/Public/JavaScript/index.js ***!
+  \**********************************************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _Components_TopBar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Components/TopBar */ \"./Resources/Public/JavaScript/Components/TopBar/index.js\");\n\nconst dropDownMenuElements = document.querySelectorAll('.neos-user-menu');\ndropDownMenuElements.forEach(dropDownElement => {\n  new _Components_TopBar__WEBPACK_IMPORTED_MODULE_0__[\"DropDownMenu\"](dropDownElement);\n});\nconst menuPanelElements = document.querySelectorAll('.neos-menu');\nmenuPanelElements.forEach(panelElement => {\n  new _Components_TopBar__WEBPACK_IMPORTED_MODULE_0__[\"MenuPanel\"](panelElement);\n});//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvaW5kZXguanMuanMiLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvaW5kZXguanM/MTYwNiJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQge0Ryb3BEb3duTWVudSwgTWVudVBhbmVsfSBmcm9tICcuL0NvbXBvbmVudHMvVG9wQmFyJ1xuXG5jb25zdCBkcm9wRG93bk1lbnVFbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLXVzZXItbWVudScpO1xuZHJvcERvd25NZW51RWxlbWVudHMuZm9yRWFjaChkcm9wRG93bkVsZW1lbnQgPT4ge1xuXHRuZXcgRHJvcERvd25NZW51KGRyb3BEb3duRWxlbWVudCk7XG59KTtcblxuY29uc3QgbWVudVBhbmVsRWxlbWVudHMgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKCcubmVvcy1tZW51Jyk7XG5tZW51UGFuZWxFbGVtZW50cy5mb3JFYWNoKHBhbmVsRWxlbWVudCA9PiB7XG5cdG5ldyBNZW51UGFuZWwocGFuZWxFbGVtZW50KTtcbn0pO1xuXG5cbiJdLCJtYXBwaW5ncyI6IkFBQUE7QUFBQTtBQUFBO0FBRUE7QUFDQTtBQUNBO0FBQ0E7QUFFQTtBQUNBO0FBQ0E7QUFDQSIsInNvdXJjZVJvb3QiOiIifQ==\n//# sourceURL=webpack-internal:///./Resources/Public/JavaScript/index.js\n");
+
+/***/ }),
+
+/***/ 0:
+/*!****************************************************!*\
+  !*** multi ./Resources/Public/JavaScript/index.js ***!
+  \****************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(/*! ./Resources/Public/JavaScript/index.js */"./Resources/Public/JavaScript/index.js");
 
-    const closeIcon = this._root.querySelector('.fa-chevron-circle-up');
-
-    if (openIcon) {
-      openIcon.classList.replace('fa-chevron-circle-down', 'fa-chevron-circle-up');
-    }
-
-    if (closeIcon) {
-      closeIcon.classList.replace('fa-chevron-circle-up', 'fa-chevron-circle-down');
-    }
-  }
-
-}
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Helper/isNil.js
-const isNil = value => value === null || value === undefined;
-
-/* harmony default export */ var Helper_isNil = (isNil);
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Helper/isEmpty.js
-
-
-const isEmpty = object => {
-  if (Helper_isNil(object)) {
-    return false;
-  }
-
-  return !Object.getOwnPropertySymbols(object).length && !Object.getOwnPropertyNames(object).length;
-};
-
-/* harmony default export */ var Helper_isEmpty = (isEmpty);
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Helper/getItemByKeyValue.js
-
-
-const getItemByKeyValue = (collection, key, value) => {
-  if (Helper_isNil(collection)) {
-    return null;
-  }
-
-  return collection.find(object => object[key] === value);
-};
-
-/* harmony default export */ var Helper_getItemByKeyValue = (getItemByKeyValue);
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Helper/index.js
-
-
-
-
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Components/TopBar/MenuPanel.js
-
-
-const SESSION_KEY = 'Neos.Neos.menuSectionStates';
-class MenuPanel_MenuPanel {
-  constructor(_root) {
-    this._root = _root;
-    this._button = this._root.querySelectorAll('.neos-menu-button');
-    this._panel = this._root.querySelectorAll('.neos-menu-panel');
-    this._menuSectionStates = this._loadSessionData();
-
-    this._setupEventListeners();
-
-    if (this._panel) {
-      this._initializeMenuSections();
-    }
-  }
-
-  _initializeMenuSections() {
-    this._panel.forEach(_panel => {
-      const menuSectionElements = _panel.querySelectorAll('.neos-menu-section');
-
-      const {
-        sections
-      } = this._menuSectionStates;
-      menuSectionElements.forEach(menuSectionElement => {
-        const sectionName = menuSectionElement.getAttribute('data-key');
-        const sectionState = Helper_getItemByKeyValue(sections, 'name', sectionName);
-        const initalState = !Helper_isNil(sectionState) ? sectionState.open : false;
-        new Expandable(menuSectionElement, '.neos-menu-panel-toggle', this._onMenuSectionStateChange.bind(this), initalState);
-      });
-    });
-  }
-
-  _setupEventListeners() {
-    this._button.forEach(_toggleButton => {
-      _toggleButton.addEventListener('click', this._toggle.bind(this));
-    });
-  }
-
-  _loadSessionData() {
-    const sessionData = sessionStorage.getItem(SESSION_KEY);
-
-    if (Helper_isNil(sessionData)) {
-      const initialSessionData = {
-        sections: []
-      };
-      sessionStorage.setItem(SESSION_KEY, JSON.stringify(initialSessionData));
-      return initialSessionData;
-    }
-
-    return JSON.parse(sessionData);
-  }
-
-  _onMenuSectionStateChange(sectionName, newValue) {
-    const {
-      sections
-    } = this._menuSectionStates;
-    const sectionState = Helper_getItemByKeyValue(sections, 'name', sectionName);
-
-    if (Helper_isNil(sections)) {
-      this._menuSectionStates.sections = [];
-    }
-
-    if (Helper_isNil(sectionState)) {
-      this._menuSectionStates.sections.push({
-        name: sectionName,
-        open: newValue
-      });
-    } else {
-      sectionState.open = newValue;
-    }
-
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify(this._menuSectionStates));
-  }
-
-  _toggle(_event) {
-    this._button.forEach(_toggleButton => {
-      _toggleButton.classList.toggle('neos-pressed');
-    });
-
-    document.body.classList.toggle('neos-menu-panel-open');
-  }
-
-}
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/Components/TopBar/index.js
-
-
-
-
-// CONCATENATED MODULE: ./Resources/Public/JavaScript/index.js
-
-const dropDownMenuElements = document.querySelectorAll('.neos-user-menu');
-dropDownMenuElements.forEach(dropDownElement => {
-  new DropDownMenu(dropDownElement);
-});
-const menuPanelElements = document.querySelectorAll('.neos-menu');
-menuPanelElements.forEach(panelElement => {
-  new MenuPanel_MenuPanel(panelElement);
-});
 
 /***/ })
-/******/ ]);
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly8vd2VicGFjay9ib290c3RyYXAiLCJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0NvbXBvbmVudHMvVG9wQmFyL0Ryb3Bkb3duTWVudS5qcyIsIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvRXhwYW5kYWJsZS5qcyIsIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2lzTmlsLmpzIiwid2VicGFjazovLy8uL1Jlc291cmNlcy9QdWJsaWMvSmF2YVNjcmlwdC9IZWxwZXIvaXNFbXB0eS5qcyIsIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvSGVscGVyL2dldEl0ZW1CeUtleVZhbHVlLmpzIiwid2VicGFjazovLy8uL1Jlc291cmNlcy9QdWJsaWMvSmF2YVNjcmlwdC9IZWxwZXIvaW5kZXguanMiLCJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L0NvbXBvbmVudHMvVG9wQmFyL01lbnVQYW5lbC5qcyIsIndlYnBhY2s6Ly8vLi9SZXNvdXJjZXMvUHVibGljL0phdmFTY3JpcHQvQ29tcG9uZW50cy9Ub3BCYXIvaW5kZXguanMiLCJ3ZWJwYWNrOi8vLy4vUmVzb3VyY2VzL1B1YmxpYy9KYXZhU2NyaXB0L2luZGV4LmpzIl0sIm5hbWVzIjpbIkRyb3BEb3duTWVudSIsImNvbnN0cnVjdG9yIiwiX3Jvb3QiLCJfYnV0dG9uIiwicXVlcnlTZWxlY3RvckFsbCIsIl9tZW51IiwiX3NldHVwRXZlbnRMaXN0ZW5lcnMiLCJmb3JFYWNoIiwiX3RvZ2dsZUJ1dHRvbiIsImFkZEV2ZW50TGlzdGVuZXIiLCJfdG9nZ2xlIiwiYmluZCIsIl9ldmVudCIsIl9jaGFuZ2VUb29nbGVJY29uIiwiY2xhc3NMaXN0IiwidG9nZ2xlIiwib3Blbkljb24iLCJxdWVyeVNlbGVjdG9yIiwiY2xvc2VJY29uIiwicmVwbGFjZSIsIkV4cGFuZGFibGUiLCJfdHJpZ2dlckNsYXNzTmFtZSIsIl9vblN0YXRlQ2hhbmdlIiwiaW5pdGlhbFN0YXRlIiwiX3RyaWdnZXIiLCJfaW5pdGlhbGl6ZSIsImhlYWRlciIsInNldEF0dHJpYnV0ZSIsIlN0cmluZyIsImFkZCIsIl90b29nbGVBcmlhRXhwYW5kYWJsZSIsImV4cGFuZGVkIiwiY29udGFpbnMiLCJzZWN0aW9uTmFtZSIsImdldEF0dHJpYnV0ZSIsImlzTmlsIiwidmFsdWUiLCJ1bmRlZmluZWQiLCJpc0VtcHR5Iiwib2JqZWN0IiwiT2JqZWN0IiwiZ2V0T3duUHJvcGVydHlTeW1ib2xzIiwibGVuZ3RoIiwiZ2V0T3duUHJvcGVydHlOYW1lcyIsImdldEl0ZW1CeUtleVZhbHVlIiwiY29sbGVjdGlvbiIsImtleSIsImZpbmQiLCJTRVNTSU9OX0tFWSIsIk1lbnVQYW5lbCIsIl9wYW5lbCIsIl9tZW51U2VjdGlvblN0YXRlcyIsIl9sb2FkU2Vzc2lvbkRhdGEiLCJfaW5pdGlhbGl6ZU1lbnVTZWN0aW9ucyIsIm1lbnVTZWN0aW9uRWxlbWVudHMiLCJzZWN0aW9ucyIsIm1lbnVTZWN0aW9uRWxlbWVudCIsInNlY3Rpb25TdGF0ZSIsImluaXRhbFN0YXRlIiwib3BlbiIsIl9vbk1lbnVTZWN0aW9uU3RhdGVDaGFuZ2UiLCJzZXNzaW9uRGF0YSIsInNlc3Npb25TdG9yYWdlIiwiZ2V0SXRlbSIsImluaXRpYWxTZXNzaW9uRGF0YSIsInNldEl0ZW0iLCJKU09OIiwic3RyaW5naWZ5IiwicGFyc2UiLCJuZXdWYWx1ZSIsInB1c2giLCJuYW1lIiwiZG9jdW1lbnQiLCJib2R5IiwiZHJvcERvd25NZW51RWxlbWVudHMiLCJkcm9wRG93bkVsZW1lbnQiLCJtZW51UGFuZWxFbGVtZW50cyIsInBhbmVsRWxlbWVudCJdLCJtYXBwaW5ncyI6IjtBQUFBO0FBQ0E7O0FBRUE7QUFDQTs7QUFFQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUFFQTtBQUNBOztBQUVBO0FBQ0E7O0FBRUE7QUFDQTtBQUNBOzs7QUFHQTtBQUNBOztBQUVBO0FBQ0E7O0FBRUE7QUFDQTtBQUNBO0FBQ0Esa0RBQTBDLGdDQUFnQztBQUMxRTtBQUNBOztBQUVBO0FBQ0E7QUFDQTtBQUNBLGdFQUF3RCxrQkFBa0I7QUFDMUU7QUFDQSx5REFBaUQsY0FBYztBQUMvRDs7QUFFQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsaURBQXlDLGlDQUFpQztBQUMxRSx3SEFBZ0gsbUJBQW1CLEVBQUU7QUFDckk7QUFDQTs7QUFFQTtBQUNBO0FBQ0E7QUFDQSxtQ0FBMkIsMEJBQTBCLEVBQUU7QUFDdkQseUNBQWlDLGVBQWU7QUFDaEQ7QUFDQTtBQUNBOztBQUVBO0FBQ0EsOERBQXNELCtEQUErRDs7QUFFckg7QUFDQTs7O0FBR0E7QUFDQTs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDbEZlLE1BQU1BLFlBQU4sQ0FBbUI7QUFDakNDLGFBQVcsQ0FBQ0MsS0FBRCxFQUFRO0FBQ2xCLFNBQUtBLEtBQUwsR0FBYUEsS0FBYjtBQUNBLFNBQUtDLE9BQUwsR0FBZSxLQUFLRCxLQUFMLENBQVdFLGdCQUFYLENBQTRCLHVCQUE1QixDQUFmO0FBQ0EsU0FBS0MsS0FBTCxHQUFhLEtBQUtILEtBQUwsQ0FBV0UsZ0JBQVgsQ0FBNEIscUJBQTVCLENBQWI7O0FBQ0EsU0FBS0Usb0JBQUw7QUFDQTs7QUFFREEsc0JBQW9CLEdBQUc7QUFDdEIsU0FBS0gsT0FBTCxDQUFhSSxPQUFiLENBQXFCQyxhQUFhLElBQUk7QUFDckNBLG1CQUFhLENBQUNDLGdCQUFkLENBQStCLE9BQS9CLEVBQXdDLEtBQUtDLE9BQUwsQ0FBYUMsSUFBYixDQUFrQixJQUFsQixDQUF4QztBQUNBLEtBRkQ7QUFHQTs7QUFFREQsU0FBTyxDQUFDRSxNQUFELEVBQVM7QUFDZixTQUFLQyxpQkFBTDs7QUFDQSxTQUFLWCxLQUFMLENBQVdZLFNBQVgsQ0FBcUJDLE1BQXJCLENBQTRCLG9CQUE1QjtBQUNBOztBQUVERixtQkFBaUIsR0FBRztBQUNuQixVQUFNRyxRQUFRLEdBQUcsS0FBS2QsS0FBTCxDQUFXZSxhQUFYLENBQXlCLGtCQUF6QixDQUFqQjs7QUFDQSxVQUFNQyxTQUFTLEdBQUcsS0FBS2hCLEtBQUwsQ0FBV2UsYUFBWCxDQUF5QixnQkFBekIsQ0FBbEI7O0FBQ0EsUUFBSUQsUUFBSixFQUFjO0FBQ2JBLGNBQVEsQ0FBQ0YsU0FBVCxDQUFtQkssT0FBbkIsQ0FBMkIsaUJBQTNCLEVBQThDLGVBQTlDO0FBQ0E7O0FBQ0QsUUFBSUQsU0FBSixFQUFlO0FBQ2RBLGVBQVMsQ0FBQ0osU0FBVixDQUFvQkssT0FBcEIsQ0FBNEIsZUFBNUIsRUFBNkMsaUJBQTdDO0FBQ0E7QUFDRDs7QUE1QmdDLEM7O0FDQW5CLE1BQU1DLFVBQU4sQ0FBaUI7QUFDL0JuQixhQUFXLENBQUNDLEtBQUQsRUFBUW1CLGlCQUFSLEVBQTJCQyxjQUEzQixFQUEyQ0MsWUFBM0MsRUFBeUQ7QUFDbkUsU0FBS3JCLEtBQUwsR0FBYUEsS0FBYjtBQUNBLFNBQUtzQixRQUFMLEdBQWdCLEtBQUt0QixLQUFMLENBQVdFLGdCQUFYLENBQTRCaUIsaUJBQTVCLENBQWhCO0FBQ0EsU0FBS0MsY0FBTCxHQUFzQkEsY0FBdEI7O0FBQ0EsU0FBS2hCLG9CQUFMOztBQUNBLFNBQUttQixXQUFMLENBQWlCRixZQUFqQjtBQUNBOztBQUVEakIsc0JBQW9CLEdBQUc7QUFDdEIsU0FBS2tCLFFBQUwsQ0FBY2pCLE9BQWQsQ0FBc0JDLGFBQWEsSUFBSTtBQUN0Q0EsbUJBQWEsQ0FBQ0MsZ0JBQWQsQ0FBK0IsT0FBL0IsRUFBd0MsS0FBS0MsT0FBTCxDQUFhQyxJQUFiLENBQWtCLElBQWxCLENBQXhDO0FBQ0EsS0FGRDtBQUdBOztBQUVEYyxhQUFXLENBQUNGLFlBQUQsRUFBZTtBQUN6QixVQUFNRyxNQUFNLEdBQUcsS0FBS3hCLEtBQUwsQ0FBV2UsYUFBWCxDQUF5QixpQkFBekIsQ0FBZjs7QUFDQVMsVUFBTSxDQUFDQyxZQUFQLENBQW9CLGVBQXBCLEVBQXFDQyxNQUFNLENBQUNMLFlBQUQsQ0FBM0M7O0FBRUEsUUFBSUEsWUFBSixFQUFrQjtBQUNqQjtBQUNBLFdBQUtyQixLQUFMLENBQVdZLFNBQVgsQ0FBcUJlLEdBQXJCLENBQXlCLFdBQXpCOztBQUNBLFdBQUtoQixpQkFBTDtBQUNBO0FBQ0Q7O0FBRURILFNBQU8sR0FBRztBQUNULFNBQUtHLGlCQUFMOztBQUNBLFNBQUtYLEtBQUwsQ0FBV1ksU0FBWCxDQUFxQkMsTUFBckIsQ0FBNEIsV0FBNUI7O0FBQ0EsU0FBS2UscUJBQUw7QUFDQTs7QUFFREEsdUJBQXFCLEdBQUc7QUFDdkIsVUFBTUosTUFBTSxHQUFHLEtBQUt4QixLQUFMLENBQVdlLGFBQVgsQ0FBeUIsaUJBQXpCLENBQWY7O0FBQ0EsVUFBTWMsUUFBUSxHQUFHLEtBQUs3QixLQUFMLENBQVdZLFNBQVgsQ0FBcUJrQixRQUFyQixDQUE4QixXQUE5QixDQUFqQjs7QUFDQU4sVUFBTSxDQUFDQyxZQUFQLENBQW9CLGVBQXBCLEVBQXFDQyxNQUFNLENBQUNHLFFBQUQsQ0FBM0M7O0FBQ0EsUUFBSSxPQUFPLEtBQUtULGNBQVosS0FBK0IsVUFBbkMsRUFBK0M7QUFDOUMsWUFBTVcsV0FBVyxHQUFHLEtBQUsvQixLQUFMLENBQVdnQyxZQUFYLENBQXdCLFVBQXhCLENBQXBCOztBQUNBLFdBQUtaLGNBQUwsQ0FBb0JXLFdBQXBCLEVBQWlDRixRQUFqQztBQUNBO0FBQ0Q7O0FBRURsQixtQkFBaUIsR0FBRztBQUNuQixVQUFNRyxRQUFRLEdBQUcsS0FBS2QsS0FBTCxDQUFXZSxhQUFYLENBQXlCLHlCQUF6QixDQUFqQjs7QUFDQSxVQUFNQyxTQUFTLEdBQUcsS0FBS2hCLEtBQUwsQ0FBV2UsYUFBWCxDQUF5Qix1QkFBekIsQ0FBbEI7O0FBQ0EsUUFBSUQsUUFBSixFQUFjO0FBQ2JBLGNBQVEsQ0FBQ0YsU0FBVCxDQUFtQkssT0FBbkIsQ0FDQyx3QkFERCxFQUVDLHNCQUZEO0FBSUE7O0FBQ0QsUUFBSUQsU0FBSixFQUFlO0FBQ2RBLGVBQVMsQ0FBQ0osU0FBVixDQUFvQkssT0FBcEIsQ0FDQyxzQkFERCxFQUVDLHdCQUZEO0FBSUE7QUFDRDs7QUF6RDhCLEM7O0FDQWhDLE1BQU1nQixLQUFLLEdBQUdDLEtBQUssSUFBSUEsS0FBSyxLQUFLLElBQVYsSUFBa0JBLEtBQUssS0FBS0MsU0FBbkQ7O0FBRWVGLHNEQUFmLEU7O0FDRkE7O0FBRUEsTUFBTUcsT0FBTyxHQUFHQyxNQUFNLElBQUk7QUFDekIsTUFBSUosWUFBSyxDQUFDSSxNQUFELENBQVQsRUFBbUI7QUFDbEIsV0FBTyxLQUFQO0FBQ0E7O0FBRUQsU0FDQyxDQUFDQyxNQUFNLENBQUNDLHFCQUFQLENBQTZCRixNQUE3QixFQUFxQ0csTUFBdEMsSUFDQSxDQUFDRixNQUFNLENBQUNHLG1CQUFQLENBQTJCSixNQUEzQixFQUFtQ0csTUFGckM7QUFJQSxDQVREOztBQVdlSiwwREFBZixFOztBQ2JBOztBQUVBLE1BQU1NLGlCQUFpQixHQUFHLENBQUNDLFVBQUQsRUFBYUMsR0FBYixFQUFrQlYsS0FBbEIsS0FBNEI7QUFDckQsTUFBSUQsWUFBSyxDQUFDVSxVQUFELENBQVQsRUFBdUI7QUFDdEIsV0FBTyxJQUFQO0FBQ0E7O0FBQ0QsU0FBT0EsVUFBVSxDQUFDRSxJQUFYLENBQWdCUixNQUFNLElBQUlBLE1BQU0sQ0FBQ08sR0FBRCxDQUFOLEtBQWdCVixLQUExQyxDQUFQO0FBQ0EsQ0FMRDs7QUFPZVEsOEVBQWYsRTs7QUNUQTtBQUNBO0FBQ0E7OztBQ0ZBO0FBQ0E7QUFFQSxNQUFNSSxXQUFXLEdBQUcsNkJBQXBCO0FBQ2UsTUFBTUMsbUJBQU4sQ0FBZ0I7QUFDOUJoRCxhQUFXLENBQUNDLEtBQUQsRUFBUTtBQUNsQixTQUFLQSxLQUFMLEdBQWFBLEtBQWI7QUFDQSxTQUFLQyxPQUFMLEdBQWUsS0FBS0QsS0FBTCxDQUFXRSxnQkFBWCxDQUE0QixtQkFBNUIsQ0FBZjtBQUNBLFNBQUs4QyxNQUFMLEdBQWMsS0FBS2hELEtBQUwsQ0FBV0UsZ0JBQVgsQ0FBNEIsa0JBQTVCLENBQWQ7QUFDQSxTQUFLK0Msa0JBQUwsR0FBMEIsS0FBS0MsZ0JBQUwsRUFBMUI7O0FBQ0EsU0FBSzlDLG9CQUFMOztBQUVBLFFBQUksS0FBSzRDLE1BQVQsRUFBaUI7QUFDaEIsV0FBS0csdUJBQUw7QUFDQTtBQUNEOztBQUVEQSx5QkFBdUIsR0FBRztBQUN6QixTQUFLSCxNQUFMLENBQVkzQyxPQUFaLENBQW9CMkMsTUFBTSxJQUFJO0FBQzdCLFlBQU1JLG1CQUFtQixHQUFHSixNQUFNLENBQUM5QyxnQkFBUCxDQUF3QixvQkFBeEIsQ0FBNUI7O0FBQ0EsWUFBTTtBQUFFbUQ7QUFBRixVQUFlLEtBQUtKLGtCQUExQjtBQUNBRyx5QkFBbUIsQ0FBQy9DLE9BQXBCLENBQTRCaUQsa0JBQWtCLElBQUk7QUFDakQsY0FBTXZCLFdBQVcsR0FBR3VCLGtCQUFrQixDQUFDdEIsWUFBbkIsQ0FBZ0MsVUFBaEMsQ0FBcEI7QUFDQSxjQUFNdUIsWUFBWSxHQUFHYix3QkFBaUIsQ0FBQ1csUUFBRCxFQUFXLE1BQVgsRUFBbUJ0QixXQUFuQixDQUF0QztBQUNBLGNBQU15QixXQUFXLEdBQUcsQ0FBQ3ZCLFlBQUssQ0FBQ3NCLFlBQUQsQ0FBTixHQUF1QkEsWUFBWSxDQUFDRSxJQUFwQyxHQUEyQyxLQUEvRDtBQUNBLFlBQUl2QyxVQUFKLENBQ0NvQyxrQkFERCxFQUVDLHlCQUZELEVBR0MsS0FBS0kseUJBQUwsQ0FBK0JqRCxJQUEvQixDQUFvQyxJQUFwQyxDQUhELEVBSUMrQyxXQUpEO0FBTUEsT0FWRDtBQVdBLEtBZEQ7QUFlQTs7QUFFRHBELHNCQUFvQixHQUFHO0FBQ3RCLFNBQUtILE9BQUwsQ0FBYUksT0FBYixDQUFxQkMsYUFBYSxJQUFJO0FBQ3JDQSxtQkFBYSxDQUFDQyxnQkFBZCxDQUErQixPQUEvQixFQUF3QyxLQUFLQyxPQUFMLENBQWFDLElBQWIsQ0FBa0IsSUFBbEIsQ0FBeEM7QUFDQSxLQUZEO0FBR0E7O0FBRUR5QyxrQkFBZ0IsR0FBRztBQUNsQixVQUFNUyxXQUFXLEdBQUdDLGNBQWMsQ0FBQ0MsT0FBZixDQUF1QmYsV0FBdkIsQ0FBcEI7O0FBQ0EsUUFBSWIsWUFBSyxDQUFDMEIsV0FBRCxDQUFULEVBQXdCO0FBQ3ZCLFlBQU1HLGtCQUFrQixHQUFHO0FBQUVULGdCQUFRLEVBQUU7QUFBWixPQUEzQjtBQUNBTyxvQkFBYyxDQUFDRyxPQUFmLENBQXVCakIsV0FBdkIsRUFBb0NrQixJQUFJLENBQUNDLFNBQUwsQ0FBZUgsa0JBQWYsQ0FBcEM7QUFDQSxhQUFPQSxrQkFBUDtBQUNBOztBQUVELFdBQU9FLElBQUksQ0FBQ0UsS0FBTCxDQUFXUCxXQUFYLENBQVA7QUFDQTs7QUFFREQsMkJBQXlCLENBQUMzQixXQUFELEVBQWNvQyxRQUFkLEVBQXdCO0FBQ2hELFVBQU07QUFBRWQ7QUFBRixRQUFlLEtBQUtKLGtCQUExQjtBQUNBLFVBQU1NLFlBQVksR0FBR2Isd0JBQWlCLENBQUNXLFFBQUQsRUFBVyxNQUFYLEVBQW1CdEIsV0FBbkIsQ0FBdEM7O0FBQ0EsUUFBSUUsWUFBSyxDQUFDb0IsUUFBRCxDQUFULEVBQXFCO0FBQ3BCLFdBQUtKLGtCQUFMLENBQXdCSSxRQUF4QixHQUFtQyxFQUFuQztBQUNBOztBQUVELFFBQUlwQixZQUFLLENBQUNzQixZQUFELENBQVQsRUFBeUI7QUFDeEIsV0FBS04sa0JBQUwsQ0FBd0JJLFFBQXhCLENBQWlDZSxJQUFqQyxDQUFzQztBQUNyQ0MsWUFBSSxFQUFFdEMsV0FEK0I7QUFFckMwQixZQUFJLEVBQUVVO0FBRitCLE9BQXRDO0FBSUEsS0FMRCxNQUtPO0FBQ05aLGtCQUFZLENBQUNFLElBQWIsR0FBb0JVLFFBQXBCO0FBQ0E7O0FBRURQLGtCQUFjLENBQUNHLE9BQWYsQ0FDQ2pCLFdBREQsRUFFQ2tCLElBQUksQ0FBQ0MsU0FBTCxDQUFlLEtBQUtoQixrQkFBcEIsQ0FGRDtBQUlBOztBQUVEekMsU0FBTyxDQUFDRSxNQUFELEVBQVM7QUFDZixTQUFLVCxPQUFMLENBQWFJLE9BQWIsQ0FBcUJDLGFBQWEsSUFBSTtBQUNyQ0EsbUJBQWEsQ0FBQ00sU0FBZCxDQUF3QkMsTUFBeEIsQ0FBK0IsY0FBL0I7QUFDQSxLQUZEOztBQUdBeUQsWUFBUSxDQUFDQyxJQUFULENBQWMzRCxTQUFkLENBQXdCQyxNQUF4QixDQUErQixzQkFBL0I7QUFDQTs7QUEzRTZCLEM7O0FDSi9CO0FBQ0E7QUFDQTs7O0FDRkE7QUFFQSxNQUFNMkQsb0JBQW9CLEdBQUdGLFFBQVEsQ0FBQ3BFLGdCQUFULENBQTBCLGlCQUExQixDQUE3QjtBQUNBc0Usb0JBQW9CLENBQUNuRSxPQUFyQixDQUE2Qm9FLGVBQWUsSUFBSTtBQUMvQyxNQUFJM0UsWUFBSixDQUFpQjJFLGVBQWpCO0FBQ0EsQ0FGRDtBQUlBLE1BQU1DLGlCQUFpQixHQUFHSixRQUFRLENBQUNwRSxnQkFBVCxDQUEwQixZQUExQixDQUExQjtBQUNBd0UsaUJBQWlCLENBQUNyRSxPQUFsQixDQUEwQnNFLFlBQVksSUFBSTtBQUN6QyxNQUFJNUIsbUJBQUosQ0FBYzRCLFlBQWQ7QUFDQSxDQUZELEUiLCJmaWxlIjoiTWFpbi5taW4uanMiLCJzb3VyY2VzQ29udGVudCI6WyIgXHQvLyBUaGUgbW9kdWxlIGNhY2hlXG4gXHR2YXIgaW5zdGFsbGVkTW9kdWxlcyA9IHt9O1xuXG4gXHQvLyBUaGUgcmVxdWlyZSBmdW5jdGlvblxuIFx0ZnVuY3Rpb24gX193ZWJwYWNrX3JlcXVpcmVfXyhtb2R1bGVJZCkge1xuXG4gXHRcdC8vIENoZWNrIGlmIG1vZHVsZSBpcyBpbiBjYWNoZVxuIFx0XHRpZihpbnN0YWxsZWRNb2R1bGVzW21vZHVsZUlkXSkge1xuIFx0XHRcdHJldHVybiBpbnN0YWxsZWRNb2R1bGVzW21vZHVsZUlkXS5leHBvcnRzO1xuIFx0XHR9XG4gXHRcdC8vIENyZWF0ZSBhIG5ldyBtb2R1bGUgKGFuZCBwdXQgaXQgaW50byB0aGUgY2FjaGUpXG4gXHRcdHZhciBtb2R1bGUgPSBpbnN0YWxsZWRNb2R1bGVzW21vZHVsZUlkXSA9IHtcbiBcdFx0XHRpOiBtb2R1bGVJZCxcbiBcdFx0XHRsOiBmYWxzZSxcbiBcdFx0XHRleHBvcnRzOiB7fVxuIFx0XHR9O1xuXG4gXHRcdC8vIEV4ZWN1dGUgdGhlIG1vZHVsZSBmdW5jdGlvblxuIFx0XHRtb2R1bGVzW21vZHVsZUlkXS5jYWxsKG1vZHVsZS5leHBvcnRzLCBtb2R1bGUsIG1vZHVsZS5leHBvcnRzLCBfX3dlYnBhY2tfcmVxdWlyZV9fKTtcblxuIFx0XHQvLyBGbGFnIHRoZSBtb2R1bGUgYXMgbG9hZGVkXG4gXHRcdG1vZHVsZS5sID0gdHJ1ZTtcblxuIFx0XHQvLyBSZXR1cm4gdGhlIGV4cG9ydHMgb2YgdGhlIG1vZHVsZVxuIFx0XHRyZXR1cm4gbW9kdWxlLmV4cG9ydHM7XG4gXHR9XG5cblxuIFx0Ly8gZXhwb3NlIHRoZSBtb2R1bGVzIG9iamVjdCAoX193ZWJwYWNrX21vZHVsZXNfXylcbiBcdF9fd2VicGFja19yZXF1aXJlX18ubSA9IG1vZHVsZXM7XG5cbiBcdC8vIGV4cG9zZSB0aGUgbW9kdWxlIGNhY2hlXG4gXHRfX3dlYnBhY2tfcmVxdWlyZV9fLmMgPSBpbnN0YWxsZWRNb2R1bGVzO1xuXG4gXHQvLyBkZWZpbmUgZ2V0dGVyIGZ1bmN0aW9uIGZvciBoYXJtb255IGV4cG9ydHNcbiBcdF9fd2VicGFja19yZXF1aXJlX18uZCA9IGZ1bmN0aW9uKGV4cG9ydHMsIG5hbWUsIGdldHRlcikge1xuIFx0XHRpZighX193ZWJwYWNrX3JlcXVpcmVfXy5vKGV4cG9ydHMsIG5hbWUpKSB7XG4gXHRcdFx0T2JqZWN0LmRlZmluZVByb3BlcnR5KGV4cG9ydHMsIG5hbWUsIHsgZW51bWVyYWJsZTogdHJ1ZSwgZ2V0OiBnZXR0ZXIgfSk7XG4gXHRcdH1cbiBcdH07XG5cbiBcdC8vIGRlZmluZSBfX2VzTW9kdWxlIG9uIGV4cG9ydHNcbiBcdF9fd2VicGFja19yZXF1aXJlX18uciA9IGZ1bmN0aW9uKGV4cG9ydHMpIHtcbiBcdFx0aWYodHlwZW9mIFN5bWJvbCAhPT0gJ3VuZGVmaW5lZCcgJiYgU3ltYm9sLnRvU3RyaW5nVGFnKSB7XG4gXHRcdFx0T2JqZWN0LmRlZmluZVByb3BlcnR5KGV4cG9ydHMsIFN5bWJvbC50b1N0cmluZ1RhZywgeyB2YWx1ZTogJ01vZHVsZScgfSk7XG4gXHRcdH1cbiBcdFx0T2JqZWN0LmRlZmluZVByb3BlcnR5KGV4cG9ydHMsICdfX2VzTW9kdWxlJywgeyB2YWx1ZTogdHJ1ZSB9KTtcbiBcdH07XG5cbiBcdC8vIGNyZWF0ZSBhIGZha2UgbmFtZXNwYWNlIG9iamVjdFxuIFx0Ly8gbW9kZSAmIDE6IHZhbHVlIGlzIGEgbW9kdWxlIGlkLCByZXF1aXJlIGl0XG4gXHQvLyBtb2RlICYgMjogbWVyZ2UgYWxsIHByb3BlcnRpZXMgb2YgdmFsdWUgaW50byB0aGUgbnNcbiBcdC8vIG1vZGUgJiA0OiByZXR1cm4gdmFsdWUgd2hlbiBhbHJlYWR5IG5zIG9iamVjdFxuIFx0Ly8gbW9kZSAmIDh8MTogYmVoYXZlIGxpa2UgcmVxdWlyZVxuIFx0X193ZWJwYWNrX3JlcXVpcmVfXy50ID0gZnVuY3Rpb24odmFsdWUsIG1vZGUpIHtcbiBcdFx0aWYobW9kZSAmIDEpIHZhbHVlID0gX193ZWJwYWNrX3JlcXVpcmVfXyh2YWx1ZSk7XG4gXHRcdGlmKG1vZGUgJiA4KSByZXR1cm4gdmFsdWU7XG4gXHRcdGlmKChtb2RlICYgNCkgJiYgdHlwZW9mIHZhbHVlID09PSAnb2JqZWN0JyAmJiB2YWx1ZSAmJiB2YWx1ZS5fX2VzTW9kdWxlKSByZXR1cm4gdmFsdWU7XG4gXHRcdHZhciBucyA9IE9iamVjdC5jcmVhdGUobnVsbCk7XG4gXHRcdF9fd2VicGFja19yZXF1aXJlX18ucihucyk7XG4gXHRcdE9iamVjdC5kZWZpbmVQcm9wZXJ0eShucywgJ2RlZmF1bHQnLCB7IGVudW1lcmFibGU6IHRydWUsIHZhbHVlOiB2YWx1ZSB9KTtcbiBcdFx0aWYobW9kZSAmIDIgJiYgdHlwZW9mIHZhbHVlICE9ICdzdHJpbmcnKSBmb3IodmFyIGtleSBpbiB2YWx1ZSkgX193ZWJwYWNrX3JlcXVpcmVfXy5kKG5zLCBrZXksIGZ1bmN0aW9uKGtleSkgeyByZXR1cm4gdmFsdWVba2V5XTsgfS5iaW5kKG51bGwsIGtleSkpO1xuIFx0XHRyZXR1cm4gbnM7XG4gXHR9O1xuXG4gXHQvLyBnZXREZWZhdWx0RXhwb3J0IGZ1bmN0aW9uIGZvciBjb21wYXRpYmlsaXR5IHdpdGggbm9uLWhhcm1vbnkgbW9kdWxlc1xuIFx0X193ZWJwYWNrX3JlcXVpcmVfXy5uID0gZnVuY3Rpb24obW9kdWxlKSB7XG4gXHRcdHZhciBnZXR0ZXIgPSBtb2R1bGUgJiYgbW9kdWxlLl9fZXNNb2R1bGUgP1xuIFx0XHRcdGZ1bmN0aW9uIGdldERlZmF1bHQoKSB7IHJldHVybiBtb2R1bGVbJ2RlZmF1bHQnXTsgfSA6XG4gXHRcdFx0ZnVuY3Rpb24gZ2V0TW9kdWxlRXhwb3J0cygpIHsgcmV0dXJuIG1vZHVsZTsgfTtcbiBcdFx0X193ZWJwYWNrX3JlcXVpcmVfXy5kKGdldHRlciwgJ2EnLCBnZXR0ZXIpO1xuIFx0XHRyZXR1cm4gZ2V0dGVyO1xuIFx0fTtcblxuIFx0Ly8gT2JqZWN0LnByb3RvdHlwZS5oYXNPd25Qcm9wZXJ0eS5jYWxsXG4gXHRfX3dlYnBhY2tfcmVxdWlyZV9fLm8gPSBmdW5jdGlvbihvYmplY3QsIHByb3BlcnR5KSB7IHJldHVybiBPYmplY3QucHJvdG90eXBlLmhhc093blByb3BlcnR5LmNhbGwob2JqZWN0LCBwcm9wZXJ0eSk7IH07XG5cbiBcdC8vIF9fd2VicGFja19wdWJsaWNfcGF0aF9fXG4gXHRfX3dlYnBhY2tfcmVxdWlyZV9fLnAgPSBcIlwiO1xuXG5cbiBcdC8vIExvYWQgZW50cnkgbW9kdWxlIGFuZCByZXR1cm4gZXhwb3J0c1xuIFx0cmV0dXJuIF9fd2VicGFja19yZXF1aXJlX18oX193ZWJwYWNrX3JlcXVpcmVfXy5zID0gMCk7XG4iLCJleHBvcnQgZGVmYXVsdCBjbGFzcyBEcm9wRG93bk1lbnUge1xuXHRjb25zdHJ1Y3Rvcihfcm9vdCkge1xuXHRcdHRoaXMuX3Jvb3QgPSBfcm9vdDtcblx0XHR0aGlzLl9idXR0b24gPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLWRyb3Bkb3duLXRvZ2dsZScpO1xuXHRcdHRoaXMuX21lbnUgPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLWRyb3Bkb3duLW1lbnUnKTtcblx0XHR0aGlzLl9zZXR1cEV2ZW50TGlzdGVuZXJzKCk7XG5cdH1cblxuXHRfc2V0dXBFdmVudExpc3RlbmVycygpIHtcblx0XHR0aGlzLl9idXR0b24uZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCB0aGlzLl90b2dnbGUuYmluZCh0aGlzKSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfdG9nZ2xlKF9ldmVudCkge1xuXHRcdHRoaXMuX2NoYW5nZVRvb2dsZUljb24oKTtcblx0XHR0aGlzLl9yb290LmNsYXNzTGlzdC50b2dnbGUoJ25lb3MtZHJvcGRvd24tb3BlbicpO1xuXHR9XG5cblx0X2NoYW5nZVRvb2dsZUljb24oKSB7XG5cdFx0Y29uc3Qgb3Blbkljb24gPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3IoJy5mYS1jaGV2cm9uLWRvd24nKTtcblx0XHRjb25zdCBjbG9zZUljb24gPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3IoJy5mYS1jaGV2cm9uLXVwJyk7XG5cdFx0aWYgKG9wZW5JY29uKSB7XG5cdFx0XHRvcGVuSWNvbi5jbGFzc0xpc3QucmVwbGFjZSgnZmEtY2hldnJvbi1kb3duJywgJ2ZhLWNoZXZyb24tdXAnKTtcblx0XHR9XG5cdFx0aWYgKGNsb3NlSWNvbikge1xuXHRcdFx0Y2xvc2VJY29uLmNsYXNzTGlzdC5yZXBsYWNlKCdmYS1jaGV2cm9uLXVwJywgJ2ZhLWNoZXZyb24tZG93bicpO1xuXHRcdH1cblx0fVxufVxuIiwiZXhwb3J0IGRlZmF1bHQgY2xhc3MgRXhwYW5kYWJsZSB7XG5cdGNvbnN0cnVjdG9yKF9yb290LCBfdHJpZ2dlckNsYXNzTmFtZSwgX29uU3RhdGVDaGFuZ2UsIGluaXRpYWxTdGF0ZSkge1xuXHRcdHRoaXMuX3Jvb3QgPSBfcm9vdDtcblx0XHR0aGlzLl90cmlnZ2VyID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKF90cmlnZ2VyQ2xhc3NOYW1lKTtcblx0XHR0aGlzLl9vblN0YXRlQ2hhbmdlID0gX29uU3RhdGVDaGFuZ2U7XG5cdFx0dGhpcy5fc2V0dXBFdmVudExpc3RlbmVycygpO1xuXHRcdHRoaXMuX2luaXRpYWxpemUoaW5pdGlhbFN0YXRlKTtcblx0fVxuXG5cdF9zZXR1cEV2ZW50TGlzdGVuZXJzKCkge1xuXHRcdHRoaXMuX3RyaWdnZXIuZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCB0aGlzLl90b2dnbGUuYmluZCh0aGlzKSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfaW5pdGlhbGl6ZShpbml0aWFsU3RhdGUpIHtcblx0XHRjb25zdCBoZWFkZXIgPSB0aGlzLl9yb290LnF1ZXJ5U2VsZWN0b3IoJ1thcmlhLWV4cGFuZGVkXScpO1xuXHRcdGhlYWRlci5zZXRBdHRyaWJ1dGUoJ2FyaWEtZXhwYW5kZWQnLCBTdHJpbmcoaW5pdGlhbFN0YXRlKSk7XG5cblx0XHRpZiAoaW5pdGlhbFN0YXRlKSB7XG5cdFx0XHQvLyBkZWZhdWx0IGlzIGNsb3NlZFxuXHRcdFx0dGhpcy5fcm9vdC5jbGFzc0xpc3QuYWRkKCduZW9zLW9wZW4nKTtcblx0XHRcdHRoaXMuX2NoYW5nZVRvb2dsZUljb24oKTtcblx0XHR9XG5cdH1cblxuXHRfdG9nZ2xlKCkge1xuXHRcdHRoaXMuX2NoYW5nZVRvb2dsZUljb24oKTtcblx0XHR0aGlzLl9yb290LmNsYXNzTGlzdC50b2dnbGUoJ25lb3Mtb3BlbicpO1xuXHRcdHRoaXMuX3Rvb2dsZUFyaWFFeHBhbmRhYmxlKCk7XG5cdH1cblxuXHRfdG9vZ2xlQXJpYUV4cGFuZGFibGUoKSB7XG5cdFx0Y29uc3QgaGVhZGVyID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yKCdbYXJpYS1leHBhbmRlZF0nKTtcblx0XHRjb25zdCBleHBhbmRlZCA9IHRoaXMuX3Jvb3QuY2xhc3NMaXN0LmNvbnRhaW5zKCduZW9zLW9wZW4nKTtcblx0XHRoZWFkZXIuc2V0QXR0cmlidXRlKCdhcmlhLWV4cGFuZGVkJywgU3RyaW5nKGV4cGFuZGVkKSk7XG5cdFx0aWYgKHR5cGVvZiB0aGlzLl9vblN0YXRlQ2hhbmdlID09PSAnZnVuY3Rpb24nKSB7XG5cdFx0XHRjb25zdCBzZWN0aW9uTmFtZSA9IHRoaXMuX3Jvb3QuZ2V0QXR0cmlidXRlKCdkYXRhLWtleScpO1xuXHRcdFx0dGhpcy5fb25TdGF0ZUNoYW5nZShzZWN0aW9uTmFtZSwgZXhwYW5kZWQpO1xuXHRcdH1cblx0fVxuXG5cdF9jaGFuZ2VUb29nbGVJY29uKCkge1xuXHRcdGNvbnN0IG9wZW5JY29uID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yKCcuZmEtY2hldnJvbi1jaXJjbGUtZG93bicpO1xuXHRcdGNvbnN0IGNsb3NlSWNvbiA9IHRoaXMuX3Jvb3QucXVlcnlTZWxlY3RvcignLmZhLWNoZXZyb24tY2lyY2xlLXVwJyk7XG5cdFx0aWYgKG9wZW5JY29uKSB7XG5cdFx0XHRvcGVuSWNvbi5jbGFzc0xpc3QucmVwbGFjZShcblx0XHRcdFx0J2ZhLWNoZXZyb24tY2lyY2xlLWRvd24nLFxuXHRcdFx0XHQnZmEtY2hldnJvbi1jaXJjbGUtdXAnXG5cdFx0XHQpO1xuXHRcdH1cblx0XHRpZiAoY2xvc2VJY29uKSB7XG5cdFx0XHRjbG9zZUljb24uY2xhc3NMaXN0LnJlcGxhY2UoXG5cdFx0XHRcdCdmYS1jaGV2cm9uLWNpcmNsZS11cCcsXG5cdFx0XHRcdCdmYS1jaGV2cm9uLWNpcmNsZS1kb3duJ1xuXHRcdFx0KTtcblx0XHR9XG5cdH1cbn1cbiIsImNvbnN0IGlzTmlsID0gdmFsdWUgPT4gdmFsdWUgPT09IG51bGwgfHwgdmFsdWUgPT09IHVuZGVmaW5lZDtcblxuZXhwb3J0IGRlZmF1bHQgaXNOaWw7XG4iLCJpbXBvcnQgaXNOaWwgZnJvbSAnLi9pc05pbCc7XG5cbmNvbnN0IGlzRW1wdHkgPSBvYmplY3QgPT4ge1xuXHRpZiAoaXNOaWwob2JqZWN0KSkge1xuXHRcdHJldHVybiBmYWxzZTtcblx0fVxuXG5cdHJldHVybiAoXG5cdFx0IU9iamVjdC5nZXRPd25Qcm9wZXJ0eVN5bWJvbHMob2JqZWN0KS5sZW5ndGggJiZcblx0XHQhT2JqZWN0LmdldE93blByb3BlcnR5TmFtZXMob2JqZWN0KS5sZW5ndGhcblx0KTtcbn07XG5cbmV4cG9ydCBkZWZhdWx0IGlzRW1wdHk7XG4iLCJpbXBvcnQgeyBpc05pbCB9IGZyb20gJy4nO1xuXG5jb25zdCBnZXRJdGVtQnlLZXlWYWx1ZSA9IChjb2xsZWN0aW9uLCBrZXksIHZhbHVlKSA9PiB7XG5cdGlmIChpc05pbChjb2xsZWN0aW9uKSkge1xuXHRcdHJldHVybiBudWxsO1xuXHR9XG5cdHJldHVybiBjb2xsZWN0aW9uLmZpbmQob2JqZWN0ID0+IG9iamVjdFtrZXldID09PSB2YWx1ZSk7XG59O1xuXG5leHBvcnQgZGVmYXVsdCBnZXRJdGVtQnlLZXlWYWx1ZTtcbiIsImltcG9ydCBpc05pbCBmcm9tICcuL2lzTmlsJztcbmltcG9ydCBpc0VtcHR5IGZyb20gJy4vaXNFbXB0eSc7XG5pbXBvcnQgZ2V0SXRlbUJ5S2V5VmFsdWUgZnJvbSAnLi9nZXRJdGVtQnlLZXlWYWx1ZSc7XG5cbmV4cG9ydCB7XG5cdGlzTmlsLFxuXHRpc0VtcHR5LFxuXHRnZXRJdGVtQnlLZXlWYWx1ZVxufTtcbiIsImltcG9ydCBFeHBhbmRhYmxlIGZyb20gJy4vRXhwYW5kYWJsZSc7XG5pbXBvcnQgeyBpc05pbCwgZ2V0SXRlbUJ5S2V5VmFsdWUgfSBmcm9tICcuLi8uLi9IZWxwZXInO1xuXG5jb25zdCBTRVNTSU9OX0tFWSA9ICdOZW9zLk5lb3MubWVudVNlY3Rpb25TdGF0ZXMnO1xuZXhwb3J0IGRlZmF1bHQgY2xhc3MgTWVudVBhbmVsIHtcblx0Y29uc3RydWN0b3IoX3Jvb3QpIHtcblx0XHR0aGlzLl9yb290ID0gX3Jvb3Q7XG5cdFx0dGhpcy5fYnV0dG9uID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKCcubmVvcy1tZW51LWJ1dHRvbicpO1xuXHRcdHRoaXMuX3BhbmVsID0gdGhpcy5fcm9vdC5xdWVyeVNlbGVjdG9yQWxsKCcubmVvcy1tZW51LXBhbmVsJyk7XG5cdFx0dGhpcy5fbWVudVNlY3Rpb25TdGF0ZXMgPSB0aGlzLl9sb2FkU2Vzc2lvbkRhdGEoKTtcblx0XHR0aGlzLl9zZXR1cEV2ZW50TGlzdGVuZXJzKCk7XG5cblx0XHRpZiAodGhpcy5fcGFuZWwpIHtcblx0XHRcdHRoaXMuX2luaXRpYWxpemVNZW51U2VjdGlvbnMoKTtcblx0XHR9XG5cdH1cblxuXHRfaW5pdGlhbGl6ZU1lbnVTZWN0aW9ucygpIHtcblx0XHR0aGlzLl9wYW5lbC5mb3JFYWNoKF9wYW5lbCA9PiB7XG5cdFx0XHRjb25zdCBtZW51U2VjdGlvbkVsZW1lbnRzID0gX3BhbmVsLnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLW1lbnUtc2VjdGlvbicpO1xuXHRcdFx0Y29uc3QgeyBzZWN0aW9ucyB9ID0gdGhpcy5fbWVudVNlY3Rpb25TdGF0ZXM7XG5cdFx0XHRtZW51U2VjdGlvbkVsZW1lbnRzLmZvckVhY2gobWVudVNlY3Rpb25FbGVtZW50ID0+IHtcblx0XHRcdFx0Y29uc3Qgc2VjdGlvbk5hbWUgPSBtZW51U2VjdGlvbkVsZW1lbnQuZ2V0QXR0cmlidXRlKCdkYXRhLWtleScpO1xuXHRcdFx0XHRjb25zdCBzZWN0aW9uU3RhdGUgPSBnZXRJdGVtQnlLZXlWYWx1ZShzZWN0aW9ucywgJ25hbWUnLCBzZWN0aW9uTmFtZSk7XG5cdFx0XHRcdGNvbnN0IGluaXRhbFN0YXRlID0gIWlzTmlsKHNlY3Rpb25TdGF0ZSkgPyBzZWN0aW9uU3RhdGUub3BlbiA6IGZhbHNlO1xuXHRcdFx0XHRuZXcgRXhwYW5kYWJsZShcblx0XHRcdFx0XHRtZW51U2VjdGlvbkVsZW1lbnQsXG5cdFx0XHRcdFx0Jy5uZW9zLW1lbnUtcGFuZWwtdG9nZ2xlJyxcblx0XHRcdFx0XHR0aGlzLl9vbk1lbnVTZWN0aW9uU3RhdGVDaGFuZ2UuYmluZCh0aGlzKSxcblx0XHRcdFx0XHRpbml0YWxTdGF0ZVxuXHRcdFx0XHQpO1xuXHRcdFx0fSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfc2V0dXBFdmVudExpc3RlbmVycygpIHtcblx0XHR0aGlzLl9idXR0b24uZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCB0aGlzLl90b2dnbGUuYmluZCh0aGlzKSk7XG5cdFx0fSk7XG5cdH1cblxuXHRfbG9hZFNlc3Npb25EYXRhKCkge1xuXHRcdGNvbnN0IHNlc3Npb25EYXRhID0gc2Vzc2lvblN0b3JhZ2UuZ2V0SXRlbShTRVNTSU9OX0tFWSk7XG5cdFx0aWYgKGlzTmlsKHNlc3Npb25EYXRhKSkge1xuXHRcdFx0Y29uc3QgaW5pdGlhbFNlc3Npb25EYXRhID0geyBzZWN0aW9uczogW10gfTtcblx0XHRcdHNlc3Npb25TdG9yYWdlLnNldEl0ZW0oU0VTU0lPTl9LRVksIEpTT04uc3RyaW5naWZ5KGluaXRpYWxTZXNzaW9uRGF0YSkpO1xuXHRcdFx0cmV0dXJuIGluaXRpYWxTZXNzaW9uRGF0YTtcblx0XHR9XG5cblx0XHRyZXR1cm4gSlNPTi5wYXJzZShzZXNzaW9uRGF0YSk7XG5cdH1cblxuXHRfb25NZW51U2VjdGlvblN0YXRlQ2hhbmdlKHNlY3Rpb25OYW1lLCBuZXdWYWx1ZSkge1xuXHRcdGNvbnN0IHsgc2VjdGlvbnMgfSA9IHRoaXMuX21lbnVTZWN0aW9uU3RhdGVzO1xuXHRcdGNvbnN0IHNlY3Rpb25TdGF0ZSA9IGdldEl0ZW1CeUtleVZhbHVlKHNlY3Rpb25zLCAnbmFtZScsIHNlY3Rpb25OYW1lKTtcblx0XHRpZiAoaXNOaWwoc2VjdGlvbnMpKSB7XG5cdFx0XHR0aGlzLl9tZW51U2VjdGlvblN0YXRlcy5zZWN0aW9ucyA9IFtdO1xuXHRcdH1cblxuXHRcdGlmIChpc05pbChzZWN0aW9uU3RhdGUpKSB7XG5cdFx0XHR0aGlzLl9tZW51U2VjdGlvblN0YXRlcy5zZWN0aW9ucy5wdXNoKHtcblx0XHRcdFx0bmFtZTogc2VjdGlvbk5hbWUsXG5cdFx0XHRcdG9wZW46IG5ld1ZhbHVlXG5cdFx0XHR9KTtcblx0XHR9IGVsc2Uge1xuXHRcdFx0c2VjdGlvblN0YXRlLm9wZW4gPSBuZXdWYWx1ZTtcblx0XHR9XG5cblx0XHRzZXNzaW9uU3RvcmFnZS5zZXRJdGVtKFxuXHRcdFx0U0VTU0lPTl9LRVksXG5cdFx0XHRKU09OLnN0cmluZ2lmeSh0aGlzLl9tZW51U2VjdGlvblN0YXRlcylcblx0XHQpO1xuXHR9XG5cblx0X3RvZ2dsZShfZXZlbnQpIHtcblx0XHR0aGlzLl9idXR0b24uZm9yRWFjaChfdG9nZ2xlQnV0dG9uID0+IHtcblx0XHRcdF90b2dnbGVCdXR0b24uY2xhc3NMaXN0LnRvZ2dsZSgnbmVvcy1wcmVzc2VkJyk7XG5cdFx0fSk7XG5cdFx0ZG9jdW1lbnQuYm9keS5jbGFzc0xpc3QudG9nZ2xlKCduZW9zLW1lbnUtcGFuZWwtb3BlbicpO1xuXHR9XG59XG4iLCJpbXBvcnQgRHJvcERvd25NZW51IGZyb20gJy4vRHJvcGRvd25NZW51J1xuaW1wb3J0IEV4cGFuZGFibGUgZnJvbSAnLi9FeHBhbmRhYmxlJ1xuaW1wb3J0IE1lbnVQYW5lbCBmcm9tICcuL01lbnVQYW5lbCdcblxuZXhwb3J0IHtcblx0RHJvcERvd25NZW51LFxuXHRFeHBhbmRhYmxlLFxuXHRNZW51UGFuZWxcbn1cbiIsImltcG9ydCB7RHJvcERvd25NZW51LCBNZW51UGFuZWx9IGZyb20gJy4vQ29tcG9uZW50cy9Ub3BCYXInXG5cbmNvbnN0IGRyb3BEb3duTWVudUVsZW1lbnRzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnLm5lb3MtdXNlci1tZW51Jyk7XG5kcm9wRG93bk1lbnVFbGVtZW50cy5mb3JFYWNoKGRyb3BEb3duRWxlbWVudCA9PiB7XG5cdG5ldyBEcm9wRG93bk1lbnUoZHJvcERvd25FbGVtZW50KTtcbn0pO1xuXG5jb25zdCBtZW51UGFuZWxFbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJy5uZW9zLW1lbnUnKTtcbm1lbnVQYW5lbEVsZW1lbnRzLmZvckVhY2gocGFuZWxFbGVtZW50ID0+IHtcblx0bmV3IE1lbnVQYW5lbChwYW5lbEVsZW1lbnQpO1xufSk7XG5cblxuIl0sInNvdXJjZVJvb3QiOiIifQ==
+
+/******/ });


### PR DESCRIPTION
The new vanilla js menu did use the session storage to save the states and it turns out that the react-ui uses the local storage. This patch synchronizes the states and takes care that when you change a menu state in the content module (react-ui) the state is also available in the user module for instance.

**What I did**
Use also the local storage in the vanilla js based menu and adopt the data structure to behave like the react-ui.

**How to verify it**
Change menu states in the content module an check then if the state is also in the user module. And vice versa.

Fixes: #2682
