### PR TITLE
!!! FEATURE: Alter ``Neos.Fusion:Tag.attributes`` to ``Neos.Fusion:DataStructure``

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
@@ -24,6 +24,7 @@ namespace Neos\Fusion\FusionObjects;
  * attributes.id = 'my-id'
  *
  * will result in the string: class="class1 class2" id="my-id"
+ * @deprecated since Neos 5.0 in favor of TagImplementation or JoinImplementation
  */
 class AttributesImplementation extends AbstractArrayFusionObject
 {

--- a/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
@@ -33,14 +33,34 @@ class AttributesImplementation extends AbstractArrayFusionObject
     public function evaluate()
     {
         $allowEmpty = $this->getAllowEmpty();
-        $attributes = [];
+
+        $renderedAttributes = '';
         foreach (array_keys($this->properties) as $attributeName) {
             if ($attributeName === '__meta' || in_array($attributeName, $this->ignoreProperties)) {
                 continue;
             }
-            $attributes[$attributeName] = $this->fusionValue($attributeName);
+
+            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
+            $attributeValue = $this->fusionValue($attributeName);
+            if ($attributeValue === null || $attributeValue === false) {
+                // No op
+            } elseif ($attributeValue === true || $attributeValue === '') {
+                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
+            } else {
+                if (is_array($attributeValue)) {
+                    $joinedAttributeValue = '';
+                    foreach ($attributeValue as $attributeValuePart) {
+                        if ((string)$attributeValuePart !== '') {
+                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
+                        }
+                    }
+                    $attributeValue = trim($joinedAttributeValue);
+                }
+                $encodedAttributeValue = htmlspecialchars($attributeValue, ENT_COMPAT, 'UTF-8', false);
+                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
+            }
         }
-        return TagImplementation::renderAttributes($attributes, $allowEmpty);
+        return $renderedAttributes;
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
@@ -33,34 +33,14 @@ class AttributesImplementation extends AbstractArrayFusionObject
     public function evaluate()
     {
         $allowEmpty = $this->getAllowEmpty();
-
-        $renderedAttributes = '';
+        $attributes = [];
         foreach (array_keys($this->properties) as $attributeName) {
             if ($attributeName === '__meta' || in_array($attributeName, $this->ignoreProperties)) {
                 continue;
             }
-
-            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
-            $attributeValue = $this->fusionValue($attributeName);
-            if ($attributeValue === null || $attributeValue === false) {
-                // No op
-            } elseif ($attributeValue === true || $attributeValue === '') {
-                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
-            } else {
-                if (is_array($attributeValue)) {
-                    $joinedAttributeValue = '';
-                    foreach ($attributeValue as $attributeValuePart) {
-                        if ((string)$attributeValuePart !== '') {
-                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
-                        }
-                    }
-                    $attributeValue = trim($joinedAttributeValue);
-                }
-                $encodedAttributeValue = htmlspecialchars($attributeValue, ENT_COMPAT, 'UTF-8', false);
-                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
-            }
+            $attributes[$attributeName] = $this->fusionValue($attributeName);
         }
-        return $renderedAttributes;
+        return TagImplementation::renderAttributes($attributes, $allowEmpty);
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -94,10 +94,11 @@ class TagImplementation extends AbstractFusionObject
     {
         $renderedAttributes = '';
         foreach ($attributes as $attributeName => $attributeValue) {
-            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
             if ($attributeValue === null || $attributeValue === false) {
-                // No op
-            } elseif ($attributeValue === true || $attributeValue === '') {
+                continue;
+            }
+            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
+            if ($attributeValue === true || $attributeValue === '') {
                 $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
             } else {
                 if (is_array($attributeValue)) {

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -76,7 +76,7 @@ class TagImplementation extends AbstractFusionObject
 
     /**
      * The tag attributes dataStructure
-     * If anything but an array is returned the value is casted to string
+     * If anything but an iterable is returned the value is casted to string
      *
      * @return array|string
      */

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -77,6 +77,42 @@ class TagImplementation extends AbstractFusionObject
         if (!$omitClosingTag && !$selfClosingTag) {
             $content = $this->fusionValue('content');
         }
-        return '<' . $tagName . $this->fusionValue('attributes') . ($selfClosingTag ? ' /' : '') . '>' . (!$omitClosingTag && !$selfClosingTag ? $content . '</' . $tagName . '>' : '');
+        $attributes = $this->fusionValue('attributes');
+        if (is_array($attributes)) {
+            $renderedAttributes = self::renderAttributes($attributes, true);
+        } else {
+            $renderedAttributes = (string)$attributes;
+        }
+        return '<' . $tagName . $renderedAttributes . ($selfClosingTag ? ' /' : '') . '>' . (!$omitClosingTag && !$selfClosingTag ? $content . '</' . $tagName . '>' : '');
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool $allowEmpty
+     */
+    public static function renderAttributes(array $attributes, $allowEmpty = true): string
+    {
+        $renderedAttributes = '';
+        foreach ($attributes as $attributeName => $attributeValue) {
+            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
+            if ($attributeValue === null || $attributeValue === false) {
+                // No op
+            } elseif ($attributeValue === true || $attributeValue === '') {
+                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
+            } else {
+                if (is_array($attributeValue)) {
+                    $joinedAttributeValue = '';
+                    foreach ($attributeValue as $attributeValuePart) {
+                        if ((string)$attributeValuePart !== '') {
+                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
+                        }
+                    }
+                    $attributeValue = trim($joinedAttributeValue);
+                }
+                $encodedAttributeValue = htmlspecialchars($attributeValue, ENT_COMPAT, 'UTF-8', false);
+                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
+            }
+        }
+        return $renderedAttributes;
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -63,6 +63,43 @@ class TagImplementation extends AbstractFusionObject
         return in_array($tagName, self::$SELF_CLOSING_TAGS, true) || (boolean)$this->fusionValue('selfClosingTag');
     }
 
+
+    /**
+     * The tag content
+     *
+     * @return string
+     */
+    protected function getContent()
+    {
+        return $this->fusionValue('content');
+    }
+
+    /**
+     * The tag attributes dataStructure
+     * If anything but an array is returned the value is casted to string
+     *
+     * @return array|string
+     */
+    protected function getAttributes()
+    {
+        return $this->fusionValue('attributes');
+    }
+
+    /**
+     * Whether empty attributes (HTML5 syntax) should be allowed
+     *
+     * @return boolean
+     */
+    protected function getAllowEmptyAttributes()
+    {
+        $allowEmpty = $this->fusionValue('allowEmptyAttributes');
+        if ($allowEmpty === null) {
+            return true;
+        } else {
+            return (boolean)$allowEmpty;
+        }
+    }
+
     /**
      * Return a tag
      *
@@ -75,11 +112,12 @@ class TagImplementation extends AbstractFusionObject
         $selfClosingTag = $this->isSelfClosingTag($tagName);
         $content = '';
         if (!$omitClosingTag && !$selfClosingTag) {
-            $content = $this->fusionValue('content');
+            $content = $this->getContent();
         }
-        $attributes = $this->fusionValue('attributes');
-        if (is_array($attributes)) {
-            $renderedAttributes = self::renderAttributes($attributes, true);
+        $attributes = $this->getAttributes();
+        $allowEmptyAttributes = $this->getAllowEmptyAttributes();
+        if (is_iterable($attributes)) {
+            $renderedAttributes = self::renderAttributes($attributes, $allowEmptyAttributes);
         } else {
             $renderedAttributes = (string)$attributes;
         }
@@ -87,10 +125,13 @@ class TagImplementation extends AbstractFusionObject
     }
 
     /**
-     * @param array $attributes
+     * Render the tag attributes for the given key->values as atring,
+     * if an value is an iterable it will be concatenated with spaces as seperator
+     *
+     * @param iterable $attributes
      * @param bool $allowEmpty
      */
-    public static function renderAttributes(array $attributes, $allowEmpty = true): string
+    protected function renderAttributes(iterable $attributes, $allowEmpty = true): string
     {
         $renderedAttributes = '';
         foreach ($attributes as $attributeName => $attributeValue) {

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -78,7 +78,7 @@ class TagImplementation extends AbstractFusionObject
      * The tag attributes dataStructure
      * If anything but an iterable is returned the value is casted to string
      *
-     * @return array|string
+     * @return iterable|string
      */
     protected function getAttributes()
     {

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -104,7 +104,7 @@ prototype(Neos.Fusion:Attributes) {
 #
 prototype(Neos.Fusion:Tag) {
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
-	attributes = Neos.Fusion:Attributes
+	attributes = Neos.Fusion:DataStructure
 	omitClosingTag = false
 	selfClosingTag = false
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
@@ -1,8 +1,8 @@
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
-prototype(Neos.Fusion:Attributes).@class = 'Neos\\Fusion\\FusionObjects\\AttributesImplementation'
+prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
 prototype(Neos.Fusion:Tag) {
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
-	attributes = Attributes
+	attributes = Neos.Fusion:DataStructure
 	omitClosingTag = false
 	selfClosingTag = false
 }
@@ -36,6 +36,32 @@ tag.dataStructureAttributes = Tag {
   attributes = Neos.Fusion:DataStructure {
     key = 'value'
     list = ${['foo', 'bar']}
+  }
+}
+
+tag.booleanAttributes = Tag {
+  attributes = Neos.Fusion:DataStructure {
+    foo = true
+    bar = false
+    baz = null
+  }
+}
+
+tag.booleanAttributesAndForbiddenEmptyAttributes = Tag {
+  allowEmptyAttributes = false
+  attributes = Neos.Fusion:DataStructure {
+    foo = true
+    bar = false
+    baz = null
+  }
+}
+
+tag.booleanAttributesAndAllowEmptyAttributes = Tag {
+  allowEmptyAttributes = true
+  attributes = Neos.Fusion:DataStructure {
+    foo = true
+    bar = false
+    baz = null
   }
 }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
@@ -1,4 +1,5 @@
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
+prototype(Neos.Fusion:Attributes).@class = 'Neos\\Fusion\\FusionObjects\\AttributesImplementation'
 prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
 prototype(Neos.Fusion:Tag) {
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
@@ -30,6 +31,13 @@ tag.arrayAttributes = Tag {
 		class.a = 'a'
 		class.b = 'b'
 	}
+}
+
+tag.fusionAttributes = Tag {
+  attributes = Neos.Fusion:Attributes {
+    key = 'value'
+    list = ${['foo', 'bar']}
+  }
 }
 
 tag.dataStructureAttributes = Tag {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Tag.fusion
@@ -32,6 +32,13 @@ tag.arrayAttributes = Tag {
 	}
 }
 
+tag.dataStructureAttributes = Tag {
+  attributes = Neos.Fusion:DataStructure {
+    key = 'value'
+    list = ${['foo', 'bar']}
+  }
+}
+
 tag.plainContent = Tag {
 	tagName = 'span'
 	content = 'test'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -60,6 +60,36 @@ class TagTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function tagWithBooleanAttributesWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('tag/booleanAttributes');
+        self::assertSame('<div foo></div>', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function tagWithBooleanAttributesAndForbiddenEmptyAttributesWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('tag/booleanAttributesAndForbiddenEmptyAttributes');
+        self::assertSame('<div foo=""></div>', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function tagWithBooleanAndAllowEmptyAttributesAttributesWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('tag/booleanAttributesAndAllowEmptyAttributes');
+        self::assertSame('<div foo></div>', $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function tagWithContentFromNonFusionObjectWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -50,6 +50,16 @@ class TagTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function tagWithFusionAttributesWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('tag/fusionAttributes');
+        self::assertSame('<div key="value" list="foo bar"></div>', $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function tagWithAttributesFromDataStructureWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -50,6 +50,16 @@ class TagTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function tagWithAttributesFromDataStructureWorks()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('tag/dataStructureAttributes');
+        self::assertSame('<div key="value" list="foo bar"></div>', $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function tagWithContentFromNonFusionObjectWorks()
     {
         $view = $this->buildView();

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -501,9 +501,9 @@ render the attributes of a tag. But it's also useful standalone to render extens
 :[key]: (string) A single attribute, array values are joined with whitespace. Boolean values will be rendered as an empty or absent attribute.
 :@allowEmpty: (boolean) Whether empty attributes (HTML5 syntax) should be used for empty, false or null attribute values
 
-.. note:: The ``Neos.Fusion:Attributes`` object is DEPRECATED in favor of a solution inside Neos.Fusion:Tag which takey attributes
+.. note:: The ``Neos.Fusion:Attributes`` object is DEPRECATED in favor of a solution inside Neos.Fusion:Tag which takes attributes
    as ``Neos.Fusion:DataStructure`` now. If you have to render attributes as string without a tag you can use
-   ``Neos.Fusion:Join`` with ``@glue`.
+   ``Neos.Fusion:Join`` with ``@glue` but you will have to concatenate array attributes yourself.
 
 Example:
 ^^^^^^^^

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -468,7 +468,8 @@ Render an HTML tag with attributes and optional body
 :omitClosingTag: (boolean) Whether to render the element ``content`` and the closing tag, defaults to ``FALSE``
 :selfClosingTag: (boolean) Whether the tag is a self-closing tag with no closing tag. Will be resolved from ``tagName`` by default, so default HTML tags are treated correctly.
 :content: (string) The inner content of the element, will only be rendered if the tag is not self-closing and the closing tag is not omitted
-:attributes: (:ref:`Neos_Fusion__Attributes`) Tag attributes
+:attributes: (iterable) Tag attributes as key-value pairs. Default is ``Neos.Fusion:DataStructure``. If a non iterable is returned the value is casted to string.
+:allowEmptyAttributes: (boolean) Whether empty attributes (HTML5 syntax) should be used for empty, false or null attribute values. By default this is ``true``
 
 Example:
 ^^^^^^^^
@@ -499,6 +500,10 @@ render the attributes of a tag. But it's also useful standalone to render extens
 
 :[key]: (string) A single attribute, array values are joined with whitespace. Boolean values will be rendered as an empty or absent attribute.
 :@allowEmpty: (boolean) Whether empty attributes (HTML5 syntax) should be used for empty, false or null attribute values
+
+.. note:: The ``Neos.Fusion:Attributes`` object is DEPRECATED in favor of a solution inside Neos.Fusion:Tag which takey attributes
+   as ``Neos.Fusion:DataStructure`` now. If you have to render attributes as string without a tag you can use
+   ``Neos.Fusion:Join`` with ``@glue`.
 
 Example:
 ^^^^^^^^

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -31,7 +31,7 @@ prototype(Neos.Neos:ContentCollectionRenderer) < prototype(Neos.Fusion:Collectio
 prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
 	tagName = 'div'
 
-	attributes = Neos.Fusion:Attributes
+	attributes = Neos.Fusion:DataStructure
 
 	# The following is used to automatically append class attribute with "neos-contentcollection" needed for editing.
 	# You can disable the following line with:


### PR DESCRIPTION
In the past integrators often expected to be able to pass data structures to `Tag.attributes` which was not possible since the Tag implementation expected attributes to be a string that usually was rendered by `Neos.Fusion:Attributes`.

This change extends the `Neos.Fusion:Tag` implementation to accept iterables (array and traversables) as `attributes` and changes the default value to `Neos.Fusion:DataStructure`. A fallback to cast non-iterable values to string is in place so if anyone uses Neos.Fusion:Attributes explicitly this will still work.

To control the wether or not empty attributes are allowed the key `allowEmptyAttributes` is added to `Neos.Fusion:Tag` that mimics the behavior of `@allowEmpty` on `Neos.Fusion:Attributes`.

`Neos.Fusion:Attributes` is marked as deprecated but will stay in there for a while. 

How to update: This change is almost 100% backwards compatible. Only if you used `attributes.@allowEmpty = false` inside a `Neos.Fusion:Tag` but did not define `attributes = Neos.Fusion:Attributes` the rendering of empty attributes will change. To fix this replace `attributes.@allowEmpty = false` with `allowEmptyAttributes = false`.