### PR TITLE
BUGFIX: Only count local assets within collections

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -247,12 +247,6 @@ class AssetController extends ActionController
      */
     public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null)
     {
-        $allCollectionsCount = 0;
-        // Calculating the asset-count of all collections before applying filters.
-        foreach ($this->assetSources as $assetSource) {
-            $allCollectionsCount += $assetSource->getAssetProxyRepository()->countAll();
-        }
-
         // First, apply all options given to indexAction() and save them in the BrowserState object.
         // Note that the order of these apply*() method calls plays a role, because they may depend on previous results:
         $this->applyActiveAssetSourceToBrowserState($assetSourceIdentifier);
@@ -274,6 +268,7 @@ class AssetController extends ActionController
         $tags = [];
         $assetProxies = [];
 
+        $allCollectionsCount = 0;
         $allCount = 0;
         $searchResultCount = 0;
         $untaggedCount = 0;
@@ -298,6 +293,7 @@ class AssetController extends ActionController
                 $assetProxies = $assetProxyRepository->findAll();
             }
 
+            $allCollectionsCount = $this->assetRepository->countAll();
             $allCount = ($activeAssetCollection ? $this->assetRepository->countByAssetCollection($activeAssetCollection) : $allCollectionsCount);
             $searchResultCount = isset($assetProxies) ? $assetProxies->count() : 0;
             $untaggedCount = ($assetProxyRepository instanceof SupportsTaggingInterface ? $assetProxyRepository->countUntagged() : 0);


### PR DESCRIPTION
Since collections only show up if the current asset source is local
("Neos"), we should not sum up all assets from external asset sources.

We do not support collections for external asset sources and the
possibly much larger number is irritating, because when clicking
the "All" link the user will only see the local assets.