### PR TITLE
!!! FEATURE: Add getVariant(string, string) to VariantSupportInterface

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Image.php
+++ b/Neos.Media/Classes/Domain/Model/Image.php
@@ -108,9 +108,31 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
      * @return array
      * @api
      */
-    public function getVariants()
+    public function getVariants(): array
     {
         return $this->variants->toArray();
+    }
+
+    /**
+     * Returns the variant identified by $presetIdentifier and $presetVariantName (if existing)
+     *
+     * @param string $presetIdentifier
+     * @param string $presetVariantName
+     * @return ImageVariant
+     */
+    public function getVariant(string $presetIdentifier, string $presetVariantName): ?ImageVariant
+    {
+        if ($this->variants->isEmpty()) {
+            return null;
+        }
+
+        $filtered = $this->variants->filter(
+            static function (AssetVariantInterface $variant) use ($presetIdentifier, $presetVariantName) {
+                return ($variant->getPresetIdentifier() === $presetIdentifier && $variant->getPresetVariantName() === $presetVariantName);
+            }
+        );
+
+        return $filtered->isEmpty() ? null : $filtered->first();
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/VariantSupportInterface.php
+++ b/Neos.Media/Classes/Domain/Model/VariantSupportInterface.php
@@ -22,5 +22,14 @@ interface VariantSupportInterface
      * @return AssetVariantInterface[]
      * @api
      */
-    public function getVariants();
+    public function getVariants(): array;
+
+    /**
+     * Returns the variant identified by $presetIdentifier and $presetVariantName (if existing)
+     *
+     * @param string $presetIdentifier
+     * @param string $presetVariantName
+     * @return ImageVariant
+     */
+    public function getVariant(string $presetIdentifier, string $presetVariantName): ?ImageVariant;
 }


### PR DESCRIPTION
This adds a new method to the `VariantSupportInterface`, allowing
to fetch a preset-generated variant of an image directly.

    public function getVariant(string $presetIdentifier, string $presetVariantName): ?ImageVariant;
