### PR TITLE
FEATURE: Sortable NodeType Post processors

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -208,7 +208,8 @@ class NodeType
         if (!isset($this->fullConfiguration['postprocessors'])) {
             return;
         }
-        foreach ($this->fullConfiguration['postprocessors'] as $postprocessorConfiguration) {
+        $sortedPostProcessors = (new PositionalArraySorter($this->fullConfiguration['postprocessors']))->toArray();
+        foreach ($sortedPostProcessors as $postprocessorConfiguration) {
             $postprocessor = new $postprocessorConfiguration['postprocessor']();
             if (!$postprocessor instanceof NodeTypePostprocessorInterface) {
                 throw new InvalidNodeTypePostprocessorException(sprintf('Expected NodeTypePostprocessorInterface but got "%s"', get_class($postprocessor)), 1364759955);

--- a/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
@@ -28,12 +28,14 @@
     'processor1':
       postprocessor: 'Neos\ContentRepository\Tests\Functional\Domain\Fixtures\TestNodePostprocessor'
       postprocessorOptions:
-        someOption: 'someValue'
-    'processor2':
-      postprocessor: 'Neos\ContentRepository\Tests\Functional\Domain\Fixtures\TestNodePostprocessor'
-      postprocessorOptions:
         someOption: 'someOverriddenValue'
         someOtherOption: 'someOtherValue'
+    'processor2':
+      position: start
+      postprocessor: 'Neos\ContentRepository\Tests\Functional\Domain\Fixtures\TestNodePostprocessor'
+      postprocessorOptions:
+        someOption: 'someValue'
+
 
 'Neos.ContentRepository.Testing:NodeTypeWithReferences':
   properties:

--- a/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.ContentRepository/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -107,5 +107,6 @@ additionalProperties:
         additionalProperties: false
         properties:
           'postprocessor': { type: string, format: class-name, required: true }
+          'position': { type: ['string', 'number', 'null'] }
           'postprocessorOptions':
             type: dictionary


### PR DESCRIPTION
Allows a `position` to be specified in the NodeType `postprocessors` configuration:

```yaml
'Some.Custom:NodeType':
  # ...
  postprocessors:
    SomeCustomTypePostprocessor:
      position: 'end'
      postprocessor: 'Some\TypePostprocessor'
```

Resolves: #2868