### PR TITLE
TASK: Render headerComment from Settings instead of fluid-template

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -35,6 +35,16 @@ Neos:
     # which is displayed if no domain pattern matches the current request
     defaultSiteNodeName: null
 
+    # The license header that is rendered in every neos page and the login form
+    headerComment: |
+
+      <!--
+      This website is powered by Neos, the Open Source Content Application Platform licensed under the GNU/GPL.
+      Neos is based on Flow, a powerful PHP application framework licensed under the MIT license.
+
+      More information and contribution opportunities at https://www.neos.io
+      -->
+
     routing:
       # Setting this to true allows to use an empty uriSegment for default dimensions.
       # The only limitation is that all segments must be unique across all dimenions.

--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -15,9 +15,11 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
         path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.backgroundImage')}
       }
 
+      headerComment = ${Configuration.setting('Neos.Neos.headerComment')}
+
       renderer = afx`
         <html lang="en">
-            <Neos.Fusion:Template templatePath="resource://Neos.Neos/Private/Templates/FusionObjects/NeosLicenseHeader.html" />
+            {props.headerComment}
             <head>
                 <meta charset="utf-8" />
                 <meta name="robots" content="noindex" />

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -13,10 +13,8 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
 		omitClosingTag = true
 	}
 
-	headerComment = Neos.Fusion:Template {
-		@position = 'before headTag'
-		templatePath = 'resource://Neos.Neos/Private/Templates/FusionObjects/NeosLicenseHeader.html'
-	}
+  headerComment = ${Configuration.setting('Neos.Neos.headerComment')}
+  headerComment.@position = 'before headTag'
 
 	# The opening head tag for the page. This is done to avoid deep nesting of Fusion paths for integrators.
 	headTag = Neos.Fusion:Tag {

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/NeosLicenseHeader.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/NeosLicenseHeader.html
@@ -1,6 +1,0 @@
-<!--
-	This website is powered by Neos, the Open Source Content Application Platform licensed under the GNU/GPL.
-	Neos is based on Flow, a powerful PHP application framework licensed under the MIT license.
-
-	More information and contribution opportunities at https://www.neos.io
--->


### PR DESCRIPTION
This avoids needlessly instantiating the fluid template engine just to render single comment.
Additionally this allows to configure the licenseHeader via setting Neos.Neos.headerComment.