### PR TITLE
TASK : Remove composer requirement for the BaseMixins package itself

### DIFF
--- a/Neos.NodeTypes.BaseMixins/composer.json
+++ b/Neos.NodeTypes.BaseMixins/composer.json
@@ -4,8 +4,7 @@
     "description": "Base mixins which are useful across projects.",
     "license": ["GPL-3.0-or-later"],
     "require": {
-        "neos/neos": "*",
-        "neos/nodetypes-basemixins": "*"
+        "neos/neos": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The BaseMixin package lists itself as a dependency. This obviously doesn't make any sense (unless there is a very specific reason for this that I'm not aware of).
