### PR TITLE
BUGFIX: createNew doesn't set title of new node

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.yaml
@@ -301,6 +301,9 @@
   options:
     fusion:
       prototypeGenerator: Neos\Neos\Domain\Service\DefaultContentPrototypeGenerator
+    nodeCreationHandlers:
+      contentTitle:
+        nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\ContentTitleNodeCreationHandler'
   ui:
     label: i18n
     icon: 'icon-square-o'


### PR DESCRIPTION
The title set in references editor in Neos.UI wasn't used for creating the new content node.

It adds a nodeCreationHandler to Content Node Type to allow setting title in createNew dialog.
This is needed by a change to the Neos.UI (see: https://github.com/neos/neos-ui/pull/2562)