### PR TITLE
BUGFIX: Add the last visited node handler

### DIFF
--- a/Neos.Neos/Resources/Public/JavaScript/LastVisitedNode.js
+++ b/Neos.Neos/Resources/Public/JavaScript/LastVisitedNode.js
@@ -1,0 +1,3 @@
+try {
+	sessionStorage.setItem('Neos.Neos.lastVisitedNode', document.querySelector('script[data-neos-node]').getAttribute('data-neos-node'));
+} catch(e) {}


### PR DESCRIPTION
While the refactoring of the javascript code in the Neos.Neos package the LastVisitedNode.js
file has been deleted. Sadly this is used by the react-ui and the removal leads to errors in the console.

Thanks to @Sebobo for reporting that :)