### PR TITLE
BUGFIX: Call getPersonalWorkspaceName just once

### DIFF
--- a/Neos.Neos/Classes/Service/UserService.php
+++ b/Neos.Neos/Classes/Service/UserService.php
@@ -70,7 +70,7 @@ class UserService
     {
         $workspaceName = $this->getPersonalWorkspaceName();
         if ($workspaceName !== null) {
-            return $this->workspaceRepository->findOneByName($this->getPersonalWorkspaceName());
+            return $this->workspaceRepository->findOneByName($workspaceName);
         }
     }
 


### PR DESCRIPTION
Use result of first call of getPersonalWorkspaceName() instead of calling it twice.