### PR TITLE
BUGFIX: Fix links and outdated docs in NodeTypeDefinition

### DIFF
--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -38,7 +38,7 @@ The following options are allowed for defining a NodeType:
 
 ``constraints``
   Constraint definitions stating which nested child node types are allowed. Also see the dedicated chapter
-  :ref:`node-constraints` for detailed explanation::
+  `NodeType Constraints`_ for detailed explanation::
 
     constraints:
       nodeTypes:
@@ -163,7 +163,7 @@ The following options are allowed for defining a NodeType:
 
     ``message``
       Help text for the node type. It supports markdown to format the help text and can
-      be translated (see :ref:`translate-nodetypes`).
+      be translated (see `NodeType Translations`_).
 
     ``thumbnail``
       This is shown in the popover and can be supplied in two ways:
@@ -224,7 +224,7 @@ The following options are allowed for defining a NodeType:
       ``collapsed``
         If the group should be collapsed by default (true or false). If left empty, the group will be expanded.
   ``creationDialog``
-    Creation dialog elements configuration. See :ref:`node-creation-dialog` for more details.
+    Creation dialog elements configuration. See `Node Creation Dialog Configuration`_ for more details.
 ``properties``
   A list of named properties for this node type. For each property the following settings are available.
 
@@ -252,7 +252,7 @@ The following options are allowed for defining a NodeType:
 
       ``message``
         Help text for this property. It supports markdown to format the help text and can
-        be translated (see :ref:`translate-nodetypes`).
+        be translated (see `NodeType Translations`_).
 
     ``reloadIfChanged``
       If `true`, the whole content element needs to be re-rendered on the server side if the value
@@ -279,7 +279,7 @@ The following options are allowed for defining a NodeType:
         The default editor is configurable in Settings.yaml under the key `Neos.Neos.Ui.frontendConfiguration.defaultInlineEditor`.
         It is strongly recommended to start using CKeditor5 today, as the CKeditor4 integration will be deprecated and removed in the future versions.
         Additional custom inline editors are registered via the `inlineEditors` registry.
-        See :ref:`ui-extensibility` for the detailed information on the topic.
+        See `Extending the Content User Interface`_ for the detailed information on the topic.
 
       ``editorOptions``
         This section controls the text formatting options the user has available for this property.
@@ -358,8 +358,8 @@ The following options are allowed for defining a NodeType:
       ``editorOptions``
         A set of options for the given editor, see the :ref:`property-editor-reference`.
 
-      ``editorListeners``
-        Allows to observe changes of other properties in order to react to them. For details see :ref:`depending-properties`
+      ``editorListeners`` (removed since Neos 3.3)
+        This feature has been removed in favor of `Depending Properties`_ with Neos 3.3
 
   ``validation``
     A list of validators to use on the property. Below each validator type any options for the validator
@@ -434,3 +434,8 @@ Here is one of the standard Neos node types (slightly shortened)::
 	        inlineEditable: true
 
 
+.. _Node Creation Dialog Configuration: https://docs.neos.io/cms/manual/content-repository/node-creation-dialog
+.. _NodeType Constraints: https://docs.neos.io/cms/manual/content-repository/node-constraints
+.. _NodeType Translations: https://docs.neos.io/cms/manual/content-repository/nodetype-translations
+.. _Extending the Content User Interface: https://docs.neos.io/cms/manual/extending-the-user-interface
+.. _Depending Properties: https://docs.neos.io/cms/manual/content-repository/nodetype-properties#depending-properties


### PR DESCRIPTION
Replaces no longer working links in the `NodeTypeDefinition` reference by corresponding docs.neos.io links and marks the `editorListeners` option deprecated