### PR TITLE
BUGFIX: Invalid ratio mode during site import

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -237,9 +237,12 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      */
     public function setRatioMode(string $ratioMode): void
     {
+        if ($ratioMode === '') {
+            $ratioMode = ImageInterface::RATIOMODE_INSET;
+        }
         $supportedModes = [ImageInterface::RATIOMODE_INSET, ImageInterface::RATIOMODE_OUTBOUND];
         if (!in_array($ratioMode, $supportedModes, true)) {
-            throw new \InvalidArgumentException(sprintf('Invalid mode "%s" specified, supported modes are: "%" (but use the ImageInterface::RATIOMODE_* constants)', $ratioMode, implode('", "', $supportedModes)), 1574686876);
+            throw new \InvalidArgumentException(sprintf('Invalid mode "%s" specified, supported modes are: "%s" (but use the ImageInterface::RATIOMODE_* constants)', $ratioMode, implode('", "', $supportedModes)), 1574686876);
         }
 
         $this->ratioMode = $ratioMode;


### PR DESCRIPTION
Sigh… This fixes one blocking and one small issue with the ratio mode
that still occurred when importing sites from XML. The error fixed is:

`During the import of the "Sites.xml" from the package "Neos.Demo" an
exception occurred: Error: During import an exception occurred:
"Could not convert target type "Neos\Media\Domain\Model\ImageVariant":
Could not convert target type
"Neos\Media\Domain\Model\Adjustment\ResizeImageAdjustment": Invalid
mode "" specified, supported modes are: "inset", "outbound" (but use
the ImageInterface::RATIOMODE_* constants)"., see log for further
information.`

The fix brings back setting the ratio mode to the default of
ImageInterface::RATIOMODE_INSET when an empty string is given and
fixes the error message sprintf pattern.
