### PR TITLE
BUGFIX: Avoid count() call on null

### DIFF
--- a/Neos.Diff/Classes/SequenceMatcher.php
+++ b/Neos.Diff/Classes/SequenceMatcher.php
@@ -358,8 +358,8 @@ class SequenceMatcher
             return $this->matchingBlocks;
         }
 
-        $aLength = count($this->a);
-        $bLength = count($this->b);
+        $aLength = $this->a === null ? 0 : count($this->a);
+        $bLength = $this->b === null ? 0 : count($this->b);
 
         $queue = array(
             array(


### PR DESCRIPTION
Fixes #2699
