### PR TITLE
BUGFIX: added FlowAnnotationDriver import to asset repository

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\Exception\InvalidQueryException;


### PR DESCRIPTION
This fixed the `array_map() expects parameter 1 to be a valid callback, class ‘Neos\Media\Domain\Repository\FlowAnnotationDriver’ not found`-Error

