### PR TITLE
FEATURE: Allow Node properties to appear in the Creation Dialog

### DIFF
--- a/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -63,6 +63,7 @@ additionalProperties:
 
               'type': { type: string, description: "PHP type of this property. Either simple type or fully qualified PHP class name." }
               'defaultValue': { type: any, description: "Default value of this property. Used at node creation time. Type must match specified 'type'." }
+              'position': { type: ['string', 'number', 'null'] }
 
               'validation':
                 type: ['dictionary', 'null']
@@ -70,7 +71,7 @@ additionalProperties:
               'ui':
                 type: dictionary
                 # we intentionally do not specify which properties are allowed here;
-                # as other packages (such as TYPO3.Neos) might do that instead.
+                # as other packages (such as Neos.Neos) might do that instead.
 
               'options':
                 type: dictionary

--- a/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
@@ -1,0 +1,102 @@
+<?php
+namespace Neos\Neos\NodeTypePostprocessor;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\Utility\Arrays;
+use Neos\Utility\PositionalArraySorter;
+
+/**
+ * Node Type post processor that looks for properties flagged with "showInCreationDialog" and sets the "creationDialog" configuration accordingly
+ *
+ * Example NodeTypes.yaml configuration:
+ *
+ * 'Some.Node:Type':
+ *   # ...
+ *   properties:
+ *     'someProperty':
+ *       type: string
+ *       ui:
+ *         label: 'Link'
+ *         showInCreationDialog: true
+ *         inspector:
+ *           editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
+ *
+ * Will be converted to:
+ *
+ * 'Some.Node:Type':
+ *   # ...
+ *   ui:
+ *     creationDialog:
+ *       elements:
+ *         'someProperty':
+ *           type: string
+ *           ui:
+ *             label: 'Link'
+ *             editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
+ *   properties:
+ *     'someProperty':
+ *       # ...
+ */
+class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
+{
+    /**
+     * @param NodeType $nodeType (uninitialized) The node type to process
+     * @param array $configuration input configuration
+     * @param array $options The processor options
+     * @return void
+     */
+    public function process(NodeType $nodeType, array &$configuration, array $options): void
+    {
+        if (!isset($configuration['properties'])) {
+            return;
+        }
+        $creationDialogElements = [];
+        foreach ($configuration['properties'] as $propertyName => $propertyConfiguration) {
+            if (!isset($propertyConfiguration['ui']['showInCreationDialog']) || $propertyConfiguration['ui']['showInCreationDialog'] !== true) {
+                continue;
+            }
+            $creationDialogElement = $this->convertPropertyConfiguration($nodeType->getConfiguration('properties.' . $propertyName) ?? []);
+            if (isset($configuration['ui']['creationDialog']['elements'][$propertyName])) {
+                $creationDialogElement = Arrays::arrayMergeRecursiveOverrule($creationDialogElement, $configuration['ui']['creationDialog']['elements'][$propertyName]);
+            }
+            $creationDialogElements[$propertyName] = $creationDialogElement;
+        }
+        $configuration['ui']['creationDialog']['elements'] = (new PositionalArraySorter($creationDialogElements))->toArray();
+    }
+
+    /**
+     * Converts a NodeType property configuration to the corresponding creationDialog "element" configuration
+     *
+     * @param array $propertyConfiguration
+     * @return array
+     */
+    private function convertPropertyConfiguration(array $propertyConfiguration): array
+    {
+        $convertedConfiguration = $propertyConfiguration;
+        unset($convertedConfiguration['ui']['inspector']);
+        $editor = $propertyConfiguration['ui']['inspector']['editor'] ?? null;
+        $editorOptions = $propertyConfiguration['ui']['inspector']['editorOptions'] ?? [];
+
+        // The following editors don't (completely) work in the Creation Dialog so they are disabled
+        // TODO should be adjusted if fixed. See https://github.com/neos/neos-ui/issues/1034
+        $unsupportedEditors = ['Neos.Neos/Inspector/Editors/ImageEditor', 'Neos.Neos/Inspector/Editors/AssetEditor', 'Neos.Neos/Inspector/Editors/RichTextEditor', 'Neos.Neos/Inspector/Editors/CodeEditor'];
+        if (\in_array($editor, $unsupportedEditors, true)) {
+            $convertedConfiguration['ui']['help']['message'] = sprintf('The "%s" editor is currently not supported in the Creation Dialog', $editor);
+            $editorOptions['disabled'] = true;
+        }
+        $convertedConfiguration['ui']['editor'] = $editor;
+        $convertedConfiguration['ui']['editorOptions'] = $editorOptions;
+        return $convertedConfiguration;
+    }
+}

--- a/Neos.Neos/Configuration/NodeTypes.Content.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Content.yaml
@@ -7,6 +7,13 @@
   constraints:
     nodeTypes:
       '*': false
+  postprocessors:
+    'CreationDialogPostprocessor':
+      postprocessor: 'Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor'
+  options:
+    nodeCreationHandlers:
+      creationDialogProperties:
+        nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\CreationDialogPropertiesCreationHandler'
   ui:
     label: i18n
     icon: 'icon-square-o'

