### PR TITLE
BUGFIX: Failing parsing of inline Fluid viewhelper array arguments

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -112,7 +112,7 @@
                                     </table>
                                     <f:if condition="{assetProxy.asset.inUse}">
                                         <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset}" class="neos-button">
-                                            {neos:backend.translate(id: 'relatedNodes', quantity: '{assetProxy.asset.usageCount}', arguments: {0: assetProxy.asset.usageCount}, package: 'Neos.Media.Browser')}
+                                            {neos:backend.translate(id: 'relatedNodes', quantity: '{assetProxy.asset.usageCount}', arguments: '{0: assetProxy.asset.usageCount}', package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                     </f:if>
                                 </fieldset>
@@ -146,7 +146,7 @@
                                     <div class="neos-modal-header">
                                         <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
                                         <div class="neos-header">
-                                            {neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: {0: assetProxy.label}, package: 'Neos.Media.Browser')}
+                                            {neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: '{0: assetProxy.label}', package: 'Neos.Media.Browser')}
                                         </div>
                                         <div>
                                             <div class="neos-subheader">
@@ -159,7 +159,7 @@
                                     </div>
                                     <div class="neos-modal-footer">
                                         <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                                        <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'delete', arguments: {asset: assetProxy.asset})}" class="neos-button neos-button-mini neos-button-danger">
+                                        <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'delete', arguments: '{asset: assetProxy.asset}')}" class="neos-button neos-button-mini neos-button-danger">
                                             {neos:backend.translate(id: 'message.confirmDelete', package: 'Neos.Media.Browser')}
                                         </button>
                                     </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -6,8 +6,8 @@
 <f:section name="Options">
     <div class="neos-file-options">
         <span class="count">
-            {neos:backend.translate(id: 'search.itemCount', arguments: {0: searchResultCount}, package: 'Neos.Media.Browser')}
-            <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: {0: searchTerm}, package: 'Neos.Media.Browser')}</f:if>
+            {neos:backend.translate(id: 'search.itemCount', arguments: '{0: searchResultCount}', package: 'Neos.Media.Browser')}
+            <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: '{0: searchTerm}', package: 'Neos.Media.Browser')}</f:if>
         </span>
         <f:if condition="!{activeAssetSource.readOnly}">
         <f:link.action action="new"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
@@ -257,7 +257,7 @@
 <f:section name="Content">
     <f:if condition="!{activeAssetSource.readOnly}">
     <div id="dropzone" class="neos-upload-area">
-        <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
+        <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: '{0: humanReadableMaximumFileUploadSize}', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
         <f:form method="post" action="create" object="{asset}" objectName="asset" enctype="multipart/form-data">
             <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
         </f:form>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -8,7 +8,7 @@
         <fieldset>
             <div class="neos-span6 neos-image-inputs">
                 <span class="neos-file-input">
-                    <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
+                    <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: '{0: humanReadableMaximumFileUploadSize}', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
                         {neos:backend.translate(id: 'chooseFile', package: 'Neos.Media.Browser')} <i class="fas fa-file"></i>
                     </label>
                     <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}"/>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/RelatedNodes.html
@@ -6,8 +6,8 @@
 
 <f:section name="Content">
   <div class="neos-media-options">
-    <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: {asset: asset.label})}
-      ({neos:backend.translate(id: 'relatedNodes', quantity: '{asset.usageCount}', arguments: {0:asset.usageCount}, package: 'Neos.Media.Browser')})
+    <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: '{asset: asset.label}')}
+      ({neos:backend.translate(id: 'relatedNodes', quantity: '{asset.usageCount}', arguments: '{0:asset.usageCount}', package: 'Neos.Media.Browser')})
     </legend>
   </div>
 
@@ -96,8 +96,8 @@
             <f:if condition="{nodeInformation.documentNode}">
               <f:then>
                 <neos:link.node node="{nodeInformation.documentNode}" target="_blank"
-                                title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: nodeInformation.documentNode.workspace.title})}">
-                  <span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: {node: nodeInformation.documentNode})}" data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
+                                title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: '{0: nodeInformation.documentNode.workspace.title}')}">
+                  <span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: '{node: nodeInformation.documentNode}')}" data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
                   <i class="fas fa-external-link-alt"></i>
                 </neos:link.node>
               </f:then>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -9,13 +9,13 @@
         <div class="neos-row-fluid">
             <div class="neos-span8">
                 <fieldset>
