### PR TITLE
TASK: Require concrete versions of fusion afx and forms for the 5.1 branch

### DIFF
--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -13,8 +13,8 @@
         "neos/twitter-bootstrap": "*",
         "neos/content-repository": "~5.1.0",
         "neos/fusion": "~5.1.0",
-        "neos/fusion-afx": "*",
-        "neos/fusion-form": "*",
+        "neos/fusion-afx": "^1.4",
+        "neos/fusion-form": "^1.0",
         "neos/fluid-adaptor": "~6.1.0",
         "behat/transliterator": "~1.0",
         "neos/media": "~5.1.0"


### PR DESCRIPTION
Until the both packages will become part of the dev dist we have to set the version constraints for each branch manually as master requires „*“