### PR TITLE
BUGFIX: Convert DateTimeImmutable "Now" into DateTime for account deactivation

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Domain\Service;
 
 /*
@@ -539,7 +540,7 @@ class UserService
     /**
      * Reactivates the given user
      *
-     * @param User $user The user to deactivate
+     * @param User $user The user to activate
      * @return void
      * @api
      */
@@ -576,7 +577,9 @@ class UserService
     {
         /** @var Account $account */
         foreach ($user->getAccounts() as $account) {
-            $account->setExpirationDate($this->now);
+            $account->setExpirationDate(
+                \DateTime::createFromFormat(\DateTimeInterface::ATOM, $this->now->format(\DateTimeInterface::ATOM))
+            );
             $this->accountRepository->update($account);
         }
         $this->emitUserDeactivated($user);


### PR DESCRIPTION
Convert "Now" based on DateTimeImmutable to DateTime, as Account::setExpirationDate expects it.

Fixes #2131 