-                    <legend>{neos:backend.translate(id: 'replaceAsset.replaceFilename', package: 'Neos.Media.Browser', arguments: {filename: asset.resource.filename})}</legend>
+                    <legend>{neos:backend.translate(id: 'replaceAsset.replaceFilename', package: 'Neos.Media.Browser', arguments: '{filename: asset.resource.filename}')}</legend>
                     <p class="neos-buffer-below">
                         {neos:backend.translate(id: 'replaceAsset.description', package: 'Neos.Media.Browser')}<br/>
                         <b>{neos:backend.translate(id: 'replaceAsset.note', package: 'Neos.Media.Browser')}: </b> {neos:backend.translate(id: 'replaceAsset.noteText', package: 'Neos.Media.Browser')}
                     </p>
                     <span class="neos-file-input">
-                        <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'replaceAsset.chooseNewFile', package: 'Neos.Media.Browser')} <i class="fas fa-file"></i></label>
+                        <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: '{0: humanReadableMaximumFileUploadSize}', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'replaceAsset.chooseNewFile', package: 'Neos.Media.Browser')} <i class="fas fa-file"></i></label>
                         <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}"/>
                     </span>
                 </fieldset>
@@ -23,7 +23,7 @@
                     <div>
                         <label class="neos-checkbox neos-inline">
                             <f:form.checkbox name="options[keepOriginalFilename]" value="1"/>
-                            <span></span> {neos:backend.translate(id: 'replace.options.keepOriginalFilename', arguments: {0: asset.resource.filename}, package: 'Neos.Media.Browser')}
+                            <span></span> {neos:backend.translate(id: 'replace.options.keepOriginalFilename', arguments: '{0: asset.resource.filename}', package: 'Neos.Media.Browser')}
                         </label>
                     </div>
                     <f:if condition="{redirectPackageEnabled}">
@@ -36,10 +36,10 @@
                     </f:if>
                 </fieldset>
                 <fieldset>
-                    <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: {asset: asset.label})}</legend>
+                    <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: '{asset: asset.label}')}</legend>
                     <f:if condition="{asset.inUse}">
                         <f:then>
-                            <p class="neos-buffer-below"><i class="fas fa-exclamation-sign"></i> {neos:backend.translate(id: 'replace.usageCount', arguments: {usageCount: asset.usageCount}, package: 'Neos.Media.Browser')}</p>
+                            <p class="neos-buffer-below"><i class="fas fa-exclamation-sign"></i> {neos:backend.translate(id: 'replace.usageCount', arguments: '{usageCount: asset.usageCount}', package: 'Neos.Media.Browser')}</p>
                             <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
                                 {neos:backend.translate(id: 'replace.allUsages', package: 'Neos.Media.Browser')}
                             </f:link.action>

--- a/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
@@ -34,7 +34,7 @@
                     <div class="neos-modal-content">
                         <div class="neos-modal-header">
                             <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: {0: assetCollection.title}, package: 'Neos.Media.Browser')}</div>
+                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: '{0: assetCollection.title}', package: 'Neos.Media.Browser')}</div>
                             <div>
                                 <div class="neos-subheader">
                                     <p>
@@ -46,7 +46,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', arguments: {assetCollection: assetCollection})}" class="neos-button neos-button-mini neos-button-danger">
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', arguments: '{assetCollection: assetCollection}')}" class="neos-button neos-button-mini neos-button-danger">
                                 {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                             </button>
                         </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
@@ -35,7 +35,7 @@
                     <div class="neos-modal-content">
                         <div class="neos-modal-header">
                             <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: {0: tag.label}, package: 'Neos.Media.Browser')}</div>
+                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset', arguments: '{0: tag.label}', package: 'Neos.Media.Browser')}</div>
                             <div>
                                 <div class="neos-subheader">
                                     <p>
@@ -47,7 +47,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', arguments: {tag: tag})}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', arguments: '{tag: tag}')}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
                         </div>
                     </div>
                 </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
@@ -6,8 +6,8 @@
 
 <f:section name="Content">
     <div class="neos-media-options">
