### PR TITLE
TASK: Update showInvisible check to be upwards compatible

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -80,7 +80,8 @@ class NodeController extends ActionController
     protected function initializeShowAction()
     {
         if ($this->arguments->hasArgument('node')
-            && (bool)$this->request->getHttpRequest()->getArgument('showInvisible')
+            && $this->request->hasArgument('showInvisible')
+            && (bool)$this->request->getArgument('showInvisible')
             && $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
         ) {
             $this->arguments->getArgument('node')->getPropertyMappingConfiguration()->setTypeConverterOption(NodeConverter::class, NodeConverter::INVISIBLE_CONTENT_SHOWN, true);


### PR DESCRIPTION
Uses `$this->request` instead of the http request, to stay upwards compatible with PSR-7 changes.

Related: #2711 