--- a/Neos.Neos/Configuration/NodeTypes.Document.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Document.yaml
@@ -12,10 +12,15 @@
     nodeTypes:
       '*': false
       'Neos.Neos:Document': true
+  postprocessors:
+    'CreationDialogPostprocessor':
+      postprocessor: 'Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor'
   options:
     nodeCreationHandlers:
       documentTitle:
         nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\DocumentTitleNodeCreationHandler'
+      creationDialogProperties:
+        nodeCreationHandler: 'Neos\Neos\Ui\NodeCreationHandler\CreationDialogPropertiesCreationHandler'
   ui:
     label: 'Document'
     group: 'general'
@@ -27,15 +32,6 @@
           label: i18n
           position: 10
           icon: 'icon-file'
-    creationDialog:
-      elements:
-        title:
-          type: string
-          ui:
-            label: i18n
-            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
-          validation:
-            'Neos.Neos/Validation/NotEmptyValidator': []
   properties:
     _nodeType:
       ui:
@@ -47,6 +43,7 @@
       ui:
         label: i18n
         reloadPageIfChanged: true
+        showInCreationDialog: true
         inspector:
           group: 'document'
       validation:

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -361,6 +361,11 @@ The following options are allowed for defining a NodeType:
       ``editorListeners``
         Allows to observe changes of other properties in order to react to them. For details see :ref:`depending-properties`
 
+    ``showInCreationDialog``
+      If `true` the corresponding property will appear in the Node Creation Dialog. Editor configuration
+      will be copied from the respective ``ui.inspector`` settings in that case and can be overridden with
+      the ``creationDialog.elements.<propertyName>``, see :ref:`node-creation-dialog`
+
   ``validation``
     A list of validators to use on the property. Below each validator type any options for the validator
     can be given. See below for more information.

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -224,7 +224,7 @@ The following options are allowed for defining a NodeType:
       ``collapsed``
         If the group should be collapsed by default (true or false). If left empty, the group will be expanded.
   ``creationDialog``
-    Creation dialog elements configuration. See :ref:`node-creation-dialog` for more details.
+    Creation dialog elements configuration. See `Node Creation Dialog Configuration`_ for more details.
 ``properties``
   A list of named properties for this node type. For each property the following settings are available.
 
@@ -364,7 +364,7 @@ The following options are allowed for defining a NodeType:
     ``showInCreationDialog``
       If `true` the corresponding property will appear in the Node Creation Dialog. Editor configuration
       will be copied from the respective ``ui.inspector`` settings in that case and can be overridden with
-      the ``creationDialog.elements.<propertyName>``, see :ref:`node-creation-dialog`
+      the ``creationDialog.elements.<propertyName>``, see `Node Creation Dialog Configuration`_
 
   ``validation``
     A list of validators to use on the property. Below each validator type any options for the validator
@@ -439,3 +439,5 @@ Here is one of the standard Neos node types (slightly shortened)::
 	        inlineEditable: true
 
 
+
+.. _Node Creation Dialog Configuration: https://docs.neos.io/cms/manual/content-repository/node-creation-dialog

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -361,7 +361,7 @@ The following options are allowed for defining a NodeType:
       ``editorListeners``
         Allows to observe changes of other properties in order to react to them. For details see :ref:`depending-properties`
 
-    ``showInCreationDialog``
+    ``showInCreationDialog`` (since Neos 5.1)
       If `true` the corresponding property will appear in the Node Creation Dialog. Editor configuration
       will be copied from the respective ``ui.inspector`` settings in that case and can be overridden with
       the ``creationDialog.elements.<propertyName>``, see `Node Creation Dialog Configuration`_

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -39,8 +39,9 @@ additionalProperties:
 
                   'inlineEditable': { type: ['null', 'boolean'], description: "Is this property inline editable, i.e. edited directly on the page?" }
 
-                  'inline':
-                    type: ['null', 'dictionary']
+                  'inline': { type: ['null', 'dictionary'] }
+
+                  'showInCreationDialog': { type: ['null', 'boolean'], description: 'If this property should occur on the CreationDialog of the corresponding node. Inspector configuration is applied from "ui.inspector" configuration in that case' }
 
                   'inspector':
                     type:


### PR DESCRIPTION
Introduces a new Node Type setting `properties.<propertyName>.ui.showInCreationDialog`
that, if `true` will add the corresponding property to the Node Creation Dialog.

Example:

    'Some.Package:SomeNodeType':
      # ...
      properties:
        'someProperty':
          ui:
            showInCreationDialog: true

In that case the configuration of the corresponding `ui.inspector.editor` is copied
to the corresponding Creation Dialog element and can be overridden using the already
existing `creationDialog` configuration::

    'Some.Package:SomeNodeType':
      creationDialog:
        elements:
          'someProperty':
            ui:
              label: 'Overridden label'
      properties:
        'someProperty':
          ui:
            showInCreationDialog: true

*Note:* This requires https://github.com/neos/neos-ui/pull/2596 to be merged first!

Related: #2173