### PR TITLE
BUGFIX: Avoid isRemoved() call on null

### DIFF
--- a/Neos.Neos/Classes/Service/PluginService.php
+++ b/Neos.Neos/Classes/Service/PluginService.php
@@ -211,7 +211,7 @@ class PluginService
         $context = $node->getContext();
         foreach ($this->getNodes(['Neos.Neos:PluginView'], $context) as $pluginViewNode) {
             /** @var NodeInterface $pluginViewNode */
-            if ($pluginViewNode->isRemoved()) {
+            if ($pluginViewNode === null || $pluginViewNode->isRemoved()) {
                 continue;
             }
             if ($pluginViewNode->getProperty('plugin') === $node->getIdentifier()


### PR DESCRIPTION
The array returned by getNodes() may have null entries, e.g. if a
node was filtered in createFromNodeData().
