### PR TITLE
BUGFIX: Change return types of some Fusion methods to mixed

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -297,7 +297,7 @@ class Runtime
      * Compared to $this->evaluate, this adds some more comments helpful for debugging.
      *
      * @param string $fusionPath
-     * @return string
+     * @return mixed
      * @throws \Exception
      * @throws SecurityException
      */

--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -130,7 +130,7 @@ class FusionView extends AbstractView
     /**
      * Render the view
      *
-     * @return string The rendered view
+     * @return mixed The rendered view
      * @api
      */
     public function render()
@@ -238,7 +238,7 @@ class FusionView extends AbstractView
 
     /**
      * Render the given Fusion and return the rendered page
-     * @return string
+     * @return mixed
      * @throws \Exception
      */
     protected function renderFusion()

--- a/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Neos.Fusion/Classes/ViewHelpers/RenderViewHelper.php
@@ -73,11 +73,11 @@ class RenderViewHelper extends AbstractViewHelper
      * @param string $path Relative Fusion path to be rendered
      * @param array $context Additional context variables to be set.
      * @param string $fusionPackageKey The key of the package to load Fusion from, if not from the current context.
-     * @return string
+     * @return mixed
      * @throws \Exception
      * @throws \Neos\Flow\Security\Exception
      */
-    public function render(): string
+    public function render()
     {
         $path = $this->arguments['path'];
         if (strpos($path, '/') === 0 || strpos($path, '.') === 0) {


### PR DESCRIPTION
https://github.com/neos/neos-development-collection/commit/ba8d1412f34820971fe6f9c0137fd23196df6612 introduced the return type `string` for Fusions RenderViewHelper, so we must always return a `string` (not `null`).