### PR TITLE
!!!TASK: Adjust constraints of `Neos.Neos:ContentCollection` to allow `Content` instead of denying `Document`

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
@@ -9,5 +9,5 @@
     inlineEditable: true
   constraints:
     nodeTypes:
-      'Neos.Neos:Document': false
-      '*': true
+      '*': false
+      'Neos.Neos:Content': true

--- a/Neos.Neos/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/Testing/NodeTypes.yaml
@@ -94,6 +94,14 @@
     assets:
       type: array<Neos\Media\Domain\Model\Asset>
 
+'Acme.Demo:TeaserGroup':
+  superTypes:
+    'Neos.Neos:Content': true
+    'Neos.Neos:ContentCollection': true
+  ui:
+    label: 'Teaser Group'
+    group: 'default'
+
 'Neos.Neos.BackendSchemaControllerTest:Node':
   abstract: true
 

--- a/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
+++ b/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
@@ -561,7 +561,7 @@
       </node>
      </node>
      <node identifier="eab73e26-0dbf-8a2f-fcd7-a3cab1821e49" nodeName="teaser">
-      <variant sortingIndex="100" workspace="live" nodeType="Neos.Neos:ContentCollection" version="2" removed="" hidden="" hiddenInIndex="">
+      <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:TeaserGroup" version="2" removed="" hidden="" hiddenInIndex="">
        <dimensions>
         <language>en_US</language>
        </dimensions>


### PR DESCRIPTION
A ContentCollection did allow all children but Documents in the past which is unexpected and makes it needlessly harder to create derived nodetypes with custom constraints. 

This constraint is now adjusted to allow nodes of `Neos.Neos:Content` inside a `Neos.Neos:ContentCollection` as anyone would expect given the nodetype name. 

Additionally the test fixtures are adjusted as in one test a `ContentCollection` was moved into another. Now the respective node has a type that inherits from Content and ContentCollection.

**How to update:**  If you created derive content collections that altered the constraints to forbid `*`  you have to adjust the constraints and now forbid `Neos.Neos:Content` instead of `*`:

```
'Vendor.Site:ContentCollection':
  superTypes:
    'Neos.Neos:ContentCollection': true
  constraints:
    nodeTypes:
      // remove constraints like:
      // '*': false
      // and add the following instead
      'Neos.Neos:Content': false
      // everything else stays the same
      'Vendor.Site:Content': true
```

Resolves: #3119