### PR TITLE
TASK: Fusion performance optimization (lazy Component props)

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -970,11 +970,11 @@ class Runtime
                                 'value' => $value
                             ];
                         }
-                    } else if ($singleApplyValues instanceof LazyProps) {
+                    } elseif ($singleApplyValues instanceof LazyProps) {
                         for ($singleApplyValues->rewind(); ($key = $singleApplyValues->key()) !== null; $singleApplyValues->next()) {
                             $combinedApplyValues[$fusionPath . '/' . $key] = [
                                 'key' => $key,
-                                'value' => function() use ($singleApplyValues, $key) {
+                                'value' => function () use ($singleApplyValues, $key) {
                                     return $singleApplyValues[$key];
                                 },
                                 'lazy' => true

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -841,11 +841,11 @@ class Runtime
                         '__value' => null
                     ];
                 } else {
-                $valueAst = [
-                    '__eelExpression' => null,
-                    '__objectType' => null,
-                    '__value' => $property['value']
-                ];
+                    $valueAst = [
+                        '__eelExpression' => null,
+                        '__objectType' => null,
+                        '__value' => $property['value']
+                    ];
                 }
 
                 // merge existing meta-configuration to valueAst

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -87,18 +87,11 @@ class Runtime
     protected $currentContext = null;
 
     /**
-     * Stack of evaluated "@apply" values
-     *
-     * @var array
-     */
-    protected $applyValueStack = [];
-
-    /**
      * Reference to the current apply value
      *
      * @var array
      */
-    protected $currentApplyValue = null;
+    protected $currentApplyValues = [];
 
     /**
      * Default context with helper definitions
@@ -264,24 +257,11 @@ class Runtime
         return $this->currentContext;
     }
 
-    /**
-     * @param null|array $values
-     * @return void
-     */
-    public function pushApplyValues(?array $values)
+    public function popApplyValues(array $paths): void
     {
-        $this->applyValueStack[] = $values;
-        $this->currentApplyValue = $values;
-    }
-
-    /**
-     * @return null|array the topmost "@apply" values as associative array
-     */
-    public function popApplyValues()
-    {
-        $lastItem = array_pop($this->applyValueStack);
-        $this->currentApplyValue = end($this->applyValueStack);
-        return $lastItem;
+        foreach ($paths as $path) {
+            unset($this->currentApplyValues[$path]);
+        }
     }
 
     /**
@@ -422,12 +402,12 @@ class Runtime
 
         // Check if the current "@apply" contain an entry for the requested fusionPath
         // in which case this value is returned after applying @if and @process rules
-        if (isset($this->currentApplyValue[$fusionPath])) {
+        if (isset($this->currentApplyValues[$fusionPath])) {
             if (isset($fusionConfiguration['__meta']['if']) && $this->evaluateIfCondition($fusionConfiguration, $fusionPath, $contextObject) === false) {
                 return null;
             }
-            $appliedValue = $this->currentApplyValue[$fusionPath]['value'];
-            if (isset($this->currentApplyValue[$fusionPath]['lazy'])) {
+            $appliedValue = $this->currentApplyValues[$fusionPath]['value'];
+            if (isset($this->currentApplyValues[$fusionPath]['lazy'])) {
                 $appliedValue = $appliedValue();
             }
             if (isset($fusionConfiguration['__meta']['process'])) {
@@ -460,26 +440,27 @@ class Runtime
             return null;
         }
 
+        $applyPathsToPop = [];
         try {
-            $needToPopApply = $this->prepareApplyValuesForFusionPath($fusionPath, $fusionConfiguration);
+            $applyPathsToPop = $this->prepareApplyValuesForFusionPath($fusionPath, $fusionConfiguration);
             $fusionObject = $this->instantiatefusionObject($fusionPath, $fusionConfiguration);
             $needToPopContext = $this->prepareContextForFusionObject($fusionObject, $fusionPath, $fusionConfiguration, $cacheContext);
             $output = $this->evaluateObjectOrRetrieveFromCache($fusionObject, $fusionPath, $fusionConfiguration, $cacheContext);
         } catch (StopActionException $stopActionException) {
-            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $needToPopApply);
+            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $applyPathsToPop);
             throw $stopActionException;
         } catch (SecurityException $securityException) {
-            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $needToPopApply);
+            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $applyPathsToPop);
             throw $securityException;
         } catch (RuntimeException $runtimeException) {
-            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $needToPopApply);
+            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $applyPathsToPop);
             throw $runtimeException;
         } catch (\Exception $exception) {
-            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $needToPopApply);
+            $this->finalizePathEvaluation($cacheContext, $needToPopContext, $applyPathsToPop);
             return $this->handleRenderingException($fusionPath, $exception, true);
         }
 
-        $this->finalizePathEvaluation($cacheContext, $needToPopContext, $needToPopApply);
+        $this->finalizePathEvaluation($cacheContext, $needToPopContext, $applyPathsToPop);
         return $output;
     }
 
@@ -560,17 +541,23 @@ class Runtime
      *
      * @param string $fusionPath
      * @param array $fusionConfiguration
-     * @return boolean
+     * @return array Paths to pop
      * @throws Exception
      * @throws RuntimeException
      * @throws SecurityException
      * @throws StopActionException
      */
-    protected function prepareApplyValuesForFusionPath($fusionPath, $fusionConfiguration)
+    protected function prepareApplyValuesForFusionPath($fusionPath, $fusionConfiguration): array
     {
         $spreadValues = $this->evaluateApplyValues($fusionConfiguration, $fusionPath);
-        $this->pushApplyValues($spreadValues);
-        return true;
+        if ($spreadValues === null) {
+            return [];
+        }
+
+        foreach ($spreadValues as $path => $entry) {
+            $this->currentApplyValues[$path] = $entry;
+        }
+        return array_keys($spreadValues);
     }
 
     /**
@@ -618,17 +605,17 @@ class Runtime
      *
      * @param array $cacheContext
      * @param boolean $needToPopContext
-     * @param boolean $needToPopApplyValues
+     * @param array $applyPathsToPop
      * @return void
      */
-    protected function finalizePathEvaluation($cacheContext, $needToPopContext = false, $needToPopApplyValues = false)
+    protected function finalizePathEvaluation($cacheContext, $needToPopContext = false, array $applyPathsToPop = [])
     {
         if ($needToPopContext) {
             $this->popContext();
         }
 
-        if ($needToPopApplyValues) {
-            $this->popApplyValues();
+        if ($applyPathsToPop !== []) {
+            $this->popApplyValues($applyPathsToPop);
         }
 
         $this->runtimeContentCache->leave($cacheContext);
@@ -829,8 +816,8 @@ class Runtime
             ObjectAccess::setProperty($fusionObject, $key, $value);
         }
 
-        if (is_array($this->currentApplyValue)) {
-            foreach ($this->currentApplyValue as $path => $property) {
+        if (is_array($this->currentApplyValues)) {
+            foreach ($this->currentApplyValues as $path => $property) {
                 $key = $property['key'];
                 if (isset($property['lazy'])) {
                     $valueAst = [

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -16,7 +16,6 @@ use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Fusion\FusionObjects\Helpers\LazyProps;
 use Neos\Utility\Arrays;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\PositionalArraySorter;
@@ -957,7 +956,9 @@ class Runtime
                 }
                 $singleApplyValues = $this->evaluateInternal($singleApplyPath, self::BEHAVIOR_EXCEPTION);
                 if ($this->getLastEvaluationStatus() !== static::EVALUATION_SKIPPED) {
-                    if (is_array($singleApplyValues)) {
+                    if ($singleApplyValues === null) {
+                        continue;
+                    } elseif (is_array($singleApplyValues)) {
                         foreach ($singleApplyValues as $key => $value) {
                             // skip keys which start with __, as they are purely internal.
                             if ($key[0] === '_' && $key[1] === '_' && in_array($key, Parser::$reservedParseTreeKeys,
@@ -970,7 +971,7 @@ class Runtime
                                 'value' => $value
                             ];
                         }
-                    } elseif ($singleApplyValues instanceof LazyProps) {
+                    } elseif ($singleApplyValues instanceof \Traversable && $singleApplyValues instanceof \ArrayAccess) {
                         for ($singleApplyValues->rewind(); ($key = $singleApplyValues->key()) !== null; $singleApplyValues->next()) {
                             $combinedApplyValues[$fusionPath . '/' . $key] = [
                                 'key' => $key,

--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\FusionObjects\Helpers\LazyProps;
 
 /**
  * A Fusion Component-Object
@@ -51,37 +52,32 @@ class ComponentImplementation extends ArrayImplementation
      * @param array $context
      * @return array
      */
-    protected function prepare($context)
+    protected function prepare(array $context): array
     {
-        $context['props'] = $this->getProps();
+        $context['props'] = $this->getProps($context);
         return $context;
     }
 
     /**
      * Calculate the component props
      *
-     * @return array
+     * @param array $context
+     * @return \ArrayAccess
      */
-    protected function getProps()
+    protected function getProps(array $context): \ArrayAccess
     {
         $sortedChildFusionKeys = $this->sortNestedFusionKeys();
-        $props = [];
-        foreach ($sortedChildFusionKeys as $key) {
-            try {
-                $props[$key] = $this->fusionValue($key);
-            } catch (\Exception $e) {
-                $props[$key] = $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
-            }
-        }
+        $props = new LazyProps($this, $this->path, $this->runtime, $sortedChildFusionKeys, $context);
         return $props;
     }
+
     /**
      * Evaluate the renderer with the give context and return
      *
-     * @param $context
+     * @param array $context
      * @return mixed
      */
-    protected function render($context)
+    protected function render(array $context)
     {
         $this->runtime->pushContextArray($context);
         $result = $this->runtime->render($this->path . '/renderer');

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -8,7 +8,7 @@ use Neos\Fusion\Core\Runtime;
 /**
  * @Flow\Proxy(false)
  */
-final class LazyProps implements \ArrayAccess
+final class LazyProps implements \ArrayAccess, \Iterator
 {
 
     /**
@@ -67,7 +67,8 @@ final class LazyProps implements \ArrayAccess
         if (!isset($this->valueCache[$path])) {
             $this->runtime->pushContextArray($this->effectiveContext);
             try {
-                $this->valueCache[$path] = $this->runtime->evaluate($this->parentPath . '/' . $path, $this->fusionObject);
+                $this->valueCache[$path] = $this->runtime->evaluate($this->parentPath . '/' . $path,
+                    $this->fusionObject);
             } finally {
                 $this->runtime->popContext();
             }
@@ -83,5 +84,34 @@ final class LazyProps implements \ArrayAccess
     public function offsetUnset($path)
     {
         // NOOP
+    }
+
+    public function current()
+    {
+        $path = key($this->keys);
+        if ($path === null) {
+            return null;
+        }
+        return $this->offsetGet($path);
+    }
+
+    public function next()
+    {
+        next($this->keys);
+    }
+
+    public function key()
+    {
+        return key($this->keys);
+    }
+
+    public function valid()
+    {
+        return current($this->keys) !== false;
+    }
+
+    public function rewind()
+    {
+        reset($this->keys);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Neos\Fusion\FusionObjects\Helpers;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Core\Runtime;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class LazyProps implements \ArrayAccess
+{
+
+    /**
+     * @var array
+     */
+    private $valueCache = [];
+
+    /**
+     * @var string
+     */
+    private $parentPath;
+
+    /**
+     * @var Runtime
+     */
+    private $runtime;
+
+    /**
+     * Index of keys
+     *
+     * @var array
+     */
+    private $keys;
+
+    /**
+     * @var object
+     */
+    private $fusionObject;
+
+    /**
+     * @var array
+     */
+    private $effectiveContext;
+
+    public function __construct(
+        object $fusionObject,
+        string $parentPath,
+        Runtime $runtime,
+        array $keys,
+        array $effectiveContext
+    ) {
+        $this->fusionObject = $fusionObject;
+        $this->parentPath = $parentPath;
+        $this->runtime = $runtime;
+        $this->keys = array_flip($keys);
+        $this->effectiveContext = $effectiveContext;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->keys[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->fusionValue($offset);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        // NOOP
+    }
+
+    public function offsetUnset($offset)
+    {
+        // NOOP
+    }
+
+    protected function fusionValue(string $path)
+    {
+        if (!isset($this->valueCache[$path])) {
+            $this->runtime->pushContextArray($this->effectiveContext);
+            try {
+                $this->valueCache[$path] = $this->runtime->evaluate($this->parentPath . '/' . $path, $this->fusionObject);
+            } finally {
+                $this->runtime->popContext();
+            }
+        }
+        return $this->valueCache[$path];
+    }
+}

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -57,27 +57,12 @@ final class LazyProps implements \ArrayAccess
         $this->effectiveContext = $effectiveContext;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($path)
     {
-        return isset($this->keys[$offset]);
+        return isset($this->keys[$path]);
     }
 
-    public function offsetGet($offset)
-    {
-        return $this->fusionValue($offset);
-    }
-
-    public function offsetSet($offset, $value)
-    {
-        // NOOP
-    }
-
-    public function offsetUnset($offset)
-    {
-        // NOOP
-    }
-
-    protected function fusionValue(string $path)
+    public function offsetGet($path)
     {
         if (!isset($this->valueCache[$path])) {
             $this->runtime->pushContextArray($this->effectiveContext);
@@ -88,5 +73,15 @@ final class LazyProps implements \ArrayAccess
             }
         }
         return $this->valueCache[$path];
+    }
+
+    public function offsetSet($path, $value)
+    {
+        // NOOP
+    }
+
+    public function offsetUnset($path)
+    {
+        // NOOP
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -8,7 +8,7 @@ use Neos\Fusion\Core\Runtime;
 /**
  * @Flow\Proxy(false)
  */
-final class LazyProps implements \ArrayAccess, \Iterator
+final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
 {
 
     /**
@@ -112,5 +112,10 @@ final class LazyProps implements \ArrayAccess, \Iterator
     public function rewind()
     {
         reset($this->keys);
+    }
+
+    public function jsonSerialize()
+    {
+        return iterator_to_array($this);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -59,16 +59,15 @@ final class LazyProps implements \ArrayAccess, \Iterator
 
     public function offsetExists($path)
     {
-        return isset($this->keys[$path]);
+        return array_key_exists($path, $this->keys);
     }
 
     public function offsetGet($path)
     {
-        if (!isset($this->valueCache[$path])) {
+        if (!array_key_exists($path, $this->valueCache)) {
             $this->runtime->pushContextArray($this->effectiveContext);
             try {
-                $this->valueCache[$path] = $this->runtime->evaluate($this->parentPath . '/' . $path,
-                    $this->fusionObject);
+                $this->valueCache[$path] = $this->runtime->evaluate($this->parentPath . '/' . $path, $this->fusionObject);
             } finally {
                 $this->runtime->popContext();
             }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -280,6 +280,6 @@ class ApplyTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('apply/renderWithNestedProps');
-        self::assertEquals('example', $view->render());
+        self::assertEquals('::example::', $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -272,4 +272,14 @@ class ApplyTest extends AbstractFusionObjectTest
         self::assertEquals('startmiddleModifiedendModified', $view->render()
         );
     }
+
+    /**
+     * @test
+     */
+    public function rendererWithNestedPropsInApply()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/renderWithNestedProps');
+        self::assertEquals('example', $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
@@ -56,4 +56,14 @@ class ComponentTest extends AbstractFusionObjectTest
         $view->setFusionPath('component/sandboxRenderer');
         self::assertEquals('Hello ', $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function componentLazyRenderer()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('component/lazyRenderer');
+        self::assertEquals('Hello', $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
@@ -141,3 +141,14 @@ apply.renderArrayWithPositionAndSpread = Neos.Fusion:Array {
   first.@position = 'start'
   @apply.applyValues = ${{last: 'endModified', middle: 'middleModified'}}
 }
+
+apply.renderWithNestedProps = Neos.Fusion:Component {
+  applyValue = "example"
+  applyError = Neos.Fusion:NotImplemented
+
+  renderer = Neos.Fusion:Component {
+    @apply.fromProps = ${props}
+
+    renderer = ${props.applyValue}
+  }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
@@ -146,9 +146,26 @@ apply.renderWithNestedProps = Neos.Fusion:Component {
   applyValue = "example"
   applyError = Neos.Fusion:NotImplemented
 
-  renderer = Neos.Fusion:Component {
-    @apply.fromProps = ${props}
+  renderer = Neos.Fusion:TestNestedPropsA {
+    applyValue = ${props.applyValue}
+    applyError = ${props.applyError}
+  }
+}
 
-    renderer = ${props.applyValue}
+prototype(Neos.Fusion:TestNestedPropsA) < prototype(Neos.Fusion:Component) {
+  applyValue = null
+
+  renderer = Neos.Fusion:TestNestedPropsB {
+    @apply.fromProps = ${props}
+  }
+}
+
+prototype(Neos.Fusion:TestNestedPropsB) < prototype(Neos.Fusion:Component) {
+  applyValue = null
+
+  renderer = Neos.Fusion:Array {
+    item_0 = '::'
+    item_1 = ${props.applyValue}
+    item_2 = '::'
   }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Component.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Component.fusion
@@ -40,3 +40,11 @@ component.sandboxRenderer = Neos.Fusion:Component {
     }
   }
 }
+
+component.lazyRenderer = Neos.Fusion:Component {
+  a = 'Hello'
+  // This prop is not evaluated, since it is not used - otherwise the test would fail
+  b = Neos.Fusion:NotImplemented
+
+  renderer = ${props.a}
+}

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Neos\Fusion\Tests\Unit\FusionObjects\Helpers;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Fusion\Core\Runtime;
+
+class LazyPropsTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function jsonEncodeSerializesAllProps()
+    {
+        /** @var Runtime $mockRuntime */
+        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+        $mockRuntime->expects($this->any())->method('evaluate')->withAnyParameters()->willReturnCallback(function($path) {
+           return $path;
+        });
+
+        $fusionObject = new \Neos\Fusion\FusionObjects\ValueImplementation($mockRuntime, 'test/path', 'Value');
+        $lazyProps = new \Neos\Fusion\FusionObjects\Helpers\LazyProps($fusionObject, 'test/path', $mockRuntime, ['foo', 'bar'], ['value' => 42]);
+
+        $serializedProps = json_encode($lazyProps);
+        $this->assertEquals('{"foo":"test\/path\/foo","bar":"test\/path\/bar"}', $serializedProps);
+    }
+}

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
@@ -23,7 +23,7 @@ class LazyPropsTest extends UnitTestCase
     {
         /** @var Runtime $mockRuntime */
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->expects($this->any())->method('evaluate')->withAnyParameters()->willReturnCallback(function($path) {
+        $mockRuntime->expects($this->any())->method('evaluate')->withAnyParameters()->willReturnCallback(function ($path) {
             return $path;
         });
 

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
@@ -24,7 +24,7 @@ class LazyPropsTest extends UnitTestCase
         /** @var Runtime $mockRuntime */
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $mockRuntime->expects($this->any())->method('evaluate')->withAnyParameters()->willReturnCallback(function($path) {
-           return $path;
+            return $path;
         });
 
         $fusionObject = new \Neos\Fusion\FusionObjects\ValueImplementation($mockRuntime, 'test/path', 'Value');


### PR DESCRIPTION
**What I did**

* Components provide a nice way to structure Fusion code but prevent lazy evaluation as Fusion does by default by eagerly evaluating all properties as `props`
* If conditions are used inside the `renderer`, it's quite probable that not all props are used - so a large amount of unnecessary evaluations could be performed (we measured that to be in the range of 20-30% in a larger project)

**How I did it**

* Introduced a `LazyProps` object implementing `ArrayAccess` that evaluates the actually accessed props lazily (and caches the results)

**How to verify it**

* Components work as before (there could be edge-cases where explicit `array` type annotations are used for `props`)
* props are only evaluated if used (verified by test)

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Resolves: #2793