### PR TITLE
FEATURE: `DataStructure` assumes nesting for subkeys without specified type

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -36,18 +36,12 @@ class DataStructureImplementation extends AbstractArrayFusionObject
 
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
+            $propertyPath = $key;
+            if (!$this->runtime->canRender($this->path . '/' . $propertyPath)) {
+                $propertyPath .= '<Neos.Fusion:DataStructure>';
+            }
             try {
-                if (is_array($this->properties[$key])
-                    && !array_key_exists('__objectType', $this->properties[$key])
-                    && !array_key_exists('__eelExpression', $this->properties[$key])
-                    && !array_key_exists('__value', $this->properties[$key])
-                    && !array_key_exists('__stopInheritanceChain', $this->properties[$key])
-                ) {
-                    $fullPath = $this->path . '/' . $key;
-                    $value = $this->runtime->evaluate($fullPath . '<Neos.Fusion:DataStructure>', $this);
-                } else {
-                    $value = $this->fusionValue($key);
-                }
+                $value = $this->fusionValue($propertyPath);
             } catch (\Exception $e) {
                 $value = $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
             }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Runtime;
 use Neos\Utility\Exception\InvalidPositionException;
 use Neos\Utility\PositionalArraySorter;
@@ -37,7 +38,7 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
             $propertyPath = $key;
-            if (!$this->runtime->canRender($this->path . '/' . $propertyPath)) {
+            if ($this->isUntypedProperty($this->properties[$key])) {
                 $propertyPath .= '<Neos.Fusion:DataStructure>';
             }
             try {
@@ -82,5 +83,19 @@ class DataStructureImplementation extends AbstractArrayFusionObject
             }
         }
         return $sortedFusionKeys;
