### PR TITLE
BUGFIX: Fix login behind basic auth

### DIFF
--- a/Neos.Neos/Classes/Controller/LoginController.php
+++ b/Neos.Neos/Classes/Controller/LoginController.php
@@ -113,7 +113,7 @@ class LoginController extends AbstractAuthenticationController
     public function indexAction($username = null, $unauthorized = false)
     {
         if ($this->securityContext->getInterceptedRequest() || $unauthorized) {
-            $this->response->setStatus(401);
+            $this->response->setHeader('X-Authentication-Required', true);
         }
         if ($this->authenticationManager->isAuthenticated()) {
             $this->redirect('index', 'Backend\Backend');


### PR DESCRIPTION
In the latest version of Chrome (79.0.3945.88) the login page will
remain white if it's protected by Basic Authentication.

Until now a 401 status code was returned whenever the login page was
opened, causing a faulty behavior in Chrome and resulting in a white
page in almost all cases.

We now use a custom header instead to identify if Authentication is
necessary to view the content.

resolves: https://github.com/neos/neos-development-collection/issues/2845