### PR TITLE
!!!TASK: Adjust constraints of `Neos.Neos:ContentCollection` to allow `Content` instead of denying `Document`

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
@@ -9,5 +9,5 @@
     inlineEditable: true
   constraints:
     nodeTypes:
-      'Neos.Neos:Document': false
-      '*': true
+      '*': false
+      'Neos.Neos:Content': true


### PR DESCRIPTION
This fixes a cumbersome rule that is often unexpected and hard to explain. 

How to update:  If you created custom collections that altered the constraints  in the following way:
```
'Vendor.Site:ContentCollection':
  superTypes:
    'Neos.Neos:ContentCollection': true
  constraints:
    nodeTypes:
      '*': false
      'Vendor.Site:Content': true
```
You have to adjust the constraints and now forbid `Neos.Neos:Content'` instead of `*`:
```
'Vendor.Site:ContentCollection':
  superTypes:
    'Neos.Neos:ContentCollection': true
  constraints:
    nodeTypes:
      'Neos.Neos:Content': false
      'Vendor.Site:Content': true
```