### PR TITLE
BUGFIX: Add code migration for MultiColumn* nodetypes

### DIFF
--- a/Neos.NodeTypes/Migrations/Code/Version20200120114136.php
+++ b/Neos.NodeTypes/Migrations/Code/Version20200120114136.php
@@ -28,8 +28,8 @@ class Version20200120114136 extends AbstractMigration
     public function up()
     {
         $nodetypeUpgradeMap = [
-            'Neos.NodeTypes:MultiColumn' => 'Neos.NodeTypes.ColumnLayouts:MultiColumn',
             'Neos.NodeTypes:MultiColumnItem' => 'Neos.NodeTypes.ColumnLayouts:MultiColumnItem',
+            'Neos.NodeTypes:MultiColumn' => 'Neos.NodeTypes.ColumnLayouts:MultiColumn',
         ];
 
         foreach ($nodetypeUpgradeMap as $search => $replace) {

--- a/Neos.NodeTypes/Migrations/Code/Version20200120114136.php
+++ b/Neos.NodeTypes/Migrations/Code/Version20200120114136.php
@@ -1,0 +1,39 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.NodeTypes package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Adjusts code to rename nodetypes that were extracted to subpackages in fusion and nodetype definitions
+ */
+class Version20200120114136 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.NodeTypes-20200120114136';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $nodetypeUpgradeMap = [
+            'Neos.NodeTypes:MultiColumn' => 'Neos.NodeTypes.ColumnLayouts:MultiColumn',
+            'Neos.NodeTypes:MultiColumnItem' => 'Neos.NodeTypes.ColumnLayouts:MultiColumnItem',
+        ];
+
+        foreach ($nodetypeUpgradeMap as $search => $replace) {
+            $this->searchAndReplace($search, $replace, ['fusion', 'ts2', 'yaml']);
+        }
+    }
+}


### PR DESCRIPTION
Add missing code migration for nodetypes Neos.NodeTypes:MultiColumn and Neos.NodeTypes:MultiColumnItem for seamless upgrade process.