### PR TITLE
BUGFIX: setting Headers while evaluating PluginView.

### DIFF
--- a/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
@@ -126,6 +126,11 @@ class PluginViewImplementation extends PluginImplementation
             return $this->pluginViewNode->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
         }
         $this->dispatcher->dispatch($pluginRequest, $pluginResponse);
+
+        foreach ($pluginResponse->getHeaders()->getAll() as $key => $value) {
+            $parentResponse->getHeaders()->set($key, $value, true);
+        }
+
         return $pluginResponse->getContent();
     }
 }


### PR DESCRIPTION
This results in redirects without delay working not only for Plugins but also for PluginViews.

While updating a Neos Project from 3.3 to 4.3 I encountered an issue with the PluginViewImplementation. Redirects without a delay inside controllers of the plugin views did not work anymore, while redirects in the controllers of the master plugin still worked.
This problem occurred because the implementation of AbstractController::redirectToUri() changed in Neos 4.
In Neos 3 the line `$this->response->setContent('<html><head><meta http-equiv="refresh" content="' . (int)$delay . ';url=' . $escapedUri . '"/></head></html>');` was always executed – in Neos 4 it is only executed if a delay is set. Without a delay only the "Location" in the Response-Header is set. 
The PluginViewImplementation (in contrast to the PluginImplementation) does not append these Headers to the ParentRequest. I copied the lines from the PluginImplementation to the PluginViewImplementation and the redirects worked fine again.

(Actually this was also kind of a Problem in Neos 3, because it resulted in redirects from PluginViews always having a visible delay in the Frontend, even if the delay was 0. But I don't know if you still want to patch it in Neos 3.3 or only in 4.3 where it does not work at all.)