### PR TITLE
BUGFIX: Remove introduced integer type setting

### DIFF
--- a/Neos.Neos/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/Testing/NodeTypes.yaml
@@ -155,7 +155,7 @@
     'Neos.Neos.BackendSchemaControllerTest:ParentSimpleNodeType': true
   properties:
     text:
-      type: integer
-      defaultValue: 0
+      type: string
+      defaultValue: '0'
       ui:
         label: 'suddenly 0'

--- a/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
+++ b/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
@@ -62,11 +62,11 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
 
         $expectedSuperTypes = ['Neos.Neos.BackendSchemaControllerTest:ParentSimpleNodeType' => true];
         $expectedPropertyConfiguration = [
-            'type' => 'integer',
+            'type' => 'string',
             'ui' => [
                 'label' => 'suddenly 0'
             ],
-            'defaultValue' => 0
+            'defaultValue' => '0'
         ];
 
         self::assertEquals($expectedSuperTypes, $this->schema['nodeTypes']['Neos.Neos.BackendSchemaControllerTest:SimpleNodeType']['superTypes']);


### PR DESCRIPTION
Introduced in https://github.com/neos/neos-development-collection/pull/2694

A property with a given name should not be defined as different
value types as this will fail as soon as you try to use
elasticsearch indexing.

With defining that in the Testing index, an elasticsearch mapping
in the tests cannot be build
