### PR TITLE
BUGFIX: Allow HtmlAugmenter operate on script tags

### DIFF
--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -71,7 +71,7 @@ class HtmlAugmenter
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
         $domDocument->loadHTML((substr($html, 0, 5) === '<?xml') ? $html : '<?xml encoding="UTF-8"?>' . $html);
         $xPath = new \DOMXPath($domDocument);
-        $rootElement = $xPath->query('//html/body|head/*');
+        $rootElement = $xPath->query('//html/body/*|//html/head/*');
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }

--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -71,7 +71,7 @@ class HtmlAugmenter
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
         $domDocument->loadHTML((substr($html, 0, 5) === '<?xml') ? $html : '<?xml encoding="UTF-8"?>' . $html);
         $xPath = new \DOMXPath($domDocument);
-        $rootElement = $xPath->query('//html/body/*');
+        $rootElement = $xPath->query('//html/body|head/*');
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -122,7 +122,13 @@ class HtmlAugmenterTest extends UnitTestCase
                 'exclusiveAttributes' => null,
                 'expectedResult' => '<fallback-tag class="some-class"><p class="some-class">Simple HTML without</p><p> unique root element</p></fallback-tag>',
             ),
-
+            array(
+                'html' => '<script>console.log("Script tag with unique root element");</script>',
+                'attributes' => array('type' => 'new-type'),
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'expectedResult' => '<script type="new-type">console.log("Script tag with unique root element");</script>',
+            ),
             // attribute handling
             array(
                 'html' => '<root class="some-class">merging attributes</root>',


### PR DESCRIPTION
**What I did**
Regarding #2763 the HtmlAugmenter does not find script tags as root elements. Ths DomDocument->loadHTML() puts them automatically into `html/head` instead of `html/body` as it does with other tags.

**How I did it**
Extend XPath query to search in head AND body for root elements.

**How to verify it**
For script-tag:
```
$html = '<script>console.log("fooo");</script>';
$domDocument = new \DOMDocument('1.0', 'UTF-8');
$domDocument->loadHTML((substr($html, 0, 5) === '<?xml') ? $html : '<?xml encoding="UTF-8"?>' . $html);
var_dump($domDocument->saveHTML());
``` 
it returns:
``` 
string(195) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<?xml encoding="UTF-8"?><html><head><script>console.log("fooo");</script></head></html>
"
```

For other tags:
```
$html = '<a>console.log("fooo");</a>';
$domDocument = new \DOMDocument('1.0', 'UTF-8');
$domDocument->loadHTML((substr($html, 0, 5) === '<?xml') ? $html : '<?xml encoding="UTF-8"?>' . $html);
var_dump($domDocument->saveHTML());
```
it returns:
```
string(185) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<?xml encoding="UTF-8"?><html><body><a>console.log("fooo");</a></body></html>
"
```