### PR TITLE
BUGFIX: Adjust PluginViewImplementation to PSR-7

### DIFF
--- a/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
@@ -125,7 +125,13 @@ class PluginViewImplementation extends PluginImplementation
             return $this->pluginViewNode->getContext()->getWorkspaceName() !== 'live' || $this->objectManager->getContext()->isDevelopment() ? '<p>' . $message . '</p>' : '<!-- ' . $message . '-->';
         }
         $this->dispatcher->dispatch($pluginRequest, $pluginResponse);
+
+        // We need to make sure to not merge content up into the parent ActionResponse because that would break the Fusion HttpResponse.
+        $content = $pluginResponse->getContent();
+        $pluginResponse->setContent('');
+
         $pluginResponse->mergeIntoParentResponse($parentResponse);
-        return $pluginResponse->getContent();
+
+        return $content;
     }
 }


### PR DESCRIPTION
This applies a fix that has been applied to PluginImplementation in
https://github.com/neos/neos-development-collection/pull/2777 to the
PluginViewImplementation. This makes plugin views work again as
expected, instead of replacing the full response content by the plugin
content.
