### PR TITLE
BUGFIX: Add leave statements for apply early returns

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -436,8 +436,10 @@ class Runtime
         $currentProperties = $this->getCurrentApplyValues();
         if (is_array($currentProperties) && array_key_exists($fusionPath, $currentProperties)) {
             if ($this->evaluateIfCondition($fusionConfiguration, $fusionPath, $contextObject) === false) {
+                $this->finalizePathEvaluation($cacheContext);
                 return null;
             }
+            $this->finalizePathEvaluation($cacheContext);
             return $this->evaluateProcessors($currentProperties[$fusionPath]['value'], $fusionConfiguration, $fusionPath, $contextObject);
         }
 


### PR DESCRIPTION
Small bugfix to have an event count of `enter` and `leave` calls, even if apply values cause an early return.

This should be refactored anyway to a more efficient solution (see #2737) where no cache context is prepared unless an object is evaluated - but it doesn't hurt and helps the Flowpack.Fusion.Tracing package to produce correct traces.