### PR TITLE
!!! TASK: Add code migration to rename nodetypes that were extracted from Neos.NodeTypes to subpackages

### DIFF
--- a/Neos.NodeTypes/Migrations/Code/Version20190917101945.php
+++ b/Neos.NodeTypes/Migrations/Code/Version20190917101945.php
@@ -1,0 +1,48 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.NodeTypes package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Adjusts code to rename nodetypes that were extracted to subpackages in fusion and nodetype definitions
+ */
+class Version20190917101945 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.NodeTypes-20190917101945';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $nodetypeUpgradeMap = [
+            'Neos.NodeTypes:AssetList' => 'Neos.NodeTypes.AssetList:AssetList',
+            'Neos.NodeTypes:ContentReferences' => 'Neos.NodeTypes.ContentReferences:ContentReferences',
+            'Neos.NodeTypes:Form' => 'Neos.NodeTypes.Form:Form',
+            'Neos.NodeTypes:Html' => 'Neos.NodeTypes.Html:Html',
+            'Neos.NodeTypes:Menu' => 'Neos.NodeTypes.Navigation:Navigation',
+            'Neos.NodeTypes:Column' => 'Neos.NodeTypes.ColumnLayouts:Column',
+            'Neos.NodeTypes:TwoColumn' => 'Neos.NodeTypes.ColumnLayouts:TwoColumn',
+            'Neos.NodeTypes:TwoColumn' => 'Neos.NodeTypes.ColumnLayouts:TwoColumn',
+            'Neos.NodeTypes:ThreeColumn' => 'Neos.NodeTypes.ColumnLayouts:ThreeColumn',
+            'Neos.NodeTypes:FourColumn' => 'Neos.NodeTypes.ColumnLayouts:FourColumn',
+            'Neos.NodeTypes:Records' => 'Neos.NodeTypes:ContentReferences'
+        ];
+
+        foreach ($nodetypeUpgradeMap as $search => $replace) {
+            $this->searchAndReplace($search, $replace, ['fusion', 'ts2', 'yaml']);
+        }
+    }
+}

--- a/Neos.NodeTypes/Migrations/Code/Version20190917101945.php
+++ b/Neos.NodeTypes/Migrations/Code/Version20190917101945.php
@@ -38,7 +38,7 @@ class Version20190917101945 extends AbstractMigration
             'Neos.NodeTypes:TwoColumn' => 'Neos.NodeTypes.ColumnLayouts:TwoColumn',
             'Neos.NodeTypes:ThreeColumn' => 'Neos.NodeTypes.ColumnLayouts:ThreeColumn',
             'Neos.NodeTypes:FourColumn' => 'Neos.NodeTypes.ColumnLayouts:FourColumn',
-            'Neos.NodeTypes:Records' => 'Neos.NodeTypes:ContentReferences'
+            'Neos.NodeTypes:Records' => 'Neos.NodeTypes.ContentReferences:ContentReferences'
         ];
 
         foreach ($nodetypeUpgradeMap as $search => $replace) {

--- a/Neos.NodeTypes/Migrations/ContentRepository/Version20190304111200.yaml
+++ b/Neos.NodeTypes/Migrations/ContentRepository/Version20190304111200.yaml
@@ -110,7 +110,7 @@ up:
         -
           type: 'ChangeNodeType'
           settings:
-            newType: 'Neos.NodeTypes:ContentReferences'
+            newType: 'Neos.NodeTypes.ContentReferences:ContentReferences'
 
 down:
   comments: 'Convert NodeTypes from subpackages of Neos.NodeTypes back to the NodeTypes package'


### PR DESCRIPTION
The NodeTypes that were migrated to subpackage namespace via node migration `20190304111200` are now migrated in yaml and fusion files aswell. So existing code that extended or altered those nodetypes will still work. 

In addition a wrong target nodetype for `Neos.NodeTypes:Records` in node migration `20190304111200` is corrected as this migration was not part of a release yet.

This is a follow up to pr: https://github.com/neos/neos-development-collection/pull/2385

Upgrade instructions: Run code migrations via `./flow flow:core:migrate Package.Key` or `./flow flow:core:migrate --version Neos.NodeTypes-20190917101945 Package.Key` to apply the migration to your code.