### PR TITLE
BUGFIX: Add type="text" to title input field

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -10,7 +10,7 @@
                 <fieldset>
                     <legend>{neos:backend.translate(id: 'basics', package: 'Neos.Media.Browser')}</legend>
                     <label for="title">{neos:backend.translate(id: 'field.title', package: 'Neos.Media.Browser')}</label>
-                    <input id="title" readonly="readonly" value="{assetProxy.iptcProperties.Title}"/>
+                    <input type="text" id="title" readonly="readonly" value="{assetProxy.iptcProperties.Title}"/>
                     <label for="caption">{neos:backend.translate(id: 'field.caption', package: 'Neos.Media.Browser')}</label>
                     <textarea id="caption" rows="3" readonly="readonly">{assetProxy.iptcProperties.CaptionAbstract}</textarea>
                 </fieldset>


### PR DESCRIPTION
Even though the input field is read-only, the type should be given. At least
that makes sure the styling is correct.
