### PR TITLE
BUGFIX: Correct default value of arguments for redirects

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -482,7 +482,7 @@ class SitesController extends AbstractModuleController
      * @param string $format The format to use for the redirect URI
      * @return void
      */
-    protected function unsetLastVisitedNodeAndRedirect($actionName, $controllerName = null, $packageKey = null, array $arguments = null, $delay = 0, $statusCode = 303, $format = null)
+    protected function unsetLastVisitedNodeAndRedirect($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $delay = 0, $statusCode = 303, $format = null)
     {
         $this->session->putData('lastVisitedNode', null);
         parent::redirect($actionName, $controllerName, $packageKey, $arguments, $delay, $statusCode, $format);


### PR DESCRIPTION
On current master the site module could not create empty sites with an existing site package  any more because the redirect method was called with null as $arguments. 

The problem was introduced by this change in flow https://github.com/neos/flow-development-collection/pull/1820 that altered the default value of $arguments from null to [].