### PR TITLE
BUGFIX: MariaDB 10.4 compatibility for events migration

### DIFF
--- a/Neos.Neos/Migrations/Mysql/Version20150224171107.php
+++ b/Neos.Neos/Migrations/Mysql/Version20150224171107.php
@@ -22,7 +22,14 @@ class Version20150224171107 extends AbstractMigration
         $this->addSql("UPDATE typo3_neos_eventlog_domain_model_event e, (SELECT DISTINCT uid, persistence_object_identifier FROM typo3_neos_eventlog_domain_model_event) p SET e.parentevent = p.uid WHERE parentevent IS NOT NULL AND p.persistence_object_identifier = e.parentevent");
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP persistence_object_identifier, CHANGE parentevent parentevent INT UNSIGNED DEFAULT NULL, CHANGE uid uid INT UNSIGNED AUTO_INCREMENT NOT NULL");
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ADD CONSTRAINT FK_30AB3A75B684C08 FOREIGN KEY (parentevent) REFERENCES typo3_neos_eventlog_domain_model_event (uid)");
+        $indexes = $this->sm->listTableIndexes('typo3_neos_eventlog_domain_model_event');
+        if (array_key_exists('uid', $indexes)) {
+            $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP INDEX uid, ADD INDEX olduid (uid)");
+        }
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ADD PRIMARY KEY (uid)");
+        if (array_key_exists('uid', $indexes)) {
+            $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP INDEX olduid");
+        }
     }
 
     /**

--- a/Neos.Neos/Migrations/Mysql/Version20150309215317.php
+++ b/Neos.Neos/Migrations/Mysql/Version20150309215317.php
@@ -36,7 +36,10 @@ class Version20150309215317 extends AbstractMigration
             $this->addSql("CREATE UNIQUE INDEX UNIQ_FC846DAAE931A6F5 ON typo3_neos_domain_model_user (preferences)");
             $this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
         }
-        $this->addSql("DROP INDEX uid ON typo3_neos_eventlog_domain_model_event");
+        $indexes = $this->sm->listTableIndexes('typo3_neos_eventlog_domain_model_event');
+        if (array_key_exists('uid', $indexes)) {
+            $this->addSql("DROP INDEX uid ON typo3_neos_eventlog_domain_model_event");
+        }
     }
 
     /**


### PR DESCRIPTION
See https://jira.mariadb.org/browse/MDEV-19598

This will first rename the existing index before adding
a new primary key as MariaDB 10.4 would complain about
the existing unique key „uid“ and not allow adding
the primary key with the same name.

As the behavior for MariaDB 10.2 and 10.4 is different
we also need to check for the existence of the indices
before changing them or it will cause trouble with 10.2.

Replaces: #2665 
Resolves neos/flow-development-collection#1704