-        <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: {asset: asset.label})}
-            ({neos:backend.translate(id: 'relatedNodes', quantity: '{asset.usageCount}', arguments: {0:asset.usageCount}, package: 'Neos.Media.Browser')})
+        <legend>{neos:backend.translate(id: 'relatedNodes.referencesTo', package: 'Neos.Media.Browser', arguments: '{asset: asset.label}')}
+            ({neos:backend.translate(id: 'relatedNodes', quantity: '{asset.usageCount}', arguments: '{0:asset.usageCount}', package: 'Neos.Media.Browser')})
         </legend>
     </div>
 
@@ -96,8 +96,8 @@
                             <f:if condition="{nodeInformation.documentNode}">
                                 <f:then>
                                     <neos:link.node node="{nodeInformation.documentNode}" target="_blank"
-                                                    title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: nodeInformation.documentNode.workspace.title})}">
-                                <span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: {node: nodeInformation.documentNode})}" data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
+                                                    title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: '{0: nodeInformation.documentNode.workspace.title}')}">
+                                <span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: '{node: nodeInformation.documentNode}')}" data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
                                         <i class="fas fa-external-link-alt"></i>
                                     </neos:link.node>
                                 </f:then>

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/EditUser.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/EditUser.html
@@ -133,7 +133,7 @@
 											</div>
 											<div class="neos-modal-footer">
 												<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel',source: 'Modules', package: 'Neos.Neos')}</a>
-												<button form="postHelper" formaction="{f:uri.action(action: 'deleteElectronicAddress', arguments: {user: user, electronicAddress: electronicAddress})}" type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'delete', value: 'delete')}">{neos:backend.translate(id: 'userSettings.electronicAddresses.buttonDelete.confirmation', source: 'Modules', package: 'Neos.Neos')}</button>
+												<button form="postHelper" formaction="{f:uri.action(action: 'deleteElectronicAddress', arguments: '{user: user, electronicAddress: electronicAddress}')}" type="submit" class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'delete', value: 'delete')}">{neos:backend.translate(id: 'userSettings.electronicAddresses.buttonDelete.confirmation', source: 'Modules', package: 'Neos.Neos')}</button>
 											</div>
 										</div>
 									</div>

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
@@ -1,6 +1,6 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <f:for each="{roles}" as="role" iteration="iteration">
-	<span class="neos-label" title="{f:render(section: 'tooltip', arguments: {role: role})}" data-neos-toggle="tooltip" data-placement="right" data-html="true">
+	<span class="neos-label" title="{f:render(section: 'tooltip', arguments: '{role: role}')}" data-neos-toggle="tooltip" data-placement="right" data-html="true">
 		{role.name}
 	</span>
 </f:for>

--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -33,12 +33,12 @@
 		{neos:backend.javascriptConfiguration()}
 	</script>
 
-	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'Neos.Neos', absolute: true, arguments: {version: '{neos:backend.configurationCacheVersion()}'})}" />
+	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'Neos.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
 	<!-- TODO: Make sure the schema information and edit / preview panel data isn't necessary in backend modules -->
-	<link rel="neos-vieschema" href="{f:uri.action(action: 'vieSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: {version: '{neos:backend.configurationCacheVersion()}'})}" />
-	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: {version: '{neos:backend.configurationCacheVersion()}'})}" />
-	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'Neos.Neos', absolute: true, arguments: {version: '{neos:backend.configurationCacheVersion()}'})}" />
-	<link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}" />
+	<link rel="neos-vieschema" href="{f:uri.action(action: 'vieSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
+	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
+	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'Neos.Neos', absolute: true, arguments: '{version: \'{neos:backend.configurationCacheVersion()}\'}')}" />
+	<link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: '{locale: \'{neos:backend.interfaceLanguage()}\', version: \'{neos:backend.xliffCacheVersion()}\'}', controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}" />
 </f:section>
 
 <f:section name="body">

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/NeosBackendEndpoints.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/NeosBackendEndpoints.html
@@ -4,19 +4,19 @@
 <meta name="neos-workspace" content="{node.context.workspace.name}" />
 <meta name="neos-csrf-token" content="{f:security.csrfToken()}" />
 
