### PR TITLE
BUGFIX: Change aloha.placeholder labels to new editorOptions

### DIFF
--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/af/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/af/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/af/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/af/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="af">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ar/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ar/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">تمكين التسمية التوضيحية</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>أدخل التسمية هنا</p>]]></target><alt-trans><target><![CDATA[<p>أدخل العنوان هنا</p>]]></target></alt-trans></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ar/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ar/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ar">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>أدخل النص هنا</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ca/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ca/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Introduir captura aquí</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ca/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ca/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ca">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Introduir text aquí</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/cs/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/cs/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/cs/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/cs/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="cs">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/da/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/da/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Aktivér billedtekst</target><alt-trans><target>Aktiver billedtekst</target></alt-trans></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Skriv billedtekst her</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/da/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/da/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="da">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Skriv tekst her</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/de/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/de/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Beschriftung anzeigen</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="final"><![CDATA[<p>Geben Sie hier eine Bildunterschrift ein</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/de/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/de/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="final"><![CDATA[<p>Text hier eingeben</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/el/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/el/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/el/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/el/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="el">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/en/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/en/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
 			<trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			</trans-unit>
-			<trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+			<trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			</trans-unit>
 		</body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/en/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/en/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 	<file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext">
 		<body>
-			<trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+			<trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			</trans-unit>
 		</body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/es/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/es/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Habilitar leyenda</target><alt-trans><target>Habilitar subtítulo</target></alt-trans><alt-trans><target>Habilitar pie de foto</target></alt-trans></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="final"><![CDATA[<p>Ingrese la leyenda aquí</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/es/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/es/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="es-ES">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="final"><![CDATA[<p>Ingrese texto aqui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fi/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fi/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Käytä kuvatekstiä</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fi/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fi/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="fi">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fr/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fr/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Activer la légende</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Entrer une légende ici</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fr/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/fr/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Entrer le texte ici</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/he/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/he/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/he/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/he/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="he">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hu/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hu/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Felirat engedélyezése</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Adja meg a feliratot</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hu/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hu/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="hu">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Adja meg a szöveget</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hy_AM/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hy_AM/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hy_AM/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/hy_AM/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="hy-AM">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/id_ID/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/id_ID/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Mengaktifkan keterangan</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Tulis keterangan di sini</p>]]></target><alt-trans><target><![CDATA[<p>Tuliskan keterangan di sini</p>]]></target></alt-trans><alt-trans><target><![CDATA[<p>Enter caption here</p>]]></target></alt-trans></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/id_ID/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/id_ID/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="id">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Tulis teks di sini</p>]]></target><alt-trans><target><![CDATA[<p>Enter text here</p>]]></target></alt-trans></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/it/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/it/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Abilita didascalia</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Inserisci la didascalia</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/it/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/it/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Inserire il testo qui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ja/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ja/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>ここにキャプションを入力してください</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ja/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ja/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>ここにテキストを入力してください</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/kk_KZ/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/kk_KZ/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/kk_KZ/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/kk_KZ/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="kk">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/km/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/km/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">អនុញ្ញាតឱ្យមានចំណងជើង</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/km/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/km/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="km">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ko/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ko/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ko/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ko/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/la/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/la/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target xml:lang="la-LA">crwdns6286:0crwdne6286:0</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target xml:lang="la-LA"><![CDATA[crwdns6287:0crwdne6287:0]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/la/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/la/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="la-LA">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target xml:lang="la-LA"><![CDATA[crwdns6293:0crwdne6293:0]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/lv/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/lv/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Ieslēgt parakstu</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Ievadiet šeit parakstu</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/lv/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/lv/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="lv">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Ievadiet šeit tekstu</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/mr/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/mr/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/mr/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/mr/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="mr">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/nl/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/nl/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Onderschrift inschakelen</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Voer hier je tekst in</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/nl/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/nl/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="nl">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Voer hier je tekst in</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/no/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/no/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Aktiver bildetekst</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/no/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/no/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="no">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pl/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pl/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Włącz etykietę</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="final"><![CDATA[<p>Wprowadź tutaj etykietę</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pl/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pl/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="pl">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="final"><![CDATA[<p>Wprowadź tekst tutaj</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ps/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ps/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ps/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ps/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ps">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Inserir a legenda aqui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="pt-PT">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Introduzir o texto aqui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt_BR/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt_BR/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Ativar a legenda</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Insira a legenda aqui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt_BR/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/pt_BR/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Insira o texto aqui</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ro/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ro/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ro/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ro/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ro">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ru/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ru/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve" approved="yes">
 				<source>Enable caption</source>
 			<target state="final">Включить подпись</target><alt-trans><target>Включить надпись</target></alt-trans></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="final"><![CDATA[<p>Введите подпись</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ru/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/ru/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve" approved="yes">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve" approved="yes">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="final"><![CDATA[<p>Введите текст здесь</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sr/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sr/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="needs-translation">Enable caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sr/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sr/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="sr">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sv/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sv/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Aktivera bildtext</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Skriv in rubrik här</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sv/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/sv/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="sv-SE">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Skriv in text här</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tl_PH/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tl_PH/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Paganahin ang caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p> Ipasok ang caption dito</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tl_PH/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tl_PH/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="tl">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>Ipasok ang teksto dito</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tr/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tr/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Başlığı etkinleştir</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>resim altyazısını buraya girin</p>]]></target><alt-trans><target><![CDATA[<p>Altyazıyı buraya yazın</p>]]></target></alt-trans></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tr/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/tr/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="tr">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>girilecek metni buraya yazın</p>]]></target><alt-trans><target><![CDATA[<p>Metni buraya Yazın</p>]]></target></alt-trans><alt-trans><target><![CDATA[<p>Metni Buraya Yazın</p>]]></target></alt-trans></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/uk/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/uk/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Включити заголовок</target><alt-trans><target>Включити підпис</target></alt-trans></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/uk/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/uk/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="uk">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/vi/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/vi/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">Bật tiêu đề</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/vi/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/vi/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="vi">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">开启标题</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>在此处输入标题</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="zh-CN">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>在此处输入文本</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh_TW/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh_TW/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target state="translated">使用圖片標題</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target state="translated"><![CDATA[<p>於此處輸入標題</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh_TW/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes.BaseMixins/Resources/Private/Translations/zh_TW/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes.BaseMixins" source-language="en" datatype="plaintext" target-language="zh-TW">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target state="translated"><![CDATA[<p>於此處輸入文字</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes/Resources/Private/Translations/tl_PH/NodeTypes/ImageCaptionMixin.xlf
+++ b/Neos.NodeTypes/Resources/Private/Translations/tl_PH/NodeTypes/ImageCaptionMixin.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="properties.hasCaption" xml:space="preserve">
 				<source>Enable caption</source>
 			<target xml:lang="tl" state="translated">Paganahin ang caption</target></trans-unit>
-      <trans-unit id="properties.caption.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.caption.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter caption here</p>]]></source>
 			<target xml:lang="tl" state="needs-translation"><![CDATA[<p>Enter caption here</p>]]></target></trans-unit>
     </body>

--- a/Neos.NodeTypes/Resources/Private/Translations/tl_PH/NodeTypes/TextMixin.xlf
+++ b/Neos.NodeTypes/Resources/Private/Translations/tl_PH/NodeTypes/TextMixin.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Neos.NodeTypes" source-language="en" datatype="plaintext" target-language="tl">
     <body>
-      <trans-unit id="properties.text.aloha.placeholder" xml:space="preserve">
+      <trans-unit id="properties.text.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source><![CDATA[<p>Enter text here</p>]]></source>
 			<target xml:lang="tl" state="needs-translation"><![CDATA[<p>Enter text here</p>]]></target></trans-unit>
     </body>


### PR DESCRIPTION
This changs the language label ids for the placeholders of the base mixins.
