### PR TITLE
BUGFIX: Use correct default value for redirect in Neos SitesController

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -482,7 +482,7 @@ class SitesController extends AbstractModuleController
      * @param string $format The format to use for the redirect URI
      * @return void
      */
-    protected function unsetLastVisitedNodeAndRedirect($actionName, $controllerName = null, $packageKey = null, array $arguments = null, $delay = 0, $statusCode = 303, $format = null)
+    protected function unsetLastVisitedNodeAndRedirect($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $delay = 0, $statusCode = 303, $format = null)
     {
         $this->session->putData('lastVisitedNode', null);
         parent::redirect($actionName, $controllerName, $packageKey, $arguments, $delay, $statusCode, $format);


### PR DESCRIPTION
https://github.com/neos/flow-development-collection/commit/0cd533a64b44961fbe9e4b43ccc3fcf8e8325ab6 changed the default value of the `$arguments` parameter from `null` to `[]`, so we must change it here too.

I found nowhere else where `AbstractController->redirect()` may be called with `$arguments = null`.