-<link rel="neos-site" href="{f:uri.action(action: 'show', controller: 'Frontend\Node', package: 'Neos.Neos', format: 'html', arguments: {node: node.context.currentSiteNode}, absolute: true)}" data-node-name="{node.context.currentSiteNode.name}" />
+<link rel="neos-site" href="{f:uri.action(action: 'show', controller: 'Frontend\Node', package: 'Neos.Neos', format: 'html', arguments: '{node: node.context.currentSiteNode}', absolute: true)}" data-node-name="{node.context.currentSiteNode.name}" />
 <link rel="neos-service-nodes" type="application/vnd.neos.neos.nodes" data-current-workspace="{node.context.workspace.name}" href="{f:uri.action(action: 'index', controller: 'Service\Nodes', package: 'Neos.Neos', absolute: true)}" />
 <link rel="neos-service-assets" type="application/vnd.neos.neos.assets" href="{f:uri.action(action: 'index', controller: 'Service\Assets', package: 'Neos.Neos', absolute: true)}" />
 
 <f:alias map="{configurationCacheIdentifier: '{neos:backend.configurationCacheVersion()}'}">
-	<link rel="neos-vieschema" href="{f:uri.action(action: 'vieSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
-	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
-	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'Neos.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
-	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'Neos.Neos', absolute: true, arguments: {version: configurationCacheIdentifier})}" />
+	<link rel="neos-vieschema" href="{f:uri.action(action: 'vieSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: '{version: configurationCacheIdentifier}')}" />
+	<link rel="neos-nodetypeschema" href="{f:uri.action(action: 'nodeTypeSchema', controller: 'Backend\Schema', package: 'Neos.Neos', absolute: true, arguments: '{version: configurationCacheIdentifier}')}" />
+	<link rel="neos-menudata" href="{f:uri.action(action: 'index', controller: 'Backend\Menu', package: 'Neos.Neos', absolute: true, arguments: '{version: configurationCacheIdentifier}')}" />
+	<link rel="neos-editpreviewdata" href="{f:uri.action(action: 'editPreview', controller: 'Backend\Settings', package: 'Neos.Neos', absolute: true, arguments: '{version: configurationCacheIdentifier}')}" />
 	<link rel="neos-service-contentdimensions" type="application/vnd.neos.neos.contentdimensions" href="{f:uri.action(action: 'index', controller: 'Service\ContentDimensions', package: 'Neos.Neos', absolute: true)}" />
 	<link rel="neos-service-workspaces" type="application/vnd.neos.neos.workspaces" href="{f:uri.action(action: 'index', controller: 'Service\Workspaces', package: 'Neos.Neos', absolute: true)}" />
 </f:alias>
-<link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}" />
+<link rel="neos-xliff" href="{f:uri.action(action: 'xliffAsJson', arguments: '{locale: \'{neos:backend.interfaceLanguage()}\'', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}" />
 
 <!-- Temporary URL endpoints, will be removed / grouped when a REST interface is fully implemented -->
 <link rel="neos-service-workspace-publishNode" href="{f:uri.action(action: 'publishNode', controller: 'Workspace', package: 'Neos.Neos', subpackage: 'Service', absolute: true, format: 'json')}" />
@@ -53,6 +53,6 @@
 <link rel="neos-public-resources" href="{f:uri.resource(path: '', package: 'Neos.Neos')}" />
 <link rel="neos-module-workspacesmanagement" href="{neos:uri.module(path: 'management/workspaces')}" />
 <link rel="neos-module-workspacesmanagement-show" href="{neos:uri.module(path: 'management/workspaces', action: 'show')}" />
-<link rel="neos-media-browser" href="{f:uri.action(action: 'index', controller: 'Asset', package: 'Neos.Media.Browser', absolute: true, arguments: {assetCollection: node.context.currentSite.assetCollection})}" />
-<link rel="neos-image-browser" href="{f:uri.action(action: 'index', controller: 'Image', package: 'Neos.Media.Browser', absolute: true, arguments: {assetCollection: node.context.currentSite.assetCollection})}" />
+<link rel="neos-media-browser" href="{f:uri.action(action: 'index', controller: 'Asset', package: 'Neos.Media.Browser', absolute: true, arguments: '{assetCollection: node.context.currentSite.assetCollection}')}" />
+<link rel="neos-image-browser" href="{f:uri.action(action: 'index', controller: 'Image', package: 'Neos.Media.Browser', absolute: true, arguments: '{assetCollection: node.context.currentSite.assetCollection}')}" />
 <link rel="neos-image-browser-edit" href="{f:uri.action(action: 'edit', controller: 'Image', package: 'Neos.Media.Browser', absolute: true)}" />

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Configuration/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Configuration/Index.html
@@ -7,7 +7,7 @@
 	</f:for>
 	<f:if condition="{validationResult.flattenedErrors -> f:count()} > 0">
 		<ul id="neos-notifications-inline">
