### PR TITLE
FEATURE: Media browser allows constraints

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Neos\Media\Browser\Controller;
 
@@ -842,7 +843,7 @@ class AssetController extends ActionController
      */
     private function getMaximumFileUploadSize(): int
     {
-        return min(Files::sizeStringToBytes(ini_get('post_max_size')), Files::sizeStringToBytes(ini_get('upload_max_filesize')));
+        return (int)min(Files::sizeStringToBytes(ini_get('post_max_size')), Files::sizeStringToBytes(ini_get('upload_max_filesize')));
     }
 
     /**

--- a/Neos.Media.Browser/Classes/Domain/Dto/BrowserConstraints.php
+++ b/Neos.Media.Browser/Classes/Domain/Dto/BrowserConstraints.php
@@ -1,0 +1,134 @@
+<?php
+namespace Neos\Media\Browser\Domain\Dto;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Media\Domain\Model\AssetSource\AssetTypeFilter;
+
+/**
+ * @Flow\Proxy(false)
+ * Media Browser constraints
+ */
+final class BrowserConstraints implements \JsonSerializable
+{
+    /**
+     * @var string[]
+     */
+    private $allowedAssetSourceIdentifiers = [];
+
+    /**
+     * @var AssetTypeFilter
+     */
+    private $typeFilter;
+
+    /**
+     * Create media browser constraints
+     *
+     * @param array $allowedAssetSourceIdentifiers Empty array means all allowed!
+     * @param AssetTypeFilter|null $typeFilter
+     */
+    private function __construct(array $allowedAssetSourceIdentifiers = [], AssetTypeFilter $typeFilter = null)
+    {
+        $this->allowedAssetSourceIdentifiers = $allowedAssetSourceIdentifiers;
+        $this->typeFilter = $typeFilter;
+    }
+
+    /**
+     * @param string $json
+     * @return BrowserConstraints
+     */
+    public static function fromJson(string $json): BrowserConstraints
+    {
+        $array = json_decode($json, true);
+
+        return static::fromArray($array);
+    }
+
+    /**
+     * @param array $array Keys: "allowedAssetSourceIdentifiers", "typeFilter"
+     * @return BrowserConstraints
+     */
+    public static function fromArray(array $array): BrowserConstraints
+    {
+        $arguments[0] = [];
+        if (isset($array['allowedAssetSourceIdentifiers']) && is_array($array['allowedAssetSourceIdentifiers'])) {
+            $arguments[0] = $array['allowedAssetSourceIdentifiers'];
+        }
+
+        $arguments[1] = new AssetTypeFilter('All');
+        if (isset($array['typeFilter'])) {
+            $arguments[1] = new AssetTypeFilter((string)$array['typeFilter']);
+        }
+
+        return new BrowserConstraints(...$arguments);
+    }
+
+    /**
+     * @param array $allowedAssetSourceIdentifiers
+     * @return BrowserConstraints
+     */
+    public function withAssetSourceConstraint(array $allowedAssetSourceIdentifiers): BrowserConstraints
+    {
+        $newInstance = clone $this;
+        $newInstance->allowedAssetSourceIdentifiers = $allowedAssetSourceIdentifiers;
+
+        return $newInstance;
+    }
+
+    /**
+     * @return BrowserConstraints
+     */
+    public function withoutAssetSourceConstraint(): BrowserConstraints
+    {
+        $newInstance = clone $this;
+        $newInstance->allowedAssetSourceIdentifiers = [];
+
+        return $newInstance;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedAssetSourceIdentifiers(): array
+    {
+        return $this->allowedAssetSourceIdentifiers;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAssetSourceConstraint(): bool
+    {
+        return $this->allowedAssetSourceIdentifiers !== [];
+    }
+
+    /**
+     * @return AssetTypeFilter
+     */
+    public function getTypeFilter(): AssetTypeFilter
+    {
+        return $this->typeFilter;
+    }
+
+    /**
+     * @param AssetTypeFilter $typeFilter
+     */
+    public function withTypeFilter(AssetTypeFilter $typeFilter)
+    {
+        $this->typeFilter = $typeFilter;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [];
+        if ($this->hasAssetSourceConstraint()) {
+            $data['allowedAssetSourceIdentifiers'] = $this->allowedAssetSourceIdentifiers;
+        }
+
+        $data['typeFilter'] = $this->typeFilter;
+
+        return $data;
+    }
+}

--- a/Neos.Media.Browser/Classes/Domain/Dto/BrowserConstraints.php
+++ b/Neos.Media.Browser/Classes/Domain/Dto/BrowserConstraints.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Media\Browser\Domain\Dto;
 
 use Neos\Flow\Annotations as Flow;
@@ -34,9 +36,9 @@ final class BrowserConstraints implements \JsonSerializable
 
     /**
      * @param string $json
-     * @return BrowserConstraints
+     * @return self
      */
-    public static function fromJson(string $json): BrowserConstraints
+    public static function fromJson(string $json): self
     {
         $array = json_decode($json, true);
 
@@ -45,16 +47,16 @@ final class BrowserConstraints implements \JsonSerializable
 
     /**
      * @param array $array Keys: "allowedAssetSourceIdentifiers", "typeFilter"
-     * @return BrowserConstraints
+     * @return self
      */
-    public static function fromArray(array $array): BrowserConstraints
+    public static function fromArray(array $array): self
     {
         $arguments[0] = [];
         if (isset($array['allowedAssetSourceIdentifiers']) && is_array($array['allowedAssetSourceIdentifiers'])) {
             $arguments[0] = $array['allowedAssetSourceIdentifiers'];
         }
 
-        $arguments[1] = new AssetTypeFilter('All');
+        $arguments[1] = new AssetTypeFilter(AssetTypeFilter::TYPE_ALL);
         if (isset($array['typeFilter'])) {
             $arguments[1] = new AssetTypeFilter((string)$array['typeFilter']);
         }
@@ -64,9 +66,9 @@ final class BrowserConstraints implements \JsonSerializable
 
     /**
      * @param array $allowedAssetSourceIdentifiers
-     * @return BrowserConstraints
+     * @return self
      */
-    public function withAssetSourceConstraint(array $allowedAssetSourceIdentifiers): BrowserConstraints
+    public function withAssetSourceConstraint(array $allowedAssetSourceIdentifiers): self
     {
         $newInstance = clone $this;
         $newInstance->allowedAssetSourceIdentifiers = $allowedAssetSourceIdentifiers;
@@ -75,9 +77,9 @@ final class BrowserConstraints implements \JsonSerializable
     }
 
     /**
-     * @return BrowserConstraints
+     * @return self
      */
-    public function withoutAssetSourceConstraint(): BrowserConstraints
+    public function withoutAssetSourceConstraint(): self
     {
         $newInstance = clone $this;
         $newInstance->allowedAssetSourceIdentifiers = [];
@@ -111,10 +113,14 @@ final class BrowserConstraints implements \JsonSerializable
 
     /**
      * @param AssetTypeFilter $typeFilter
+     * @return BrowserConstraints
      */
-    public function withTypeFilter(AssetTypeFilter $typeFilter)
+    public function withTypeFilter(AssetTypeFilter $typeFilter): self
     {
-        $this->typeFilter = $typeFilter;
+        $newInstance = clone $this;
+        $newInstance->typeFilter = $typeFilter;
+
+        return $newInstance;
     }
 
     /**

--- a/Neos.Media.Browser/Configuration/Routes.yaml
+++ b/Neos.Media.Browser/Configuration/Routes.yaml
@@ -3,9 +3,11 @@
   uriPattern: 'neos/media/browser/images(/{@action}).{@format}'
   defaults:
     '@package': 'Neos.Media.Browser'
-    '@controller': 'Image'
+    '@controller': 'Asset'
     '@format': 'html'
     '@action': 'index'
+    'browserConstraints':
+      'typeFilter': 'Image'
   appendExceedingArguments: true
 
 -

--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -13,13 +13,13 @@
                             <f:then>
                                 <f:if condition="{sortDirection} === 'ASC'">
                                     <f:then>
-                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE">
+                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                             {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                         <i class="fas fa-caret-up"></i>
                                     </f:then>
                                     <f:else>
-                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.asc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE">
+                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.asc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'ASC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                             {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                         <i class="fas fa-caret-down"></i>
@@ -27,7 +27,7 @@
                                 </f:if>
                             </f:then>
                             <f:else>
-                                <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}" arguments="{sortBy: 'Name'}" addQueryString="TRUE">
+                                <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}" arguments="{sortBy: 'Name', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                     {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
                                 </f:link.action>
                             </f:else>
@@ -38,13 +38,13 @@
                             <f:then>
                                 <f:if condition="{sortDirection} === 'ASC'">
                                     <f:then>
-                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE">
+                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.desc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'DESC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                             {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                         <i class="fas fa-caret-up"></i>
                                     </f:then>
                                     <f:else>
-                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.asc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE">
+                                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')} ({neos:backend.translate(id: 'sortdirection.asc', package: 'Neos.Media.Browser') -> f:format.case(mode: 'lower')})" data="{neos-toggle: 'tooltip'}" arguments="{sortDirection: 'ASC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                             {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                         <i class="fas fa-caret-down"></i>
@@ -52,7 +52,7 @@
                                 </f:if>
                             </f:then>
                             <f:else>
-                                <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}" arguments="{sortBy: 'Modified'}" addQueryString="TRUE">
+                                <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}" arguments="{sortBy: 'Modified', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE">
                                     {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
                                 </f:link.action>
                             </f:else>
@@ -123,13 +123,13 @@
                                     <f:if condition="!{activeAssetSource.readOnly}">
                                         <f:then>
                                             <li>
-                                                <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-edit icon-white"></i> {editLabel}
                                                 </f:link.action>
                                             </li>
                                             <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
                                                 <li>
-                                                    <f:link.action action="replaceAssetResource" arguments="{assetSourceIdentifier: activeAssetSource.identifier, asset: assetProxy.asset}" data="{asset-identifier: '{assetProxy.identifier}'}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                    <f:link.action action="replaceAssetResource" arguments="{assetSourceIdentifier: activeAssetSource.identifier, asset: assetProxy.asset, browserConstraints: '{browserConstraints -> f:format.json()}'}" data="{asset-identifier: '{assetProxy.identifier}'}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                         <i class="fas fa-random icon-white"></i> {replaceAssetResourceLabel}
                                                     </f:link.action>
                                                 </li>
@@ -142,7 +142,7 @@
                                         </f:then>
                                         <f:else>
                                             <li>
-                                                <f:link.action action="show" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{viewAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="show" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{viewAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-eye icon-white"></i> {viewLabel}
                                                 </f:link.action>
                                             </li>

--- a/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
@@ -15,7 +15,7 @@
                 <li class="asset">
                     <f:if condition="!{activeAssetSource.readOnly}">
                         <f:then>
-                            <f:link.action action="edit" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
+                            <f:link.action action="edit" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container draggable-asset {f:if(condition: '{assetProxy.asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}">
                                     <f:if condition="{assetProxy.thumbnailUri}">
                                         <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
@@ -25,7 +25,7 @@
                             </f:link.action>
                         </f:then>
                         <f:else>
-                            <f:link.action action="show" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
+                            <f:link.action action="show" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container">
                                     <f:if condition="{assetProxy.thumbnailUri}">
                                         <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
@@ -45,13 +45,13 @@
                                 <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
                                     <ul>
                                         <li>
-                                            <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                            <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                 <i class="fas fa-edit icon-white"></i> {editLabel}
                                             </f:link.action>
                                         </li>
                                         <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
                                             <li>
-                                                <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-random icon-white"></i> {replaceLabel}
                                                 </f:link.action>
                                             </li>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -18,14 +18,14 @@
                     <a href="#" role="tab">Overview</a>
                 </li>
                 <li role="presentation">
-                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'edit'}">Variants</f:link.action>
+            <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'edit', browserConstraints: '{browserConstraints -> f:format.json()}'}">Variants</f:link.action>
                 </li>
             </ul>
             </f:if>
 
             <div class="neos-tab-content">
                 <div role="tabpanel" class="neos-tab-pane neos-active">
-                    <f:form method="post" action="update" object="{assetProxy.asset}" objectName="asset">
+            <f:form method="post" action="update" object="{assetProxy.asset}" objectName="asset" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}">
                         <div class="neos-row-fluid">
                             <div class="neos-span6 neos-image-inputs">
                                 <fieldset>
@@ -111,7 +111,7 @@
                                         </tbody>
                                     </table>
                                     <f:if condition="{assetProxy.asset.inUse}">
-                                        <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset}" class="neos-button">
+                                <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset, browserConstraints: '{browserConstraints -> f:format.json()}'}" class="neos-button">
                                             {neos:backend.translate(id: 'relatedNodes', quantity: '{assetProxy.asset.usageCount}', arguments: {0: assetProxy.asset.usageCount}, package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                     </f:if>
@@ -122,7 +122,7 @@
                             </div>
                         </div>
                         <div class="neos-footer">
-                            <f:link.action action="index" class="neos-button neos-action-cancel">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+                    <f:link.action action="index" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}" class="neos-button neos-action-cancel">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
                             <f:if condition="!{assetSource.readOnly}">
                                 <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
                                     <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" class="neos-button" title="{neos:backend.translate(id: 'replaceAssetResource', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', container: 'body'}">
@@ -168,7 +168,7 @@
                             <div class="neos-modal-backdrop neos-in"></div>
                         </div>
                     </f:form>
-                    <f:form action="index" id="postHelper" method="post"></f:form>
+            <f:form action="index" id="postHelper" method="post" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}"></f:form>
                 </div>
             </div>
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -10,7 +10,7 @@
             <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: {0: searchTerm}, package: 'Neos.Media.Browser')}</f:if>
         </span>
         <f:if condition="!{activeAssetSource.readOnly}">
-        <f:link.action action="new"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
+        <f:link.action action="new" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
         </f:if>
     </div>
     <div class="neos-view-options">
@@ -24,19 +24,19 @@
                 </span>
                     <ul class="neos-dropdown-menu neos-pull-right" role="menu">
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
                         </li>
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
                         </li>
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
                         </li>
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
                         </li>
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
                         </li>
                     </ul>
                 </div>
@@ -61,19 +61,19 @@
                 <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
                 <ul>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                 </ul>
                 <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
                 <ul>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                 </ul>
             </div>
@@ -82,10 +82,10 @@
         </f:if>
         <f:if condition="{view} === 'Thumbnail'">
             <f:then>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
             </f:then>
             <f:else>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
             </f:else>
         </f:if>
     </div>
@@ -93,6 +93,7 @@
 
 <f:section name="Sidebar">
     <form action="{f:uri.action(action: 'index')}" method="get" class="neos-search">
+        <input type="hidden" name="browserConstraints" value="{browserConstraints -> f:format.json()}" />
         <button type="submit" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
         <div>
             <input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}" value="{searchTerm}"{f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')} />
@@ -104,7 +105,7 @@
         <ul class="neos-media-aside-list">
             <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
                 <li>
-                    <f:link.action action="index" title="{assetSource.label}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier}">
+                    <f:link.action action="index" title="{assetSource.label}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier, browserConstraints: '{browserConstraints -> f:format.json()}'}">
                         {assetSource.label}
                     </f:link.action>
                 </li>
@@ -130,19 +131,19 @@
             <f:if condition="{assetCollections -> f:count()}">
             <ul class="neos-media-aside-list">
                 <li>
-                    <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}">
+                    <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1, browserConstraints: '{browserConstraints -> f:format.json()}'}">
                         {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
                         <span class="count">{allCollectionsCount}</span>
                     </f:link.action>
                 </li>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
-                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object, browserConstraints: '{browserConstraints -> f:format.json()}'}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
                             {assetCollection.object.title}
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <div class="neos-sidelist-edit-actions">
-                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                             <button type="submit" class="neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                         </div>
                     </li>
@@ -194,25 +195,25 @@
         </h2>
         <ul class="neos-media-aside-list">
             <li class="neos-media-list-all">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}">
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1, browserConstraints: '{browserConstraints -> f:format.json()}'}">
                     {neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
                     <span class="count">{allCount}</span>
                 </f:link.action>
             </li>
             <li class="neos-media-list-untagged">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}">
+                <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2, browserConstraints: '{browserConstraints -> f:format.json()}'}">
                     {neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
                     <span class="count">{untaggedCount}</span>
                 </f:link.action>
             </li>
             <f:for each="{tags}" as="tag">
                 <li>
-                    <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+                    <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object, browserConstraints: '{browserConstraints -> f:format.json()}'}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
                         {tag.object.label}
                         <span class="count">{tag.count}</span>
                     </f:link.action>
                     <div class="neos-sidelist-edit-actions">
-                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object, browserConstraints: '{browserConstraints -> f:format.json()}'}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                         <button class="neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="fas fa-trash"></i></button>
                     </div>
                 </li>
@@ -234,7 +235,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteTag" class="neos-inline">
+                            <f:form action="deleteTag" class="neos-inline" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}">
                                 <f:form.hidden name="tag" id="modal-form-object" />
                                 <button type="submit" class="neos-button neos-button-danger">
                                     {neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}
@@ -246,7 +247,7 @@
                 <div class="neos-modal-backdrop neos-in"></div>
             </div>
         </ul>
-        <f:form action="createTag" id="neos-tags-create-form">
+        <f:form action="createTag" id="neos-tags-create-form" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}">
             <f:form.textfield name="label" placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}" /><br /><br />
             <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createTag', package: 'Neos.Media.Browser')}</button>
         </f:form>
@@ -258,7 +259,7 @@
     <f:if condition="!{activeAssetSource.readOnly}">
     <div id="dropzone" class="neos-upload-area">
         <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
-        <f:form method="post" action="create" object="{asset}" objectName="asset" enctype="multipart/form-data">
+        <f:form method="post" action="create" object="{asset}" objectName="asset" enctype="multipart/form-data" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}">
             <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
         </f:form>
     </div>
@@ -279,7 +280,7 @@
                 <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package: 'Neos.Media.Browser')}
             </div>
                     </f:if>
-                    <f:render partial="{view}View" arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}" />
+                    <f:render partial="{view}View" arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection, browserConstraints: browserConstraints}" />
 
             <div class="neos-hide" id="delete-asset-modal">
                 <div class="neos-modal-centered">
@@ -298,7 +299,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="delete" method="post" class="neos-inline">
+                            <f:form action="delete" method="post" class="neos-inline" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}">
                                 <f:form.hidden name="asset" id="modal-form-object" />
                                 <button type="submit" class="neos-button neos-button-mini neos-button-danger">
                                     {neos:backend.translate(id: 'message.confirmDelete', package: 'Neos.Media.Browser')}

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -22,6 +22,7 @@
                         <i class="fas fa-filter"></i>
                     </a>
                 </span>
+                    <!-- Note: the "values" in this menu are "magic strings" see \Neos\Media\Domain\Model\AssetSource\AssetTypeFilter  -->
                     <ul class="neos-dropdown-menu neos-pull-right" role="menu">
                         <li>
                             <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All', browserConstraints: '{browserConstraints -> f:format.json()}'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -4,7 +4,7 @@
 <f:section name="Title">Upload view</f:section>
 
 <f:section name="Content">
-    <f:form method="post" action="create" object="{asset}" objectName="asset" enctype="multipart/form-data">
+    <f:form method="post" action="create" object="{asset}" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}" objectName="asset" enctype="multipart/form-data">
         <fieldset>
             <div class="neos-span6 neos-image-inputs">
                 <span class="neos-file-input">
@@ -40,7 +40,7 @@
             </div>
         </fieldset>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
             <f:form.submit id="import" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}"/>
         </div>
     </f:form>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -5,7 +5,7 @@
 <f:section name="Title">Replace view of AssetController</f:section>
 
 <f:section name="Content">
-    <f:form method="post" arguments="{asset: asset}" action="updateAssetResource" enctype="multipart/form-data">
+    <f:form method="post" arguments="{asset: asset, browserConstraints: '{browserConstraints -> f:format.json()}'}" action="updateAssetResource" enctype="multipart/form-data">
         <div class="neos-row-fluid">
             <div class="neos-span8">
                 <fieldset>
@@ -40,7 +40,7 @@
                     <f:if condition="{asset.inUse}">
                         <f:then>
                             <p class="neos-buffer-below"><i class="fas fa-exclamation-sign"></i> {neos:backend.translate(id: 'replace.usageCount', arguments: {usageCount: asset.usageCount}, package: 'Neos.Media.Browser')}</p>
-                            <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
+                            <f:link.action action="relatedNodes" arguments="{asset:asset, browserConstraints: '{browserConstraints -> f:format.json()}'}" class="neos-button">
                                 {neos:backend.translate(id: 'replace.allUsages', package: 'Neos.Media.Browser')}
                             </f:link.action>
                         </f:then>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -11,7 +11,7 @@
                     <a href="#" role="tab">Overview</a>
                 </li>
                 <li role="presentation">
-                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'show'}">Variants</f:link.action>
+                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'show', browserConstraints: '{browserConstraints -> f:format.json()}'}">Variants</f:link.action>
                 </li>
             </ul>
         </f:if>
@@ -78,7 +78,7 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'back', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" arguments="{browserConstraints: '{browserConstraints -> f:format.json()}'}" class="neos-button">{neos:backend.translate(id: 'back', package: 'Neos.Neos')}</f:link.action>
         </div>
 </f:section>
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
@@ -8,10 +8,10 @@
 
     <ul class="neos-nav neos-nav-tabs" role="tablist">
         <li role="presentation">
-            <f:link.action action="{overviewAction}" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}">Overview</f:link.action>
+            <f:link.action action="{overviewAction}" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}">Overview</f:link.action>
         </li>
         <li role="presentation" class="neos-active">
-            <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}">Variants</f:link.action>
+            <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, browserConstraints: '{browserConstraints -> f:format.json()}'}">Variants</f:link.action>
         </li>
     </ul>
 

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Media\Domain\Model\AssetSource;
 
 /*
@@ -13,10 +15,16 @@ namespace Neos\Media\Domain\Model\AssetSource;
 
 final class AssetTypeFilter implements \JsonSerializable
 {
+    const TYPE_ALL = 'All';
+    const TYPE_IMAGE = 'Image';
+    const TYPE_DOCUMENT = 'Document';
+    const TYPE_VIDEO = 'Video';
+    const TYPE_AUDIO = 'Audio';
+
     /**
      * @var string
      */
-    private $assetType = 'All';
+    private $assetType;
 
     /**
      * AssetType constructor.
@@ -25,7 +33,7 @@ final class AssetTypeFilter implements \JsonSerializable
      */
     public function __construct(string $assetType)
     {
-        if (!in_array($assetType, ['All', 'Image', 'Document', 'Video', 'Audio'])) {
+        if (!in_array($assetType, [static::TYPE_ALL, static::TYPE_IMAGE, static::TYPE_DOCUMENT, static::TYPE_VIDEO, static::TYPE_AUDIO])) {
             throw new \InvalidArgumentException(sprintf('Invalid asset type "%s".', $assetType), 1524130064);
         }
         $this->assetType = $assetType;
@@ -44,7 +52,7 @@ final class AssetTypeFilter implements \JsonSerializable
      */
     public function hasAllAllowed(): bool
     {
-        return $this->assetType === 'All';
+        return $this->assetType === static::TYPE_ALL;
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
@@ -40,6 +40,14 @@ final class AssetTypeFilter implements \JsonSerializable
     }
 
     /**
+     * @return bool
+     */
+    public function hasAllAllowed(): bool
+    {
+        return $this->assetType === 'All';
+    }
+
+    /**
      * @return string
      */
     public function __toString(): string

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\Exception\InvalidQueryException;


### PR DESCRIPTION
With this feature the browser can be called with a constraints argument
that will limit the possibilities. For now constraints on asset proxies
and asset type (according to our object types) are possible. More can be
added as needed.

In itself this is not extremly helpful yet, but in combination with
the Neos UI this can be a powerful feature.
