### PR TITLE
BUGFIX: Avoid null as argument to recreateVariant()

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -314,6 +314,12 @@ class AssetService
                             LogEnvironment::fromMethodName(__METHOD__)
                         );
                     }
+                } else {
+                    foreach ($variant->getAdjustments() as $adjustment) {
+                        if (method_exists($adjustment, 'refit') && $this->imageService->getImageSize($originalAssetResource) !== $this->imageService->getImageSize($resource)) {
+                            $adjustment->refit($asset);
+                        }
+                    }
                 }
             }
         }

--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -315,6 +315,7 @@ class AssetService
                         );
                     }
                 } else {
+                    $variant->refresh();
                     foreach ($variant->getAdjustments() as $adjustment) {
                         if (method_exists($adjustment, 'refit') && $this->imageService->getImageSize($originalAssetResource) !== $this->imageService->getImageSize($resource)) {
                             $adjustment->refit($asset);


### PR DESCRIPTION
Fixes #2837