### PR TITLE
BUGFIX: Set default ratio mode in ResizeImageAdjustment

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -76,7 +76,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @var string
      * @ORM\Column(nullable = true)
      */
-    protected $ratioMode;
+    protected $ratioMode = ImageInterface::RATIOMODE_INSET;
 
     /**
      * @var boolean
@@ -237,6 +237,12 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      */
     public function setRatioMode(string $ratioMode): void
     {
+        if ($ratioMode !== ImageInterface::RATIOMODE_INSET &&
+            $ratioMode !== ImageInterface::RATIOMODE_OUTBOUND
+        ) {
+            throw new \InvalidArgumentException('Invalid mode specified', 1574686876);
+        }
+
         $this->ratioMode = $ratioMode;
     }
 
@@ -294,8 +300,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      */
     public function applyToImage(ImagineImageInterface $image)
     {
-        $ratioMode = $this->ratioMode ?: ImageInterface::RATIOMODE_INSET;
-        return $this->resize($image, $ratioMode, $this->filter);
+        return $this->resize($image, $this->ratioMode, $this->filter);
     }
 
     /**
@@ -344,9 +349,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      */
     protected function calculateWithFixedDimensions(BoxInterface $originalDimensions, int $requestedWidth, int $requestedHeight): BoxInterface
     {
-        $ratioMode = $this->ratioMode ?: ImageInterface::RATIOMODE_INSET;
-
-        if ($ratioMode === ImageInterface::RATIOMODE_OUTBOUND) {
+        if ($this->ratioMode === ImageInterface::RATIOMODE_OUTBOUND) {
             return $this->calculateOutboundBox($originalDimensions, $requestedWidth, $requestedHeight);
         }
 
@@ -448,7 +451,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
         if ($mode !== ImageInterface::RATIOMODE_INSET &&
             $mode !== ImageInterface::RATIOMODE_OUTBOUND
         ) {
-            throw new \InvalidArgumentException('Invalid mode specified');
+            throw new \InvalidArgumentException('Invalid mode specified', 1574686891);
         }
 
         $imageSize = $image->getSize();

--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -237,10 +237,9 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      */
     public function setRatioMode(string $ratioMode): void
     {
-        if ($ratioMode !== ImageInterface::RATIOMODE_INSET &&
-            $ratioMode !== ImageInterface::RATIOMODE_OUTBOUND
-        ) {
-            throw new \InvalidArgumentException('Invalid mode specified', 1574686876);
+        $supportedModes = [ImageInterface::RATIOMODE_INSET, ImageInterface::RATIOMODE_OUTBOUND];
+        if (!in_array($ratioMode, $supportedModes, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid mode "%s" specified, supported modes are: "%" (but use the ImageInterface::RATIOMODE_* constants)', $ratioMode, implode('", "', $supportedModes)), 1574686876);
         }
 
         $this->ratioMode = $ratioMode;

--- a/Neos.Media/Migrations/Mysql/Version20191125132700.php
+++ b/Neos.Media/Migrations/Mysql/Version20191125132700.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Migrations\AbortMigrationException;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Set default for ratio mode for image adjustments
+ */
+class Version20191125132700 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Set default for ratio mode for image adjustments';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('UPDATE neos_media_domain_model_adjustment_abstractimageadjustment SET ratiomode=\'inset\' WHERE ratiomode IS NULL AND dtype=\'neos_media_adjustment_resizeimageadjustment\'');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment CHANGE ratiomode ratiomode VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment CHANGE ratiomode ratiomode VARCHAR(255) NULL');
+    }
+}

--- a/Neos.Media/Migrations/Mysql/Version20191125132700.php
+++ b/Neos.Media/Migrations/Mysql/Version20191125132700.php
@@ -31,8 +31,7 @@ class Version20191125132700 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
-        $this->addSql('UPDATE neos_media_domain_model_adjustment_abstractimageadjustment SET ratiomode=\'inset\' WHERE ratiomode IS NULL AND dtype=\'neos_media_adjustment_resizeimageadjustment\'');
-        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment CHANGE ratiomode ratiomode VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE neos_media_domain_model_adjustment_abstractimageadjustment SET ratiomode=\'inset\' WHERE (ratiomode IS NULL OR ratiomode=\'\') AND dtype=\'neos_media_adjustment_resizeimageadjustment\'');
     }
 
     /**
@@ -44,6 +43,5 @@ class Version20191125132700 extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
-        $this->addSql('ALTER TABLE neos_media_domain_model_adjustment_abstractimageadjustment CHANGE ratiomode ratiomode VARCHAR(255) NULL');
     }
 }

--- a/Neos.Media/Migrations/Postgresql/Version20191125132701.php
+++ b/Neos.Media/Migrations/Postgresql/Version20191125132701.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Migrations\AbortMigrationException;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Set default for ratio mode for image adjustments
+ */
+class Version20191125132701 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Set default for ratio mode for image adjustments';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
+        $this->addSql('UPDATE neos_media_domain_model_adjustment_abstractimageadjustment SET ratiomode=\'inset\' WHERE ratiomode IS NULL AND dtype=\'neos_media_adjustment_resizeimageadjustment\'');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws DBALException
+     * @throws AbortMigrationException
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
+    }
+}


### PR DESCRIPTION
The default was assigned during runtime, but this lead to `getRatioMode()`
potentially failing, since it was declared to return a string, non-nullable.

This is a followup to #2716

Fixes #2811