-			<li data-type="warning" data-title="{neos:backend.translate(id: 'numberValidationErrors', source: 'ValidationErrors', arguments: {0: '{validationResult.flattenedErrors-> f:count()}'}, value: '{validationResult.flattenedErrors -> f:count()} errors were found')}">
+			<li data-type="warning" data-title="{neos:backend.translate(id: 'numberValidationErrors', source: 'ValidationErrors', arguments: '{0: \'{validationResult.flattenedErrors-> f:count()}\'}', value: '{validationResult.flattenedErrors -> f:count()} errors were found')}">
 				<f:for each="{validationResult.flattenedErrors}" key="path" as="errors">
 					<f:for each="{errors}" as="error">
 						<pre>{path} -> {neos:backend.translate(id: error.code, source: 'ValidationErrors', package: 'Neos.Flow', arguments: error.arguments, value: error)}</pre>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Edit.html
@@ -75,12 +75,12 @@
 										</f:link.action>
 										<f:if condition="{domain.active} === 1">
 											<f:then>
-												<button form="postHelper" formaction="{f:uri.action(action: 'deactivateDomain', arguments: {domain: domain})}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}" data-neos-toggle="tooltip">
+												<button form="postHelper" formaction="{f:uri.action(action: 'deactivateDomain', arguments: '{domain: domain}')}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}" data-neos-toggle="tooltip">
 													<i class="fas fa-minus-circle icon-white"></i>
 												</button>
 											</f:then>
 											<f:else>
-												<button form="postHelper" formaction="{f:uri.action(action: 'activateDomain', arguments: {domain: domain})}" type="submit" class="neos-button neos-button-success" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}" data-neos-toggle="tooltip">
+												<button form="postHelper" formaction="{f:uri.action(action: 'activateDomain', arguments: '{domain: domain}')}" type="submit" class="neos-button neos-button-success" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}" data-neos-toggle="tooltip">
 													<i class="fas fa-plus-circle icon-white"></i>
 												</button>
 											</f:else>
@@ -93,11 +93,11 @@
 												<div class="neos-modal-content">
 													<div class="neos-modal-header">
 														<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-														<div class="neos-header">{neos:backend.translate(id: 'domain.deleteConfirmQuestion', arguments: {0: domain}, source: 'Modules', value: 'Do you really want to delete "{domain}"? This action cannot be undone.')}</div>
+														<div class="neos-header">{neos:backend.translate(id: 'domain.deleteConfirmQuestion', arguments: '{0: domain}', source: 'Modules', value: 'Do you really want to delete "{domain}"? This action cannot be undone.')}</div>
 													</div>
 													<div class="neos-modal-footer">
 														<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>
-														<button form="postHelper" formaction="{f:uri.action(action: 'deleteDomain', arguments: {site: site, domain: domain})}" type="submit" class="neos-button-danger neos-button" title="{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!', source: 'Modules')}">
+														<button form="postHelper" formaction="{f:uri.action(action: 'deleteDomain', arguments: '{site: site, domain: domain}')}" type="submit" class="neos-button-danger neos-button" title="{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!', source: 'Modules')}">
 															{neos:backend.translate(id: 'deleteConfirm', value: 'Yes, delete it!', source: 'Modules')}
 														</button>
 													</div>
@@ -151,12 +151,12 @@
 			</button>
 			<f:if condition="{site.online}">
 				<f:then>
-					<button form="postHelper" formaction="{f:uri.action(action: 'deactivateSite', arguments: {site: site})}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}">
+					<button form="postHelper" formaction="{f:uri.action(action: 'deactivateSite', arguments: '{site: site}')}" type="submit" class="neos-button neos-button-warning" title="{neos:backend.translate(id: 'clickToDeactivate', value: 'Click to deactivate')}">
 						{neos:backend.translate(id: 'sites.deactivate', value: 'Deactivate site', source: 'Modules')}
 					</button>
 				</f:then>
 				<f:else>
