### PR TITLE
TASK: Preparation for fixing plugin redirects

### DIFF
--- a/Neos.Neos/Classes/Fusion/PluginImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginImplementation.php
@@ -182,9 +182,13 @@ class PluginImplementation extends AbstractArrayFusionObject
         $parentResponse = $this->runtime->getControllerContext()->getResponse();
         $pluginResponse = new ActionResponse();
 
-        $this->dispatcher->dispatch($this->buildPluginRequest(), $pluginResponse);
+        // We need to make sure to not merge content up into the parent ActionResponse because that would break the Fusion HttpResponse.
+        $content = $pluginResponse->getContent();
+        $pluginResponse->setContent('');
+
         $pluginResponse->mergeIntoParentResponse($parentResponse);
-        return $pluginResponse->getContent();
+
+        return $content;
     }
 
     /**

--- a/Neos.Neos/Classes/Fusion/PluginImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginImplementation.php
@@ -181,6 +181,7 @@ class PluginImplementation extends AbstractArrayFusionObject
         /** @var $parentResponse ActionResponse */
         $parentResponse = $this->runtime->getControllerContext()->getResponse();
         $pluginResponse = new ActionResponse();
+        $this->dispatcher->dispatch($this->buildPluginRequest(), $pluginResponse);
 
         // We need to make sure to not merge content up into the parent ActionResponse because that would break the Fusion HttpResponse.
         $content = $pluginResponse->getContent();


### PR DESCRIPTION
This prevents the plugin content to end up in the main ActionReponse,
which is a preparation for the fix to plugin redirects and needs to
happen first in order to stay backwards compatible.

This change alone should change absolutely nothing in no circumstance.
