### PR TITLE
BUGFIX: Add missing translation in pagination

### DIFF
--- a/Neos.ContentRepository/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
+++ b/Neos.ContentRepository/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
@@ -19,7 +19,7 @@
 								<f:widget.link action="index" arguments="{currentPage: pagination.previousPage}">{f:translate(id: 'previous')}</f:widget.link>
 							</f:then>
 							<f:else>
-								<f:widget.link action="index">previous</f:widget.link>
+								<f:widget.link action="index">{f:translate(id: 'previous')}</f:widget.link>
 							</f:else>
 						</f:if>
 					</li>


### PR DESCRIPTION
The labels were only partially translated in https://github.com/neos/neos-development-collection/commit/8d1c98a9999fac1830b78f17c08f87c0f67a6065#diff-86d35dae35fd27aa00b7d0723d538960
