### PR TITLE
BUGFIX: Don't show empty Creation Dialog

### DIFF
--- a/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
@@ -72,7 +72,9 @@ class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
             }
             $creationDialogElements[$propertyName] = $creationDialogElement;
         }
-        $configuration['ui']['creationDialog']['elements'] = (new PositionalArraySorter($creationDialogElements))->toArray();
+        if ($creationDialogElements !== []) {
+            $configuration['ui']['creationDialog']['elements'] = (new PositionalArraySorter($creationDialogElements))->toArray();
+        }
     }
 
     /**

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -1,0 +1,124 @@
+<?php
+namespace Neos\Neos\Tests\Unit\NodeTypePostprocessor;
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor;
+use Neos\Utility\ObjectAccess;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CreationDialogPostprocessorTest extends UnitTestCase
+{
+
+    /**
+     * @var CreationDialogPostprocessor
+     */
+    private $creationDialogPostprocessor;
+
+    /**
+     * @var NodeType|MockObject
+     */
+    private $mockNodeType;
+
+    public function setUp(): void
+    {
+        $this->creationDialogPostprocessor = new CreationDialogPostprocessor();
+        $this->mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function processCopiesInspectorConfigurationToCreationDialogElements()
+    {
+        $configuration = [
+            'properties' => [
+                'foo' => [
+                    'ui' => [
+                        'showInCreationDialog' => true,
+                        'inspector' => [
+                            'editor' => 'Some\Editor',
+                            'editorOptions' => ['some' => 'option'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function($propertyPath) use ($configuration) {
+            return ObjectAccess::getPropertyPath($configuration, $propertyPath);
+        });
+
+        $this->creationDialogPostprocessor->process($this->mockNodeType, $configuration, []);
+
+        $expected = [
+            'properties' => [
+                'foo' => [
+                    'ui' => [
+                        'showInCreationDialog' => true,
+                        'inspector' => [
+                            'editor' => 'Some\Editor',
+                            'editorOptions' => ['some' => 'option'],
+                        ],
+                    ],
+                ],
+            ],
+            'ui' => [
+                'creationDialog' => [
+                    'elements' => [
+                        'foo' => [
+                            'ui' => [
+                                'showInCreationDialog' => true,
+                                'editor' => 'Some\Editor',
+                                'editorOptions' => ['some' => 'option'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        self::assertSame($expected, $configuration);
+    }
+
+    /**
+     * @test
+     */
+    public function bla()
+    {
+        $configuration = [
+            'properties' => [
+                'foo' => [
+                    'ui' => [
+                        'inspector' => [
+                            'editor' => 'Some\Editor',
+                            'editorOptions' => ['some' => 'option'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function($propertyPath) use ($configuration) {
+            return ObjectAccess::getPropertyPath($configuration, $propertyPath);
+        });
+
+        $this->creationDialogPostprocessor->process($this->mockNodeType, $configuration, []);
+
+        $expected = [
+            'properties' => [
+                'foo' => [
+                    'ui' => [
+                        'inspector' => [
+                            'editor' => 'Some\Editor',
+                            'editorOptions' => ['some' => 'option'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $configuration);
+    }
+
+}

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -29,7 +29,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function processCopiesInspectorConfigurationToCreationDialogElements()
+    public function processCopiesInspectorConfigurationToCreationDialogElements(): void
     {
         $configuration = [
             'properties' => [
@@ -84,7 +84,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function bla()
+    public function processDoesNotCreateEmptyCreationDialogs(): void
     {
         $configuration = [
             'properties' => [

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -45,7 +45,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
             ],
         ];
 
-        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function($propertyPath) use ($configuration) {
+        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function ($propertyPath) use ($configuration) {
             return ObjectAccess::getPropertyPath($configuration, $propertyPath);
         });
 
@@ -99,7 +99,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
             ],
         ];
 
-        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function($propertyPath) use ($configuration) {
+        $this->mockNodeType->method('getConfiguration')->willReturnCallback(static function ($propertyPath) use ($configuration) {
             return ObjectAccess::getPropertyPath($configuration, $propertyPath);
         });
 

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -120,5 +120,4 @@ class CreationDialogPostprocessorTest extends UnitTestCase
 
         self::assertSame($expected, $configuration);
     }
-
 }


### PR DESCRIPTION
Fixes the `CreationDialogPostprocessor` so that it doesn't create
an empty `ui.creationDialog.elements` configuration if no node
properties are flagged with `showInCreationDialog`

Related: #2173