-					<button form="postHelper" formaction="{f:uri.action(action: 'activateSite', arguments: {site: site})}" type="submit" class="neos-button neos-button-success" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}">
+					<button form="postHelper" formaction="{f:uri.action(action: 'activateSite', arguments: '{site: site}')}" type="submit" class="neos-button neos-button-success" title="{neos:backend.translate(id: 'clickToActivate', value: 'Click to activate')}">
 						{neos:backend.translate(id: 'sites.activate', value: 'Activate site', source: 'Modules')}
 					</button>
 				</f:else>
@@ -167,11 +167,11 @@
 			<div class="neos-modal">
 				<div class="neos-modal-header">
 					<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-					<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', source: 'Modules', arguments: {0: site.name}, value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
+					<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', source: 'Modules', arguments: '{0: site.name}', value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
 				</div>
 				<div class="neos-modal-footer">
 					<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>
-					<button form="postHelper" formaction="{f:uri.action(action: 'deleteSite', arguments: {site: site, domain: domain})}" type="submit" class="neos-button neos-button-danger" title="Yes, delete the site">
+					<button form="postHelper" formaction="{f:uri.action(action: 'deleteSite', arguments: '{site: site, domain: domain}')}" type="submit" class="neos-button neos-button-danger" title="Yes, delete the site">
 						{neos:backend.translate(id: 'sites.confirmDelete', value: 'Yes, delete the site', source: 'Modules', source: 'Modules')}
 					</button>
 				</div>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
@@ -68,7 +68,7 @@
 												<div class="neos-modal-content">
 													<div class="neos-modal-header">
 														<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-														<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', arguments: {0: site.name}, source: 'Modules', value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
+														<div class="neos-header">{neos:backend.translate(id: 'sites.confirmDeleteQuestion', arguments: '{0: site.name}', source: 'Modules', value: 'Do you really want to delete "{site.name}"? This action cannot be undone.')}</div>
 													</div>
 													<div class="neos-modal-footer">
 														<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</a>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Edit.html
@@ -36,7 +36,7 @@
 				<div class="neos-modal-content">
 					<div class="neos-modal-header">
 						<button type="button" class="neos-close" data-dismiss="modal"></button>
-						<div class="neos-header">{neos:backend.translate(id: 'users.show.buttonDelete', value: 'Do you really want to delete the user "{user.name}"?', arguments: {0: user.name}, source: 'Modules', package: 'Neos.Neos')}</div>
+						<div class="neos-header">{neos:backend.translate(id: 'users.show.buttonDelete', value: 'Do you really want to delete the user "{user.name}"?', arguments: '{0: user.name}', source: 'Modules', package: 'Neos.Neos')}</div>
 						<div>
 							<div class="neos-subheader">
 								{neos:backend.translate(id: 'users.show.deleteDialogWarning', value: 'This will delete the user, the related accounts and his personal workspace, including all unpublished content.', source: 'Modules', package: 'Neos.Neos')}

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/EditAccount.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/EditAccount.html
@@ -3,7 +3,7 @@
 
 <f:section name="subtitle">
 	<div class="neos-module-container">
-		<h2>{neos:backend.translate(source: 'Modules', id: 'users.editAccount.title', arguments: {accountIdentifier: account.accountIdentifier})}</h2>
+		<h2>{neos:backend.translate(source: 'Modules', id: 'users.editAccount.title', arguments: '{accountIdentifier: account.accountIdentifier}')}</h2>
 	</div>
 </f:section>
 

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Show.html
@@ -113,7 +113,7 @@
 				<div class="neos-modal-content">
 					<div class="neos-modal-header">
 					<button type="button" class="neos-close" data-dismiss="modal"></button>
-					<div class="neos-header">{neos:backend.translate(id: 'users.show.buttonDelete', value: 'Do you really want to delete the user "{user.name}"?', arguments: {0: user.name}, source: 'Modules', package: 'Neos.Neos')}</div>
+					<div class="neos-header">{neos:backend.translate(id: 'users.show.buttonDelete', value: 'Do you really want to delete the user "{user.name}"?', arguments: '{0: user.name}', source: 'Modules', package: 'Neos.Neos')}</div>
 					<div>
 						<div class="neos-subheader">
 							{neos:backend.translate(id: 'users.show.deleteDialogWarning', value: 'This will delete the user, the related accounts and his personal workspace, including all unpublished content.', source: 'Modules', package: 'Neos.Neos')}

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Edit.html
@@ -2,7 +2,7 @@
 <f:layout name="BackendSubModule"/>
 
 <f:section name="subtitle">
