### PR TITLE
BUGFIX: CropIimageAdjustment::refit only produces int sizes

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -192,11 +192,13 @@ class CropImageAdjustment extends AbstractImageAdjustment
 
         $ratio = $this->getWidth() / $image->getWidth();
         $this->setWidth($image->getWidth());
-        $this->setHeight($this->getHeight() / $ratio);
+        $roundedHeight = (int)round($this->getHeight() / $ratio, 0);
+        $this->setHeight($roundedHeight);
 
         if ($this->getHeight() > $image->getHeight()) {
             $ratio = $this->getHeight() / $image->getHeight();
-            $this->setWidth($this->getWidth() / $ratio);
+            $roundedWidth = (int)round($this->getWidth() / $ratio, 0);
+            $this->setWidth($roundedWidth);
             $this->setHeight($image->getHeight());
         }
     }


### PR DESCRIPTION
This is not a direct problem for Neos 3.3 but it becomes a problem
as soon as PHP type hints come into play. The ratio divided widths
and heights can easily be floats and that is unexpected. Therefore
rounding and casting to int makes sense to prevent problems.

In versions of Neos that include type hints this is an actual major
bug that prevents refitting to work.
