### PR TITLE
FEATURE: Keep tags and collections of assets when exporting sites

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -119,7 +119,7 @@ class Asset implements AssetInterface
 
     /**
      * @var Collection<\Neos\Media\Domain\Model\Tag>
-     * @ORM\ManyToMany
+     * @ORM\ManyToMany(cascade={"persist"})
      * @ORM\OrderBy({"label"="ASC"})
      * @Flow\Lazy
      */

--- a/Neos.Media/Classes/Domain/Model/AssetCollection.php
+++ b/Neos.Media/Classes/Domain/Model/AssetCollection.php
@@ -38,7 +38,7 @@ class AssetCollection
 
     /**
      * @var Collection<\Neos\Media\Domain\Model\Tag>
-     * @ORM\ManyToMany(inversedBy="assetCollections")
+     * @ORM\ManyToMany(inversedBy="assetCollections", cascade={"persist"})
      * @ORM\OrderBy({"label"="ASC"})
      * @Flow\Lazy
      */

--- a/Neos.Media/Classes/TypeConverter/ArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ArrayConverter.php
@@ -14,13 +14,13 @@ namespace Neos\Media\TypeConverter;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetVariantInterface;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\ImageVariant;
-use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 
 /**
  * This converter transforms Neos.Media AssetInterface instances to arrays.
@@ -60,7 +60,6 @@ class ArrayConverter extends AbstractTypeConverter
     {
         return ($source instanceof AssetInterface);
     }
-
 
     /**
      * Return a list of sub-properties inside the source object.
@@ -149,7 +148,7 @@ class ArrayConverter extends AbstractTypeConverter
                     'caption' => $source->getCaption(),
                     'resource' => $convertedChildProperties['resource'],
                     'tags' => $convertedChildProperties['tags'],
-                    'assetCollections' => $convertedChildProperties['assetCollections'],
+                    'assetCollections' => $convertedChildProperties['assetCollections']
                 ];
         }
     }

--- a/Neos.Media/Classes/TypeConverter/ArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ArrayConverter.php
@@ -81,6 +81,10 @@ class ArrayConverter extends AbstractTypeConverter
         if ($source instanceof ImageVariant) {
             $sourceChildPropertiesToBeConverted['adjustments'] = $source->getAdjustments();
         }
+        if ($source instanceof AssetInterface) {
+            $sourceChildPropertiesToBeConverted['tags'] = $source->getTags();
+            $sourceChildPropertiesToBeConverted['assetCollections'] = $source->getAssetCollections();
+        }
 
         return $sourceChildPropertiesToBeConverted;
     }
@@ -128,6 +132,12 @@ class ArrayConverter extends AbstractTypeConverter
                 if (!isset($convertedChildProperties['resource']) || !is_array($convertedChildProperties['resource'])) {
                     return null;
                 }
+                if (!isset($convertedChildProperties['tags']) || !is_array($convertedChildProperties['tags'])) {
+                    return null;
+                }
+                if (!isset($convertedChildProperties['assetCollections']) || !is_array($convertedChildProperties['assetCollections'])) {
+                    return null;
+                }
 
                 $convertedChildProperties['resource']['__identity'] = $this->persistenceManager->getIdentifierByObject($source->getResource());
 
@@ -137,7 +147,9 @@ class ArrayConverter extends AbstractTypeConverter
                     'title' => $source->getTitle(),
                     'copyrightNotice' => $source->getCopyrightNotice(),
                     'caption' => $source->getCaption(),
-                    'resource' => $convertedChildProperties['resource']
+                    'resource' => $convertedChildProperties['resource'],
+                    'tags' => $convertedChildProperties['tags'],
+                    'assetCollections' => $convertedChildProperties['assetCollections'],
                 ];
         }
     }

--- a/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
@@ -16,7 +16,6 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Media\Domain\Model\AssetCollection;
-use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 
 /**
  * This converter transforms Neos.Media AssetCollection instances to arrays.

--- a/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
@@ -14,6 +14,7 @@ namespace Neos\Media\TypeConverter;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 
@@ -66,7 +67,7 @@ class AssetCollectionToArrayConverter extends AbstractTypeConverter
      */
     public function getSourceChildPropertiesToBeConverted($source)
     {
-        $sourceChildPropertiesToBeConverted = [
+        return [
             'tags' => $source->getTags()
         ];
 
@@ -105,7 +106,7 @@ class AssetCollectionToArrayConverter extends AbstractTypeConverter
 
         return [
             '__identity' => $identity,
-            '__type' => "Neos\\Media\\Domain\\Model\\AssetCollection",
+            '__type' => AssetCollection::class,
             'title' => $source->getTitle(),
             'tags' => $convertedChildProperties['tags'],
         ];

--- a/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
@@ -1,0 +1,113 @@
+<?php
+namespace Neos\Media\TypeConverter;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
+
+/**
+ * This converter transforms Neos.Media AssetCollection instances to arrays.
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class AssetCollectionToArrayConverter extends AbstractTypeConverter
+{
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
+     * @var array
+     */
+    protected $sourceTypes = [AssetCollection::class];
+
+    /**
+     * @var string
+     */
+    protected $targetType = 'array';
+
+    /**
+     * @var integer
+     */
+    protected $priority = 2;
+
+    /**
+     * @param mixed $source
+     * @param string $targetType
+     * @return boolean
+     */
+    public function canConvertFrom($source, $targetType)
+    {
+        return ($source instanceof AssetCollection);
+    }
+
+
+    /**
+     * Return a list of sub-properties inside the source object.
+     * The "key" is the sub-property name, and the "value" is the value of the sub-property.
+     *
+     * @param mixed $source
+     * @return array
+     */
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        $sourceChildPropertiesToBeConverted = [
+            'tags' => $source->getTags()
+        ];
+
+        return $sourceChildPropertiesToBeConverted;
+    }
+
+    /**
+     * Return the type of a given sub-property inside the $targetType, in this case always "array"
+     *
+     * @param string $targetType is ignored
+     * @param string $propertyName is ignored
+     * @param PropertyMappingConfigurationInterface $configuration is ignored
+     * @return string always "array"
+     */
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        return 'array';
+    }
+
+    /**
+     * Convert an object from $source to an array
+     *
+     * @param AssetCollection $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return array The converted asset collection or NULL
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        $identity = $this->persistenceManager->getIdentifierByObject($source);
+
+        if (!isset($convertedChildProperties['tags']) || !is_array($convertedChildProperties['tags'])) {
+            return null;
+        }
+
+        return [
+            '__identity' => $identity,
+            '__type' => "Neos\\Media\\Domain\\Model\\AssetCollection",
+            'title' => $source->getTitle(),
+            'tags' => $convertedChildProperties['tags'],
+        ];
+    }
+}

--- a/Neos.Media/Classes/TypeConverter/TagConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagConverter.php
@@ -1,0 +1,64 @@
+<?php
+namespace Neos\Media\TypeConverter;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
+use Neos\Media\Domain\Model\Tag;
+
+/**
+ * This converter transforms to \Neos\Media\Domain\Model\Tag objects.
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class TagConverter extends PersistentObjectConverter
+{
+    /**
+     * @var array
+     */
+    protected $sourceTypes = ['array'];
+
+    /**
+     * @var string
+     */
+    protected $targetType = Tag::class;
+
+    /**
+     * @var integer
+     */
+    protected $priority = 1;
+
+    /**
+     * Convert an object from $source to an \Neos\Media\Domain\Model\Tag implementation
+     *
+     * @param mixed $source
+     * @param string $targetType must implement 'Neos\Media\Domain\Model\Tag'
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return Error|Tag The converted Tag, a Validation Error or NULL
+     * @throws InvalidTargetException
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        $object = parent::convertFrom($source, $targetType, $convertedChildProperties, $configuration);
+
+        if ($object instanceof Tag) {
+            // Persist tag immediately after it is converted, since otherwise the following happens:
+            // If an asset and a collection to which the asset belongs are both tagged with the same tag, during the import two different tags with the same identity are created. This leads to an error when persisting the image.
+            $this->persistenceManager->isNewObject($object) ? $this->persistenceManager->add($object) : $this->persistenceManager->update($object);
+        }
+
+        return $object;
+    }
+}

--- a/Neos.Media/Classes/TypeConverter/TagConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagConverter.php
@@ -12,7 +12,10 @@ namespace Neos\Media\TypeConverter;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Exception\UnknownObjectException;
+use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Media\Domain\Model\Tag;
 
@@ -46,7 +49,8 @@ class TagConverter extends PersistentObjectConverter
      * @param string $targetType must implement 'Neos\Media\Domain\Model\Tag'
      * @param array $convertedChildProperties
      * @param PropertyMappingConfigurationInterface $configuration
-     * @return Error|Tag The converted Tag, a Validation Error or NULL
+     * @return Tag|TargetNotFoundError The converted Tag, a Validation Error or NULL
+     * @throws UnknownObjectException
      * @throws InvalidTargetException
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)

--- a/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
@@ -1,0 +1,106 @@
+<?php
+namespace Neos\Media\TypeConverter;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Media\Domain\Model\Tag;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
+
+/**
+ * This converter transforms Neos.Media Tag instances to arrays.
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class TagToArrayConverter extends AbstractTypeConverter
+{
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
+     * @var array
+     */
+    protected $sourceTypes = [Tag::class];
+
+    /**
+     * @var string
+     */
+    protected $targetType = 'array';
+
+    /**
+     * @var integer
+     */
+    protected $priority = 2;
+
+    /**
+     * @param mixed $source
+     * @param string $targetType
+     * @return boolean
+     */
+    public function canConvertFrom($source, $targetType)
+    {
+        return ($source instanceof Tag);
+    }
+
+
+    /**
+     * Return a list of sub-properties inside the source object.
+     * The "key" is the sub-property name, and the "value" is the value of the sub-property.
+     *
+     * @param mixed $source
+     * @return array
+     */
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        $sourceChildPropertiesToBeConverted = [];
+
+        return $sourceChildPropertiesToBeConverted;
+    }
+
+    /**
+     * Return the type of a given sub-property inside the $targetType, in this case always "array"
+     *
+     * @param string $targetType is ignored
+     * @param string $propertyName is ignored
+     * @param PropertyMappingConfigurationInterface $configuration is ignored
+     * @return string always "array"
+     */
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        return 'array';
+    }
+
+    /**
+     * Convert an object from $source to an array
+     *
+     * @param Tag $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return array The converted tag or NULL
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        $identity = $this->persistenceManager->getIdentifierByObject($source);
+
+        return [
+            '__identity' => $identity,
+            '__type' => "Neos\\Media\\Domain\\Model\\Tag",
+            'label' => $source->getLabel(),
+        ];
+    }
+}

--- a/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
@@ -16,7 +16,6 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Media\Domain\Model\Tag;
-use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 
 /**
  * This converter transforms Neos.Media Tag instances to arrays.

--- a/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
@@ -14,6 +14,7 @@ namespace Neos\Media\TypeConverter;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 
@@ -66,9 +67,7 @@ class TagToArrayConverter extends AbstractTypeConverter
      */
     public function getSourceChildPropertiesToBeConverted($source)
     {
-        $sourceChildPropertiesToBeConverted = [];
-
-        return $sourceChildPropertiesToBeConverted;
+        return [];
     }
 
     /**
@@ -99,7 +98,7 @@ class TagToArrayConverter extends AbstractTypeConverter
 
         return [
             '__identity' => $identity,
-            '__type' => "Neos\\Media\\Domain\\Model\\Tag",
+            '__type' => Tag::class,
             'label' => $source->getLabel(),
         ];
     }


### PR DESCRIPTION
With this change tags and collections of assets are included in site exports to XML and are imported properly, too.

See also #2503 and #2537.
Fixes #1097