+    }
+
+    /**
+     * Returns TRUE if the given property has no object type assigned
+     *
+     * @param mixed $property
+     * @return bool
+     */
+    private function isUntypedProperty($property): bool
+    {
+        if (!is_array($property)) {
+            return false;
+        }
+        return array_intersect_key(array_flip(Parser::$reservedParseTreeKeys), $property) === [];
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -37,7 +37,17 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
             try {
-                $value = $this->fusionValue($key);
+                if (is_array($this->properties[$key])
+                    && !array_key_exists('__objectType', $this->properties[$key])
+                    && !array_key_exists('__eelExpression', $this->properties[$key])
+                    && !array_key_exists('__value', $this->properties[$key])
+                    && !array_key_exists('__stopInheritanceChain', $this->properties[$key])
+                ) {
+                    $fullPath = $this->path . '/' . $key;
+                    $value = $this->runtime->evaluate($fullPath . '<Neos.Fusion:DataStructure>', $this);
+                } else {
+                    $value = $this->fusionValue($key);
+                }
             } catch (\Exception $e) {
                 $value = $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
             }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -70,4 +70,14 @@ class DataStructureTest extends AbstractFusionObjectTest
         $view->setFusionPath('dataStructure/ignoreProperties');
         self::assertEquals(['c' => 'Xbefore', 'a' => 'Xafter'], $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function nestedKeysWithoutObjectTypesRenderAsDataStructure(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/nestingWithAndWithoutObjectName');
+        self::assertEquals(['keyWithoutType' => ['bar' => ['baz' => 123 ]], 'keyWithType' => 456, 'keyWithValue' => 789], $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -11,6 +11,8 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Exception\MissingFusionImplementationException;
+
 /**
  * Testcase for the Fusion Dictionary
  */
@@ -79,5 +81,18 @@ class DataStructureTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->setFusionPath('dataStructure/nestingWithAndWithoutObjectName');
         self::assertEquals(['keyWithoutType' => ['bar' => ['baz' => 123 ]], 'keyWithType' => 456, 'keyWithValue' => 789], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function nestingWithNonExistingChildObjectThrowsException(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/nestingWithNonExistingChildObject');
+
+        $this->expectException(MissingFusionImplementationException::class);
+
+        $view->render();
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -86,3 +86,15 @@ dataStructure.advancedStartEndOrdering = Neos.Fusion:DataStructure {
 dataStructure.ignoreProperties < dataStructure.positionalOrdering {
 	@ignoreProperties = ${['f']}
 }
+
+dataStructure.nestingWithAndWithoutObjectName = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    bar {
+      baz = 123
+    }
+  }
+  keyWithType = Neos.Fusion:Value {
+    value = 456
+  }
+  keyWithValue = 789
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -98,3 +98,12 @@ dataStructure.nestingWithAndWithoutObjectName = Neos.Fusion:DataStructure {
   }
   keyWithValue = 789
 }
+
+dataStructure.nestingWithNonExistingChildObject = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    bar {
+      baz = 123
+    }
+  }
+  errorProperty = Some.NonExisting:Prototype
+}

--- a/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
@@ -26,7 +26,6 @@ class ArrayImplementationTest extends UnitTestCase
     public function evaluateWithEmptyArrayRendersNull()
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->method('canRender')->willReturn(true);
         $path = 'array/test';
         $fusionObjectName = 'Neos.Fusion:Array';
         $renderer = new ArrayImplementation($mockRuntime, $path, $fusionObjectName);
@@ -119,7 +118,6 @@ class ArrayImplementationTest extends UnitTestCase
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->method('canRender')->willReturn(true);
 
         $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;

--- a/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
@@ -26,6 +26,7 @@ class ArrayImplementationTest extends UnitTestCase
     public function evaluateWithEmptyArrayRendersNull()
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime->method('canRender')->willReturn(true);
         $path = 'array/test';
         $fusionObjectName = 'Neos.Fusion:Array';
         $renderer = new ArrayImplementation($mockRuntime, $path, $fusionObjectName);
@@ -118,6 +119,7 @@ class ArrayImplementationTest extends UnitTestCase
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime->method('canRender')->willReturn(true);
 
         $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;

--- a/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/ArrayImplementationTest.php
@@ -41,12 +41,12 @@ class ArrayImplementationTest extends UnitTestCase
         return [
             [
                 'Position end should put element to end',
-                ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
                 ['/first', '/second']
             ],
             [
                 'Position start should put element to start',
-                ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
+                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'start']]],
                 ['/first', '/second']
             ],
             [
@@ -66,42 +66,42 @@ class ArrayImplementationTest extends UnitTestCase
             ],
             [
                 'Position before adds before named element if present',
-                ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'before second']]],
                 ['/first', '/second']
             ],
             [
                 'Position before adds after start if named element not present',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position before works recursively',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after adds after named element if present',
-                ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
                 ['/first', '/second']
             ],
             [
                 'Position after adds before end if named element not present',
-                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
-                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
+                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after works recursively',
-                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ]
         ];

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -118,6 +118,7 @@ class DataStructureImplementationTest extends UnitTestCase
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime->method('canRender')->willReturn(true);
 
         $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -118,7 +118,6 @@ class DataStructureImplementationTest extends UnitTestCase
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->method('canRender')->willReturn(true);
 
         $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -41,12 +41,12 @@ class DataStructureImplementationTest extends UnitTestCase
         return [
             [
                 'Position end should put element to end',
-                ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
                 ['/first', '/second']
             ],
             [
                 'Position start should put element to start',
-                ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
+                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'start']]],
                 ['/first', '/second']
             ],
             [
@@ -66,42 +66,42 @@ class DataStructureImplementationTest extends UnitTestCase
             ],
             [
                 'Position before adds before named element if present',
-                ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'before second']]],
                 ['/first', '/second']
             ],
             [
                 'Position before adds after start if named element not present',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position before works recursively',
-                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after adds after named element if present',
-                ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
                 ['/first', '/second']
             ],
             [
                 'Position after adds before end if named element not present',
-                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
-                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
+                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after works recursively',
-                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
                 ['/first', '/second', '/third']
             ]
         ];


### PR DESCRIPTION
When a `DataStructure` is rendered for nested keys that have no specified type the fusion  type `DataStructure` is assumed. This makes it much easier to describe larger data structure in fusion for instance to create json ld structures or define complex mappings.