-	<h2>{neos:backend.translate(id: 'workspaces.editWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: workspace.title})}</h2>
+	<h2>{neos:backend.translate(id: 'workspaces.editWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: '{0: workspace.title}')}</h2>
 </f:section>
 
 <f:section name="content">

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Index.html
@@ -89,7 +89,7 @@
 						<td class="neos-action">
 							<div class="neos-pull-right">
 								<f:if condition="{canManage}">
-									<f:link.action action="edit" arguments="{workspace: workspace}" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'workspaces.editWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: workspace.title})}" additionalAttributes="{data-neos-toggle: 'tooltip'}">
+									<f:link.action action="edit" arguments="{workspace: workspace}" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'workspaces.editWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: '{0: workspace.title}')}" additionalAttributes="{data-neos-toggle: 'tooltip'}">
 										<i class="fas fa-pencil-alt icon-white"></i>
 									</f:link.action>
 								</f:if>
@@ -118,7 +118,7 @@
 																	<div class="neos-modal-content">
 																		<div class="neos-modal-header">
 																			<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-																			<div class="neos-header">{neos:backend.translate(id: 'workspaces.dialog.confirmWorkspaceDeletion', source: 'Modules', package: 'Neos.Neos', arguments: {0: workspace.title})}</div>
+																			<div class="neos-header">{neos:backend.translate(id: 'workspaces.dialog.confirmWorkspaceDeletion', source: 'Modules', package: 'Neos.Neos', arguments: '{0: workspace.title}')}</div>
 																			<div>
 																				<div class="neos-subheader">
 																					<p>{neos:backend.translate(id: 'workspaces.dialog.thisWillDeleteTheWorkspace', source: 'Modules', package: 'Neos.Neos')}</p>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -10,7 +10,7 @@
 		<f:then>
 			<f:form action="publishOrDiscardNodes">
 				<f:form.hidden name="selectedWorkspace" value="{selectedWorkspace}"/>
-				<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
+				<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: '{0: selectedWorkspaceLabel}')}</legend>
 				<br />
 				<div class="neos-row-fluid">
 					<table class="neos-table">
@@ -49,7 +49,7 @@
 											<div class="neos-span2 neos-pull-right neos-aRight">
 												<f:if condition="{document.documentNode.removed}">
 													<f:else>
-														<neos:link.node node="{document.documentNode}" absolute="1" target="neosPreview" class="neos-button" title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', value: 'Open page in \"{0}\" workspace', arguments: {0: selectedWorkspaceLabel})}" additionalAttributes="{data-neos-toggle: 'tooltip'}"><i class="fas fa-external-link-alt icon-white"></i></neos:link.node><button form="postHelper" formaction="{f:uri.action(action: 'rebaseAndRedirect', arguments: {targetNode: document.documentNode, targetWorkspace: selectedWorkspace})}" type="submit" class="neos-button" title="{neos:backend.translate(id: 'edit', source: 'Main', package: 'Neos.Neos', value: 'Edit')}" data-neos-toggle="tooltip"><i class="fas fa-pencil-alt icon-white"></i></button>
+														<neos:link.node node="{document.documentNode}" absolute="1" target="neosPreview" class="neos-button" title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', value: 'Open page in \"{0}\" workspace', arguments: '{0: selectedWorkspaceLabel}')}" additionalAttributes="{data-neos-toggle: 'tooltip'}"><i class="fas fa-external-link-alt icon-white"></i></neos:link.node><button form="postHelper" formaction="{f:uri.action(action: 'rebaseAndRedirect', arguments: '{targetNode: document.documentNode, targetWorkspace: selectedWorkspace}')}" type="submit" class="neos-button" title="{neos:backend.translate(id: 'edit', source: 'Main', package: 'Neos.Neos', value: 'Edit')}" data-neos-toggle="tooltip"><i class="fas fa-pencil-alt icon-white"></i></button>
 													</f:else>
 												</f:if>
 											</div>
@@ -64,16 +64,16 @@
 										<td class="check neos-priority1">
 											<label for="{change.node.identifier}" class="neos-checkbox"><f:form.checkbox name="nodes[]" value="{change.node.contextPath}" id="{change.node.identifier}" /><span></span></label>
 										</td>
-										<td id="change-{change.node.identifier}" {f:render(partial: 'Module/Management/Workspaces/ContentChangeAttributes', arguments: {change: change})} data-neos-toggle="tooltip" data-placement="left" data-container="body">
+										<td id="change-{change.node.identifier}" {f:render(partial: 'Module/Management/Workspaces/ContentChangeAttributes', arguments: '{change: change}')} data-neos-toggle="tooltip" data-placement="left" data-container="body">
 											<f:render partial="Module/Management/Workspaces/ContentChangeDiff" arguments="{change: change, contentDimensions: contentDimensions}"/>
 										</td>
 										<td class="neos-action">
 											<f:if condition="{canPublishToBaseWorkspace}">
-												<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-success neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
+												<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: '{node: change.node.contextPath, selectedWorkspace: selectedWorkspace}')}" type="submit" class="neos-button neos-button-success neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
 													<i class="fas fa-check icon-white"></i>
 												</button>
 											</f:if>
