### PR TITLE
BUGFIX: Translate labels when modifying tag and collections

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AddFlashMessageTrait.php
+++ b/Neos.Media.Browser/Classes/Controller/AddFlashMessageTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Neos\Media\Browser\Controller;
+
+/*
+ * This file is part of the Neos.Media.Browser package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Error\Messages\Message;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A trait to add backend translation based on the backend users settings
+ */
+trait AddFlashMessageTrait
+{
+    /**
+     * @Flow\Inject
+     * @var \Neos\Flow\I18n\Translator
+     */
+    protected $_translator;
+
+    /**
+     * Add a translated flashMessage.
+     *
+     * @param string $messageBody The translation id for the message body.
+     * @param string $messageTitle The translation id for the message title.
+     * @param string $severity
+     * @param array $messageArguments
+     * @param integer $messageCode
+     * @return void
+     */
+    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null): void
+    {
+        if (is_string($messageBody)) {
+            $messageBody = $this->_translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'Neos.Media.Browser') ?: $messageBody;
+        }
+
+        $messageTitle = (string)$this->_translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'Neos.Media.Browser');
+        parent::addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
+    }
+}

--- a/Neos.Media.Browser/Classes/Controller/AddFlashMessageTrait.php
+++ b/Neos.Media.Browser/Classes/Controller/AddFlashMessageTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Neos\Media\Browser\Controller;
 

--- a/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
@@ -28,6 +28,8 @@ use Neos\Neos\Domain\Repository\SiteRepository;
  */
 class AssetCollectionController extends ActionController
 {
+    use AddFlashMessageTrait;
+
     /**
      * @Flow\Inject
      * @var AssetCollectionRepository

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\EntityNotFoundException;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\InvalidArgumentValueException;
 use Neos\Flow\Mvc\Exception\StopActionException;
@@ -63,6 +62,7 @@ class AssetController extends ActionController
 {
     use CreateContentContextTrait;
     use BackendUserTranslationTrait;
+    use AddFlashMessageTrait;
 
     const TAG_GIVEN = 0;
     const TAG_ALL = 1;
@@ -126,12 +126,6 @@ class AssetController extends ActionController
      * @var AssetService
      */
     protected $assetService;
-
-    /**
-     * @Flow\Inject
-     * @var Translator
-     */
-    protected $translator;
 
     /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
@@ -701,26 +695,6 @@ class AssetController extends ActionController
         }
 
         return new Error($errorMessage, null, [get_class($this), $this->actionMethodName]);
-    }
-
-    /**
-     * Add a translated flashMessage.
-     *
-     * @param string $messageBody The translation id for the message body.
-     * @param string $messageTitle The translation id for the message title.
-     * @param string $severity
-     * @param array $messageArguments
-     * @param integer $messageCode
-     * @return void
-     */
-    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null)
-    {
-        if (is_string($messageBody)) {
-            $messageBody = $this->translator->translateById($messageBody, $messageArguments, null, null, 'Main', 'Neos.Media.Browser') ?: $messageBody;
-        }
-
-        $messageTitle = $this->translator->translateById($messageTitle, $messageArguments, null, null, 'Main', 'Neos.Media.Browser');
-        parent::addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
     }
 
     /**

--- a/Neos.Media.Browser/Classes/Controller/TagController.php
+++ b/Neos.Media.Browser/Classes/Controller/TagController.php
@@ -28,6 +28,8 @@ use Neos\Media\Domain\Repository\TagRepository;
  */
 class TagController extends ActionController
 {
+    use AddFlashMessageTrait;
+
     /**
      * @Flow\Inject
      * @var AssetCollectionRepository


### PR DESCRIPTION
**What I did**

Allow all media browser controllers to use the modified `addFlashMessage` method.

**How I did it**

Use a trait for adding the method to all related controllers.

**How to verify it**

Add or delete a tag or collection in the media browser.