-											<button form="postHelper" formaction="{f:uri.action(action: 'discardNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-danger neos-pull-right" title="{neos:backend.translate(id: 'discard', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip" data-placement="bottom">
+											<button form="postHelper" formaction="{f:uri.action(action: 'discardNode', arguments: '{node: change.node.contextPath, selectedWorkspace: selectedWorkspace}')}" type="submit" class="neos-button neos-button-danger neos-pull-right" title="{neos:backend.translate(id: 'discard', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip" data-placement="bottom">
 												<i class="fas fa-trash-alt icon-white"></i>
 											</button>
 										</td>
@@ -92,11 +92,11 @@
 					<div class="neos-modal-content">
 						<div class="neos-modal-header">
 							<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardAllChangesInWorkspaceConfirmation', arguments: {0: selectedWorkspaceLabel}, source: 'Modules', package: 'Neos.Neos')}</div>
+							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardAllChangesInWorkspaceConfirmation', arguments: '{0: selectedWorkspaceLabel}', source: 'Modules', package: 'Neos.Neos')}</div>
 						</div>
 						<div class="neos-modal-footer">
 							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</a>
-							<button form="postHelper" formaction="{f:uri.action(action: 'discardWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-danger">
+							<button form="postHelper" formaction="{f:uri.action(action: 'discardWorkspace', arguments: '{workspace: selectedWorkspace}')}" type="submit" class="neos-button neos-button-danger">
 								<i class="fas fa-trash-alt icon-white"></i>
 								{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 							</button>
@@ -159,7 +159,7 @@
 
 		</f:then>
 		<f:else>
-			<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
+			<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: '{0: selectedWorkspaceLabel}')}</legend>
 			<p>{neos:backend.translate(id: 'workspaces.thereAreNoUnpublishedChanges', source: 'Modules', package: 'Neos.Neos')}</p>
 			<div class="neos-footer">
 				<div class="pull-left">
@@ -181,7 +181,7 @@
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
 					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
 					<button class="neos-button neos-button-danger" data-toggle="modal" href="#discard">{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}</button>
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: '{workspace: selectedWorkspace}')}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: '{0: baseWorkspaceLabel}')}</button>
 				</f:then>
 				<f:else>
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>

--- a/Neos.Neos/Resources/Private/Templates/Module/User/UserSettings/EditAccount.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/User/UserSettings/EditAccount.html
@@ -3,7 +3,7 @@
 
 <f:section name="subtitle">
 	<div class="neos-module-container">
-		<h2>{neos:backend.translate(source: 'Modules', id: 'users.editAccount.title', arguments: {accountIdentifier: account.accountIdentifier})}</h2>
+		<h2>{neos:backend.translate(source: 'Modules', id: 'users.editAccount.title', arguments: '{accountIdentifier: account.accountIdentifier}')}</h2>
 	</div>
 </f:section>
 


### PR DESCRIPTION
The parsing of subarrays in the inline viewhelper syntax of Fluid fails
on specific system setups. This change adds additional quoting to prevent
the issue from occuring.

This is a workaround but in most cases leads to more readable / understandable
code.

See: https://github.com/neos/neos-development-collection/issues/2776

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

**How I did it**

**How to verify it**

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
