### PR TITLE
FEATURE: Reduced stylesheet for backend modules

### DIFF
--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -47,6 +47,7 @@ Neos:
             label: 'Neos.Media.Browser:Main:module.label'
             description: 'Neos.Media.Browser:Main:module.description'
             icon: 'fas fa-camera'
+            mainStylesheet: 'Lite'
             privilegeTarget: 'Neos.Media.Browser:ManageAssets'
             additionalResources:
               styleSheets:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -304,34 +304,43 @@ Neos:
 
     moduleConfiguration:
       widgetTemplatePathAndFileName: 'resource://Neos.Neos/Private/Templates/Module/Widget.html'
+      # This stylesheet can be overriden in the configuration of a submodule to reference a reduced stylesheet.
+      # Use `Main` for backwards compatibility
+      # Use `Lite` for a reduced variant with a less aggressive reset and other non essential styles removed.
+      mainStylesheet: 'Main'
     modules:
       management:
         label: 'Neos.Neos:Modules:management.label'
         controller: 'Neos\Neos\Controller\Module\ManagementController'
         description: 'Neos.Neos:Modules:management.description'
         icon: fas fa-briefcase
+        mainStylesheet: 'Lite'
         submodules:
           workspaces:
             label: 'Neos.Neos:Modules:workspaces.label'
             controller: 'Neos\Neos\Controller\Module\Management\WorkspacesController'
             description: 'Neos.Neos:Modules:workspaces.description'
             icon: fas fa-th-large
+            mainStylesheet: 'Lite'
           history:
             label: 'Neos.Neos:Modules:history.label'
             controller: 'Neos\Neos\Controller\Module\Management\HistoryController'
             description: 'Neos.Neos:Modules:history.description'
             icon: fas fa-calendar-alt
+            mainStylesheet: 'Lite'
       administration:
         label: 'Neos.Neos:Modules:administration.label'
         controller: 'Neos\Neos\Controller\Module\AdministrationController'
         description: 'Neos.Neos:Modules:administration.description'
         icon: fas fa-cogs
+        mainStylesheet: 'Lite'
         submodules:
           users:
             label: 'Neos.Neos:Modules:users.label'
             controller: 'Neos\Neos\Controller\Module\Administration\UsersController'
             description: 'Neos.Neos:Modules:users.description'
             icon: fas fa-users
+            mainStylesheet: 'Lite'
             actions:
               new:
                 label: 'Neos.Neos:Modules:users.actions.new.label'
@@ -341,11 +350,13 @@ Neos:
             controller: 'Neos\Neos\Controller\Module\Administration\PackagesController'
             description: 'Neos.Neos:Modules:packages.description'
             icon: fas fa-archive
+            mainStylesheet: 'Lite'
           sites:
             label: 'Neos.Neos:Modules:sites.label'
             controller: 'Neos\Neos\Controller\Module\Administration\SitesController'
             description: 'Neos.Neos:Modules:sites.description'
             icon: fas fa-globe
+            mainStylesheet: 'Lite'
             actions:
               newSite:
                 label: 'Neos.Neos:Modules:sites.actions.newSite.label'
@@ -355,21 +366,25 @@ Neos:
             controller: 'Neos\Neos\Controller\Module\Administration\ConfigurationController'
             description: 'Neos.Neos:Modules:configuration.description'
             icon: fas fa-list-alt
+            mainStylesheet: 'Lite'
           dimensions:
             label: 'Neos.Neos:Modules:dimensions.label'
             controller: 'Neos\Neos\Controller\Module\Administration\DimensionController'
             description: 'Neos.Neos:Modules:dimensions.description'
             icon: fas fa-code-branch
+            mainStylesheet: 'Lite'
       user:
         label: 'Neos.Neos:Modules:user.label'
         controller: \Neos\Neos\Controller\Module\UserController
         hideInMenu: true
+        mainStylesheet: 'Lite'
         submodules:
           usersettings:
             label: 'Neos.Neos:Modules:userSettings.label'
             controller: \Neos\Neos\Controller\Module\User\UserSettingsController
             description: 'Neos.Neos:Modules:userSettings.description'
             icon: fas fa-user
+            mainStylesheet: 'Lite'
 
      # Settings for the Neos Event Log (** DO NOT USE, NO PUBLIC API YET **)
     eventLog:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -307,6 +307,7 @@ Neos:
       # This stylesheet can be overriden in the configuration of a submodule to reference a reduced stylesheet.
       # Use `Main` for backwards compatibility
       # Use `Lite` for a reduced variant with a less aggressive reset and other non essential styles removed.
+      # Use `Minimal` when your module provides its own styles and Neos only needs to show the top and bottom bar.
       mainStylesheet: 'Main'
     modules:
       management:

--- a/Neos.Neos/Resources/Private/Styles/Lite.scss
+++ b/Neos.Neos/Resources/Private/Styles/Lite.scss
@@ -1,0 +1,80 @@
+// Core variables and mixins
+@import "Foundation/variables";
+@import "Foundation/mixins";
+@import "Constants";
+@import "Mixins";
+@import "Fonts";
+@import "FontAwesome/fontawesome.scss";
+@import "FontAwesome/brands.scss";
+@import "FontAwesome/regular.scss";
+@import "FontAwesome/solid.scss";
+@import "Icons";
+
+// Reusable CSS variables for all backend modules
+@import "CSSVariables";
+
+// CSS Reset
+@import "Foundation/reset";
+@import "Reset";
+
+.neos {
+	// Grid system and page structure
+	@import "Foundation/grid";
+	@import "Foundation/layouts";
+
+	// Base CSS
+	@import "Foundation/forms";
+	@import "Foundation/tables";
+
+	// Components: common
+	@import "Foundation/dropdowns";
+	@import "Foundation/wells";
+	@import "Foundation/component-animations";
+	@import "Foundation/close";
+	@import "Foundation/thumbnails";
+
+	// Components: Buttons & Alerts
+	@import "Foundation/buttons";
+	@import "Foundation/button-groups";
+
+	// Components: Nav
+	@import "Foundation/breadcrumbs";
+
+	// Components: Modals, Tooltips & Popovers
+	@import "Foundation/modals";
+	@import "Foundation/tooltip";
+	@import "Foundation/popovers";
+
+	// Components: Misc
+	@import "Foundation/labels-badges";
+
+	// Utility classes
+	@import "Foundation/utilities"; // Has to be last to override when necessary
+
+	// Large desktops
+	@import "Foundation/responsive-1200px-min";
+
+	// Tablets to regular desktops
+	@import "Foundation/responsive-768px-979px";
+
+	// Phones to portrait tablets and narrow desktops
+	@import "Foundation/responsive-767px-max";
+
+	// Neos font definition
+	font-size: 14px;
+	line-height: 1em;
+	text-align: left;
+	color: $textOnGray;
+	@include font;
+
+	@import "Tree";
+	@import "General";
+	@import "TopBar/TopBar";
+	@import "TopBar/UserMenu";
+	@import "Menu/MenuPanel";
+	@import "Modules/Modules";
+	@import "Modules/Widget";
+	@import "Notifications";
+}
+
+@import "Global";

--- a/Neos.Neos/Resources/Private/Styles/Minimal.scss
+++ b/Neos.Neos/Resources/Private/Styles/Minimal.scss
@@ -1,0 +1,43 @@
+// Core variables and mixins
+@import "Foundation/variables";
+@import "Foundation/mixins";
+@import "Constants";
+@import "Mixins";
+@import "Fonts";
+@import "FontAwesome/fontawesome.scss";
+@import "FontAwesome/brands.scss";
+@import "FontAwesome/regular.scss";
+@import "FontAwesome/solid.scss";
+@import "Icons";
+
+// Reusable CSS variables for all backend modules
+@import "CSSVariables";
+
+// CSS Reset
+@import "Foundation/reset";
+@import "Reset";
+
+.neos {
+	// Essentials from Foundation for the top and bottom bar
+	@import "Foundation/breadcrumbs";
+	@import "Foundation/buttons";
+	@import "Foundation/button-groups";
+	@import "Foundation/layouts";
+	@import "Foundation/dropdowns";
+
+	// Neos font definition
+	font-size: 14px;
+	line-height: 1em;
+	text-align: left;
+	color: $textOnGray;
+	@include font;
+
+	// Essential Neos styles for the top bar and notifications
+	@import "TopBar/TopBar";
+	@import "TopBar/UserMenu";
+	@import "Menu/MenuPanel";
+	@import "Modules/Modules";
+	@import "Notifications";
+}
+
+@import "Global";

--- a/Neos.Neos/Resources/Private/Styles/Modules/_Modules.scss
+++ b/Neos.Neos/Resources/Private/Styles/Modules/_Modules.scss
@@ -435,7 +435,7 @@
 
 			.neos-label {
 				background-color: $grayLight;
-				box-shadow: $textContrast 0 0 ($unit/4) ($unit/8);
+				box-shadow: 0 0 3px 2px rgba(0, 0, 0, .1);
 				font-weight: normal;
 				letter-spacing: 0.05em;
 				padding: 2px 0.5em;

--- a/Neos.Neos/Resources/Private/Styles/_CSSVariables.scss
+++ b/Neos.Neos/Resources/Private/Styles/_CSSVariables.scss
@@ -1,0 +1,108 @@
+:root {
+	// Neos backend variables
+	--base-font-size: #{$baseFontSize};
+
+	/* Color palette */
+	--grayDarker: #{$grayDarker};
+	--grayDark: #{$grayDark};
+	--grayMedium: #{$grayMedium};
+	--grayLight: #{$grayLight};
+	--grayLighter: #{$grayLighter};
+	--textOnWhite: #{$textOnWhite};
+	--textContrast: #{$textContrast};
+	--textOnGray: #{$textOnGray};
+	--textSubtle: #{$textSubtle};
+	--textSubtleLight: #{$textSubtleLight};
+	--blue: #{$blue};
+	--blueLight: #{$blueLight};
+	--blueDark: #{$blueDark};
+	--green: #{$green};
+	--warning: #{$warning};
+	--orange: #{$orange};
+
+	/* Sizes & margins */
+	--unit: #{$unit};
+	--defaultMargin: #{$defaultMargin};
+	--relatedMargin: #{$relatedMargin};
+	--tightMargin: #{$tightMargin};
+	--wideMargin: #{$wideMargin};
+
+	/* Components */
+	--inspectorWidth: #{$inspectorWidth};
+	--navigatePanelWidth: #{$navigatePanelWidth};
+	--menuWidth: #{$menuWidth};
+	--editPreviewPanelHeight: #{$editPreviewPanelHeight};
+	--menuButtonWidth: #{$menuButtonWidth};
+	--generalFontSize: #{$generalFontSize};
+
+	--zindexTooltip: #{$zindexTooltip};
+	--errorText: #{$errorText};
+	--successText: #{$successText};
+	--warningText: #{$warningText};
+	--infoText: #{$infoText};
+
+	// Variables from Neos UI for usage in standalone react components
+	--spacing-GoldenUnit: #{$unit};
+	--spacing-Full: #{$defaultMargin};
+	--spacing-Half: #{$relatedMargin};
+	--spacing-Quarter: #{$tightMargin};
+
+	--size-SidebarWidth: #{$navigatePanelWidth};
+
+	--transition-Fast: .1s;
+	--transition-Default: .25s;
+	--transition-Slow: .5s;
+
+	--zIndex-SecondaryToolbar-LinkIconButtonFlyout: 1;
+	--zIndex-FlashMessageContainer: 6;
+	--zIndex-LoadingIndicatorContainer: 5;
+	--zIndex-SecondaryInspector-Context: 1;
+	--zIndex-SecondaryInspector-Iframe: 2;
+	--zIndex-SecondaryInspector-Close: 3;
+	--zIndex-SecondaryInspectorElevated-Context: 1;
+	--zIndex-SecondaryInspectorElevated-DropdownContents: 2;
+	--zIndex-Dialog-Context: 1;
+	--zIndex-FullScreenClose-Context: 1;
+	--zIndex-Drawer-Context: 1;
+	--zIndex-Bar-Context: 1;
+	--zIndex-PrimaryToolbar: 4;
+	--zIndex-CheckboxInput-Context: 1;
+	--zIndex-DropdownContents-Context: 1;
+	--zIndex-SelectBoxContents: 3;
+	--zIndex-NotInlineEditableOverlay-Context: 1;
+	--zIndex-CalendarFakeInputMirror-Context: 1;
+	--zIndex-RdtPicker-Context: 1;
+	--zIndex-SideBar-DropTargetBefore: 1;
+	--zIndex-SideBar-DropTargetAfter: 2;
+	--zIndex-WrapperDropdown-Context: 1;
+	--zIndex-UnappliedChangesOverlay-Context: 1;
+	--zIndex-NodeToolBar: 2147483646;
+
+	--fontSize-Base: #{$generalFontSize};
+	--fontSize-Small: 12px;
+	--fontsHeadings-Family: Noto Sans;
+	--fontsHeadings-Style: Regular;
+	--fontsHeadings-CssWeight: 400;
+	--fontsCopy-Family: Noto Sans;
+	--fontsCopy-Style: Regular;
+	--fontsCopy-CssWeight: 400;
+
+	--colors-PrimaryViolet: #26224C;
+	--colors-PrimaryVioletHover: #342f5f;
+	--colors-PrimaryBlue: #00ADEE;
+	--colors-PrimaryBlueHover: #35c3f8;
+	--colors-ContrastDarkest: #{$grayDarker};
+	--colors-ContrastDarker: #{$grayDark};
+	--colors-ContrastDark: #{$grayLight};
+	--colors-ContrastNeutral: #{$grayMedium};
+	--colors-ContrastBright: #999;
+	--colors-ContrastBrighter: #{$textSubtleLight};
+	--colors-ContrastBrightest: #{$textOnGray};
+	--colors-Success: #{$green};
+	--colors-SuccessHover: #0bb344;
+	--colors-Warn: #{$orange};
+	--colors-WarnHover: #fda23d;
+	--colors-Error: #{$warning};
+	--colors-ErrorHover: #ff6a3c;
+	--colors-UncheckedCheckboxTick: #5B5B5B;
+}

--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -7,7 +7,7 @@
 	<link
 		rel="stylesheet"
 		type="text/css"
-		href="{f:uri.resource(path: 'Styles/Main.css', package: 'Neos.Neos')}?bust={neos:backend.cssBuiltVersion()}"
+		href="{f:uri.resource(package: 'Neos.Neos', path: '/Styles/{f:if(condition: moduleConfiguration.mainStylesheet, then: moduleConfiguration.mainStylesheet, else: settings.moduleConfiguration.mainStylesheet)}')}.css?bust={neos:backend.cssBuiltVersion()}"
 	/>
 
 	<f:if condition="{moduleConfiguration.additionalResources.styleSheets}">

--- a/Neos.Neos/Resources/Public/Styles/Lite.css
+++ b/Neos.Neos/Resources/Public/Styles/Lite.css
@@ -44,14 +44,10 @@
 .neos ul.neos-tree-container .neos-tree-node .neos-tree-expander,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span::before,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div:after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr::after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-search,
 .neos.neos-module .neos-select:after,
 .neos.neos-module .neos-checkbox input + span::before,
 .neos.neos-module .neos-radio input + span::before,
 .neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button,
-.neos .neos-position-selector::after,
 .far,
 .fal,
 .fad,
@@ -147,14 +143,10 @@
 .neos ul.neos-tree-container .neos-tree-node .fa-pull-left.neos-tree-expander,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-left::before,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span.fa-pull-left::before,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div.fa-pull-left:after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr.fa-pull-left::after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .fa-pull-left.chosen-search,
 .neos.neos-module .fa-pull-left.neos-select:after,
 .neos.neos-module .neos-checkbox input + span.fa-pull-left::before,
 .neos.neos-module .neos-radio input + span.fa-pull-left::before,
 .neos #neos-notification-container.neos-notification-top > .neos-notification i.fa-pull-left.neos-close-button,
-.neos .fa-pull-left.neos-position-selector::after,
 .far.fa-pull-left,
 .fal.fa-pull-left,
 .fab.fa-pull-left {
@@ -173,14 +165,10 @@
 .neos ul.neos-tree-container .neos-tree-node .fa-pull-right.neos-tree-expander,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-right::before,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span.fa-pull-right::before,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div.fa-pull-right:after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr.fa-pull-right::after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .fa-pull-right.chosen-search,
 .neos.neos-module .fa-pull-right.neos-select:after,
 .neos.neos-module .neos-checkbox input + span.fa-pull-right::before,
 .neos.neos-module .neos-radio input + span.fa-pull-right::before,
 .neos #neos-notification-container.neos-notification-top > .neos-notification i.fa-pull-right.neos-close-button,
-.neos .fa-pull-right.neos-position-selector::after,
 .far.fa-pull-right,
 .fal.fa-pull-right,
 .fab.fa-pull-right {
@@ -4553,14 +4541,10 @@ readers do not read off random characters that represent icons */
 .neos ul.neos-tree-container .neos-tree-node .neos-tree-expander,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span::before,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div:after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr::after,
-.neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-search,
 .neos.neos-module .neos-select:after,
 .neos.neos-module .neos-checkbox input + span::before,
 .neos.neos-module .neos-radio input + span::before,
-.neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button,
-.neos .neos-position-selector::after {
+.neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900; }
 
@@ -4586,6 +4570,285 @@ readers do not read off random characters that represent icons */
       top: 8px;
       left: 7px; }
 
+:root {
+  --base-font-size: 100%;
+  /* Color palette */
+  --grayDarker: #141414;
+  --grayDark: #222;
+  --grayMedium: #323232;
+  --grayLight: #3f3f3f;
+  --grayLighter: #eee;
+  --textOnWhite: #252525;
+  --textContrast: #2d2d2d;
+  --textOnGray: #fff;
+  --textSubtle: #5b5b5b;
+  --textSubtleLight: #adadad;
+  --blue: #00b5ff;
+  --blueLight: #39c6ff;
+  --blueDark: #007fb2;
+  --green: #00a338;
+  --warning: #ff460d;
+  --orange: #ff8700;
+  /* Sizes & margins */
+  --unit: 40px;
+  --defaultMargin: 16px;
+  --relatedMargin: 8px;
+  --tightMargin: 4px;
+  --wideMargin: 32px;
+  /* Components */
+  --inspectorWidth: 320px;
+  --navigatePanelWidth: 320px;
+  --menuWidth: 320px;
+  --editPreviewPanelHeight: 110px;
+  --menuButtonWidth: 54px;
+  --generalFontSize: 14px;
+  --zindexTooltip: 999999;
+  --errorText: #ff460d;
+  --successText: #00a338;
+  --warningText: #ff8700;
+  --infoText: #00b5ff;
+  --spacing-GoldenUnit: 40px;
+  --spacing-Full: 16px;
+  --spacing-Half: 8px;
+  --spacing-Quarter: 4px;
+  --size-SidebarWidth: 320px;
+  --transition-Fast: .1s;
+  --transition-Default: .25s;
+  --transition-Slow: .5s;
+  --zIndex-SecondaryToolbar-LinkIconButtonFlyout: 1;
+  --zIndex-FlashMessageContainer: 6;
+  --zIndex-LoadingIndicatorContainer: 5;
+  --zIndex-SecondaryInspector-Context: 1;
+  --zIndex-SecondaryInspector-Iframe: 2;
+  --zIndex-SecondaryInspector-Close: 3;
+  --zIndex-SecondaryInspectorElevated-Context: 1;
+  --zIndex-SecondaryInspectorElevated-DropdownContents: 2;
+  --zIndex-Dialog-Context: 1;
+  --zIndex-FullScreenClose-Context: 1;
+  --zIndex-Drawer-Context: 1;
+  --zIndex-Bar-Context: 1;
+  --zIndex-PrimaryToolbar: 4;
+  --zIndex-CheckboxInput-Context: 1;
+  --zIndex-DropdownContents-Context: 1;
+  --zIndex-SelectBoxContents: 3;
+  --zIndex-NotInlineEditableOverlay-Context: 1;
+  --zIndex-CalendarFakeInputMirror-Context: 1;
+  --zIndex-RdtPicker-Context: 1;
+  --zIndex-SideBar-DropTargetBefore: 1;
+  --zIndex-SideBar-DropTargetAfter: 2;
+  --zIndex-WrapperDropdown-Context: 1;
+  --zIndex-UnappliedChangesOverlay-Context: 1;
+  --zIndex-NodeToolBar: 2147483646;
+  --fontSize-Base: 14px;
+  --fontSize-Small: 12px;
+  --fontsHeadings-Family: Noto Sans;
+  --fontsHeadings-Style: Regular;
+  --fontsHeadings-CssWeight: 400;
+  --fontsCopy-Family: Noto Sans;
+  --fontsCopy-Style: Regular;
+  --fontsCopy-CssWeight: 400;
+  --colors-PrimaryViolet: #26224C;
+  --colors-PrimaryVioletHover: #342f5f;
+  --colors-PrimaryBlue: #00ADEE;
+  --colors-PrimaryBlueHover: #35c3f8;
+  --colors-ContrastDarkest: #141414;
+  --colors-ContrastDarker: #222;
+  --colors-ContrastDark: #3f3f3f;
+  --colors-ContrastNeutral: #323232;
+  --colors-ContrastBright: #999;
+  --colors-ContrastBrighter: #adadad;
+  --colors-ContrastBrightest: #fff;
+  --colors-Success: #00a338;
+  --colors-SuccessHover: #0bb344;
+  --colors-Warn: #ff8700;
+  --colors-WarnHover: #fda23d;
+  --colors-Error: #ff460d;
+  --colors-ErrorHover: #ff6a3c;
+  --colors-UncheckedCheckboxTick: #5B5B5B; }
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+nav,
+section {
+  display: block; }
+
+audio,
+canvas,
+video {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1; }
+
+audio:not([controls]) {
+  display: none; }
+
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%; }
+
+a:focus {
+  outline: thin dotted #333;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px; }
+
+a:hover,
+a:active {
+  outline: 0; }
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+img {
+  /* Responsive images (ensure images don't scale beyond their parents) */
+  max-width: 100%;
+  /* Part 1: Set a maxium relative to the parent */
+  width: auto\9;
+  /* IE7-8 need help adjusting responsive images */
+  height: auto;
+  /* Part 2: Scale the height according to the width, otherwise you get stretching */
+  vertical-align: middle;
+  border: 0;
+  -ms-interpolation-mode: bicubic; }
+
+#map_canvas img,
+.neos-google-maps img {
+  max-width: none; }
+
+button,
+input,
+select,
+textarea {
+  margin: 0;
+  font-size: 100%;
+  vertical-align: middle; }
+
+button,
+input {
+  *overflow: visible;
+  line-height: normal; }
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  padding: 0;
+  border: 0; }
+
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer; }
+
+label[for],
+select,
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
+input[type="radio"],
+input[type="checkbox"] {
+  cursor: pointer; }
+
+input[type="search"] {
+  box-sizing: content-box;
+  -webkit-appearance: textfield; }
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none; }
+
+textarea {
+  overflow: auto;
+  vertical-align: top; }
+
+@media print {
+  * {
+    text-shadow: none !important;
+    color: #000 !important;
+    background: transparent !important;
+    box-shadow: none !important; }
+  a,
+  a:visited {
+    text-decoration: underline; }
+  a[href]:after {
+    content: " (" attr(href) ")"; }
+  abbr[title]:after {
+    content: " (" attr(title) ")"; }
+  .neos-ir a:after,
+  a[href^="javascript:"]:after,
+  a[href^="#"]:after {
+    content: ""; }
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid; }
+  thead {
+    display: table-header-group; }
+  tr,
+  img {
+    page-break-inside: avoid; }
+  img {
+    max-width: 100% !important; }
+  @page {
+    margin: 0.5cm; }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3; }
+  h2,
+  h3 {
+    page-break-after: avoid; } }
+
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, fieldset, input, p, blockquote, th, td {
+  margin: 0;
+  padding: 0; }
+
+img {
+  border: 0; }
+
+address, caption, cite, code, dfn, em, strong, th, var {
+  font-style: normal;
+  font-weight: normal; }
+
+ol, ul, ol li, ul li {
+  list-style: none; }
+
+caption, th {
+  text-align: left; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-size: 14px; }
+
+q:before,
+q:after {
+  content: ''; }
+
+*, *:before, *:after {
+  box-sizing: content-box; }
+
+@media only screen {
+  button, .button {
+    transition: none;
+    box-shadow: none; } }
+
 .neos {
   /* Allow for input prepend/append in search forms */
   font-size: 14px;
@@ -4593,140 +4856,7 @@ readers do not read off random characters that represent icons */
   text-align: left;
   color: #fff;
   font-family: 'Noto Sans', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  /* Modal Dialog Content area */ }
-  .neos article,
-  .neos aside,
-  .neos details,
-  .neos figcaption,
-  .neos figure,
-  .neos footer,
-  .neos header,
-  .neos hgroup,
-  .neos nav,
-  .neos section {
-    display: block; }
-  .neos audio,
-  .neos canvas,
-  .neos video {
-    display: inline-block;
-    *display: inline;
-    *zoom: 1; }
-  .neos audio:not([controls]) {
-    display: none; }
-  .neos html {
-    font-size: 100%;
-    -webkit-text-size-adjust: 100%;
-    -ms-text-size-adjust: 100%; }
-  .neos a:focus {
-    outline: thin dotted #333;
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px; }
-  .neos a:hover,
-  .neos a:active {
-    outline: 0; }
-  .neos sub,
-  .neos sup {
-    position: relative;
-    font-size: 75%;
-    line-height: 0;
-    vertical-align: baseline; }
-  .neos sup {
-    top: -0.5em; }
-  .neos sub {
-    bottom: -0.25em; }
-  .neos img {
-    /* Responsive images (ensure images don't scale beyond their parents) */
-    max-width: 100%;
-    /* Part 1: Set a maxium relative to the parent */
-    width: auto\9;
-    /* IE7-8 need help adjusting responsive images */
-    height: auto;
-    /* Part 2: Scale the height according to the width, otherwise you get stretching */
-    vertical-align: middle;
-    border: 0;
-    -ms-interpolation-mode: bicubic; }
-  .neos #map_canvas img,
-  .neos .neos-google-maps img {
-    max-width: none; }
-  .neos button,
-  .neos input,
-  .neos select,
-  .neos textarea {
-    margin: 0;
-    font-size: 100%;
-    vertical-align: middle; }
-  .neos button,
-  .neos input {
-    *overflow: visible;
-    line-height: normal; }
-  .neos button::-moz-focus-inner,
-  .neos input::-moz-focus-inner {
-    padding: 0;
-    border: 0; }
-  .neos button,
-  .neos html input[type="button"],
-  .neos input[type="reset"],
-  .neos input[type="submit"] {
-    -webkit-appearance: button;
-    cursor: pointer; }
-  .neos label[for],
-  .neos select,
-  .neos button,
-  .neos input[type="button"],
-  .neos input[type="reset"],
-  .neos input[type="submit"],
-  .neos input[type="radio"],
-  .neos input[type="checkbox"] {
-    cursor: pointer; }
-  .neos input[type="search"] {
-    box-sizing: content-box;
-    -webkit-appearance: textfield; }
-  .neos input[type="search"]::-webkit-search-decoration,
-  .neos input[type="search"]::-webkit-search-cancel-button {
-    -webkit-appearance: none; }
-  .neos textarea {
-    overflow: auto;
-    vertical-align: top; }
-  @media print {
-    .neos * {
-      text-shadow: none !important;
-      color: #000 !important;
-      background: transparent !important;
-      box-shadow: none !important; }
-    .neos a,
-    .neos a:visited {
-      text-decoration: underline; }
-    .neos a[href]:after {
-      content: " (" attr(href) ")"; }
-    .neos abbr[title]:after {
-      content: " (" attr(title) ")"; }
-    .neos .neos-ir a:after,
-    .neos a[href^="javascript:"]:after,
-    .neos a[href^="#"]:after {
-      content: ""; }
-    .neos pre,
-    .neos blockquote {
-      border: 1px solid #999;
-      page-break-inside: avoid; }
-    .neos thead {
-      display: table-header-group; }
-    .neos tr,
-    .neos img {
-      page-break-inside: avoid; }
-    .neos img {
-      max-width: 100% !important; }
-    @page {
-      .neos {
-        margin: 0.5cm; } }
-    .neos p,
-    .neos h2,
-    .neos h3 {
-      orphans: 3;
-      widows: 3; }
-    .neos h2,
-    .neos h3 {
-      page-break-after: avoid; } }
+  -webkit-font-smoothing: antialiased; }
   .neos .neos-row {
     margin-left: -20px; }
     .neos .neos-row:after {
@@ -7240,29 +7370,6 @@ readers do not read off random characters that represent icons */
     .neos .neos-modal-header .neos-close {
       padding: 10px;
       margin: -10px; } }
-  .neos div, .neos dl, .neos dt, .neos dd, .neos ul, .neos ol, .neos li, .neos h1, .neos h2, .neos h3, .neos h4, .neos h5, .neos h6, .neos pre, .neos form, .neos fieldset, .neos input, .neos p, .neos blockquote, .neos th, .neos td {
-    margin: 0;
-    padding: 0; }
-  .neos img {
-    border: 0; }
-  .neos address, .neos caption, .neos cite, .neos code, .neos dfn, .neos em, .neos strong, .neos th, .neos var {
-    font-style: normal;
-    font-weight: normal; }
-  .neos ol, .neos ul, .neos ol li, .neos ul li {
-    list-style: none; }
-  .neos caption, .neos th {
-    text-align: left; }
-  .neos h1, .neos h2, .neos h3, .neos h4, .neos h5, .neos h6 {
-    font-size: 14px; }
-  .neos q:before,
-  .neos q:after {
-    content: ''; }
-  .neos *, .neos *:before, .neos *:after {
-    box-sizing: content-box; }
-  @media only screen {
-    .neos button, .neos .button {
-      transition: none;
-      box-shadow: none; } }
   .neos ul.neos-tree-container {
     padding: 0;
     margin: 0;
@@ -7515,88 +7622,6 @@ readers do not read off random characters that represent icons */
     margin-top: 20px; }
   .neos iframe {
     border: 0; }
-
-@keyframes dot {
-  0% {
-    text-indent: -20px; }
-  25% {
-    text-indent: -15px; }
-  50% {
-    text-indent: -7px; }
-  75% {
-    text-indent: 0px; }
-  100% {
-    text-indent: -20px; } }
-  .neos .neos-ellipsis::after {
-    display: inline-block;
-    width: 12px;
-    content: '...';
-    overflow: hidden;
-    vertical-align: top;
-    animation: dot 1.3s infinite;
-    animation-timing-function: step-start; }
-  .neos ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px; }
-  .neos ::-webkit-scrollbar-track {
-    background-color: #3f3f3f; }
-  .neos ::-webkit-scrollbar-thumb {
-    background-color: #222;
-    border: 1px solid #3f3f3f; }
-  .neos ::-webkit-scrollbar-corner {
-    background-color: #3f3f3f; }
-  .neos button.fa-trash:before {
-    padding-right: 3px; }
-  .neos .neos-popover {
-    display: none; }
-    .neos .neos-popover.neos-active {
-      display: block; }
-  .neos .scrollbar {
-    position: absolute;
-    content: '';
-    display: block;
-    border-radius: 100px;
-    opacity: 0;
-    z-index: 100; }
-  .neos .vertical {
-    width: 7px;
-    right: 2px;
-    top: 2px; }
-  .neos .horizontal {
-    height: 7px;
-    bottom: 2px;
-    left: 2px; }
-  .neos .scrollbar_bg {
-    position: absolute;
-    content: '';
-    display: block;
-    border-radius: 100px;
-    opacity: 0;
-    z-index: 99; }
-  .neos .scrollbar_bg.horizontal {
-    width: 100%; }
-  .neos .scrollbar_bg.vertical {
-    height: 100%; }
-  .neos .scrollbar.light {
-    background: rgba(255, 255, 255, 0.5); }
-  .neos .scrollbar_bg.light {
-    background: rgba(255, 255, 255, 0.1); }
-  .neos .scrollbar.dark {
-    background: rgba(0, 0, 0, 0.3); }
-  .neos .scrollbar_bg.dark {
-    background: rgba(0, 0, 0, 0.1); }
-  .neos .nWrap {
-    overflow: auto;
-    display: inline-block; }
-  .neos .ui-tabs .ui-tabs-nav li a:focus {
-    outline: none; }
-  .neos .neos-link-inputfield.ui-autocomplete-loading {
-    background-image: url(data:image/gif;base64,R0lGODlhEAAQAPQAAP///wAAAPDw8IqKiuDg4EZGRnp6egAAAFhYWCQkJKysrL6+vhQUFJycnAQEBDY2NmhoaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAAFdyAgAgIJIeWoAkRCCMdBkKtIHIngyMKsErPBYbADpkSCwhDmQCBethRB6Vj4kFCkQPG4IlWDgrNRIwnO4UKBXDufzQvDMaoSDBgFb886MiQadgNABAokfCwzBA8LCg0Egl8jAggGAA1kBIA1BAYzlyILczULC2UhACH5BAkKAAAALAAAAAAQABAAAAV2ICACAmlAZTmOREEIyUEQjLKKxPHADhEvqxlgcGgkGI1DYSVAIAWMx+lwSKkICJ0QsHi9RgKBwnVTiRQQgwF4I4UFDQQEwi6/3YSGWRRmjhEETAJfIgMFCnAKM0KDV4EEEAQLiF18TAYNXDaSe3x6mjidN1s3IQAh+QQJCgAAACwAAAAAEAAQAAAFeCAgAgLZDGU5jgRECEUiCI+yioSDwDJyLKsXoHFQxBSHAoAAFBhqtMJg8DgQBgfrEsJAEAg4YhZIEiwgKtHiMBgtpg3wbUZXGO7kOb1MUKRFMysCChAoggJCIg0GC2aNe4gqQldfL4l/Ag1AXySJgn5LcoE3QXI3IQAh+QQJCgAAACwAAAAAEAAQAAAFdiAgAgLZNGU5joQhCEjxIssqEo8bC9BRjy9Ag7GILQ4QEoE0gBAEBcOpcBA0DoxSK/e8LRIHn+i1cK0IyKdg0VAoljYIg+GgnRrwVS/8IAkICyosBIQpBAMoKy9dImxPhS+GKkFrkX+TigtLlIyKXUF+NjagNiEAIfkECQoAAAAsAAAAABAAEAAABWwgIAICaRhlOY4EIgjH8R7LKhKHGwsMvb4AAy3WODBIBBKCsYA9TjuhDNDKEVSERezQEL0WrhXucRUQGuik7bFlngzqVW9LMl9XWvLdjFaJtDFqZ1cEZUB0dUgvL3dgP4WJZn4jkomWNpSTIyEAIfkECQoAAAAsAAAAABAAEAAABX4gIAICuSxlOY6CIgiD8RrEKgqGOwxwUrMlAoSwIzAGpJpgoSDAGifDY5kopBYDlEpAQBwevxfBtRIUGi8xwWkDNBCIwmC9Vq0aiQQDQuK+VgQPDXV9hCJjBwcFYU5pLwwHXQcMKSmNLQcIAExlbH8JBwttaX0ABAcNbWVbKyEAIfkECQoAAAAsAAAAABAAEAAABXkgIAICSRBlOY7CIghN8zbEKsKoIjdFzZaEgUBHKChMJtRwcWpAWoWnifm6ESAMhO8lQK0EEAV3rFopIBCEcGwDKAqPh4HUrY4ICHH1dSoTFgcHUiZjBhAJB2AHDykpKAwHAwdzf19KkASIPl9cDgcnDkdtNwiMJCshACH5BAkKAAAALAAAAAAQABAAAAV3ICACAkkQZTmOAiosiyAoxCq+KPxCNVsSMRgBsiClWrLTSWFoIQZHl6pleBh6suxKMIhlvzbAwkBWfFWrBQTxNLq2RG2yhSUkDs2b63AYDAoJXAcFRwADeAkJDX0AQCsEfAQMDAIPBz0rCgcxky0JRWE1AmwpKyEAIfkECQoAAAAsAAAAABAAEAAABXkgIAICKZzkqJ4nQZxLqZKv4NqNLKK2/Q4Ek4lFXChsg5ypJjs1II3gEDUSRInEGYAw6B6zM4JhrDAtEosVkLUtHA7RHaHAGJQEjsODcEg0FBAFVgkQJQ1pAwcDDw8KcFtSInwJAowCCA6RIwqZAgkPNgVpWndjdyohACH5BAkKAAAALAAAAAAQABAAAAV5ICACAimc5KieLEuUKvm2xAKLqDCfC2GaO9eL0LABWTiBYmA06W6kHgvCqEJiAIJiu3gcvgUsscHUERm+kaCxyxa+zRPk0SgJEgfIvbAdIAQLCAYlCj4DBw0IBQsMCjIqBAcPAooCBg9pKgsJLwUFOhCZKyQDA3YqIQAh+QQJCgAAACwAAAAAEAAQAAAFdSAgAgIpnOSonmxbqiThCrJKEHFbo8JxDDOZYFFb+A41E4H4OhkOipXwBElYITDAckFEOBgMQ3arkMkUBdxIUGZpEb7kaQBRlASPg0FQQHAbEEMGDSVEAA1QBhAED1E0NgwFAooCDWljaQIQCE5qMHcNhCkjIQAh+QQJCgAAACwAAAAAEAAQAAAFeSAgAgIpnOSoLgxxvqgKLEcCC65KEAByKK8cSpA4DAiHQ/DkKhGKh4ZCtCyZGo6F6iYYPAqFgYy02xkSaLEMV34tELyRYNEsCQyHlvWkGCzsPgMCEAY7Cg04Uk48LAsDhRA8MVQPEF0GAgqYYwSRlycNcWskCkApIyEAOwAAAAAAAAAAAA==);
-    background-repeat: no-repeat;
-    background-position: 198px; }
-  .neos img {
-    display: inline-block;
-    margin: 0; }
   .neos #neos-top-bar {
     position: fixed;
     display: none;
@@ -7901,348 +7926,6 @@ readers do not read off random characters that represent icons */
         padding-left: 54px;
         position: relative;
         font-weight: normal; }
-  .neos #neos-navigate-button {
-    position: relative;
-    background-color: #222;
-    border-right: 1px solid #3f3f3f; }
-    .neos #neos-navigate-button:hover, .neos #neos-navigate-button.neos-pressed {
-      color: #00b5ff; }
-    .neos-menu-panel-open:not(.neos-menu-panel-sticky) .neos #neos-navigate-button.neos-pressed:after {
-      display: none; }
-    .neos #neos-navigate-button.neos-pressed:after {
-      display: block;
-      content: "";
-      width: 100%;
-      height: 1px;
-      left: 0;
-      bottom: -1px;
-      position: absolute;
-      background-color: #222; }
-  .neos #neos-navigate-panel {
-    background-color: #222;
-    width: 321px;
-    margin: 0;
-    padding: 0;
-    position: fixed;
-    overflow: hidden;
-    left: -321px;
-    top: 40px;
-    bottom: 0;
-    z-index: 10020;
-    padding-top: 82px;
-    padding-bottom: 41px;
-    border-top: 1px solid #3f3f3f;
-    border-right: 1px solid #3f3f3f;
-    box-sizing: border-box;
-    transition-property: left, margin-top;
-    transition-duration: .2s;
-    font-family: 'Noto Sans', sans-serif;
-    -webkit-font-smoothing: antialiased; }
-    .neos-navigate-panel-open .neos #neos-navigate-panel {
-      left: 0; }
-    .neos-navigate-panel-open.neos-menu-panel-open.neos-menu-panel-sticky .neos #neos-navigate-panel {
-      left: 54px; }
-    .neos #neos-navigate-panel #neos-node-tree {
-      position: relative; }
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node span + span,
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node a {
-        color: #5b5b5b; }
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node.neos-matched span + span,
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node.neos-matched a {
-        color: #fff; }
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node.neos-matched.neos-dynatree-selected span + span,
-      .neos #neos-navigate-panel #neos-node-tree.neos-node-tree-filtering .neos-dynatree-node.neos-matched.neos-dynatree-selected a {
-        color: #00b5ff; }
-      .neos #neos-navigate-panel #neos-node-tree #neos-node-tree-container {
-        position: relative;
-        white-space: nowrap;
-        margin: 0;
-        width: 100%;
-        height: 100%;
-        overflow: auto;
-        padding: 8px 0;
-        box-sizing: border-box; }
-        .neos #neos-navigate-panel #neos-node-tree #neos-node-tree-container input {
-          padding: 0px 3px;
-          margin: 0 -3px;
-          width: 100%;
-          height: 24px;
-          vertical-align: top;
-          outline: none;
-          border: none;
-          background-color: #fff;
-          color: #141414;
-          font-family: 'Noto Sans', sans-serif;
-          -webkit-font-smoothing: antialiased; }
-    .neos #neos-navigate-panel .neos-node-tree-toolbar {
-      width: 100%;
-      position: absolute;
-      top: -82px;
-      box-sizing: border-box; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container {
-        color: #fff;
-        line-height: 40px;
-        font-size: 14px; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single {
-          height: 40px;
-          border: none;
-          background-color: #323232;
-          background-image: none;
-          padding-left: 16px;
-          border-radius: 0;
-          box-shadow: none;
-          color: inherit;
-          line-height: inherit;
-          text-decoration: none; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single.chosen-default {
-            color: #adadad; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single.chosen-default div {
-              color: #fff; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single.chosen-single-with-deselect span {
-            margin-right: 75px; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single span {
-            margin-right: 57px; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div {
-            width: 40px; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div:before {
-              display: block;
-              content: '';
-              position: absolute;
-              width: 1px;
-              height: 24px;
-              top: 8px;
-              left: 0;
-              background-color: #fff;
-              opacity: .15; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div:after {
-              content: "\f0d7";
-              display: block;
-              position: absolute;
-              width: 40px;
-              text-align: center;
-              line-height: 40px; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single div b {
-              display: none;
-              background-image: none !important; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr {
-            top: 12px;
-            right: 52px;
-            color: #fff;
-            font-size: 16px;
-            line-height: 1; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr:hover {
-              color: #00b5ff; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single abbr::after {
-              content: "\f057"; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop {
-          border: none;
-          background-color: #323232;
-          background-image: none;
-          border-radius: 0;
-          box-shadow: 1px 2px 5px #222;
-          color: inherit;
-          margin-top: 0; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-search {
-            padding: 0;
-            color: #000;
-            font-size: 0; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-search input {
-              min-width: 0px;
-              width: 100%;
-              height: 40px;
-              border: none;
-              color: #fff;
-              font-family: 'Noto Sans', sans-serif;
-              -webkit-font-smoothing: antialiased;
-              font-size: 14px;
-              margin: 0;
-              padding: 0 16px;
-              box-sizing: border-box;
-              box-shadow: none;
-              background: none;
-              background-image: none !important;
-              background-color: #fff; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-search:after {
-              position: absolute;
-              top: 14px;
-              right: 12px;
-              width: 16px;
-              height: 16px;
-              text-decoration: inherit;
-              display: inline-block;
-              speak: none;
-              content: "\f002";
-              line-height: 100%;
-              font-size: 12px; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results {
-            margin: 0;
-            padding: 0;
-            max-height: 247px; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li {
-              width: 100%;
-              border-bottom: 1px solid #222;
-              line-height: 24px;
-              padding: 8px 16px;
-              box-sizing: border-box; }
-              .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li:first-child {
-                border-top: 1px solid #222; }
-              .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li.highlighted {
-                background-color: #00b5ff;
-                background-image: none; }
-              .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li.no-results {
-                background-color: #323232; }
-              .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li.disabled-result {
-                color: #5b5b5b; }
-              .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li em {
-                background: none;
-                font-weight: bold;
-                line-height: 38px; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-single {
-        background-color: #222; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop {
-        margin-top: 1px; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .chosen-container .chosen-drop .chosen-results li:first-child {
-          border-top: none; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-node-tree-toolbar-top,
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-node-tree-toolbar-bottom {
-        height: 40px;
-        border-bottom: 1px solid #3f3f3f; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-chooser {
-        float: left;
-        font-size: 14px;
-        line-height: 40px;
-        padding-left: 16px; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button {
-        float: right;
-        width: 40px;
-        color: #fff;
-        background-color: transparent;
-        text-align: center; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button i {
-          margin-left: -3px; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled], .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled]:hover {
-          color: #5b5b5b; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button.neos-pressed, .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button:hover {
-          color: #00b5ff; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search {
-        overflow: hidden;
-        position: relative; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search input {
-          width: 100%;
-          height: 40px;
-          float: left;
-          background-color: #222;
-          color: #fff;
-          font-family: 'Noto Sans', sans-serif;
-          -webkit-font-smoothing: antialiased;
-          font-size: 14px;
-          padding-left: 14px;
-          padding-right: 30px;
-          padding-top: 0;
-          padding-bottom: 0;
-          margin: 0;
-          border: none;
-          box-sizing: border-box;
-          box-shadow: none;
-          transition: none; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search input:focus {
-            background-color: #fff;
-            color: #252525;
-            box-shadow: none; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search input:focus + span {
-              color: #252525; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search span {
-          position: absolute;
-          top: 0;
-          right: 9px;
-          width: 16px;
-          height: 16px;
-          display: block;
-          font-size: 14px;
-          line-height: 40px; }
-          .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search span.fa-remove-sign {
-            cursor: pointer;
-            font-size: 16px; }
-            .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search span.fa-remove-sign:hover {
-              color: #00b5ff; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-sorting {
-        width: 40px;
-        height: 40px;
-        line-height: 40px;
-        border-left: 1px solid #323232;
-        float: right;
-        text-align: center;
-        display: none; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-filter {
-        width: 50%;
-        float: right;
-        border-left: 1px solid #323232; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-filter select {
-          width: 100%;
-          padding: 0; }
-    .neos #neos-navigate-panel #neos-context-structure {
-      position: relative; }
-    .neos #neos-navigate-panel .neos-node-tree-toolbar.neos-context-structure-toolbar {
-      position: relative;
-      height: 40px;
-      top: 0;
-      font-size: 14px;
-      line-height: 40px;
-      border-top: 1px solid #3f3f3f;
-      margin-top: -1px;
-      text-indent: 16px; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar.neos-context-structure-toolbar i {
-        text-indent: 0; }
-    .neos #neos-navigate-panel #neos-context-structure-tree-container {
-      position: relative;
-      white-space: nowrap;
-      margin: 0;
-      width: 100%;
-      height: 100%;
-      overflow: auto;
-      padding: 8px 0;
-      box-sizing: border-box; }
-      .neos #neos-navigate-panel #neos-context-structure-tree-container ul.neos-dynatree-container {
-        padding-top: 0;
-        padding-bottom: 0; }
-    .neos #neos-navigate-panel .neos-context-structure-collapse {
-      float: right;
-      width: 40px;
-      height: 40px;
-      cursor: pointer;
-      text-indent: 0; }
-      .neos #neos-navigate-panel .neos-context-structure-collapse:hover {
-        background-color: #00b5ff;
-        color: #fff; }
-      .neos #neos-navigate-panel .neos-context-structure-collapse::before {
-        content: "›";
-        font-size: 26px;
-        font-weight: normal;
-        display: inline-block;
-        position: relative;
-        top: 0;
-        line-height: 40px; }
-      .neos #neos-navigate-panel .neos-context-structure-collapse.collapsed::before {
-        rotate: -90deg;
-        left: 13px; }
-      .neos #neos-navigate-panel .neos-context-structure-collapse.open::before {
-        rotate: 90deg;
-        left: 19px; }
-    .neos #neos-navigate-panel #neos-node-tree {
-      height: 50%;
-      transition-property: height;
-      transition-duration: .2s; }
-    .neos #neos-navigate-panel #neos-context-structure {
-      height: 50%; }
-    .neos #neos-navigate-panel.neos-navigate-panel-context-structure-open #neos-node-tree {
-      height: 100%;
-      box-sizing: border-box; }
-    .neos #neos-navigate-panel.neos-navigate-panel-context-structure-open #neos-context-structure {
-      height: 41px; }
-      .neos #neos-navigate-panel.neos-navigate-panel-context-structure-open #neos-context-structure #neos-context-structure-toolbar {
-        border-bottom: none; }
-      .neos #neos-navigate-panel.neos-navigate-panel-context-structure-open #neos-context-structure #neos-context-structure-tree-container {
-        display: none; }
   .neos.neos-module {
     font-family: 'Noto Sans', sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -9148,10 +8831,6 @@ readers do not read off random characters that represent icons */
       margin-left: 5px; }
     .neos .widget .widget-footer .neos-button-group .neos-button + .neos-button {
       margin-left: -1px; }
-  .neos .neos-button-group.neos-open .neos-dropdown-toggle {
-    box-shadow: 0px 0px 0px transparent; }
-  .neos .neos-button-group + .neos-button-group {
-    margin-left: 8px; }
   .neos #neos-notification-container.neos-notification-top {
     position: fixed;
     z-index: 999999;
@@ -9252,201 +8931,6 @@ readers do not read off random characters that represent icons */
         color: white;
         font-weight: 400;
         font-size: 14px; }
-  .neos .neos-login-dialog .neos-modal, .neos .neos-login-dialog .neos-modal-content {
-    width: 400px;
-    top: 240px;
-    margin: 0px 0px 0px -160px; }
-  .neos .neos-login-dialog input[type="text"],
-  .neos .neos-login-dialog input[type="password"] {
-    width: 100%;
-    min-width: 288px;
-    height: 40px;
-    border: 2px solid #323232;
-    background-color: #323232;
-    color: #fff;
-    font-size: 14px;
-    padding: 0 14px;
-    margin: 0 0 15px 0;
-    border-radius: 0;
-    box-sizing: border-box;
-    box-shadow: none;
-    transition: none;
-    font-family: 'Noto Sans', sans-serif;
-    -webkit-font-smoothing: antialiased; }
-    .neos .neos-login-dialog input[type="text"]:focus,
-    .neos .neos-login-dialog input[type="password"]:focus {
-      background-color: #fff;
-      border: 2px solid #fff;
-      color: #252525;
-      box-shadow: none; }
-    .neos .neos-login-dialog input[type="text"]:-webkit-autofill,
-    .neos .neos-login-dialog input[type="password"]:-webkit-autofill {
-      -webkit-box-shadow: 0 0 0 50px #323232 inset;
-      -webkit-text-fill-color: #fff; }
-      .neos .neos-login-dialog input[type="text"]:-webkit-autofill:focus,
-      .neos .neos-login-dialog input[type="password"]:-webkit-autofill:focus {
-        -webkit-box-shadow: 0 0 0 50px #fff inset;
-        -webkit-text-fill-color: #252525; }
-  .neos .neos-login-dialog .neos-modal-body {
-    padding: 16px; }
-  .neos .neos-login-dialog .neos-button {
-    width: 100%; }
-  .neos .neos-login-dialog .neos-tooltip {
-    left: -4px;
-    top: 0;
-    width: 100%;
-    position: relative;
-    clear: both;
-    float: none; }
-    .neos .neos-login-dialog .neos-tooltip.neos-bottom {
-      padding: 8px 0 0 0;
-      margin-left: 4px;
-      margin-top: -1px; }
-    .neos .neos-login-dialog .neos-tooltip.neos-in {
-      opacity: 1; }
-    .neos .neos-login-dialog .neos-tooltip .neos-tooltip-arrow {
-      margin-left: -8px;
-      border-width: 0 8px 8px 8px;
-      border-bottom-color: #ff460d; }
-    .neos .neos-login-dialog .neos-tooltip .neos-tooltip-inner {
-      max-width: 100%;
-      background-color: #ff460d;
-      font-size: 13px;
-      color: #fff;
-      border-radius: 0;
-      box-sizing: border-box; }
-  .neos .neos-position-selector {
-    position: relative;
-    text-indent: 0;
-    user-select: none; }
-    .neos .neos-position-selector.neos-disabled {
-      cursor: not-allowed;
-      color: #5b5b5b !important;
-      opacity: 1; }
-      .neos .neos-position-selector.neos-disabled:hover, .neos .neos-position-selector.neos-disabled::after {
-        color: #5b5b5b !important; }
-      .neos .neos-position-selector.neos-disabled .neos-arrow {
-        border-bottom-color: #5b5b5b; }
-    .neos .neos-position-selector::before {
-      font-size: 14px; }
-    .neos .neos-position-selector::after {
-      position: absolute;
-      font-size: 14px;
-      color: #00b5ff; }
-    .neos .neos-position-selector.neos-position-selector-node-into::after {
-      content: "\f30b";
-      font-weight: 900;
-      left: 18px;
-      bottom: 4px; }
-    .neos .neos-position-selector.neos-position-selector-node-before::after {
-      content: "\f3bf";
-      font-weight: 900;
-      left: 24px;
-      bottom: 7px; }
-    .neos .neos-position-selector.neos-position-selector-node-after::after {
-      content: "\f3be";
-      font-weight: 900;
-      left: 24px;
-      bottom: 6px; }
-    .neos .neos-position-selector.neos-expanded .neos-position-selector-position {
-      display: block; }
-    .neos .neos-position-selector.neos-expanded .neos-arrow {
-      display: none; }
-    .neos .neos-position-selector .neos-arrow {
-      position: absolute;
-      bottom: 4px;
-      right: 4px;
-      border-left: 4px solid transparent;
-      border-bottom: 4px solid #00b5ff;
-      transform: rotate(45deg); }
-  .neos .neos-position-selector-position {
-    display: none;
-    position: absolute;
-    top: 40px;
-    left: -1px;
-    z-index: 1;
-    background-color: #222;
-    border: 1px solid #3f3f3f;
-    border-top: none;
-    box-shadow: 1px 2px 5px #222; }
-    .neos .neos-position-selector-position .neos-button {
-      width: 38px;
-      height: 40px;
-      color: #fff;
-      border: none; }
-      .neos .neos-position-selector-position .neos-button.neos-active {
-        color: #00b5ff;
-        background-color: inherit; }
-      .neos .neos-position-selector-position .neos-button.neos-disabled {
-        color: #5b5b5b !important;
-        opacity: 1; }
-      .neos .neos-position-selector-position .neos-button:hover:not(.neos-disabled) {
-        color: #00b5ff;
-        background-color: inherit; }
-  .neos .neos-help-message-button:active, .neos .neos-help-message-button:focus {
-    outline: none; }
-  .neos .neos-help-message-icon {
-    color: #fff;
-    vertical-align: baseline;
-    position: relative;
-    cursor: pointer;
-    text-decoration: none; }
-  .neos .page-navigation ul {
-    border-top: 1px solid #3f3f3f;
-    text-align: center;
-    font-size: 0; }
-    .neos .page-navigation ul li {
-      display: inline-block;
-      font-size: 14px;
-      width: 40px; }
-      .neos .page-navigation ul li.previous, .neos .page-navigation ul li.next {
-        position: relative;
-        border: 1px solid #3f3f3f;
-        border-top: 0;
-        overflow: hidden; }
-        .neos .page-navigation ul li.previous a, .neos .page-navigation ul li.next a {
-          text-indent: -9999px; }
-          .neos .page-navigation ul li.previous a:before, .neos .page-navigation ul li.next a:before {
-            position: relative;
-            top: 5px;
-            display: block;
-            width: 40px;
-            height: 40px;
-            text-align: center;
-            font-size: 26px;
-            line-height: 26px;
-            font-weight: normal;
-            font-style: normal;
-            text-decoration: inherit;
-            -webkit-font-smoothing: antialiased;
-            text-indent: 0;
-            color: #fff; }
-      .neos .page-navigation ul li.previous {
-        float: left; }
-        .neos .page-navigation ul li.previous a:before {
-          content: "‹"; }
-      .neos .page-navigation ul li.next {
-        float: right; }
-        .neos .page-navigation ul li.next a:before {
-          content: "›"; }
-      .neos .page-navigation ul li.current {
-        border: 1px solid #3f3f3f;
-        border-top: 0;
-        height: 40px;
-        width: 40px;
-        line-height: 40px;
-        color: #00b5ff; }
-      .neos .page-navigation ul li a {
-        display: block;
-        width: 40px;
-        height: 40px;
-        line-height: 40px;
-        text-align: center;
-        color: #fff; }
-        .neos .page-navigation ul li a:hover {
-          color: #fff;
-          background-color: #00b5ff;
-          text-decoration: none; }
 
 body.neos-backend {
   transition-property: margin;

--- a/Neos.Neos/Resources/Public/Styles/Minimal.css
+++ b/Neos.Neos/Resources/Public/Styles/Minimal.css
@@ -1,0 +1,6654 @@
+@charset "UTF-8";
+/* Color palette */
+/* Sizes & margins */
+/* Components */
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local("Noto Sans"), local("NotoSans"), url(../Fonts/NotoSans-Regular.ttf) format("truetype"); }
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local("Noto Sans Bold"), local("NotoSans-Bold"), url(../Fonts/NotoSans-Bold.ttf) format("truetype"); }
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local("Noto Sans Italic"), local("NotoSans-Italic"), url(../Fonts/NotoSans-Italic.ttf) format("truetype"); }
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 700;
+  src: local("Noto Sans Bold Italic"), local("NotoSans-BoldItalic"), url(../Fonts/NotoSans-BoldItalic.ttf) format("truetype"); }
+
+/*!
+ * Font Awesome Free 5.12.1 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+.fa,
+.fas,
+.neos button[class^="fa-"],
+.neos button[class*=" fa-"],
+.neos .neos-button[class^="fa-"],
+.neos .neos-button[class*=" fa-"],
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span::before,
+.neos.neos-module .neos-select:after,
+.neos.neos-module .neos-checkbox input + span::before,
+.neos.neos-module .neos-radio input + span::before,
+.neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button,
+.far,
+.fal,
+.fad,
+.fab {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1; }
+
+.fa-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -.0667em; }
+
+.fa-xs {
+  font-size: .75em; }
+
+.fa-sm {
+  font-size: .875em; }
+
+.fa-1x {
+  font-size: 1em; }
+
+.fa-2x {
+  font-size: 2em; }
+
+.fa-3x {
+  font-size: 3em; }
+
+.fa-4x {
+  font-size: 4em; }
+
+.fa-5x {
+  font-size: 5em; }
+
+.fa-6x {
+  font-size: 6em; }
+
+.fa-7x {
+  font-size: 7em; }
+
+.fa-8x {
+  font-size: 8em; }
+
+.fa-9x {
+  font-size: 9em; }
+
+.fa-10x {
+  font-size: 10em; }
+
+.fa-fw {
+  text-align: center;
+  width: 1.25em; }
+
+.fa-ul {
+  list-style-type: none;
+  margin-left: 2.5em;
+  padding-left: 0; }
+  .fa-ul > li {
+    position: relative; }
+
+.fa-li {
+  left: -2em;
+  position: absolute;
+  text-align: center;
+  width: 2em;
+  line-height: inherit; }
+
+.fa-border {
+  border: solid 0.08em #eee;
+  border-radius: .1em;
+  padding: .2em .25em .15em; }
+
+.fa-pull-left {
+  float: left; }
+
+.fa-pull-right {
+  float: right; }
+
+.fa.fa-pull-left,
+.fas.fa-pull-left,
+.neos button.fa-pull-left[class^="fa-"],
+.neos button.fa-pull-left[class*=" fa-"],
+.neos .fa-pull-left.neos-button[class^="fa-"],
+.neos .fa-pull-left.neos-button[class*=" fa-"],
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-left::before,
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span.fa-pull-left::before,
+.neos.neos-module .fa-pull-left.neos-select:after,
+.neos.neos-module .neos-checkbox input + span.fa-pull-left::before,
+.neos.neos-module .neos-radio input + span.fa-pull-left::before,
+.neos #neos-notification-container.neos-notification-top > .neos-notification i.fa-pull-left.neos-close-button,
+.far.fa-pull-left,
+.fal.fa-pull-left,
+.fab.fa-pull-left {
+  margin-right: .3em; }
+
+.fa.fa-pull-right,
+.fas.fa-pull-right,
+.neos button.fa-pull-right[class^="fa-"],
+.neos button.fa-pull-right[class*=" fa-"],
+.neos .fa-pull-right.neos-button[class^="fa-"],
+.neos .fa-pull-right.neos-button[class*=" fa-"],
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-right::before,
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span.fa-pull-right::before,
+.neos.neos-module .fa-pull-right.neos-select:after,
+.neos.neos-module .neos-checkbox input + span.fa-pull-right::before,
+.neos.neos-module .neos-radio input + span.fa-pull-right::before,
+.neos #neos-notification-container.neos-notification-top > .neos-notification i.fa-pull-right.neos-close-button,
+.far.fa-pull-right,
+.fal.fa-pull-right,
+.fab.fa-pull-right {
+  margin-left: .3em; }
+
+.fa-spin {
+  animation: fa-spin 2s infinite linear; }
+
+.fa-pulse {
+  animation: fa-spin 1s infinite steps(8); }
+
+@keyframes fa-spin {
+  0% {
+    transform: rotate(0deg); }
+  100% {
+    transform: rotate(360deg); } }
+
+.fa-rotate-90 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  transform: rotate(90deg); }
+
+.fa-rotate-180 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+  transform: rotate(180deg); }
+
+.fa-rotate-270 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+  transform: rotate(270deg); }
+
+.fa-flip-horizontal {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+  transform: scale(-1, 1); }
+
+.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(1, -1); }
+
+.fa-flip-both, .fa-flip-horizontal.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(-1, -1); }
+
+:root .fa-rotate-90,
+:root .fa-rotate-180,
+:root .fa-rotate-270,
+:root .fa-flip-horizontal,
+:root .fa-flip-vertical,
+:root .fa-flip-both {
+  filter: none; }
+
+.fa-stack {
+  display: inline-block;
+  height: 2em;
+  line-height: 2em;
+  position: relative;
+  vertical-align: middle;
+  width: 2.5em; }
+
+.fa-stack-1x,
+.fa-stack-2x {
+  left: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%; }
+
+.fa-stack-1x {
+  line-height: inherit; }
+
+.fa-stack-2x {
+  font-size: 2em; }
+
+.fa-inverse {
+  color: #fff; }
+
+/* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+readers do not read off random characters that represent icons */
+.fa-500px:before {
+  content: "\f26e"; }
+
+.fa-accessible-icon:before {
+  content: "\f368"; }
+
+.fa-accusoft:before {
+  content: "\f369"; }
+
+.fa-acquisitions-incorporated:before {
+  content: "\f6af"; }
+
+.fa-ad:before {
+  content: "\f641"; }
+
+.fa-address-book:before {
+  content: "\f2b9"; }
+
+.fa-address-card:before {
+  content: "\f2bb"; }
+
+.fa-adjust:before {
+  content: "\f042"; }
+
+.fa-adn:before {
+  content: "\f170"; }
+
+.fa-adobe:before {
+  content: "\f778"; }
+
+.fa-adversal:before {
+  content: "\f36a"; }
+
+.fa-affiliatetheme:before {
+  content: "\f36b"; }
+
+.fa-air-freshener:before {
+  content: "\f5d0"; }
+
+.fa-airbnb:before {
+  content: "\f834"; }
+
+.fa-algolia:before {
+  content: "\f36c"; }
+
+.fa-align-center:before {
+  content: "\f037"; }
+
+.fa-align-justify:before {
+  content: "\f039"; }
+
+.fa-align-left:before {
+  content: "\f036"; }
+
+.fa-align-right:before {
+  content: "\f038"; }
+
+.fa-alipay:before {
+  content: "\f642"; }
+
+.fa-allergies:before {
+  content: "\f461"; }
+
+.fa-amazon:before {
+  content: "\f270"; }
+
+.fa-amazon-pay:before {
+  content: "\f42c"; }
+
+.fa-ambulance:before {
+  content: "\f0f9"; }
+
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3"; }
+
+.fa-amilia:before {
+  content: "\f36d"; }
+
+.fa-anchor:before {
+  content: "\f13d"; }
+
+.fa-android:before {
+  content: "\f17b"; }
+
+.fa-angellist:before {
+  content: "\f209"; }
+
+.fa-angle-double-down:before {
+  content: "\f103"; }
+
+.fa-angle-double-left:before {
+  content: "\f100"; }
+
+.fa-angle-double-right:before {
+  content: "\f101"; }
+
+.fa-angle-double-up:before {
+  content: "\f102"; }
+
+.fa-angle-down:before {
+  content: "\f107"; }
+
+.fa-angle-left:before {
+  content: "\f104"; }
+
+.fa-angle-right:before {
+  content: "\f105"; }
+
+.fa-angle-up:before {
+  content: "\f106"; }
+
+.fa-angry:before {
+  content: "\f556"; }
+
+.fa-angrycreative:before {
+  content: "\f36e"; }
+
+.fa-angular:before {
+  content: "\f420"; }
+
+.fa-ankh:before {
+  content: "\f644"; }
+
+.fa-app-store:before {
+  content: "\f36f"; }
+
+.fa-app-store-ios:before {
+  content: "\f370"; }
+
+.fa-apper:before {
+  content: "\f371"; }
+
+.fa-apple:before {
+  content: "\f179"; }
+
+.fa-apple-alt:before {
+  content: "\f5d1"; }
+
+.fa-apple-pay:before {
+  content: "\f415"; }
+
+.fa-archive:before {
+  content: "\f187"; }
+
+.fa-archway:before {
+  content: "\f557"; }
+
+.fa-arrow-alt-circle-down:before {
+  content: "\f358"; }
+
+.fa-arrow-alt-circle-left:before {
+  content: "\f359"; }
+
+.fa-arrow-alt-circle-right:before {
+  content: "\f35a"; }
+
+.fa-arrow-alt-circle-up:before {
+  content: "\f35b"; }
+
+.fa-arrow-circle-down:before {
+  content: "\f0ab"; }
+
+.fa-arrow-circle-left:before {
+  content: "\f0a8"; }
+
+.fa-arrow-circle-right:before {
+  content: "\f0a9"; }
+
+.fa-arrow-circle-up:before {
+  content: "\f0aa"; }
+
+.fa-arrow-down:before {
+  content: "\f063"; }
+
+.fa-arrow-left:before {
+  content: "\f060"; }
+
+.fa-arrow-right:before {
+  content: "\f061"; }
+
+.fa-arrow-up:before {
+  content: "\f062"; }
+
+.fa-arrows-alt:before {
+  content: "\f0b2"; }
+
+.fa-arrows-alt-h:before {
+  content: "\f337"; }
+
+.fa-arrows-alt-v:before {
+  content: "\f338"; }
+
+.fa-artstation:before {
+  content: "\f77a"; }
+
+.fa-assistive-listening-systems:before {
+  content: "\f2a2"; }
+
+.fa-asterisk:before {
+  content: "\f069"; }
+
+.fa-asymmetrik:before {
+  content: "\f372"; }
+
+.fa-at:before {
+  content: "\f1fa"; }
+
+.fa-atlas:before {
+  content: "\f558"; }
+
+.fa-atlassian:before {
+  content: "\f77b"; }
+
+.fa-atom:before {
+  content: "\f5d2"; }
+
+.fa-audible:before {
+  content: "\f373"; }
+
+.fa-audio-description:before {
+  content: "\f29e"; }
+
+.fa-autoprefixer:before {
+  content: "\f41c"; }
+
+.fa-avianex:before {
+  content: "\f374"; }
+
+.fa-aviato:before {
+  content: "\f421"; }
+
+.fa-award:before {
+  content: "\f559"; }
+
+.fa-aws:before {
+  content: "\f375"; }
+
+.fa-baby:before {
+  content: "\f77c"; }
+
+.fa-baby-carriage:before {
+  content: "\f77d"; }
+
+.fa-backspace:before {
+  content: "\f55a"; }
+
+.fa-backward:before {
+  content: "\f04a"; }
+
+.fa-bacon:before {
+  content: "\f7e5"; }
+
+.fa-bahai:before {
+  content: "\f666"; }
+
+.fa-balance-scale:before {
+  content: "\f24e"; }
+
+.fa-balance-scale-left:before {
+  content: "\f515"; }
+
+.fa-balance-scale-right:before {
+  content: "\f516"; }
+
+.fa-ban:before, .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-error .fa-error:before {
+  content: "\f05e"; }
+
+.fa-band-aid:before {
+  content: "\f462"; }
+
+.fa-bandcamp:before {
+  content: "\f2d5"; }
+
+.fa-barcode:before {
+  content: "\f02a"; }
+
+.fa-bars:before {
+  content: "\f0c9"; }
+
+.fa-baseball-ball:before {
+  content: "\f433"; }
+
+.fa-basketball-ball:before {
+  content: "\f434"; }
+
+.fa-bath:before {
+  content: "\f2cd"; }
+
+.fa-battery-empty:before {
+  content: "\f244"; }
+
+.fa-battery-full:before {
+  content: "\f240"; }
+
+.fa-battery-half:before {
+  content: "\f242"; }
+
+.fa-battery-quarter:before {
+  content: "\f243"; }
+
+.fa-battery-three-quarters:before {
+  content: "\f241"; }
+
+.fa-battle-net:before {
+  content: "\f835"; }
+
+.fa-bed:before {
+  content: "\f236"; }
+
+.fa-beer:before {
+  content: "\f0fc"; }
+
+.fa-behance:before {
+  content: "\f1b4"; }
+
+.fa-behance-square:before {
+  content: "\f1b5"; }
+
+.fa-bell:before {
+  content: "\f0f3"; }
+
+.fa-bell-slash:before {
+  content: "\f1f6"; }
+
+.fa-bezier-curve:before {
+  content: "\f55b"; }
+
+.fa-bible:before {
+  content: "\f647"; }
+
+.fa-bicycle:before {
+  content: "\f206"; }
+
+.fa-biking:before {
+  content: "\f84a"; }
+
+.fa-bimobject:before {
+  content: "\f378"; }
+
+.fa-binoculars:before {
+  content: "\f1e5"; }
+
+.fa-biohazard:before {
+  content: "\f780"; }
+
+.fa-birthday-cake:before {
+  content: "\f1fd"; }
+
+.fa-bitbucket:before {
+  content: "\f171"; }
+
+.fa-bitcoin:before {
+  content: "\f379"; }
+
+.fa-bity:before {
+  content: "\f37a"; }
+
+.fa-black-tie:before {
+  content: "\f27e"; }
+
+.fa-blackberry:before {
+  content: "\f37b"; }
+
+.fa-blender:before {
+  content: "\f517"; }
+
+.fa-blender-phone:before {
+  content: "\f6b6"; }
+
+.fa-blind:before {
+  content: "\f29d"; }
+
+.fa-blog:before {
+  content: "\f781"; }
+
+.fa-blogger:before {
+  content: "\f37c"; }
+
+.fa-blogger-b:before {
+  content: "\f37d"; }
+
+.fa-bluetooth:before {
+  content: "\f293"; }
+
+.fa-bluetooth-b:before {
+  content: "\f294"; }
+
+.fa-bold:before {
+  content: "\f032"; }
+
+.fa-bolt:before {
+  content: "\f0e7"; }
+
+.fa-bomb:before {
+  content: "\f1e2"; }
+
+.fa-bone:before {
+  content: "\f5d7"; }
+
+.fa-bong:before {
+  content: "\f55c"; }
+
+.fa-book:before {
+  content: "\f02d"; }
+
+.fa-book-dead:before {
+  content: "\f6b7"; }
+
+.fa-book-medical:before {
+  content: "\f7e6"; }
+
+.fa-book-open:before {
+  content: "\f518"; }
+
+.fa-book-reader:before {
+  content: "\f5da"; }
+
+.fa-bookmark:before {
+  content: "\f02e"; }
+
+.fa-bootstrap:before {
+  content: "\f836"; }
+
+.fa-border-all:before {
+  content: "\f84c"; }
+
+.fa-border-none:before {
+  content: "\f850"; }
+
+.fa-border-style:before {
+  content: "\f853"; }
+
+.fa-bowling-ball:before {
+  content: "\f436"; }
+
+.fa-box:before {
+  content: "\f466"; }
+
+.fa-box-open:before {
+  content: "\f49e"; }
+
+.fa-boxes:before {
+  content: "\f468"; }
+
+.fa-braille:before {
+  content: "\f2a1"; }
+
+.fa-brain:before {
+  content: "\f5dc"; }
+
+.fa-bread-slice:before {
+  content: "\f7ec"; }
+
+.fa-briefcase:before {
+  content: "\f0b1"; }
+
+.fa-briefcase-medical:before {
+  content: "\f469"; }
+
+.fa-broadcast-tower:before {
+  content: "\f519"; }
+
+.fa-broom:before {
+  content: "\f51a"; }
+
+.fa-brush:before {
+  content: "\f55d"; }
+
+.fa-btc:before {
+  content: "\f15a"; }
+
+.fa-buffer:before {
+  content: "\f837"; }
+
+.fa-bug:before {
+  content: "\f188"; }
+
+.fa-building:before {
+  content: "\f1ad"; }
+
+.fa-bullhorn:before {
+  content: "\f0a1"; }
+
+.fa-bullseye:before {
+  content: "\f140"; }
+
+.fa-burn:before {
+  content: "\f46a"; }
+
+.fa-buromobelexperte:before {
+  content: "\f37f"; }
+
+.fa-bus:before {
+  content: "\f207"; }
+
+.fa-bus-alt:before {
+  content: "\f55e"; }
+
+.fa-business-time:before {
+  content: "\f64a"; }
+
+.fa-buy-n-large:before {
+  content: "\f8a6"; }
+
+.fa-buysellads:before {
+  content: "\f20d"; }
+
+.fa-calculator:before {
+  content: "\f1ec"; }
+
+.fa-calendar:before {
+  content: "\f133"; }
+
+.fa-calendar-alt:before {
+  content: "\f073"; }
+
+.fa-calendar-check:before {
+  content: "\f274"; }
+
+.fa-calendar-day:before {
+  content: "\f783"; }
+
+.fa-calendar-minus:before {
+  content: "\f272"; }
+
+.fa-calendar-plus:before {
+  content: "\f271"; }
+
+.fa-calendar-times:before {
+  content: "\f273"; }
+
+.fa-calendar-week:before {
+  content: "\f784"; }
+
+.fa-camera:before {
+  content: "\f030"; }
+
+.fa-camera-retro:before {
+  content: "\f083"; }
+
+.fa-campground:before {
+  content: "\f6bb"; }
+
+.fa-canadian-maple-leaf:before {
+  content: "\f785"; }
+
+.fa-candy-cane:before {
+  content: "\f786"; }
+
+.fa-cannabis:before {
+  content: "\f55f"; }
+
+.fa-capsules:before {
+  content: "\f46b"; }
+
+.fa-car:before {
+  content: "\f1b9"; }
+
+.fa-car-alt:before {
+  content: "\f5de"; }
+
+.fa-car-battery:before {
+  content: "\f5df"; }
+
+.fa-car-crash:before {
+  content: "\f5e1"; }
+
+.fa-car-side:before {
+  content: "\f5e4"; }
+
+.fa-caravan:before {
+  content: "\f8ff"; }
+
+.fa-caret-down:before {
+  content: "\f0d7"; }
+
+.fa-caret-left:before {
+  content: "\f0d9"; }
+
+.fa-caret-right:before {
+  content: "\f0da"; }
+
+.fa-caret-square-down:before {
+  content: "\f150"; }
+
+.fa-caret-square-left:before {
+  content: "\f191"; }
+
+.fa-caret-square-right:before {
+  content: "\f152"; }
+
+.fa-caret-square-up:before {
+  content: "\f151"; }
+
+.fa-caret-up:before {
+  content: "\f0d8"; }
+
+.fa-carrot:before {
+  content: "\f787"; }
+
+.fa-cart-arrow-down:before {
+  content: "\f218"; }
+
+.fa-cart-plus:before {
+  content: "\f217"; }
+
+.fa-cash-register:before {
+  content: "\f788"; }
+
+.fa-cat:before {
+  content: "\f6be"; }
+
+.fa-cc-amazon-pay:before {
+  content: "\f42d"; }
+
+.fa-cc-amex:before {
+  content: "\f1f3"; }
+
+.fa-cc-apple-pay:before {
+  content: "\f416"; }
+
+.fa-cc-diners-club:before {
+  content: "\f24c"; }
+
+.fa-cc-discover:before {
+  content: "\f1f2"; }
+
+.fa-cc-jcb:before {
+  content: "\f24b"; }
+
+.fa-cc-mastercard:before {
+  content: "\f1f1"; }
+
+.fa-cc-paypal:before {
+  content: "\f1f4"; }
+
+.fa-cc-stripe:before {
+  content: "\f1f5"; }
+
+.fa-cc-visa:before {
+  content: "\f1f0"; }
+
+.fa-centercode:before {
+  content: "\f380"; }
+
+.fa-centos:before {
+  content: "\f789"; }
+
+.fa-certificate:before {
+  content: "\f0a3"; }
+
+.fa-chair:before {
+  content: "\f6c0"; }
+
+.fa-chalkboard:before {
+  content: "\f51b"; }
+
+.fa-chalkboard-teacher:before {
+  content: "\f51c"; }
+
+.fa-charging-station:before {
+  content: "\f5e7"; }
+
+.fa-chart-area:before {
+  content: "\f1fe"; }
+
+.fa-chart-bar:before {
+  content: "\f080"; }
+
+.fa-chart-line:before {
+  content: "\f201"; }
+
+.fa-chart-pie:before {
+  content: "\f200"; }
+
+.fa-check:before, .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-success .fa-success:before {
+  content: "\f00c"; }
+
+.fa-check-circle:before {
+  content: "\f058"; }
+
+.fa-check-double:before {
+  content: "\f560"; }
+
+.fa-check-square:before {
+  content: "\f14a"; }
+
+.fa-cheese:before {
+  content: "\f7ef"; }
+
+.fa-chess:before {
+  content: "\f439"; }
+
+.fa-chess-bishop:before {
+  content: "\f43a"; }
+
+.fa-chess-board:before {
+  content: "\f43c"; }
+
+.fa-chess-king:before {
+  content: "\f43f"; }
+
+.fa-chess-knight:before {
+  content: "\f441"; }
+
+.fa-chess-pawn:before {
+  content: "\f443"; }
+
+.fa-chess-queen:before {
+  content: "\f445"; }
+
+.fa-chess-rook:before {
+  content: "\f447"; }
+
+.fa-chevron-circle-down:before {
+  content: "\f13a"; }
+
+.fa-chevron-circle-left:before {
+  content: "\f137"; }
+
+.fa-chevron-circle-right:before {
+  content: "\f138"; }
+
+.fa-chevron-circle-up:before {
+  content: "\f139"; }
+
+.fa-chevron-down:before {
+  content: "\f078"; }
+
+.fa-chevron-left:before {
+  content: "\f053"; }
+
+.fa-chevron-right:before {
+  content: "\f054"; }
+
+.fa-chevron-up:before {
+  content: "\f077"; }
+
+.fa-child:before {
+  content: "\f1ae"; }
+
+.fa-chrome:before {
+  content: "\f268"; }
+
+.fa-chromecast:before {
+  content: "\f838"; }
+
+.fa-church:before {
+  content: "\f51d"; }
+
+.fa-circle:before {
+  content: "\f111"; }
+
+.fa-circle-notch:before {
+  content: "\f1ce"; }
+
+.fa-city:before {
+  content: "\f64f"; }
+
+.fa-clinic-medical:before {
+  content: "\f7f2"; }
+
+.fa-clipboard:before {
+  content: "\f328"; }
+
+.fa-clipboard-check:before {
+  content: "\f46c"; }
+
+.fa-clipboard-list:before {
+  content: "\f46d"; }
+
+.fa-clock:before {
+  content: "\f017"; }
+
+.fa-clone:before {
+  content: "\f24d"; }
+
+.fa-closed-captioning:before {
+  content: "\f20a"; }
+
+.fa-cloud:before {
+  content: "\f0c2"; }
+
+.fa-cloud-download-alt:before {
+  content: "\f381"; }
+
+.fa-cloud-meatball:before {
+  content: "\f73b"; }
+
+.fa-cloud-moon:before {
+  content: "\f6c3"; }
+
+.fa-cloud-moon-rain:before {
+  content: "\f73c"; }
+
+.fa-cloud-rain:before {
+  content: "\f73d"; }
+
+.fa-cloud-showers-heavy:before {
+  content: "\f740"; }
+
+.fa-cloud-sun:before {
+  content: "\f6c4"; }
+
+.fa-cloud-sun-rain:before {
+  content: "\f743"; }
+
+.fa-cloud-upload-alt:before {
+  content: "\f382"; }
+
+.fa-cloudscale:before {
+  content: "\f383"; }
+
+.fa-cloudsmith:before {
+  content: "\f384"; }
+
+.fa-cloudversify:before {
+  content: "\f385"; }
+
+.fa-cocktail:before {
+  content: "\f561"; }
+
+.fa-code:before {
+  content: "\f121"; }
+
+.fa-code-branch:before {
+  content: "\f126"; }
+
+.fa-codepen:before {
+  content: "\f1cb"; }
+
+.fa-codiepie:before {
+  content: "\f284"; }
+
+.fa-coffee:before {
+  content: "\f0f4"; }
+
+.fa-cog:before {
+  content: "\f013"; }
+
+.fa-cogs:before {
+  content: "\f085"; }
+
+.fa-coins:before {
+  content: "\f51e"; }
+
+.fa-columns:before {
+  content: "\f0db"; }
+
+.fa-comment:before {
+  content: "\f075"; }
+
+.fa-comment-alt:before {
+  content: "\f27a"; }
+
+.fa-comment-dollar:before {
+  content: "\f651"; }
+
+.fa-comment-dots:before {
+  content: "\f4ad"; }
+
+.fa-comment-medical:before {
+  content: "\f7f5"; }
+
+.fa-comment-slash:before {
+  content: "\f4b3"; }
+
+.fa-comments:before {
+  content: "\f086"; }
+
+.fa-comments-dollar:before {
+  content: "\f653"; }
+
+.fa-compact-disc:before {
+  content: "\f51f"; }
+
+.fa-compass:before {
+  content: "\f14e"; }
+
+.fa-compress:before {
+  content: "\f066"; }
+
+.fa-compress-alt:before {
+  content: "\f422"; }
+
+.fa-compress-arrows-alt:before {
+  content: "\f78c"; }
+
+.fa-concierge-bell:before {
+  content: "\f562"; }
+
+.fa-confluence:before {
+  content: "\f78d"; }
+
+.fa-connectdevelop:before {
+  content: "\f20e"; }
+
+.fa-contao:before {
+  content: "\f26d"; }
+
+.fa-cookie:before {
+  content: "\f563"; }
+
+.fa-cookie-bite:before {
+  content: "\f564"; }
+
+.fa-copy:before {
+  content: "\f0c5"; }
+
+.fa-copyright:before {
+  content: "\f1f9"; }
+
+.fa-cotton-bureau:before {
+  content: "\f89e"; }
+
+.fa-couch:before {
+  content: "\f4b8"; }
+
+.fa-cpanel:before {
+  content: "\f388"; }
+
+.fa-creative-commons:before {
+  content: "\f25e"; }
+
+.fa-creative-commons-by:before {
+  content: "\f4e7"; }
+
+.fa-creative-commons-nc:before {
+  content: "\f4e8"; }
+
+.fa-creative-commons-nc-eu:before {
+  content: "\f4e9"; }
+
+.fa-creative-commons-nc-jp:before {
+  content: "\f4ea"; }
+
+.fa-creative-commons-nd:before {
+  content: "\f4eb"; }
+
+.fa-creative-commons-pd:before {
+  content: "\f4ec"; }
+
+.fa-creative-commons-pd-alt:before {
+  content: "\f4ed"; }
+
+.fa-creative-commons-remix:before {
+  content: "\f4ee"; }
+
+.fa-creative-commons-sa:before {
+  content: "\f4ef"; }
+
+.fa-creative-commons-sampling:before {
+  content: "\f4f0"; }
+
+.fa-creative-commons-sampling-plus:before {
+  content: "\f4f1"; }
+
+.fa-creative-commons-share:before {
+  content: "\f4f2"; }
+
+.fa-creative-commons-zero:before {
+  content: "\f4f3"; }
+
+.fa-credit-card:before {
+  content: "\f09d"; }
+
+.fa-critical-role:before {
+  content: "\f6c9"; }
+
+.fa-crop:before {
+  content: "\f125"; }
+
+.fa-crop-alt:before {
+  content: "\f565"; }
+
+.fa-cross:before {
+  content: "\f654"; }
+
+.fa-crosshairs:before {
+  content: "\f05b"; }
+
+.fa-crow:before {
+  content: "\f520"; }
+
+.fa-crown:before {
+  content: "\f521"; }
+
+.fa-crutch:before {
+  content: "\f7f7"; }
+
+.fa-css3:before {
+  content: "\f13c"; }
+
+.fa-css3-alt:before {
+  content: "\f38b"; }
+
+.fa-cube:before {
+  content: "\f1b2"; }
+
+.fa-cubes:before {
+  content: "\f1b3"; }
+
+.fa-cut:before {
+  content: "\f0c4"; }
+
+.fa-cuttlefish:before {
+  content: "\f38c"; }
+
+.fa-d-and-d:before {
+  content: "\f38d"; }
+
+.fa-d-and-d-beyond:before {
+  content: "\f6ca"; }
+
+.fa-dailymotion:before {
+  content: "\f952"; }
+
+.fa-dashcube:before {
+  content: "\f210"; }
+
+.fa-database:before {
+  content: "\f1c0"; }
+
+.fa-deaf:before {
+  content: "\f2a4"; }
+
+.fa-delicious:before {
+  content: "\f1a5"; }
+
+.fa-democrat:before {
+  content: "\f747"; }
+
+.fa-deploydog:before {
+  content: "\f38e"; }
+
+.fa-deskpro:before {
+  content: "\f38f"; }
+
+.fa-desktop:before {
+  content: "\f108"; }
+
+.fa-dev:before {
+  content: "\f6cc"; }
+
+.fa-deviantart:before {
+  content: "\f1bd"; }
+
+.fa-dharmachakra:before {
+  content: "\f655"; }
+
+.fa-dhl:before {
+  content: "\f790"; }
+
+.fa-diagnoses:before {
+  content: "\f470"; }
+
+.fa-diaspora:before {
+  content: "\f791"; }
+
+.fa-dice:before {
+  content: "\f522"; }
+
+.fa-dice-d20:before {
+  content: "\f6cf"; }
+
+.fa-dice-d6:before {
+  content: "\f6d1"; }
+
+.fa-dice-five:before {
+  content: "\f523"; }
+
+.fa-dice-four:before {
+  content: "\f524"; }
+
+.fa-dice-one:before {
+  content: "\f525"; }
+
+.fa-dice-six:before {
+  content: "\f526"; }
+
+.fa-dice-three:before {
+  content: "\f527"; }
+
+.fa-dice-two:before {
+  content: "\f528"; }
+
+.fa-digg:before {
+  content: "\f1a6"; }
+
+.fa-digital-ocean:before {
+  content: "\f391"; }
+
+.fa-digital-tachograph:before {
+  content: "\f566"; }
+
+.fa-directions:before {
+  content: "\f5eb"; }
+
+.fa-discord:before {
+  content: "\f392"; }
+
+.fa-discourse:before {
+  content: "\f393"; }
+
+.fa-divide:before {
+  content: "\f529"; }
+
+.fa-dizzy:before {
+  content: "\f567"; }
+
+.fa-dna:before {
+  content: "\f471"; }
+
+.fa-dochub:before {
+  content: "\f394"; }
+
+.fa-docker:before {
+  content: "\f395"; }
+
+.fa-dog:before {
+  content: "\f6d3"; }
+
+.fa-dollar-sign:before {
+  content: "\f155"; }
+
+.fa-dolly:before {
+  content: "\f472"; }
+
+.fa-dolly-flatbed:before {
+  content: "\f474"; }
+
+.fa-donate:before {
+  content: "\f4b9"; }
+
+.fa-door-closed:before {
+  content: "\f52a"; }
+
+.fa-door-open:before {
+  content: "\f52b"; }
+
+.fa-dot-circle:before {
+  content: "\f192"; }
+
+.fa-dove:before {
+  content: "\f4ba"; }
+
+.fa-download:before {
+  content: "\f019"; }
+
+.fa-draft2digital:before {
+  content: "\f396"; }
+
+.fa-drafting-compass:before {
+  content: "\f568"; }
+
+.fa-dragon:before {
+  content: "\f6d5"; }
+
+.fa-draw-polygon:before {
+  content: "\f5ee"; }
+
+.fa-dribbble:before {
+  content: "\f17d"; }
+
+.fa-dribbble-square:before {
+  content: "\f397"; }
+
+.fa-dropbox:before {
+  content: "\f16b"; }
+
+.fa-drum:before {
+  content: "\f569"; }
+
+.fa-drum-steelpan:before {
+  content: "\f56a"; }
+
+.fa-drumstick-bite:before {
+  content: "\f6d7"; }
+
+.fa-drupal:before {
+  content: "\f1a9"; }
+
+.fa-dumbbell:before {
+  content: "\f44b"; }
+
+.fa-dumpster:before {
+  content: "\f793"; }
+
+.fa-dumpster-fire:before {
+  content: "\f794"; }
+
+.fa-dungeon:before {
+  content: "\f6d9"; }
+
+.fa-dyalog:before {
+  content: "\f399"; }
+
+.fa-earlybirds:before {
+  content: "\f39a"; }
+
+.fa-ebay:before {
+  content: "\f4f4"; }
+
+.fa-edge:before {
+  content: "\f282"; }
+
+.fa-edit:before {
+  content: "\f044"; }
+
+.fa-egg:before {
+  content: "\f7fb"; }
+
+.fa-eject:before {
+  content: "\f052"; }
+
+.fa-elementor:before {
+  content: "\f430"; }
+
+.fa-ellipsis-h:before {
+  content: "\f141"; }
+
+.fa-ellipsis-v:before {
+  content: "\f142"; }
+
+.fa-ello:before {
+  content: "\f5f1"; }
+
+.fa-ember:before {
+  content: "\f423"; }
+
+.fa-empire:before {
+  content: "\f1d1"; }
+
+.fa-envelope:before {
+  content: "\f0e0"; }
+
+.fa-envelope-open:before {
+  content: "\f2b6"; }
+
+.fa-envelope-open-text:before {
+  content: "\f658"; }
+
+.fa-envelope-square:before {
+  content: "\f199"; }
+
+.fa-envira:before {
+  content: "\f299"; }
+
+.fa-equals:before {
+  content: "\f52c"; }
+
+.fa-eraser:before {
+  content: "\f12d"; }
+
+.fa-erlang:before {
+  content: "\f39d"; }
+
+.fa-ethereum:before {
+  content: "\f42e"; }
+
+.fa-ethernet:before {
+  content: "\f796"; }
+
+.fa-etsy:before {
+  content: "\f2d7"; }
+
+.fa-euro-sign:before {
+  content: "\f153"; }
+
+.fa-evernote:before {
+  content: "\f839"; }
+
+.fa-exchange-alt:before {
+  content: "\f362"; }
+
+.fa-exclamation:before {
+  content: "\f12a"; }
+
+.fa-exclamation-circle:before {
+  content: "\f06a"; }
+
+.fa-exclamation-triangle:before, .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-warning .fa-warning:before {
+  content: "\f071"; }
+
+.fa-expand:before {
+  content: "\f065"; }
+
+.fa-expand-alt:before {
+  content: "\f424"; }
+
+.fa-expand-arrows-alt:before {
+  content: "\f31e"; }
+
+.fa-expeditedssl:before {
+  content: "\f23e"; }
+
+.fa-external-link-alt:before {
+  content: "\f35d"; }
+
+.fa-external-link-square-alt:before {
+  content: "\f360"; }
+
+.fa-eye:before {
+  content: "\f06e"; }
+
+.fa-eye-dropper:before {
+  content: "\f1fb"; }
+
+.fa-eye-slash:before {
+  content: "\f070"; }
+
+.fa-facebook:before {
+  content: "\f09a"; }
+
+.fa-facebook-f:before {
+  content: "\f39e"; }
+
+.fa-facebook-messenger:before {
+  content: "\f39f"; }
+
+.fa-facebook-square:before {
+  content: "\f082"; }
+
+.fa-fan:before {
+  content: "\f863"; }
+
+.fa-fantasy-flight-games:before {
+  content: "\f6dc"; }
+
+.fa-fast-backward:before {
+  content: "\f049"; }
+
+.fa-fast-forward:before {
+  content: "\f050"; }
+
+.fa-fax:before {
+  content: "\f1ac"; }
+
+.fa-feather:before {
+  content: "\f52d"; }
+
+.fa-feather-alt:before {
+  content: "\f56b"; }
+
+.fa-fedex:before {
+  content: "\f797"; }
+
+.fa-fedora:before {
+  content: "\f798"; }
+
+.fa-female:before {
+  content: "\f182"; }
+
+.fa-fighter-jet:before {
+  content: "\f0fb"; }
+
+.fa-figma:before {
+  content: "\f799"; }
+
+.fa-file:before {
+  content: "\f15b"; }
+
+.fa-file-alt:before {
+  content: "\f15c"; }
+
+.fa-file-archive:before {
+  content: "\f1c6"; }
+
+.fa-file-audio:before {
+  content: "\f1c7"; }
+
+.fa-file-code:before {
+  content: "\f1c9"; }
+
+.fa-file-contract:before {
+  content: "\f56c"; }
+
+.fa-file-csv:before {
+  content: "\f6dd"; }
+
+.fa-file-download:before {
+  content: "\f56d"; }
+
+.fa-file-excel:before {
+  content: "\f1c3"; }
+
+.fa-file-export:before {
+  content: "\f56e"; }
+
+.fa-file-image:before {
+  content: "\f1c5"; }
+
+.fa-file-import:before {
+  content: "\f56f"; }
+
+.fa-file-invoice:before {
+  content: "\f570"; }
+
+.fa-file-invoice-dollar:before {
+  content: "\f571"; }
+
+.fa-file-medical:before {
+  content: "\f477"; }
+
+.fa-file-medical-alt:before {
+  content: "\f478"; }
+
+.fa-file-pdf:before {
+  content: "\f1c1"; }
+
+.fa-file-powerpoint:before {
+  content: "\f1c4"; }
+
+.fa-file-prescription:before {
+  content: "\f572"; }
+
+.fa-file-signature:before {
+  content: "\f573"; }
+
+.fa-file-upload:before {
+  content: "\f574"; }
+
+.fa-file-video:before {
+  content: "\f1c8"; }
+
+.fa-file-word:before {
+  content: "\f1c2"; }
+
+.fa-fill:before {
+  content: "\f575"; }
+
+.fa-fill-drip:before {
+  content: "\f576"; }
+
+.fa-film:before {
+  content: "\f008"; }
+
+.fa-filter:before {
+  content: "\f0b0"; }
+
+.fa-fingerprint:before {
+  content: "\f577"; }
+
+.fa-fire:before {
+  content: "\f06d"; }
+
+.fa-fire-alt:before {
+  content: "\f7e4"; }
+
+.fa-fire-extinguisher:before {
+  content: "\f134"; }
+
+.fa-firefox:before {
+  content: "\f269"; }
+
+.fa-firefox-browser:before {
+  content: "\f907"; }
+
+.fa-first-aid:before {
+  content: "\f479"; }
+
+.fa-first-order:before {
+  content: "\f2b0"; }
+
+.fa-first-order-alt:before {
+  content: "\f50a"; }
+
+.fa-firstdraft:before {
+  content: "\f3a1"; }
+
+.fa-fish:before {
+  content: "\f578"; }
+
+.fa-fist-raised:before {
+  content: "\f6de"; }
+
+.fa-flag:before {
+  content: "\f024"; }
+
+.fa-flag-checkered:before {
+  content: "\f11e"; }
+
+.fa-flag-usa:before {
+  content: "\f74d"; }
+
+.fa-flask:before {
+  content: "\f0c3"; }
+
+.fa-flickr:before {
+  content: "\f16e"; }
+
+.fa-flipboard:before {
+  content: "\f44d"; }
+
+.fa-flushed:before {
+  content: "\f579"; }
+
+.fa-fly:before {
+  content: "\f417"; }
+
+.fa-folder:before {
+  content: "\f07b"; }
+
+.fa-folder-minus:before {
+  content: "\f65d"; }
+
+.fa-folder-open:before {
+  content: "\f07c"; }
+
+.fa-folder-plus:before {
+  content: "\f65e"; }
+
+.fa-font:before {
+  content: "\f031"; }
+
+.fa-font-awesome:before {
+  content: "\f2b4"; }
+
+.fa-font-awesome-alt:before {
+  content: "\f35c"; }
+
+.fa-font-awesome-flag:before {
+  content: "\f425"; }
+
+.fa-font-awesome-logo-full:before {
+  content: "\f4e6"; }
+
+.fa-fonticons:before {
+  content: "\f280"; }
+
+.fa-fonticons-fi:before {
+  content: "\f3a2"; }
+
+.fa-football-ball:before {
+  content: "\f44e"; }
+
+.fa-fort-awesome:before {
+  content: "\f286"; }
+
+.fa-fort-awesome-alt:before {
+  content: "\f3a3"; }
+
+.fa-forumbee:before {
+  content: "\f211"; }
+
+.fa-forward:before {
+  content: "\f04e"; }
+
+.fa-foursquare:before {
+  content: "\f180"; }
+
+.fa-free-code-camp:before {
+  content: "\f2c5"; }
+
+.fa-freebsd:before {
+  content: "\f3a4"; }
+
+.fa-frog:before {
+  content: "\f52e"; }
+
+.fa-frown:before {
+  content: "\f119"; }
+
+.fa-frown-open:before {
+  content: "\f57a"; }
+
+.fa-fulcrum:before {
+  content: "\f50b"; }
+
+.fa-funnel-dollar:before {
+  content: "\f662"; }
+
+.fa-futbol:before {
+  content: "\f1e3"; }
+
+.fa-galactic-republic:before {
+  content: "\f50c"; }
+
+.fa-galactic-senate:before {
+  content: "\f50d"; }
+
+.fa-gamepad:before {
+  content: "\f11b"; }
+
+.fa-gas-pump:before {
+  content: "\f52f"; }
+
+.fa-gavel:before {
+  content: "\f0e3"; }
+
+.fa-gem:before {
+  content: "\f3a5"; }
+
+.fa-genderless:before {
+  content: "\f22d"; }
+
+.fa-get-pocket:before {
+  content: "\f265"; }
+
+.fa-gg:before {
+  content: "\f260"; }
+
+.fa-gg-circle:before {
+  content: "\f261"; }
+
+.fa-ghost:before {
+  content: "\f6e2"; }
+
+.fa-gift:before {
+  content: "\f06b"; }
+
+.fa-gifts:before {
+  content: "\f79c"; }
+
+.fa-git:before {
+  content: "\f1d3"; }
+
+.fa-git-alt:before {
+  content: "\f841"; }
+
+.fa-git-square:before {
+  content: "\f1d2"; }
+
+.fa-github:before {
+  content: "\f09b"; }
+
+.fa-github-alt:before {
+  content: "\f113"; }
+
+.fa-github-square:before {
+  content: "\f092"; }
+
+.fa-gitkraken:before {
+  content: "\f3a6"; }
+
+.fa-gitlab:before {
+  content: "\f296"; }
+
+.fa-gitter:before {
+  content: "\f426"; }
+
+.fa-glass-cheers:before {
+  content: "\f79f"; }
+
+.fa-glass-martini:before {
+  content: "\f000"; }
+
+.fa-glass-martini-alt:before {
+  content: "\f57b"; }
+
+.fa-glass-whiskey:before {
+  content: "\f7a0"; }
+
+.fa-glasses:before {
+  content: "\f530"; }
+
+.fa-glide:before {
+  content: "\f2a5"; }
+
+.fa-glide-g:before {
+  content: "\f2a6"; }
+
+.fa-globe:before {
+  content: "\f0ac"; }
+
+.fa-globe-africa:before {
+  content: "\f57c"; }
+
+.fa-globe-americas:before {
+  content: "\f57d"; }
+
+.fa-globe-asia:before {
+  content: "\f57e"; }
+
+.fa-globe-europe:before {
+  content: "\f7a2"; }
+
+.fa-gofore:before {
+  content: "\f3a7"; }
+
+.fa-golf-ball:before {
+  content: "\f450"; }
+
+.fa-goodreads:before {
+  content: "\f3a8"; }
+
+.fa-goodreads-g:before {
+  content: "\f3a9"; }
+
+.fa-google:before {
+  content: "\f1a0"; }
+
+.fa-google-drive:before {
+  content: "\f3aa"; }
+
+.fa-google-play:before {
+  content: "\f3ab"; }
+
+.fa-google-plus:before {
+  content: "\f2b3"; }
+
+.fa-google-plus-g:before {
+  content: "\f0d5"; }
+
+.fa-google-plus-square:before {
+  content: "\f0d4"; }
+
+.fa-google-wallet:before {
+  content: "\f1ee"; }
+
+.fa-gopuram:before {
+  content: "\f664"; }
+
+.fa-graduation-cap:before {
+  content: "\f19d"; }
+
+.fa-gratipay:before {
+  content: "\f184"; }
+
+.fa-grav:before {
+  content: "\f2d6"; }
+
+.fa-greater-than:before {
+  content: "\f531"; }
+
+.fa-greater-than-equal:before {
+  content: "\f532"; }
+
+.fa-grimace:before {
+  content: "\f57f"; }
+
+.fa-grin:before {
+  content: "\f580"; }
+
+.fa-grin-alt:before {
+  content: "\f581"; }
+
+.fa-grin-beam:before {
+  content: "\f582"; }
+
+.fa-grin-beam-sweat:before {
+  content: "\f583"; }
+
+.fa-grin-hearts:before {
+  content: "\f584"; }
+
+.fa-grin-squint:before {
+  content: "\f585"; }
+
+.fa-grin-squint-tears:before {
+  content: "\f586"; }
+
+.fa-grin-stars:before {
+  content: "\f587"; }
+
+.fa-grin-tears:before {
+  content: "\f588"; }
+
+.fa-grin-tongue:before {
+  content: "\f589"; }
+
+.fa-grin-tongue-squint:before {
+  content: "\f58a"; }
+
+.fa-grin-tongue-wink:before {
+  content: "\f58b"; }
+
+.fa-grin-wink:before {
+  content: "\f58c"; }
+
+.fa-grip-horizontal:before {
+  content: "\f58d"; }
+
+.fa-grip-lines:before {
+  content: "\f7a4"; }
+
+.fa-grip-lines-vertical:before {
+  content: "\f7a5"; }
+
+.fa-grip-vertical:before {
+  content: "\f58e"; }
+
+.fa-gripfire:before {
+  content: "\f3ac"; }
+
+.fa-grunt:before {
+  content: "\f3ad"; }
+
+.fa-guitar:before {
+  content: "\f7a6"; }
+
+.fa-gulp:before {
+  content: "\f3ae"; }
+
+.fa-h-square:before {
+  content: "\f0fd"; }
+
+.fa-hacker-news:before {
+  content: "\f1d4"; }
+
+.fa-hacker-news-square:before {
+  content: "\f3af"; }
+
+.fa-hackerrank:before {
+  content: "\f5f7"; }
+
+.fa-hamburger:before {
+  content: "\f805"; }
+
+.fa-hammer:before {
+  content: "\f6e3"; }
+
+.fa-hamsa:before {
+  content: "\f665"; }
+
+.fa-hand-holding:before {
+  content: "\f4bd"; }
+
+.fa-hand-holding-heart:before {
+  content: "\f4be"; }
+
+.fa-hand-holding-usd:before {
+  content: "\f4c0"; }
+
+.fa-hand-lizard:before {
+  content: "\f258"; }
+
+.fa-hand-middle-finger:before {
+  content: "\f806"; }
+
+.fa-hand-paper:before {
+  content: "\f256"; }
+
+.fa-hand-peace:before {
+  content: "\f25b"; }
+
+.fa-hand-point-down:before {
+  content: "\f0a7"; }
+
+.fa-hand-point-left:before {
+  content: "\f0a5"; }
+
+.fa-hand-point-right:before {
+  content: "\f0a4"; }
+
+.fa-hand-point-up:before {
+  content: "\f0a6"; }
+
+.fa-hand-pointer:before {
+  content: "\f25a"; }
+
+.fa-hand-rock:before {
+  content: "\f255"; }
+
+.fa-hand-scissors:before {
+  content: "\f257"; }
+
+.fa-hand-spock:before {
+  content: "\f259"; }
+
+.fa-hands:before {
+  content: "\f4c2"; }
+
+.fa-hands-helping:before {
+  content: "\f4c4"; }
+
+.fa-handshake:before {
+  content: "\f2b5"; }
+
+.fa-hanukiah:before {
+  content: "\f6e6"; }
+
+.fa-hard-hat:before {
+  content: "\f807"; }
+
+.fa-hashtag:before {
+  content: "\f292"; }
+
+.fa-hat-cowboy:before {
+  content: "\f8c0"; }
+
+.fa-hat-cowboy-side:before {
+  content: "\f8c1"; }
+
+.fa-hat-wizard:before {
+  content: "\f6e8"; }
+
+.fa-hdd:before {
+  content: "\f0a0"; }
+
+.fa-heading:before {
+  content: "\f1dc"; }
+
+.fa-headphones:before {
+  content: "\f025"; }
+
+.fa-headphones-alt:before {
+  content: "\f58f"; }
+
+.fa-headset:before {
+  content: "\f590"; }
+
+.fa-heart:before {
+  content: "\f004"; }
+
+.fa-heart-broken:before {
+  content: "\f7a9"; }
+
+.fa-heartbeat:before {
+  content: "\f21e"; }
+
+.fa-helicopter:before {
+  content: "\f533"; }
+
+.fa-highlighter:before {
+  content: "\f591"; }
+
+.fa-hiking:before {
+  content: "\f6ec"; }
+
+.fa-hippo:before {
+  content: "\f6ed"; }
+
+.fa-hips:before {
+  content: "\f452"; }
+
+.fa-hire-a-helper:before {
+  content: "\f3b0"; }
+
+.fa-history:before {
+  content: "\f1da"; }
+
+.fa-hockey-puck:before {
+  content: "\f453"; }
+
+.fa-holly-berry:before {
+  content: "\f7aa"; }
+
+.fa-home:before {
+  content: "\f015"; }
+
+.fa-hooli:before {
+  content: "\f427"; }
+
+.fa-hornbill:before {
+  content: "\f592"; }
+
+.fa-horse:before {
+  content: "\f6f0"; }
+
+.fa-horse-head:before {
+  content: "\f7ab"; }
+
+.fa-hospital:before {
+  content: "\f0f8"; }
+
+.fa-hospital-alt:before {
+  content: "\f47d"; }
+
+.fa-hospital-symbol:before {
+  content: "\f47e"; }
+
+.fa-hot-tub:before {
+  content: "\f593"; }
+
+.fa-hotdog:before {
+  content: "\f80f"; }
+
+.fa-hotel:before {
+  content: "\f594"; }
+
+.fa-hotjar:before {
+  content: "\f3b1"; }
+
+.fa-hourglass:before {
+  content: "\f254"; }
+
+.fa-hourglass-end:before {
+  content: "\f253"; }
+
+.fa-hourglass-half:before {
+  content: "\f252"; }
+
+.fa-hourglass-start:before {
+  content: "\f251"; }
+
+.fa-house-damage:before {
+  content: "\f6f1"; }
+
+.fa-houzz:before {
+  content: "\f27c"; }
+
+.fa-hryvnia:before {
+  content: "\f6f2"; }
+
+.fa-html5:before {
+  content: "\f13b"; }
+
+.fa-hubspot:before {
+  content: "\f3b2"; }
+
+.fa-i-cursor:before {
+  content: "\f246"; }
+
+.fa-ice-cream:before {
+  content: "\f810"; }
+
+.fa-icicles:before {
+  content: "\f7ad"; }
+
+.fa-icons:before {
+  content: "\f86d"; }
+
+.fa-id-badge:before {
+  content: "\f2c1"; }
+
+.fa-id-card:before {
+  content: "\f2c2"; }
+
+.fa-id-card-alt:before {
+  content: "\f47f"; }
+
+.fa-ideal:before {
+  content: "\f913"; }
+
+.fa-igloo:before {
+  content: "\f7ae"; }
+
+.fa-image:before {
+  content: "\f03e"; }
+
+.fa-images:before {
+  content: "\f302"; }
+
+.fa-imdb:before {
+  content: "\f2d8"; }
+
+.fa-inbox:before {
+  content: "\f01c"; }
+
+.fa-indent:before {
+  content: "\f03c"; }
+
+.fa-industry:before {
+  content: "\f275"; }
+
+.fa-infinity:before {
+  content: "\f534"; }
+
+.fa-info:before {
+  content: "\f129"; }
+
+.fa-info-circle:before, .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-info .fa-info-circle:before {
+  content: "\f05a"; }
+
+.fa-instagram:before {
+  content: "\f16d"; }
+
+.fa-instagram-square:before {
+  content: "\f955"; }
+
+.fa-intercom:before {
+  content: "\f7af"; }
+
+.fa-internet-explorer:before {
+  content: "\f26b"; }
+
+.fa-invision:before {
+  content: "\f7b0"; }
+
+.fa-ioxhost:before {
+  content: "\f208"; }
+
+.fa-italic:before {
+  content: "\f033"; }
+
+.fa-itch-io:before {
+  content: "\f83a"; }
+
+.fa-itunes:before {
+  content: "\f3b4"; }
+
+.fa-itunes-note:before {
+  content: "\f3b5"; }
+
+.fa-java:before {
+  content: "\f4e4"; }
+
+.fa-jedi:before {
+  content: "\f669"; }
+
+.fa-jedi-order:before {
+  content: "\f50e"; }
+
+.fa-jenkins:before {
+  content: "\f3b6"; }
+
+.fa-jira:before {
+  content: "\f7b1"; }
+
+.fa-joget:before {
+  content: "\f3b7"; }
+
+.fa-joint:before {
+  content: "\f595"; }
+
+.fa-joomla:before {
+  content: "\f1aa"; }
+
+.fa-journal-whills:before {
+  content: "\f66a"; }
+
+.fa-js:before {
+  content: "\f3b8"; }
+
+.fa-js-square:before {
+  content: "\f3b9"; }
+
+.fa-jsfiddle:before {
+  content: "\f1cc"; }
+
+.fa-kaaba:before {
+  content: "\f66b"; }
+
+.fa-kaggle:before {
+  content: "\f5fa"; }
+
+.fa-key:before {
+  content: "\f084"; }
+
+.fa-keybase:before {
+  content: "\f4f5"; }
+
+.fa-keyboard:before {
+  content: "\f11c"; }
+
+.fa-keycdn:before {
+  content: "\f3ba"; }
+
+.fa-khanda:before {
+  content: "\f66d"; }
+
+.fa-kickstarter:before {
+  content: "\f3bb"; }
+
+.fa-kickstarter-k:before {
+  content: "\f3bc"; }
+
+.fa-kiss:before {
+  content: "\f596"; }
+
+.fa-kiss-beam:before {
+  content: "\f597"; }
+
+.fa-kiss-wink-heart:before {
+  content: "\f598"; }
+
+.fa-kiwi-bird:before {
+  content: "\f535"; }
+
+.fa-korvue:before {
+  content: "\f42f"; }
+
+.fa-landmark:before {
+  content: "\f66f"; }
+
+.fa-language:before {
+  content: "\f1ab"; }
+
+.fa-laptop:before {
+  content: "\f109"; }
+
+.fa-laptop-code:before {
+  content: "\f5fc"; }
+
+.fa-laptop-medical:before {
+  content: "\f812"; }
+
+.fa-laravel:before {
+  content: "\f3bd"; }
+
+.fa-lastfm:before {
+  content: "\f202"; }
+
+.fa-lastfm-square:before {
+  content: "\f203"; }
+
+.fa-laugh:before {
+  content: "\f599"; }
+
+.fa-laugh-beam:before {
+  content: "\f59a"; }
+
+.fa-laugh-squint:before {
+  content: "\f59b"; }
+
+.fa-laugh-wink:before {
+  content: "\f59c"; }
+
+.fa-layer-group:before {
+  content: "\f5fd"; }
+
+.fa-leaf:before {
+  content: "\f06c"; }
+
+.fa-leanpub:before {
+  content: "\f212"; }
+
+.fa-lemon:before {
+  content: "\f094"; }
+
+.fa-less:before {
+  content: "\f41d"; }
+
+.fa-less-than:before {
+  content: "\f536"; }
+
+.fa-less-than-equal:before {
+  content: "\f537"; }
+
+.fa-level-down-alt:before {
+  content: "\f3be"; }
+
+.fa-level-up-alt:before {
+  content: "\f3bf"; }
+
+.fa-life-ring:before {
+  content: "\f1cd"; }
+
+.fa-lightbulb:before {
+  content: "\f0eb"; }
+
+.fa-line:before {
+  content: "\f3c0"; }
+
+.fa-link:before {
+  content: "\f0c1"; }
+
+.fa-linkedin:before {
+  content: "\f08c"; }
+
+.fa-linkedin-in:before {
+  content: "\f0e1"; }
+
+.fa-linode:before {
+  content: "\f2b8"; }
+
+.fa-linux:before {
+  content: "\f17c"; }
+
+.fa-lira-sign:before {
+  content: "\f195"; }
+
+.fa-list:before {
+  content: "\f03a"; }
+
+.fa-list-alt:before {
+  content: "\f022"; }
+
+.fa-list-ol:before {
+  content: "\f0cb"; }
+
+.fa-list-ul:before {
+  content: "\f0ca"; }
+
+.fa-location-arrow:before {
+  content: "\f124"; }
+
+.fa-lock:before {
+  content: "\f023"; }
+
+.fa-lock-open:before {
+  content: "\f3c1"; }
+
+.fa-long-arrow-alt-down:before {
+  content: "\f309"; }
+
+.fa-long-arrow-alt-left:before {
+  content: "\f30a"; }
+
+.fa-long-arrow-alt-right:before {
+  content: "\f30b"; }
+
+.fa-long-arrow-alt-up:before {
+  content: "\f30c"; }
+
+.fa-low-vision:before {
+  content: "\f2a8"; }
+
+.fa-luggage-cart:before {
+  content: "\f59d"; }
+
+.fa-lyft:before {
+  content: "\f3c3"; }
+
+.fa-magento:before {
+  content: "\f3c4"; }
+
+.fa-magic:before {
+  content: "\f0d0"; }
+
+.fa-magnet:before {
+  content: "\f076"; }
+
+.fa-mail-bulk:before {
+  content: "\f674"; }
+
+.fa-mailchimp:before {
+  content: "\f59e"; }
+
+.fa-male:before {
+  content: "\f183"; }
+
+.fa-mandalorian:before {
+  content: "\f50f"; }
+
+.fa-map:before {
+  content: "\f279"; }
+
+.fa-map-marked:before {
+  content: "\f59f"; }
+
+.fa-map-marked-alt:before {
+  content: "\f5a0"; }
+
+.fa-map-marker:before {
+  content: "\f041"; }
+
+.fa-map-marker-alt:before {
+  content: "\f3c5"; }
+
+.fa-map-pin:before {
+  content: "\f276"; }
+
+.fa-map-signs:before {
+  content: "\f277"; }
+
+.fa-markdown:before {
+  content: "\f60f"; }
+
+.fa-marker:before {
+  content: "\f5a1"; }
+
+.fa-mars:before {
+  content: "\f222"; }
+
+.fa-mars-double:before {
+  content: "\f227"; }
+
+.fa-mars-stroke:before {
+  content: "\f229"; }
+
+.fa-mars-stroke-h:before {
+  content: "\f22b"; }
+
+.fa-mars-stroke-v:before {
+  content: "\f22a"; }
+
+.fa-mask:before {
+  content: "\f6fa"; }
+
+.fa-mastodon:before {
+  content: "\f4f6"; }
+
+.fa-maxcdn:before {
+  content: "\f136"; }
+
+.fa-mdb:before {
+  content: "\f8ca"; }
+
+.fa-medal:before {
+  content: "\f5a2"; }
+
+.fa-medapps:before {
+  content: "\f3c6"; }
+
+.fa-medium:before {
+  content: "\f23a"; }
+
+.fa-medium-m:before {
+  content: "\f3c7"; }
+
+.fa-medkit:before {
+  content: "\f0fa"; }
+
+.fa-medrt:before {
+  content: "\f3c8"; }
+
+.fa-meetup:before {
+  content: "\f2e0"; }
+
+.fa-megaport:before {
+  content: "\f5a3"; }
+
+.fa-meh:before {
+  content: "\f11a"; }
+
+.fa-meh-blank:before {
+  content: "\f5a4"; }
+
+.fa-meh-rolling-eyes:before {
+  content: "\f5a5"; }
+
+.fa-memory:before {
+  content: "\f538"; }
+
+.fa-mendeley:before {
+  content: "\f7b3"; }
+
+.fa-menorah:before {
+  content: "\f676"; }
+
+.fa-mercury:before {
+  content: "\f223"; }
+
+.fa-meteor:before {
+  content: "\f753"; }
+
+.fa-microblog:before {
+  content: "\f91a"; }
+
+.fa-microchip:before {
+  content: "\f2db"; }
+
+.fa-microphone:before {
+  content: "\f130"; }
+
+.fa-microphone-alt:before {
+  content: "\f3c9"; }
+
+.fa-microphone-alt-slash:before {
+  content: "\f539"; }
+
+.fa-microphone-slash:before {
+  content: "\f131"; }
+
+.fa-microscope:before {
+  content: "\f610"; }
+
+.fa-microsoft:before {
+  content: "\f3ca"; }
+
+.fa-minus:before {
+  content: "\f068"; }
+
+.fa-minus-circle:before {
+  content: "\f056"; }
+
+.fa-minus-square:before {
+  content: "\f146"; }
+
+.fa-mitten:before {
+  content: "\f7b5"; }
+
+.fa-mix:before {
+  content: "\f3cb"; }
+
+.fa-mixcloud:before {
+  content: "\f289"; }
+
+.fa-mixer:before {
+  content: "\f956"; }
+
+.fa-mizuni:before {
+  content: "\f3cc"; }
+
+.fa-mobile:before {
+  content: "\f10b"; }
+
+.fa-mobile-alt:before {
+  content: "\f3cd"; }
+
+.fa-modx:before {
+  content: "\f285"; }
+
+.fa-monero:before {
+  content: "\f3d0"; }
+
+.fa-money-bill:before {
+  content: "\f0d6"; }
+
+.fa-money-bill-alt:before {
+  content: "\f3d1"; }
+
+.fa-money-bill-wave:before {
+  content: "\f53a"; }
+
+.fa-money-bill-wave-alt:before {
+  content: "\f53b"; }
+
+.fa-money-check:before {
+  content: "\f53c"; }
+
+.fa-money-check-alt:before {
+  content: "\f53d"; }
+
+.fa-monument:before {
+  content: "\f5a6"; }
+
+.fa-moon:before {
+  content: "\f186"; }
+
+.fa-mortar-pestle:before {
+  content: "\f5a7"; }
+
+.fa-mosque:before {
+  content: "\f678"; }
+
+.fa-motorcycle:before {
+  content: "\f21c"; }
+
+.fa-mountain:before {
+  content: "\f6fc"; }
+
+.fa-mouse:before {
+  content: "\f8cc"; }
+
+.fa-mouse-pointer:before {
+  content: "\f245"; }
+
+.fa-mug-hot:before {
+  content: "\f7b6"; }
+
+.fa-music:before {
+  content: "\f001"; }
+
+.fa-napster:before {
+  content: "\f3d2"; }
+
+.fa-neos:before {
+  content: "\f612"; }
+
+.fa-network-wired:before {
+  content: "\f6ff"; }
+
+.fa-neuter:before {
+  content: "\f22c"; }
+
+.fa-newspaper:before {
+  content: "\f1ea"; }
+
+.fa-nimblr:before {
+  content: "\f5a8"; }
+
+.fa-node:before {
+  content: "\f419"; }
+
+.fa-node-js:before {
+  content: "\f3d3"; }
+
+.fa-not-equal:before {
+  content: "\f53e"; }
+
+.fa-notes-medical:before {
+  content: "\f481"; }
+
+.fa-npm:before {
+  content: "\f3d4"; }
+
+.fa-ns8:before {
+  content: "\f3d5"; }
+
+.fa-nutritionix:before {
+  content: "\f3d6"; }
+
+.fa-object-group:before {
+  content: "\f247"; }
+
+.fa-object-ungroup:before {
+  content: "\f248"; }
+
+.fa-odnoklassniki:before {
+  content: "\f263"; }
+
+.fa-odnoklassniki-square:before {
+  content: "\f264"; }
+
+.fa-oil-can:before {
+  content: "\f613"; }
+
+.fa-old-republic:before {
+  content: "\f510"; }
+
+.fa-om:before {
+  content: "\f679"; }
+
+.fa-opencart:before {
+  content: "\f23d"; }
+
+.fa-openid:before {
+  content: "\f19b"; }
+
+.fa-opera:before {
+  content: "\f26a"; }
+
+.fa-optin-monster:before {
+  content: "\f23c"; }
+
+.fa-orcid:before {
+  content: "\f8d2"; }
+
+.fa-osi:before {
+  content: "\f41a"; }
+
+.fa-otter:before {
+  content: "\f700"; }
+
+.fa-outdent:before {
+  content: "\f03b"; }
+
+.fa-page4:before {
+  content: "\f3d7"; }
+
+.fa-pagelines:before {
+  content: "\f18c"; }
+
+.fa-pager:before {
+  content: "\f815"; }
+
+.fa-paint-brush:before {
+  content: "\f1fc"; }
+
+.fa-paint-roller:before {
+  content: "\f5aa"; }
+
+.fa-palette:before {
+  content: "\f53f"; }
+
+.fa-palfed:before {
+  content: "\f3d8"; }
+
+.fa-pallet:before {
+  content: "\f482"; }
+
+.fa-paper-plane:before {
+  content: "\f1d8"; }
+
+.fa-paperclip:before {
+  content: "\f0c6"; }
+
+.fa-parachute-box:before {
+  content: "\f4cd"; }
+
+.fa-paragraph:before {
+  content: "\f1dd"; }
+
+.fa-parking:before {
+  content: "\f540"; }
+
+.fa-passport:before {
+  content: "\f5ab"; }
+
+.fa-pastafarianism:before {
+  content: "\f67b"; }
+
+.fa-paste:before {
+  content: "\f0ea"; }
+
+.fa-patreon:before {
+  content: "\f3d9"; }
+
+.fa-pause:before {
+  content: "\f04c"; }
+
+.fa-pause-circle:before {
+  content: "\f28b"; }
+
+.fa-paw:before {
+  content: "\f1b0"; }
+
+.fa-paypal:before {
+  content: "\f1ed"; }
+
+.fa-peace:before {
+  content: "\f67c"; }
+
+.fa-pen:before {
+  content: "\f304"; }
+
+.fa-pen-alt:before {
+  content: "\f305"; }
+
+.fa-pen-fancy:before {
+  content: "\f5ac"; }
+
+.fa-pen-nib:before {
+  content: "\f5ad"; }
+
+.fa-pen-square:before {
+  content: "\f14b"; }
+
+.fa-pencil-alt:before {
+  content: "\f303"; }
+
+.fa-pencil-ruler:before {
+  content: "\f5ae"; }
+
+.fa-penny-arcade:before {
+  content: "\f704"; }
+
+.fa-people-carry:before {
+  content: "\f4ce"; }
+
+.fa-pepper-hot:before {
+  content: "\f816"; }
+
+.fa-percent:before {
+  content: "\f295"; }
+
+.fa-percentage:before {
+  content: "\f541"; }
+
+.fa-periscope:before {
+  content: "\f3da"; }
+
+.fa-person-booth:before {
+  content: "\f756"; }
+
+.fa-phabricator:before {
+  content: "\f3db"; }
+
+.fa-phoenix-framework:before {
+  content: "\f3dc"; }
+
+.fa-phoenix-squadron:before {
+  content: "\f511"; }
+
+.fa-phone:before {
+  content: "\f095"; }
+
+.fa-phone-alt:before {
+  content: "\f879"; }
+
+.fa-phone-slash:before {
+  content: "\f3dd"; }
+
+.fa-phone-square:before {
+  content: "\f098"; }
+
+.fa-phone-square-alt:before {
+  content: "\f87b"; }
+
+.fa-phone-volume:before {
+  content: "\f2a0"; }
+
+.fa-photo-video:before {
+  content: "\f87c"; }
+
+.fa-php:before {
+  content: "\f457"; }
+
+.fa-pied-piper:before {
+  content: "\f2ae"; }
+
+.fa-pied-piper-alt:before {
+  content: "\f1a8"; }
+
+.fa-pied-piper-hat:before {
+  content: "\f4e5"; }
+
+.fa-pied-piper-pp:before {
+  content: "\f1a7"; }
+
+.fa-pied-piper-square:before {
+  content: "\f91e"; }
+
+.fa-piggy-bank:before {
+  content: "\f4d3"; }
+
+.fa-pills:before {
+  content: "\f484"; }
+
+.fa-pinterest:before {
+  content: "\f0d2"; }
+
+.fa-pinterest-p:before {
+  content: "\f231"; }
+
+.fa-pinterest-square:before {
+  content: "\f0d3"; }
+
+.fa-pizza-slice:before {
+  content: "\f818"; }
+
+.fa-place-of-worship:before {
+  content: "\f67f"; }
+
+.fa-plane:before {
+  content: "\f072"; }
+
+.fa-plane-arrival:before {
+  content: "\f5af"; }
+
+.fa-plane-departure:before {
+  content: "\f5b0"; }
+
+.fa-play:before {
+  content: "\f04b"; }
+
+.fa-play-circle:before {
+  content: "\f144"; }
+
+.fa-playstation:before {
+  content: "\f3df"; }
+
+.fa-plug:before {
+  content: "\f1e6"; }
+
+.fa-plus:before {
+  content: "\f067"; }
+
+.fa-plus-circle:before {
+  content: "\f055"; }
+
+.fa-plus-square:before {
+  content: "\f0fe"; }
+
+.fa-podcast:before {
+  content: "\f2ce"; }
+
+.fa-poll:before {
+  content: "\f681"; }
+
+.fa-poll-h:before {
+  content: "\f682"; }
+
+.fa-poo:before {
+  content: "\f2fe"; }
+
+.fa-poo-storm:before {
+  content: "\f75a"; }
+
+.fa-poop:before {
+  content: "\f619"; }
+
+.fa-portrait:before {
+  content: "\f3e0"; }
+
+.fa-pound-sign:before {
+  content: "\f154"; }
+
+.fa-power-off:before {
+  content: "\f011"; }
+
+.fa-pray:before {
+  content: "\f683"; }
+
+.fa-praying-hands:before {
+  content: "\f684"; }
+
+.fa-prescription:before {
+  content: "\f5b1"; }
+
+.fa-prescription-bottle:before {
+  content: "\f485"; }
+
+.fa-prescription-bottle-alt:before {
+  content: "\f486"; }
+
+.fa-print:before {
+  content: "\f02f"; }
+
+.fa-procedures:before {
+  content: "\f487"; }
+
+.fa-product-hunt:before {
+  content: "\f288"; }
+
+.fa-project-diagram:before {
+  content: "\f542"; }
+
+.fa-pushed:before {
+  content: "\f3e1"; }
+
+.fa-puzzle-piece:before {
+  content: "\f12e"; }
+
+.fa-python:before {
+  content: "\f3e2"; }
+
+.fa-qq:before {
+  content: "\f1d6"; }
+
+.fa-qrcode:before {
+  content: "\f029"; }
+
+.fa-question:before {
+  content: "\f128"; }
+
+.fa-question-circle:before {
+  content: "\f059"; }
+
+.fa-quidditch:before {
+  content: "\f458"; }
+
+.fa-quinscape:before {
+  content: "\f459"; }
+
+.fa-quora:before {
+  content: "\f2c4"; }
+
+.fa-quote-left:before {
+  content: "\f10d"; }
+
+.fa-quote-right:before {
+  content: "\f10e"; }
+
+.fa-quran:before {
+  content: "\f687"; }
+
+.fa-r-project:before {
+  content: "\f4f7"; }
+
+.fa-radiation:before {
+  content: "\f7b9"; }
+
+.fa-radiation-alt:before {
+  content: "\f7ba"; }
+
+.fa-rainbow:before {
+  content: "\f75b"; }
+
+.fa-random:before {
+  content: "\f074"; }
+
+.fa-raspberry-pi:before {
+  content: "\f7bb"; }
+
+.fa-ravelry:before {
+  content: "\f2d9"; }
+
+.fa-react:before {
+  content: "\f41b"; }
+
+.fa-reacteurope:before {
+  content: "\f75d"; }
+
+.fa-readme:before {
+  content: "\f4d5"; }
+
+.fa-rebel:before {
+  content: "\f1d0"; }
+
+.fa-receipt:before {
+  content: "\f543"; }
+
+.fa-record-vinyl:before {
+  content: "\f8d9"; }
+
+.fa-recycle:before {
+  content: "\f1b8"; }
+
+.fa-red-river:before {
+  content: "\f3e3"; }
+
+.fa-reddit:before {
+  content: "\f1a1"; }
+
+.fa-reddit-alien:before {
+  content: "\f281"; }
+
+.fa-reddit-square:before {
+  content: "\f1a2"; }
+
+.fa-redhat:before {
+  content: "\f7bc"; }
+
+.fa-redo:before {
+  content: "\f01e"; }
+
+.fa-redo-alt:before {
+  content: "\f2f9"; }
+
+.fa-registered:before {
+  content: "\f25d"; }
+
+.fa-remove-format:before {
+  content: "\f87d"; }
+
+.fa-renren:before {
+  content: "\f18b"; }
+
+.fa-reply:before {
+  content: "\f3e5"; }
+
+.fa-reply-all:before {
+  content: "\f122"; }
+
+.fa-replyd:before {
+  content: "\f3e6"; }
+
+.fa-republican:before {
+  content: "\f75e"; }
+
+.fa-researchgate:before {
+  content: "\f4f8"; }
+
+.fa-resolving:before {
+  content: "\f3e7"; }
+
+.fa-restroom:before {
+  content: "\f7bd"; }
+
+.fa-retweet:before {
+  content: "\f079"; }
+
+.fa-rev:before {
+  content: "\f5b2"; }
+
+.fa-ribbon:before {
+  content: "\f4d6"; }
+
+.fa-ring:before {
+  content: "\f70b"; }
+
+.fa-road:before {
+  content: "\f018"; }
+
+.fa-robot:before {
+  content: "\f544"; }
+
+.fa-rocket:before {
+  content: "\f135"; }
+
+.fa-rocketchat:before {
+  content: "\f3e8"; }
+
+.fa-rockrms:before {
+  content: "\f3e9"; }
+
+.fa-route:before {
+  content: "\f4d7"; }
+
+.fa-rss:before {
+  content: "\f09e"; }
+
+.fa-rss-square:before {
+  content: "\f143"; }
+
+.fa-ruble-sign:before {
+  content: "\f158"; }
+
+.fa-ruler:before {
+  content: "\f545"; }
+
+.fa-ruler-combined:before {
+  content: "\f546"; }
+
+.fa-ruler-horizontal:before {
+  content: "\f547"; }
+
+.fa-ruler-vertical:before {
+  content: "\f548"; }
+
+.fa-running:before {
+  content: "\f70c"; }
+
+.fa-rupee-sign:before {
+  content: "\f156"; }
+
+.fa-sad-cry:before {
+  content: "\f5b3"; }
+
+.fa-sad-tear:before {
+  content: "\f5b4"; }
+
+.fa-safari:before {
+  content: "\f267"; }
+
+.fa-salesforce:before {
+  content: "\f83b"; }
+
+.fa-sass:before {
+  content: "\f41e"; }
+
+.fa-satellite:before {
+  content: "\f7bf"; }
+
+.fa-satellite-dish:before {
+  content: "\f7c0"; }
+
+.fa-save:before {
+  content: "\f0c7"; }
+
+.fa-schlix:before {
+  content: "\f3ea"; }
+
+.fa-school:before {
+  content: "\f549"; }
+
+.fa-screwdriver:before {
+  content: "\f54a"; }
+
+.fa-scribd:before {
+  content: "\f28a"; }
+
+.fa-scroll:before {
+  content: "\f70e"; }
+
+.fa-sd-card:before {
+  content: "\f7c2"; }
+
+.fa-search:before {
+  content: "\f002"; }
+
+.fa-search-dollar:before {
+  content: "\f688"; }
+
+.fa-search-location:before {
+  content: "\f689"; }
+
+.fa-search-minus:before {
+  content: "\f010"; }
+
+.fa-search-plus:before {
+  content: "\f00e"; }
+
+.fa-searchengin:before {
+  content: "\f3eb"; }
+
+.fa-seedling:before {
+  content: "\f4d8"; }
+
+.fa-sellcast:before {
+  content: "\f2da"; }
+
+.fa-sellsy:before {
+  content: "\f213"; }
+
+.fa-server:before {
+  content: "\f233"; }
+
+.fa-servicestack:before {
+  content: "\f3ec"; }
+
+.fa-shapes:before {
+  content: "\f61f"; }
+
+.fa-share:before {
+  content: "\f064"; }
+
+.fa-share-alt:before {
+  content: "\f1e0"; }
+
+.fa-share-alt-square:before {
+  content: "\f1e1"; }
+
+.fa-share-square:before {
+  content: "\f14d"; }
+
+.fa-shekel-sign:before {
+  content: "\f20b"; }
+
+.fa-shield-alt:before {
+  content: "\f3ed"; }
+
+.fa-ship:before {
+  content: "\f21a"; }
+
+.fa-shipping-fast:before {
+  content: "\f48b"; }
+
+.fa-shirtsinbulk:before {
+  content: "\f214"; }
+
+.fa-shoe-prints:before {
+  content: "\f54b"; }
+
+.fa-shopify:before {
+  content: "\f957"; }
+
+.fa-shopping-bag:before {
+  content: "\f290"; }
+
+.fa-shopping-basket:before {
+  content: "\f291"; }
+
+.fa-shopping-cart:before {
+  content: "\f07a"; }
+
+.fa-shopware:before {
+  content: "\f5b5"; }
+
+.fa-shower:before {
+  content: "\f2cc"; }
+
+.fa-shuttle-van:before {
+  content: "\f5b6"; }
+
+.fa-sign:before {
+  content: "\f4d9"; }
+
+.fa-sign-in-alt:before {
+  content: "\f2f6"; }
+
+.fa-sign-language:before {
+  content: "\f2a7"; }
+
+.fa-sign-out-alt:before {
+  content: "\f2f5"; }
+
+.fa-signal:before {
+  content: "\f012"; }
+
+.fa-signature:before {
+  content: "\f5b7"; }
+
+.fa-sim-card:before {
+  content: "\f7c4"; }
+
+.fa-simplybuilt:before {
+  content: "\f215"; }
+
+.fa-sistrix:before {
+  content: "\f3ee"; }
+
+.fa-sitemap:before {
+  content: "\f0e8"; }
+
+.fa-sith:before {
+  content: "\f512"; }
+
+.fa-skating:before {
+  content: "\f7c5"; }
+
+.fa-sketch:before {
+  content: "\f7c6"; }
+
+.fa-skiing:before {
+  content: "\f7c9"; }
+
+.fa-skiing-nordic:before {
+  content: "\f7ca"; }
+
+.fa-skull:before {
+  content: "\f54c"; }
+
+.fa-skull-crossbones:before {
+  content: "\f714"; }
+
+.fa-skyatlas:before {
+  content: "\f216"; }
+
+.fa-skype:before {
+  content: "\f17e"; }
+
+.fa-slack:before {
+  content: "\f198"; }
+
+.fa-slack-hash:before {
+  content: "\f3ef"; }
+
+.fa-slash:before {
+  content: "\f715"; }
+
+.fa-sleigh:before {
+  content: "\f7cc"; }
+
+.fa-sliders-h:before {
+  content: "\f1de"; }
+
+.fa-slideshare:before {
+  content: "\f1e7"; }
+
+.fa-smile:before {
+  content: "\f118"; }
+
+.fa-smile-beam:before {
+  content: "\f5b8"; }
+
+.fa-smile-wink:before {
+  content: "\f4da"; }
+
+.fa-smog:before {
+  content: "\f75f"; }
+
+.fa-smoking:before {
+  content: "\f48d"; }
+
+.fa-smoking-ban:before {
+  content: "\f54d"; }
+
+.fa-sms:before {
+  content: "\f7cd"; }
+
+.fa-snapchat:before {
+  content: "\f2ab"; }
+
+.fa-snapchat-ghost:before {
+  content: "\f2ac"; }
+
+.fa-snapchat-square:before {
+  content: "\f2ad"; }
+
+.fa-snowboarding:before {
+  content: "\f7ce"; }
+
+.fa-snowflake:before {
+  content: "\f2dc"; }
+
+.fa-snowman:before {
+  content: "\f7d0"; }
+
+.fa-snowplow:before {
+  content: "\f7d2"; }
+
+.fa-socks:before {
+  content: "\f696"; }
+
+.fa-solar-panel:before {
+  content: "\f5ba"; }
+
+.fa-sort:before {
+  content: "\f0dc"; }
+
+.fa-sort-alpha-down:before {
+  content: "\f15d"; }
+
+.fa-sort-alpha-down-alt:before {
+  content: "\f881"; }
+
+.fa-sort-alpha-up:before {
+  content: "\f15e"; }
+
+.fa-sort-alpha-up-alt:before {
+  content: "\f882"; }
+
+.fa-sort-amount-down:before {
+  content: "\f160"; }
+
+.fa-sort-amount-down-alt:before {
+  content: "\f884"; }
+
+.fa-sort-amount-up:before {
+  content: "\f161"; }
+
+.fa-sort-amount-up-alt:before {
+  content: "\f885"; }
+
+.fa-sort-down:before {
+  content: "\f0dd"; }
+
+.fa-sort-numeric-down:before {
+  content: "\f162"; }
+
+.fa-sort-numeric-down-alt:before {
+  content: "\f886"; }
+
+.fa-sort-numeric-up:before {
+  content: "\f163"; }
+
+.fa-sort-numeric-up-alt:before {
+  content: "\f887"; }
+
+.fa-sort-up:before {
+  content: "\f0de"; }
+
+.fa-soundcloud:before {
+  content: "\f1be"; }
+
+.fa-sourcetree:before {
+  content: "\f7d3"; }
+
+.fa-spa:before {
+  content: "\f5bb"; }
+
+.fa-space-shuttle:before {
+  content: "\f197"; }
+
+.fa-speakap:before {
+  content: "\f3f3"; }
+
+.fa-speaker-deck:before {
+  content: "\f83c"; }
+
+.fa-spell-check:before {
+  content: "\f891"; }
+
+.fa-spider:before {
+  content: "\f717"; }
+
+.fa-spinner:before {
+  content: "\f110"; }
+
+.fa-splotch:before {
+  content: "\f5bc"; }
+
+.fa-spotify:before {
+  content: "\f1bc"; }
+
+.fa-spray-can:before {
+  content: "\f5bd"; }
+
+.fa-square:before {
+  content: "\f0c8"; }
+
+.fa-square-full:before {
+  content: "\f45c"; }
+
+.fa-square-root-alt:before {
+  content: "\f698"; }
+
+.fa-squarespace:before {
+  content: "\f5be"; }
+
+.fa-stack-exchange:before {
+  content: "\f18d"; }
+
+.fa-stack-overflow:before {
+  content: "\f16c"; }
+
+.fa-stackpath:before {
+  content: "\f842"; }
+
+.fa-stamp:before {
+  content: "\f5bf"; }
+
+.fa-star:before {
+  content: "\f005"; }
+
+.fa-star-and-crescent:before {
+  content: "\f699"; }
+
+.fa-star-half:before {
+  content: "\f089"; }
+
+.fa-star-half-alt:before {
+  content: "\f5c0"; }
+
+.fa-star-of-david:before {
+  content: "\f69a"; }
+
+.fa-star-of-life:before {
+  content: "\f621"; }
+
+.fa-staylinked:before {
+  content: "\f3f5"; }
+
+.fa-steam:before {
+  content: "\f1b6"; }
+
+.fa-steam-square:before {
+  content: "\f1b7"; }
+
+.fa-steam-symbol:before {
+  content: "\f3f6"; }
+
+.fa-step-backward:before {
+  content: "\f048"; }
+
+.fa-step-forward:before {
+  content: "\f051"; }
+
+.fa-stethoscope:before {
+  content: "\f0f1"; }
+
+.fa-sticker-mule:before {
+  content: "\f3f7"; }
+
+.fa-sticky-note:before {
+  content: "\f249"; }
+
+.fa-stop:before {
+  content: "\f04d"; }
+
+.fa-stop-circle:before {
+  content: "\f28d"; }
+
+.fa-stopwatch:before {
+  content: "\f2f2"; }
+
+.fa-store:before {
+  content: "\f54e"; }
+
+.fa-store-alt:before {
+  content: "\f54f"; }
+
+.fa-strava:before {
+  content: "\f428"; }
+
+.fa-stream:before {
+  content: "\f550"; }
+
+.fa-street-view:before {
+  content: "\f21d"; }
+
+.fa-strikethrough:before {
+  content: "\f0cc"; }
+
+.fa-stripe:before {
+  content: "\f429"; }
+
+.fa-stripe-s:before {
+  content: "\f42a"; }
+
+.fa-stroopwafel:before {
+  content: "\f551"; }
+
+.fa-studiovinari:before {
+  content: "\f3f8"; }
+
+.fa-stumbleupon:before {
+  content: "\f1a4"; }
+
+.fa-stumbleupon-circle:before {
+  content: "\f1a3"; }
+
+.fa-subscript:before {
+  content: "\f12c"; }
+
+.fa-subway:before {
+  content: "\f239"; }
+
+.fa-suitcase:before {
+  content: "\f0f2"; }
+
+.fa-suitcase-rolling:before {
+  content: "\f5c1"; }
+
+.fa-sun:before {
+  content: "\f185"; }
+
+.fa-superpowers:before {
+  content: "\f2dd"; }
+
+.fa-superscript:before {
+  content: "\f12b"; }
+
+.fa-supple:before {
+  content: "\f3f9"; }
+
+.fa-surprise:before {
+  content: "\f5c2"; }
+
+.fa-suse:before {
+  content: "\f7d6"; }
+
+.fa-swatchbook:before {
+  content: "\f5c3"; }
+
+.fa-swift:before {
+  content: "\f8e1"; }
+
+.fa-swimmer:before {
+  content: "\f5c4"; }
+
+.fa-swimming-pool:before {
+  content: "\f5c5"; }
+
+.fa-symfony:before {
+  content: "\f83d"; }
+
+.fa-synagogue:before {
+  content: "\f69b"; }
+
+.fa-sync:before {
+  content: "\f021"; }
+
+.fa-sync-alt:before {
+  content: "\f2f1"; }
+
+.fa-syringe:before {
+  content: "\f48e"; }
+
+.fa-table:before {
+  content: "\f0ce"; }
+
+.fa-table-tennis:before {
+  content: "\f45d"; }
+
+.fa-tablet:before {
+  content: "\f10a"; }
+
+.fa-tablet-alt:before {
+  content: "\f3fa"; }
+
+.fa-tablets:before {
+  content: "\f490"; }
+
+.fa-tachometer-alt:before {
+  content: "\f3fd"; }
+
+.fa-tag:before {
+  content: "\f02b"; }
+
+.fa-tags:before {
+  content: "\f02c"; }
+
+.fa-tape:before {
+  content: "\f4db"; }
+
+.fa-tasks:before {
+  content: "\f0ae"; }
+
+.fa-taxi:before {
+  content: "\f1ba"; }
+
+.fa-teamspeak:before {
+  content: "\f4f9"; }
+
+.fa-teeth:before {
+  content: "\f62e"; }
+
+.fa-teeth-open:before {
+  content: "\f62f"; }
+
+.fa-telegram:before {
+  content: "\f2c6"; }
+
+.fa-telegram-plane:before {
+  content: "\f3fe"; }
+
+.fa-temperature-high:before {
+  content: "\f769"; }
+
+.fa-temperature-low:before {
+  content: "\f76b"; }
+
+.fa-tencent-weibo:before {
+  content: "\f1d5"; }
+
+.fa-tenge:before {
+  content: "\f7d7"; }
+
+.fa-terminal:before {
+  content: "\f120"; }
+
+.fa-text-height:before {
+  content: "\f034"; }
+
+.fa-text-width:before {
+  content: "\f035"; }
+
+.fa-th:before {
+  content: "\f00a"; }
+
+.fa-th-large:before {
+  content: "\f009"; }
+
+.fa-th-list:before {
+  content: "\f00b"; }
+
+.fa-the-red-yeti:before {
+  content: "\f69d"; }
+
+.fa-theater-masks:before {
+  content: "\f630"; }
+
+.fa-themeco:before {
+  content: "\f5c6"; }
+
+.fa-themeisle:before {
+  content: "\f2b2"; }
+
+.fa-thermometer:before {
+  content: "\f491"; }
+
+.fa-thermometer-empty:before {
+  content: "\f2cb"; }
+
+.fa-thermometer-full:before {
+  content: "\f2c7"; }
+
+.fa-thermometer-half:before {
+  content: "\f2c9"; }
+
+.fa-thermometer-quarter:before {
+  content: "\f2ca"; }
+
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8"; }
+
+.fa-think-peaks:before {
+  content: "\f731"; }
+
+.fa-thumbs-down:before {
+  content: "\f165"; }
+
+.fa-thumbs-up:before {
+  content: "\f164"; }
+
+.fa-thumbtack:before {
+  content: "\f08d"; }
+
+.fa-ticket-alt:before {
+  content: "\f3ff"; }
+
+.fa-times:before {
+  content: "\f00d"; }
+
+.fa-times-circle:before, .neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button:before {
+  content: "\f057"; }
+
+.fa-tint:before {
+  content: "\f043"; }
+
+.fa-tint-slash:before {
+  content: "\f5c7"; }
+
+.fa-tired:before {
+  content: "\f5c8"; }
+
+.fa-toggle-off:before {
+  content: "\f204"; }
+
+.fa-toggle-on:before {
+  content: "\f205"; }
+
+.fa-toilet:before {
+  content: "\f7d8"; }
+
+.fa-toilet-paper:before {
+  content: "\f71e"; }
+
+.fa-toolbox:before {
+  content: "\f552"; }
+
+.fa-tools:before {
+  content: "\f7d9"; }
+
+.fa-tooth:before {
+  content: "\f5c9"; }
+
+.fa-torah:before {
+  content: "\f6a0"; }
+
+.fa-torii-gate:before {
+  content: "\f6a1"; }
+
+.fa-tractor:before {
+  content: "\f722"; }
+
+.fa-trade-federation:before {
+  content: "\f513"; }
+
+.fa-trademark:before {
+  content: "\f25c"; }
+
+.fa-traffic-light:before {
+  content: "\f637"; }
+
+.fa-trailer:before {
+  content: "\f941"; }
+
+.fa-train:before {
+  content: "\f238"; }
+
+.fa-tram:before {
+  content: "\f7da"; }
+
+.fa-transgender:before {
+  content: "\f224"; }
+
+.fa-transgender-alt:before {
+  content: "\f225"; }
+
+.fa-trash:before {
+  content: "\f1f8"; }
+
+.fa-trash-alt:before {
+  content: "\f2ed"; }
+
+.fa-trash-restore:before {
+  content: "\f829"; }
+
+.fa-trash-restore-alt:before {
+  content: "\f82a"; }
+
+.fa-tree:before {
+  content: "\f1bb"; }
+
+.fa-trello:before {
+  content: "\f181"; }
+
+.fa-tripadvisor:before {
+  content: "\f262"; }
+
+.fa-trophy:before {
+  content: "\f091"; }
+
+.fa-truck:before {
+  content: "\f0d1"; }
+
+.fa-truck-loading:before {
+  content: "\f4de"; }
+
+.fa-truck-monster:before {
+  content: "\f63b"; }
+
+.fa-truck-moving:before {
+  content: "\f4df"; }
+
+.fa-truck-pickup:before {
+  content: "\f63c"; }
+
+.fa-tshirt:before {
+  content: "\f553"; }
+
+.fa-tty:before {
+  content: "\f1e4"; }
+
+.fa-tumblr:before {
+  content: "\f173"; }
+
+.fa-tumblr-square:before {
+  content: "\f174"; }
+
+.fa-tv:before {
+  content: "\f26c"; }
+
+.fa-twitch:before {
+  content: "\f1e8"; }
+
+.fa-twitter:before {
+  content: "\f099"; }
+
+.fa-twitter-square:before {
+  content: "\f081"; }
+
+.fa-typo3:before {
+  content: "\f42b"; }
+
+.fa-uber:before {
+  content: "\f402"; }
+
+.fa-ubuntu:before {
+  content: "\f7df"; }
+
+.fa-uikit:before {
+  content: "\f403"; }
+
+.fa-umbraco:before {
+  content: "\f8e8"; }
+
+.fa-umbrella:before {
+  content: "\f0e9"; }
+
+.fa-umbrella-beach:before {
+  content: "\f5ca"; }
+
+.fa-underline:before {
+  content: "\f0cd"; }
+
+.fa-undo:before {
+  content: "\f0e2"; }
+
+.fa-undo-alt:before {
+  content: "\f2ea"; }
+
+.fa-uniregistry:before {
+  content: "\f404"; }
+
+.fa-unity:before {
+  content: "\f949"; }
+
+.fa-universal-access:before {
+  content: "\f29a"; }
+
+.fa-university:before {
+  content: "\f19c"; }
+
+.fa-unlink:before {
+  content: "\f127"; }
+
+.fa-unlock:before {
+  content: "\f09c"; }
+
+.fa-unlock-alt:before {
+  content: "\f13e"; }
+
+.fa-untappd:before {
+  content: "\f405"; }
+
+.fa-upload:before {
+  content: "\f093"; }
+
+.fa-ups:before {
+  content: "\f7e0"; }
+
+.fa-usb:before {
+  content: "\f287"; }
+
+.fa-user:before {
+  content: "\f007"; }
+
+.fa-user-alt:before {
+  content: "\f406"; }
+
+.fa-user-alt-slash:before {
+  content: "\f4fa"; }
+
+.fa-user-astronaut:before {
+  content: "\f4fb"; }
+
+.fa-user-check:before {
+  content: "\f4fc"; }
+
+.fa-user-circle:before {
+  content: "\f2bd"; }
+
+.fa-user-clock:before {
+  content: "\f4fd"; }
+
+.fa-user-cog:before {
+  content: "\f4fe"; }
+
+.fa-user-edit:before {
+  content: "\f4ff"; }
+
+.fa-user-friends:before {
+  content: "\f500"; }
+
+.fa-user-graduate:before {
+  content: "\f501"; }
+
+.fa-user-injured:before {
+  content: "\f728"; }
+
+.fa-user-lock:before {
+  content: "\f502"; }
+
+.fa-user-md:before {
+  content: "\f0f0"; }
+
+.fa-user-minus:before {
+  content: "\f503"; }
+
+.fa-user-ninja:before {
+  content: "\f504"; }
+
+.fa-user-nurse:before {
+  content: "\f82f"; }
+
+.fa-user-plus:before {
+  content: "\f234"; }
+
+.fa-user-secret:before {
+  content: "\f21b"; }
+
+.fa-user-shield:before {
+  content: "\f505"; }
+
+.fa-user-slash:before {
+  content: "\f506"; }
+
+.fa-user-tag:before {
+  content: "\f507"; }
+
+.fa-user-tie:before {
+  content: "\f508"; }
+
+.fa-user-times:before {
+  content: "\f235"; }
+
+.fa-users:before {
+  content: "\f0c0"; }
+
+.fa-users-cog:before {
+  content: "\f509"; }
+
+.fa-usps:before {
+  content: "\f7e1"; }
+
+.fa-ussunnah:before {
+  content: "\f407"; }
+
+.fa-utensil-spoon:before {
+  content: "\f2e5"; }
+
+.fa-utensils:before {
+  content: "\f2e7"; }
+
+.fa-vaadin:before {
+  content: "\f408"; }
+
+.fa-vector-square:before {
+  content: "\f5cb"; }
+
+.fa-venus:before {
+  content: "\f221"; }
+
+.fa-venus-double:before {
+  content: "\f226"; }
+
+.fa-venus-mars:before {
+  content: "\f228"; }
+
+.fa-viacoin:before {
+  content: "\f237"; }
+
+.fa-viadeo:before {
+  content: "\f2a9"; }
+
+.fa-viadeo-square:before {
+  content: "\f2aa"; }
+
+.fa-vial:before {
+  content: "\f492"; }
+
+.fa-vials:before {
+  content: "\f493"; }
+
+.fa-viber:before {
+  content: "\f409"; }
+
+.fa-video:before {
+  content: "\f03d"; }
+
+.fa-video-slash:before {
+  content: "\f4e2"; }
+
+.fa-vihara:before {
+  content: "\f6a7"; }
+
+.fa-vimeo:before {
+  content: "\f40a"; }
+
+.fa-vimeo-square:before {
+  content: "\f194"; }
+
+.fa-vimeo-v:before {
+  content: "\f27d"; }
+
+.fa-vine:before {
+  content: "\f1ca"; }
+
+.fa-vk:before {
+  content: "\f189"; }
+
+.fa-vnv:before {
+  content: "\f40b"; }
+
+.fa-voicemail:before {
+  content: "\f897"; }
+
+.fa-volleyball-ball:before {
+  content: "\f45f"; }
+
+.fa-volume-down:before {
+  content: "\f027"; }
+
+.fa-volume-mute:before {
+  content: "\f6a9"; }
+
+.fa-volume-off:before {
+  content: "\f026"; }
+
+.fa-volume-up:before {
+  content: "\f028"; }
+
+.fa-vote-yea:before {
+  content: "\f772"; }
+
+.fa-vr-cardboard:before {
+  content: "\f729"; }
+
+.fa-vuejs:before {
+  content: "\f41f"; }
+
+.fa-walking:before {
+  content: "\f554"; }
+
+.fa-wallet:before {
+  content: "\f555"; }
+
+.fa-warehouse:before {
+  content: "\f494"; }
+
+.fa-water:before {
+  content: "\f773"; }
+
+.fa-wave-square:before {
+  content: "\f83e"; }
+
+.fa-waze:before {
+  content: "\f83f"; }
+
+.fa-weebly:before {
+  content: "\f5cc"; }
+
+.fa-weibo:before {
+  content: "\f18a"; }
+
+.fa-weight:before {
+  content: "\f496"; }
+
+.fa-weight-hanging:before {
+  content: "\f5cd"; }
+
+.fa-weixin:before {
+  content: "\f1d7"; }
+
+.fa-whatsapp:before {
+  content: "\f232"; }
+
+.fa-whatsapp-square:before {
+  content: "\f40c"; }
+
+.fa-wheelchair:before {
+  content: "\f193"; }
+
+.fa-whmcs:before {
+  content: "\f40d"; }
+
+.fa-wifi:before {
+  content: "\f1eb"; }
+
+.fa-wikipedia-w:before {
+  content: "\f266"; }
+
+.fa-wind:before {
+  content: "\f72e"; }
+
+.fa-window-close:before {
+  content: "\f410"; }
+
+.fa-window-maximize:before {
+  content: "\f2d0"; }
+
+.fa-window-minimize:before {
+  content: "\f2d1"; }
+
+.fa-window-restore:before {
+  content: "\f2d2"; }
+
+.fa-windows:before {
+  content: "\f17a"; }
+
+.fa-wine-bottle:before {
+  content: "\f72f"; }
+
+.fa-wine-glass:before {
+  content: "\f4e3"; }
+
+.fa-wine-glass-alt:before {
+  content: "\f5ce"; }
+
+.fa-wix:before {
+  content: "\f5cf"; }
+
+.fa-wizards-of-the-coast:before {
+  content: "\f730"; }
+
+.fa-wolf-pack-battalion:before {
+  content: "\f514"; }
+
+.fa-won-sign:before {
+  content: "\f159"; }
+
+.fa-wordpress:before {
+  content: "\f19a"; }
+
+.fa-wordpress-simple:before {
+  content: "\f411"; }
+
+.fa-wpbeginner:before {
+  content: "\f297"; }
+
+.fa-wpexplorer:before {
+  content: "\f2de"; }
+
+.fa-wpforms:before {
+  content: "\f298"; }
+
+.fa-wpressr:before {
+  content: "\f3e4"; }
+
+.fa-wrench:before {
+  content: "\f0ad"; }
+
+.fa-x-ray:before {
+  content: "\f497"; }
+
+.fa-xbox:before {
+  content: "\f412"; }
+
+.fa-xing:before {
+  content: "\f168"; }
+
+.fa-xing-square:before {
+  content: "\f169"; }
+
+.fa-y-combinator:before {
+  content: "\f23b"; }
+
+.fa-yahoo:before {
+  content: "\f19e"; }
+
+.fa-yammer:before {
+  content: "\f840"; }
+
+.fa-yandex:before {
+  content: "\f413"; }
+
+.fa-yandex-international:before {
+  content: "\f414"; }
+
+.fa-yarn:before {
+  content: "\f7e3"; }
+
+.fa-yelp:before {
+  content: "\f1e9"; }
+
+.fa-yen-sign:before {
+  content: "\f157"; }
+
+.fa-yin-yang:before {
+  content: "\f6ad"; }
+
+.fa-yoast:before {
+  content: "\f2b1"; }
+
+.fa-youtube:before {
+  content: "\f167"; }
+
+.fa-youtube-square:before {
+  content: "\f431"; }
+
+.fa-zhihu:before {
+  content: "\f63f"; }
+
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; }
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto; }
+
+/*!
+ * Font Awesome Free 5.12.1 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Brands';
+  font-style: normal;
+  font-weight: 400;
+  font-display: auto;
+  src: url(../Fonts/fa-brands-400.eot);
+  src: url(../Fonts/fa-brands-400.eot?#iefix) format("embedded-opentype"), url(../Fonts/fa-brands-400.woff2) format("woff2"), url(../Fonts/fa-brands-400.woff) format("woff"), url(../Fonts/fa-brands-400.ttf) format("truetype"), url(../Fonts/fa-brands-400.svg#fontawesome) format("svg"); }
+
+.fab {
+  font-family: 'Font Awesome 5 Brands';
+  font-weight: 400; }
+
+/*!
+ * Font Awesome Free 5.12.1 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 400;
+  font-display: auto;
+  src: url(../Fonts/fa-regular-400.eot);
+  src: url(../Fonts/fa-regular-400.eot?#iefix) format("embedded-opentype"), url(../Fonts/fa-regular-400.woff2) format("woff2"), url(../Fonts/fa-regular-400.woff) format("woff"), url(../Fonts/fa-regular-400.ttf) format("truetype"), url(../Fonts/fa-regular-400.svg#fontawesome) format("svg"); }
+
+.far {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 400; }
+
+/*!
+ * Font Awesome Free 5.12.1 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+  font-display: auto;
+  src: url(../Fonts/fa-solid-900.eot);
+  src: url(../Fonts/fa-solid-900.eot?#iefix) format("embedded-opentype"), url(../Fonts/fa-solid-900.woff2) format("woff2"), url(../Fonts/fa-solid-900.woff) format("woff"), url(../Fonts/fa-solid-900.ttf) format("truetype"), url(../Fonts/fa-solid-900.svg#fontawesome) format("svg"); }
+
+.fa,
+.fas,
+.neos button[class^="fa-"],
+.neos button[class*=" fa-"],
+.neos .neos-button[class^="fa-"],
+.neos .neos-button[class*=" fa-"],
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
+.neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span::before,
+.neos.neos-module .neos-select:after,
+.neos.neos-module .neos-checkbox input + span::before,
+.neos.neos-module .neos-radio input + span::before,
+.neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900; }
+
+.neos [class^="fa-"],
+.neos [class*=" fa-"] {
+  vertical-align: baseline; }
+  .neos [class^="fa-"].fa-review,
+  .neos [class*=" fa-"].fa-review {
+    position: relative;
+    padding-right: 4px; }
+    .neos [class^="fa-"].fa-review:before,
+    .neos [class*=" fa-"].fa-review:before {
+      content: "\f15c";
+      font-weight: 400; }
+    .neos [class^="fa-"].fa-review:after,
+    .neos [class*=" fa-"].fa-review:after {
+      content: "\f058";
+      text-decoration: inherit;
+      display: inline-block;
+      speak: none;
+      position: absolute;
+      font-size: 12px;
+      top: 8px;
+      left: 7px; }
+
+:root {
+  --base-font-size: 100%;
+  /* Color palette */
+  --grayDarker: #141414;
+  --grayDark: #222;
+  --grayMedium: #323232;
+  --grayLight: #3f3f3f;
+  --grayLighter: #eee;
+  --textOnWhite: #252525;
+  --textContrast: #2d2d2d;
+  --textOnGray: #fff;
+  --textSubtle: #5b5b5b;
+  --textSubtleLight: #adadad;
+  --blue: #00b5ff;
+  --blueLight: #39c6ff;
+  --blueDark: #007fb2;
+  --green: #00a338;
+  --warning: #ff460d;
+  --orange: #ff8700;
+  /* Sizes & margins */
+  --unit: 40px;
+  --defaultMargin: 16px;
+  --relatedMargin: 8px;
+  --tightMargin: 4px;
+  --wideMargin: 32px;
+  /* Components */
+  --inspectorWidth: 320px;
+  --navigatePanelWidth: 320px;
+  --menuWidth: 320px;
+  --editPreviewPanelHeight: 110px;
+  --menuButtonWidth: 54px;
+  --generalFontSize: 14px;
+  --zindexTooltip: 999999;
+  --errorText: #ff460d;
+  --successText: #00a338;
+  --warningText: #ff8700;
+  --infoText: #00b5ff;
+  --spacing-GoldenUnit: 40px;
+  --spacing-Full: 16px;
+  --spacing-Half: 8px;
+  --spacing-Quarter: 4px;
+  --size-SidebarWidth: 320px;
+  --transition-Fast: .1s;
+  --transition-Default: .25s;
+  --transition-Slow: .5s;
+  --zIndex-SecondaryToolbar-LinkIconButtonFlyout: 1;
+  --zIndex-FlashMessageContainer: 6;
+  --zIndex-LoadingIndicatorContainer: 5;
+  --zIndex-SecondaryInspector-Context: 1;
+  --zIndex-SecondaryInspector-Iframe: 2;
+  --zIndex-SecondaryInspector-Close: 3;
+  --zIndex-SecondaryInspectorElevated-Context: 1;
+  --zIndex-SecondaryInspectorElevated-DropdownContents: 2;
+  --zIndex-Dialog-Context: 1;
+  --zIndex-FullScreenClose-Context: 1;
+  --zIndex-Drawer-Context: 1;
+  --zIndex-Bar-Context: 1;
+  --zIndex-PrimaryToolbar: 4;
+  --zIndex-CheckboxInput-Context: 1;
+  --zIndex-DropdownContents-Context: 1;
+  --zIndex-SelectBoxContents: 3;
+  --zIndex-NotInlineEditableOverlay-Context: 1;
+  --zIndex-CalendarFakeInputMirror-Context: 1;
+  --zIndex-RdtPicker-Context: 1;
+  --zIndex-SideBar-DropTargetBefore: 1;
+  --zIndex-SideBar-DropTargetAfter: 2;
+  --zIndex-WrapperDropdown-Context: 1;
+  --zIndex-UnappliedChangesOverlay-Context: 1;
+  --zIndex-NodeToolBar: 2147483646;
+  --fontSize-Base: 14px;
+  --fontSize-Small: 12px;
+  --fontsHeadings-Family: Noto Sans;
+  --fontsHeadings-Style: Regular;
+  --fontsHeadings-CssWeight: 400;
+  --fontsCopy-Family: Noto Sans;
+  --fontsCopy-Style: Regular;
+  --fontsCopy-CssWeight: 400;
+  --colors-PrimaryViolet: #26224C;
+  --colors-PrimaryVioletHover: #342f5f;
+  --colors-PrimaryBlue: #00ADEE;
+  --colors-PrimaryBlueHover: #35c3f8;
+  --colors-ContrastDarkest: #141414;
+  --colors-ContrastDarker: #222;
+  --colors-ContrastDark: #3f3f3f;
+  --colors-ContrastNeutral: #323232;
+  --colors-ContrastBright: #999;
+  --colors-ContrastBrighter: #adadad;
+  --colors-ContrastBrightest: #fff;
+  --colors-Success: #00a338;
+  --colors-SuccessHover: #0bb344;
+  --colors-Warn: #ff8700;
+  --colors-WarnHover: #fda23d;
+  --colors-Error: #ff460d;
+  --colors-ErrorHover: #ff6a3c;
+  --colors-UncheckedCheckboxTick: #5B5B5B; }
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+nav,
+section {
+  display: block; }
+
+audio,
+canvas,
+video {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1; }
+
+audio:not([controls]) {
+  display: none; }
+
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%; }
+
+a:focus {
+  outline: thin dotted #333;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px; }
+
+a:hover,
+a:active {
+  outline: 0; }
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+img {
+  /* Responsive images (ensure images don't scale beyond their parents) */
+  max-width: 100%;
+  /* Part 1: Set a maxium relative to the parent */
+  width: auto\9;
+  /* IE7-8 need help adjusting responsive images */
+  height: auto;
+  /* Part 2: Scale the height according to the width, otherwise you get stretching */
+  vertical-align: middle;
+  border: 0;
+  -ms-interpolation-mode: bicubic; }
+
+#map_canvas img,
+.neos-google-maps img {
+  max-width: none; }
+
+button,
+input,
+select,
+textarea {
+  margin: 0;
+  font-size: 100%;
+  vertical-align: middle; }
+
+button,
+input {
+  *overflow: visible;
+  line-height: normal; }
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  padding: 0;
+  border: 0; }
+
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer; }
+
+label[for],
+select,
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
+input[type="radio"],
+input[type="checkbox"] {
+  cursor: pointer; }
+
+input[type="search"] {
+  box-sizing: content-box;
+  -webkit-appearance: textfield; }
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none; }
+
+textarea {
+  overflow: auto;
+  vertical-align: top; }
+
+@media print {
+  * {
+    text-shadow: none !important;
+    color: #000 !important;
+    background: transparent !important;
+    box-shadow: none !important; }
+  a,
+  a:visited {
+    text-decoration: underline; }
+  a[href]:after {
+    content: " (" attr(href) ")"; }
+  abbr[title]:after {
+    content: " (" attr(title) ")"; }
+  .neos-ir a:after,
+  a[href^="javascript:"]:after,
+  a[href^="#"]:after {
+    content: ""; }
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid; }
+  thead {
+    display: table-header-group; }
+  tr,
+  img {
+    page-break-inside: avoid; }
+  img {
+    max-width: 100% !important; }
+  @page {
+    margin: 0.5cm; }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3; }
+  h2,
+  h3 {
+    page-break-after: avoid; } }
+
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, fieldset, input, p, blockquote, th, td {
+  margin: 0;
+  padding: 0; }
+
+img {
+  border: 0; }
+
+address, caption, cite, code, dfn, em, strong, th, var {
+  font-style: normal;
+  font-weight: normal; }
+
+ol, ul, ol li, ul li {
+  list-style: none; }
+
+caption, th {
+  text-align: left; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-size: 14px; }
+
+q:before,
+q:after {
+  content: ''; }
+
+*, *:before, *:after {
+  box-sizing: content-box; }
+
+@media only screen {
+  button, .button {
+    transition: none;
+    box-shadow: none; } }
+
+.neos {
+  font-size: 14px;
+  line-height: 1em;
+  text-align: left;
+  color: #fff;
+  font-family: 'Noto Sans', sans-serif;
+  -webkit-font-smoothing: antialiased; }
+  .neos .neos-breadcrumb {
+    padding: 8px 15px;
+    margin: 0 0 20px;
+    list-style: none;
+    background-color: #f5f5f5;
+    border-radius: 4px; }
+    .neos .neos-breadcrumb > li {
+      display: inline-block;
+      text-shadow: 0 1px 0 #fff; }
+      .neos .neos-breadcrumb > li > .neos-divider {
+        padding: 0 5px;
+        color: #ccc; }
+    .neos .neos-breadcrumb .neos-active {
+      color: #3f3f3f; }
+  .neos button,
+  .neos .neos-button {
+    display: inline-block;
+    padding: 0 16px;
+    margin: 0;
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    color: #fff;
+    font-size: 14px;
+    text-align: center;
+    vertical-align: middle;
+    cursor: pointer;
+    width: auto;
+    height: 40px;
+    line-height: 40px;
+    background-color: #3f3f3f;
+    background-image: none;
+    border: none;
+    border-radius: 0;
+    text-shadow: none;
+    box-shadow: none;
+    box-sizing: border-box;
+    transition: all 0 ease 0; }
+    .neos button.neos-button-small,
+    .neos .neos-button.neos-button-small {
+      height: 24px;
+      line-height: 24px;
+      font-size: 12px;
+      padding: 0 8px; }
+    .neos button:not([disabled]):hover, .neos button:not([disabled]):active, .neos button:not([disabled]).neos-active, .neos button:not([disabled]).neos-pressed, .neos button:not(.neos-disabled):hover, .neos button:not(.neos-disabled):active, .neos button:not(.neos-disabled).neos-active, .neos button:not(.neos-disabled).neos-pressed,
+    .neos .neos-button:not([disabled]):hover,
+    .neos .neos-button:not([disabled]):active,
+    .neos .neos-button:not([disabled]).neos-active,
+    .neos .neos-button:not([disabled]).neos-pressed,
+    .neos .neos-button:not(.neos-disabled):hover,
+    .neos .neos-button:not(.neos-disabled):active,
+    .neos .neos-button:not(.neos-disabled).neos-active,
+    .neos .neos-button:not(.neos-disabled).neos-pressed {
+      color: #fff;
+      background-color: #00b5ff;
+      text-decoration: none; }
+    .neos button:focus,
+    .neos .neos-button:focus {
+      outline: thin dotted #333;
+      outline: 5px auto -webkit-focus-ring-color;
+      outline-offset: -2px;
+      outline: 1px dotted #fff;
+      outline-offset: 0; }
+    .neos button.neos-disabled, .neos button[disabled],
+    .neos .neos-button.neos-disabled,
+    .neos .neos-button[disabled] {
+      cursor: not-allowed;
+      opacity: .65; }
+    .neos button.neos-button-primary,
+    .neos .neos-button.neos-button-primary {
+      background-color: #00b5ff; }
+      .neos button.neos-button-primary:focus,
+      .neos .neos-button.neos-button-primary:focus {
+        outline: 1px dotted #fff; }
+    .neos button.neos-button-success,
+    .neos .neos-button.neos-button-success {
+      background-color: #00a338; }
+      .neos button.neos-button-success:hover, .neos button.neos-button-success:active,
+      .neos .neos-button.neos-button-success:hover,
+      .neos .neos-button.neos-button-success:active {
+        background-color: #00a338; }
+      .neos button.neos-button-success:focus,
+      .neos .neos-button.neos-button-success:focus {
+        outline: 1px dotted #fff; }
+    .neos button.neos-button-warning,
+    .neos .neos-button.neos-button-warning {
+      background-color: #ff8700; }
+      .neos button.neos-button-warning:hover, .neos button.neos-button-warning:active,
+      .neos .neos-button.neos-button-warning:hover,
+      .neos .neos-button.neos-button-warning:active {
+        background-color: #ff8700; }
+      .neos button.neos-button-warning:focus,
+      .neos .neos-button.neos-button-warning:focus {
+        outline: 1px dotted #fff; }
+    .neos button.neos-button-danger,
+    .neos .neos-button.neos-button-danger {
+      background-color: #ff460d; }
+      .neos button.neos-button-danger:hover, .neos button.neos-button-danger:active,
+      .neos .neos-button.neos-button-danger:hover,
+      .neos .neos-button.neos-button-danger:active {
+        background-color: #ff460d; }
+      .neos button.neos-button-danger:focus,
+      .neos .neos-button.neos-button-danger:focus {
+        outline: 1px dotted #fff; }
+  .neos a.neos-button {
+    color: #fff; }
+    .neos a.neos-button:hover, .neos a.neos-button:focus {
+      color: #fff; }
+    .neos a.neos-button i {
+      display: inline-block !important; }
+  .neos .neos-button-group {
+    position: relative;
+    display: inline-block;
+    font-size: 0;
+    vertical-align: middle;
+    white-space: nowrap; }
+  .neos .neos-button-group + .neos-button-group {
+    margin-left: 5px; }
+  .neos .neos-button-toolbar {
+    font-size: 0;
+    margin-top: 10px;
+    margin-bottom: 10px; }
+    .neos .neos-button-toolbar > .neos-button + .neos-button,
+    .neos .neos-button-toolbar > .neos-button-group + .neos-button,
+    .neos .neos-button-toolbar > .neos-button + .neos-button-group {
+      margin-left: 5px; }
+  .neos .neos-button-group > .neos-button {
+    position: relative;
+    border-radius: 0; }
+  .neos .neos-button-group > .neos-button + .neos-button {
+    margin-left: -1px; }
+  .neos .neos-button-group > .neos-button-mini {
+    font-size: 10.5px; }
+  .neos .neos-button-group > .neos-button-small {
+    font-size: 11.9px; }
+  .neos .neos-button-group > .neos-button-large {
+    font-size: 17.5px; }
+  .neos .neos-button-group > .neos-button:first-child {
+    margin-left: 0; }
+  .neos .neos-button-group > .neos-button.neos-large:first-child {
+    margin-left: 0; }
+  .neos .neos-button-group > .neos-button:hover,
+  .neos .neos-button-group > .neos-button:focus,
+  .neos .neos-button-group > .neos-button:active,
+  .neos .neos-button-group > .neos-button.neos-active {
+    z-index: 2; }
+  .neos .neos-button-group .neos-dropdown-toggle:active,
+  .neos .neos-button-group.neos-open .neos-dropdown-toggle {
+    outline: 0; }
+  .neos .neos-button-group > .neos-button + .neos-dropdown-toggle {
+    padding-left: 8px;
+    padding-right: 8px;
+    box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+    *padding-top: 5px;
+    *padding-bottom: 5px; }
+  .neos .neos-button-group > .neos-button-mini + .neos-dropdown-toggle {
+    padding-left: 5px;
+    padding-right: 5px;
+    *padding-top: 2px;
+    *padding-bottom: 2px; }
+  .neos .neos-button-group > .neos-button-small + .neos-dropdown-toggle {
+    *padding-top: 5px;
+    *padding-bottom: 4px; }
+  .neos .neos-button-group > .neos-button-large + .neos-dropdown-toggle {
+    padding-left: 12px;
+    padding-right: 12px;
+    *padding-top: 7px;
+    *padding-bottom: 7px; }
+  .neos .neos-button-group.neos-open .neos-dropdown-toggle {
+    background-image: none;
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05); }
+  .neos .neos-button-group.neos-open .neos-button-primary.neos-dropdown-toggle {
+    background-color: #0044cc; }
+  .neos .neos-button-group.neos-open .neos-button-warning.neos-dropdown-toggle {
+    background-color: #f89406; }
+  .neos .neos-button-group.neos-open .neos-button-danger.neos-dropdown-toggle {
+    background-color: #bd362f; }
+  .neos .neos-button-group.neos-open .neos-button-success.neos-dropdown-toggle {
+    background-color: #51a351; }
+  .neos .neos-button-group.neos-open .neos-button-info.neos-dropdown-toggle {
+    background-color: #2f96b4; }
+  .neos .neos-button-group.neos-open .neos-button-inverse.neos-dropdown-toggle {
+    background-color: #222; }
+  .neos .neos-button .neos-caret {
+    margin-top: 8px;
+    margin-left: 0; }
+  .neos .neos-button-large .neos-caret {
+    margin-top: 6px; }
+  .neos .neos-button-large .neos-caret {
+    border-left-width: 5px;
+    border-right-width: 5px;
+    border-top-width: 5px; }
+  .neos .neos-button-mini .neos-caret,
+  .neos .neos-button-small .neos-caret {
+    margin-top: 8px; }
+  .neos .neos-dropup .neos-button-large .neos-caret {
+    border-bottom-width: 5px; }
+  .neos .neos-button-primary .neos-caret,
+  .neos .neos-button-warning .neos-caret,
+  .neos .neos-button-danger .neos-caret,
+  .neos .neos-button-info .neos-caret,
+  .neos .neos-button-success .neos-caret,
+  .neos .neos-button-inverse .neos-caret {
+    border-top-color: #fff;
+    border-bottom-color: #fff; }
+  .neos .neos-button-group-vertical {
+    display: inline-block; }
+  .neos .neos-button-group-vertical > .neos-button {
+    display: block;
+    float: none;
+    max-width: 100%;
+    border-radius: 0; }
+  .neos .neos-button-group-vertical > .neos-button + .neos-button {
+    margin-left: 0;
+    margin-top: -1px; }
+  .neos .neos-button-group-vertical > .neos-button:first-child {
+    border-radius: 4px 4px 0 0; }
+  .neos .neos-button-group-vertical > .neos-button:last-child {
+    border-radius: 0 0 4px 4px; }
+  .neos .neos-button-group-vertical > .neos-button-large:first-child {
+    border-radius: 6px 6px 0 0; }
+  .neos .neos-button-group-vertical > .neos-button-large:last-child {
+    border-radius: 0 0 6px 6px; }
+  .neos .neos-container {
+    margin-right: auto;
+    margin-left: auto; }
+    .neos .neos-container:after {
+      content: "";
+      display: table;
+      clear: both; }
+  .neos .neos-container-fluid {
+    padding-right: 20px;
+    padding-left: 20px; }
+    .neos .neos-container-fluid:after {
+      content: "";
+      display: table;
+      clear: both; }
+  .neos .neos-dropup,
+  .neos .neos-dropdown {
+    position: relative; }
+  .neos .neos-dropdown-toggle {
+    *margin-bottom: -3px; }
+  .neos .neos-dropdown-toggle:active,
+  .neos .neos-open .neos-dropdown-toggle {
+    outline: 0; }
+  .neos .neos-caret {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    vertical-align: top;
+    border-top: 4px solid #fff;
+    border-right: 4px solid transparent;
+    border-left: 4px solid transparent;
+    content: ""; }
+  .neos .neos-dropdown .neos-caret {
+    margin-top: 8px;
+    margin-left: 2px; }
+  .neos .neos-dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    float: left;
+    min-width: 160px;
+    padding: 0;
+    margin: 1px 0 0;
+    list-style: none;
+    background-color: #323232;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); }
+    .neos .neos-dropdown-menu.neos-pull-right {
+      right: 0;
+      left: auto; }
+    .neos .neos-dropdown-menu > li {
+      display: block;
+      height: 40px;
+      clear: both;
+      font-weight: normal;
+      line-height: 20px;
+      color: #fff;
+      white-space: nowrap;
+      padding: 0; }
+      .neos .neos-dropdown-menu > li + li {
+        border-top: 1px solid #222; }
+      .neos .neos-dropdown-menu > li > a {
+        display: block;
+        width: 100%;
+        text-align: left;
+        line-height: 40px;
+        padding: 0 16px;
+        box-sizing: border-box; }
+        .neos .neos-dropdown-menu > li > a:hover, .neos .neos-dropdown-menu > li > a.neos-active {
+          background-color: #00b5ff;
+          color: #fff; }
+        .neos .neos-dropdown-menu > li > a [class^="fa-"],
+        .neos .neos-dropdown-menu > li > a [class*=" fa-"] {
+          margin: 0 8px;
+          line-height: 40px;
+          vertical-align: top; }
+  .neos .neos-dropdown-menu-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    background-color: #323232;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); }
+    .neos .neos-dropdown-menu-list.neos-pull-right {
+      right: 0;
+      left: auto; }
+    .neos .neos-dropdown-menu-list .neos-dropdown-menu-list-title {
+      display: block;
+      height: 40px;
+      clear: both;
+      font-weight: normal;
+      color: #fff;
+      white-space: nowrap;
+      padding: 0 16px;
+      line-height: 40px;
+      font-size: 14px;
+      border-bottom: 1px solid #222;
+      font-weight: bold; }
+    .neos .neos-dropdown-menu-list ul {
+      list-style: none;
+      padding: 0;
+      float: left;
+      min-width: 160px;
+      margin: 1px 0 0 0; }
+      .neos .neos-dropdown-menu-list ul > li {
+        display: block;
+        height: 40px;
+        clear: both;
+        font-weight: normal;
+        line-height: 20px;
+        color: #fff;
+        white-space: nowrap;
+        padding: 0;
+        border-bottom: 1px solid #222; }
+        .neos .neos-dropdown-menu-list ul > li > a {
+          display: block;
+          width: 100%;
+          text-align: left;
+          line-height: 40px;
+          padding: 0 16px;
+          box-sizing: border-box; }
+          .neos .neos-dropdown-menu-list ul > li > a:hover, .neos .neos-dropdown-menu-list ul > li > a.neos-active {
+            background-color: #00b5ff;
+            color: #fff; }
+          .neos .neos-dropdown-menu-list ul > li > a [class^="fa-"],
+          .neos .neos-dropdown-menu-list ul > li > a [class*=" fa-"] {
+            margin: 0 8px;
+            line-height: 40px;
+            vertical-align: top; }
+  .neos .neos-dropdown-menu > li > a:hover,
+  .neos .neos-dropdown-menu > li > a:focus,
+  .neos .neos-dropdown-submenu:hover > a,
+  .neos .neos-dropdown-submenu:focus > a {
+    text-decoration: none;
+    color: #fff;
+    background-color: #00b5ff; }
+  .neos .neos-dropdown-menu > .neos-active > a,
+  .neos .neos-dropdown-menu > .neos-active > a:hover,
+  .neos .neos-dropdown-menu > .neos-active > a:focus {
+    color: #fff;
+    text-decoration: none;
+    outline: 0;
+    background-color: #00b5ff; }
+  .neos .neos-dropdown-menu > .neos-disabled > a,
+  .neos .neos-dropdown-menu > .neos-disabled > a:hover,
+  .neos .neos-dropdown-menu > .neos-disabled > a:focus {
+    color: #3f3f3f; }
+  .neos .neos-dropdown-menu > .neos-disabled > a:hover,
+  .neos .neos-dropdown-menu > .neos-disabled > a:focus {
+    text-decoration: none;
+    background-color: transparent;
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+    cursor: default; }
+  .neos .neos-open {
+    *z-index: 1000; }
+    .neos .neos-open > .neos-dropdown-menu {
+      display: block; }
+    .neos .neos-open > .neos-dropdown-menu-list {
+      display: block; }
+  .neos .neos-pull-right > .neos-dropdown-menu {
+    right: 0;
+    left: auto; }
+  .neos .neos-dropup .neos-caret,
+  .neos .neos-navbar-fixed-bottom .neos-dropdown .neos-caret {
+    border-top: 0;
+    border-bottom: 4px solid #000;
+    content: ""; }
+  .neos .neos-dropup .neos-dropdown-menu,
+  .neos .neos-navbar-fixed-bottom .neos-dropdown .neos-dropdown-menu {
+    top: auto;
+    bottom: 100%;
+    margin-bottom: 1px; }
+  .neos .neos-dropdown-submenu {
+    position: relative; }
+  .neos .neos-dropdown-submenu > .neos-dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: -6px;
+    margin-left: -1px; }
+  .neos .neos-dropdown-submenu:hover > .neos-dropdown-menu {
+    display: block; }
+  .neos .neos-dropup .neos-dropdown-submenu > .neos-dropdown-menu {
+    top: auto;
+    bottom: 0;
+    margin-top: 0;
+    margin-bottom: -2px; }
+  .neos .neos-dropdown-submenu > a:after {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 26px;
+    line-height: 26px;
+    font-weight: normal;
+    content: "›"; }
+  .neos .neos-dropdown-submenu:hover > a:after {
+    border-left-color: #fff; }
+  .neos .neos-dropdown-submenu.neos-pull-left {
+    float: none; }
+    .neos .neos-dropdown-submenu.neos-pull-left > .neos-dropdown-menu {
+      left: -100%;
+      margin-left: 10px; }
+  .neos .neos-dropdown .neos-dropdown-menu .neos-nav-header {
+    padding-left: 20px;
+    padding-right: 20px; }
+  .neos .neos-typeahead {
+    z-index: 1051;
+    margin-top: 2px;
+    border-radius: 4px; }
+  .neos #neos-top-bar {
+    position: fixed;
+    display: none;
+    -webkit-flex-flow: row wrap;
+    justify-content: space-between;
+    left: 0;
+    right: 0;
+    top: 0;
+    z-index: 10021;
+    background-color: #222;
+    height: 40px;
+    border-bottom: 1px solid #3f3f3f;
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 0;
+    transition-property: top;
+    transition-duration: 0.2s; }
+    .neos #neos-top-bar .neos-top-bar-left {
+      display: flex;
+      -webkit-flex-flow: row wrap;
+      justify-content: space-around; }
+      .neos #neos-top-bar .neos-top-bar-left .neos-branding {
+        padding: 8px 1px; }
+        .neos #neos-top-bar .neos-top-bar-left .neos-branding svg {
+          height: 24px;
+          width: auto; }
+    .neos #neos-top-bar .neos-top-bar-right {
+      display: flex;
+      -webkit-flex-flow: row wrap;
+      justify-content: space-around; }
+    .neos #neos-top-bar #neos-user-actions {
+      float: left; }
+      .neos #neos-top-bar #neos-user-actions i {
+        margin-left: 8px;
+        margin-right: 8px; }
+      .neos #neos-top-bar #neos-user-actions .neos-dropdown-toggle {
+        outline: none; }
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-toggle:hover {
+          color: #00b5ff; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-toggle:hover i {
+            color: white; }
+      .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu {
+        border: 0;
+        right: 0;
+        background: none;
+        padding: 2px;
+        margin: -2px 0 0;
+        -webkit-box-shadow: 0 5px 5px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 5px 5px rgba(0, 0, 0, 0.2); }
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox,
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio {
+          position: relative;
+          display: inline-block;
+          overflow: hidden;
+          min-height: 22px;
+          min-width: 22px;
+          line-height: 22px;
+          vertical-align: middle;
+          padding: 0 !important; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox.neos-inline,
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio.neos-inline {
+            margin-bottom: 8px;
+            margin-right: 32px; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox.neos-inline + .neos-inline,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio.neos-inline + .neos-inline {
+              margin-left: 0;
+              margin-right: 32px; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input,
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input {
+            position: absolute;
+            left: -9999px;
+            vertical-align: top; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span {
+              width: 22px;
+              height: 22px;
+              margin-right: 8px;
+              overflow: hidden;
+              float: left;
+              position: relative; }
+              .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
+              .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input + span::before {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 20px;
+                height: 20px;
+                background-color: #3f3f3f;
+                border: 1px solid #adadad;
+                color: #5b5b5b;
+                cursor: pointer;
+                content: "\f00c";
+                line-height: 20px;
+                text-align: center; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input:checked + span::before,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input:checked + span::before {
+              background-color: #39c6ff;
+              border: 1px solid #39c6ff;
+              text-align: center;
+              color: #fff; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input:checked:hover + span::before,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input:checked:hover + span::before {
+              background-color: #3f3f3f; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input[type='radio'] + span::before,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input[type='radio'] + span::before {
+              content: "";
+              border-radius: 50%; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input[type='radio'] + span::after,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input[type='radio'] + span::after {
+              content: "";
+              position: absolute;
+              background: #5b5b5b;
+              border-radius: 50%;
+              width: 8px;
+              height: 8px;
+              left: 7px;
+              top: 7px; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input[type='radio']:checked + span::after,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input[type='radio']:checked + span::after {
+              background: #fff; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input:hover + span::before,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input:hover + span::before {
+              border-color: #39c6ff; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input[disabled] + span,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input[disabled] + span {
+              opacity: .35;
+              cursor: not-allowed; }
+              .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input[disabled] + span::before,
+              .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-radio input[disabled] + span::before {
+                border-color: #adadad; }
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu label.neos-inline + label:not(.neos-inline) {
+          margin-top: 12px; }
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li {
+          height: 40px;
+          background: #141414;
+          border-top: 1px solid #222; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li a,
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li button {
+            height: 40px;
+            color: white;
+            font-size: 14px;
+            line-height: 40px;
+            padding: 0 16px;
+            box-sizing: border-box; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li a:hover,
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li button:hover {
+              background: #00b5ff; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li button {
+            width: 100%;
+            text-align: left;
+            background-color: #141414; }
+            .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li button:hover {
+              background-color: #00b5ff; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li label {
+            padding-top: 9px; }
+          .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu li button i {
+            line-height: 18px; }
+        .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu label {
+          font-size: 14px; }
+  .neos .neos-user-menu.neos-button-group {
+    font-size: 14px; }
+    .neos .neos-user-menu.neos-button-group .neos-button {
+      background: none;
+      padding: 0 16px; }
+  .neos .neos-menu-button {
+    float: left;
+    width: 54px;
+    height: 40px;
+    background-color: #222;
+    transition-property: top;
+    transition-duration: 0.2s; }
+    .neos .neos-menu-button:hover, .neos .neos-menu-button.neos-pressed {
+      background: transparent !important; }
+      .neos .neos-menu-button:hover:before, .neos .neos-menu-button.neos-pressed:before {
+        border-top: 3px solid #00b5ff;
+        border-bottom: 3px solid #00b5ff; }
+      .neos .neos-menu-button:hover:after, .neos .neos-menu-button.neos-pressed:after {
+        background-color: #00b5ff; }
+    .neos .neos-menu-button.neos-pressed {
+      height: 41px; }
+    .neos .neos-menu-button:before {
+      display: block;
+      position: absolute;
+      left: 16px;
+      top: 12px;
+      width: 22px;
+      height: 3px;
+      border-top: 3px solid #fff;
+      border-bottom: 3px solid #fff;
+      content: ''; }
+    .neos .neos-menu-button:after {
+      display: block;
+      position: absolute;
+      left: 16px;
+      top: 24px;
+      width: 22px;
+      height: 3px;
+      background-color: #fff;
+      content: ''; }
+  .neos .neos-menu .neos-menu-button {
+    outline: none; }
+  .neos .neos-menu-panel {
+    display: none;
+    position: fixed;
+    top: 40px;
+    bottom: 0;
+    left: -321px;
+    width: 320px;
+    background-color: #222;
+    z-index: 10020;
+    border-right: 1px solid #3f3f3f;
+    overflow-x: hidden;
+    overflow-y: auto;
+    transition-property: left, width;
+    transition-duration: 0.2s;
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased; }
+    .neos .neos-menu-panel .neos-menu-wrapper {
+      margin: 0;
+      padding: 0; }
+    .neos-menu-panel-open .neos .neos-menu-panel {
+      left: 0;
+      display: block; }
+    .neos .neos-menu-panel.neos-noscript {
+      top: 0;
+      left: 0; }
+    .neos .neos-menu-panel > .neos-menu-section:first-child .neos-menu-headline {
+      border: none; }
+    .neos .neos-menu-panel a {
+      font-family: 'Noto Sans', sans-serif;
+      -webkit-font-smoothing: antialiased;
+      color: #fff; }
+      .neos .neos-menu-panel a:hover, .neos .neos-menu-panel a:active {
+        color: #00b5ff;
+        text-decoration: none; }
+    .neos .neos-menu-panel .neos-menu-container {
+      height: 100%; }
+    .neos .neos-menu-panel .neos-menu-section {
+      position: relative; }
+      .neos .neos-menu-panel .neos-menu-section .neos-menu-section-header .neos-menu-panel-toggle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        background-color: transparent;
+        outline: none; }
+        .neos .neos-menu-panel .neos-menu-section .neos-menu-section-header .neos-menu-panel-toggle:hover i {
+          color: #00b5ff;
+          text-decoration: none; }
+      .neos .neos-menu-panel .neos-menu-section .neos-menu-section-content {
+        display: none;
+        opacity: 0; }
+      .neos .neos-menu-panel .neos-menu-section.neos-open .neos-menu-section-content {
+        display: block;
+        opacity: 1;
+        transition: opacity 0.25s ease-in; }
+      .neos .neos-menu-panel .neos-menu-section .neos-menu-headline {
+        box-sizing: border-box;
+        padding-left: 54px;
+        height: 40px;
+        border-top: 1px solid #3f3f3f;
+        cursor: pointer;
+        line-height: 40px;
+        position: relative; }
+      .neos .neos-menu-panel .neos-menu-section a,
+      .neos .neos-menu-panel .neos-menu-section span.neos-menu-item {
+        display: block;
+        font-family: 'Noto Sans', sans-serif;
+        -webkit-font-smoothing: antialiased;
+        font-size: 14px;
+        font-weight: bold;
+        line-height: 40px;
+        height: 40px;
+        user-select: none;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        padding-left: 38px;
+        padding-right: 16px; }
+        .neos .neos-menu-panel .neos-menu-section a:hover, .neos .neos-menu-panel .neos-menu-section a.neos-active,
+        .neos .neos-menu-panel .neos-menu-section span.neos-menu-item:hover,
+        .neos .neos-menu-panel .neos-menu-section span.neos-menu-item.neos-active {
+          color: #00b5ff; }
+        .neos .neos-menu-panel .neos-menu-section a.neos-disabled,
+        .neos .neos-menu-panel .neos-menu-section span.neos-menu-item.neos-disabled {
+          color: #5b5b5b; }
+        .neos .neos-menu-panel .neos-menu-section a i,
+        .neos .neos-menu-panel .neos-menu-section span.neos-menu-item i {
+          display: block;
+          position: absolute;
+          background-color: #222;
+          top: 0;
+          left: 0;
+          width: 54px;
+          height: 40px;
+          font-size: 14px;
+          line-height: 40px;
+          vertical-align: middle;
+          text-align: center;
+          z-index: 10010; }
+      .neos .neos-menu-panel .neos-menu-section .neos-menu-list a,
+      .neos .neos-menu-panel .neos-menu-section .neos-menu-list span.neos-menu-item {
+        padding-left: 54px;
+        position: relative;
+        font-weight: normal; }
+  .neos.neos-module {
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    background-color: #141414;
+    color: #fff;
+    margin: 0;
+    /* wrapper for dark background */ }
+    .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container {
+      display: block; }
+      .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container > li > span {
+        display: none; }
+      .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container .neos-tree-node {
+        cursor: pointer;
+        height: auto; }
+        .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container .neos-tree-node.neos-tree-folder .neos-tree-title {
+          user-select: none; }
+        .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container .neos-tree-node .neos-tree-icon {
+          display: none; }
+        .neos.neos-module.neos-module-administration-configuration #configuration > ul.neos-tree-container .neos-tree-node .neos-tree-title {
+          width: calc(100% - 24px);
+          height: auto;
+          white-space: normal;
+          text-align: left;
+          word-break: break-word;
+          word-wrap: break-word; }
+    .neos.neos-module.neos-module-administration-configuration #configuration .key,
+    .neos.neos-module.neos-module-administration-configuration #configuration .value {
+      display: inline; }
+    .neos.neos-module.neos-module-administration-configuration #configuration .value[title="boolean"], .neos.neos-module.neos-module-administration-configuration #configuration .value[title="NULL"] {
+      color: #ff8700; }
+    .neos.neos-module.neos-module-administration-configuration #configuration .value[title="integer"], .neos.neos-module.neos-module-administration-configuration #configuration .value[title="double"] {
+      color: #ff460d; }
+    .neos.neos-module.neos-module-administration-configuration #configuration .value[title="string"] {
+      color: #00b5ff; }
+    .neos.neos-module.neos-module-administration-packages table {
+      table-layout: auto; }
+      .neos.neos-module.neos-module-administration-packages table label {
+        padding: 0;
+        margin-bottom: 0;
+        line-height: 40px;
+        font-size: inherit;
+        user-select: none; }
+      .neos.neos-module.neos-module-administration-packages table .fold-toggle {
+        cursor: pointer;
+        margin-top: -1px;
+        margin-right: 11px; }
+      .neos.neos-module.neos-module-administration-packages table td {
+        max-width: 20%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap; }
+        .neos.neos-module.neos-module-administration-packages table td.check {
+          width: 22px; }
+        .neos.neos-module.neos-module-administration-packages table td.package-name {
+          width: 200px; }
+        .neos.neos-module.neos-module-administration-packages table td.package-version {
+          width: 5%; }
+        .neos.neos-module.neos-module-administration-packages table td.package-key {
+          width: 8%; }
+        .neos.neos-module.neos-module-administration-packages table td.package-type {
+          width: 15%; }
+        .neos.neos-module.neos-module-administration-packages table td.neos-action {
+          width: 20%;
+          text-align: right; }
+    .neos.neos-module.neos-module-administration-sites .fold-toggle {
+      cursor: pointer; }
+    .neos.neos-module.neos-module-administration-sites .neos-control-label + .neos-control-label {
+      margin-left: 2px; }
+    .neos.neos-module.neos-module-management-history .neos-history-events-divider {
+      margin: 0;
+      padding: 0;
+      border: 2px solid #323232; }
+    .neos.neos-module.neos-module-management-history .neos-history {
+      max-width: 1000px;
+      margin: 0 auto; }
+    .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-date {
+      margin-left: 50%; }
+      .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-date .neos-history-date-inner {
+        text-align: center;
+        line-height: 80px;
+        overflow: hidden;
+        border-radius: 50%;
+        width: 80px;
+        height: 80px;
+        background: #007fb2;
+        margin-left: -42px;
+        font-size: 100%;
+        border: solid 4px #323232; }
+    .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events {
+      width: 50%;
+      padding-top: 20px; }
+      .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events::after {
+        border: 1px solid rgba(0, 0, 0, 0);
+        content: "";
+        clear: both; }
+      .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events .neos-history-event {
+        text-align: left;
+        clear: both;
+        position: relative;
+        padding-top: 8px;
+        padding-right: 16px; }
+        .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events .neos-history-event::after {
+          border: 1px solid rgba(0, 0, 0, 0);
+          content: "";
+          clear: both; }
+        .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events .neos-history-event .neos-history-event-user {
+          border-radius: 50%;
+          width: 40px;
+          height: 40px;
+          background: #007fb2;
+          overflow: hidden;
+          text-align: center;
+          line-height: 40px;
+          float: left;
+          border: 4px solid #323232;
+          margin-right: 20px; }
+        .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events .neos-history-event .neos-history-event-description {
+          padding: 5px;
+          margin-right: 20px; }
+          .neos.neos-module.neos-module-management-history .neos-history-day .neos-history-events .neos-history-event .neos-history-event-description a {
+            text-decoration: underline; }
+    .neos.neos-module.neos-module-management-history .neos-history-day:nth-child(even) .neos-history-events.neos-history-alignment {
+      text-align: right;
+      border-right: 4px solid #323232; }
+      .neos.neos-module.neos-module-management-history .neos-history-day:nth-child(even) .neos-history-events.neos-history-alignment .neos-history-event-time {
+        float: right;
+        margin-right: 10px;
+        width: 65px;
+        text-align: right; }
+    .neos.neos-module.neos-module-management-history .neos-history-day:nth-child(odd) .neos-history-events.neos-history-alignment {
+      text-align: left;
+      margin-left: 50%;
+      border-left: 4px solid #323232; }
+      .neos.neos-module.neos-module-management-history .neos-history-day:nth-child(odd) .neos-history-events.neos-history-alignment .neos-history-event-time {
+        float: left;
+        margin-left: 10px;
+        width: 65px;
+        text-align: left; }
+    .neos.neos-module.neos-module-management-history .loadMore {
+      text-align: center; }
+      .neos.neos-module.neos-module-management-history .loadMore button {
+        margin-top: 25px;
+        margin-bottom: 25px; }
+    .neos.neos-module .neos-hidden {
+      display: none;
+      visibility: hidden; }
+    .neos.neos-module.neos-module-management-workspaces .neos-footer p {
+      font-size: 11.9px;
+      margin-right: 8px; }
+    .neos.neos-module.neos-module-management-workspaces tr.neos-change + tr.neos-change td.neos-content-change {
+      border-top: 1px solid #ddd; }
+    .neos.neos-module.neos-module-management-workspaces td {
+      white-space: nowrap; }
+      .neos.neos-module.neos-module-management-workspaces td.description {
+        white-space: normal;
+        line-height: 20px;
+        padding: 10px 0 5px 0; }
+      .neos.neos-module.neos-module-management-workspaces td.node-type img {
+        vertical-align: baseline; }
+      .neos.neos-module.neos-module-management-workspaces td.path-caption .neos-aRight {
+        border-right: 1px solid #222; }
+      .neos.neos-module.neos-module-management-workspaces td label {
+        padding: 0;
+        margin-bottom: 0;
+        font-size: inherit;
+        line-height: 40px;
+        user-select: none; }
+    .neos.neos-module.neos-module-management-workspaces td.neos-content-change {
+      background-color: #eee;
+      color: #252525; }
+    .neos.neos-module.neos-module-management-workspaces .neos-content-diff {
+      line-height: 23.52941px; }
+      .neos.neos-module.neos-module-management-workspaces .neos-content-diff table {
+        table-layout: fixed;
+        width: 100%; }
+      .neos.neos-module.neos-module-management-workspaces .neos-content-diff table.neos-content-diff td, .neos.neos-module.neos-module-management-workspaces .neos-content-diff table.neos-content-diff th {
+        height: auto;
+        width: 50%;
+        vertical-align: top;
+        line-height: 20px;
+        padding: 10px 20px 10px 10px !important;
+        border-top: none;
+        white-space: normal;
+        background-color: #eee;
+        color: #252525; }
+        .neos.neos-module.neos-module-management-workspaces .neos-content-diff table.neos-content-diff td img, .neos.neos-module.neos-module-management-workspaces .neos-content-diff table.neos-content-diff th img {
+          max-width: 100%;
+          min-width: 50%;
+          max-height: 500px;
+          border: 20px solid #fff;
+          box-sizing: border-box; }
+    .neos.neos-module.neos-module-management-workspaces td.neos-folder i[class*='icon'] {
+      height: 40px;
+      line-height: 40px;
+      padding: 0 16px;
+      margin: 0;
+      text-align: center;
+      font-size: 10px;
+      vertical-align: middle; }
+      .neos.neos-module.neos-module-management-workspaces td.neos-folder i[class*='icon']:hover {
+        background: #00b5ff; }
+    .neos.neos-module.neos-module-management-workspaces .path-caption {
+      padding-left: 15px !important;
+      padding-right: 0; }
+    .neos.neos-module.neos-module-management-workspaces .fold-toggle {
+      cursor: pointer;
+      margin-top: -1px;
+      margin-right: 11px; }
+    .neos.neos-module.neos-module-management-workspaces .legend-edited {
+      border-left: 8px solid #ff8700; }
+    .neos.neos-module.neos-module-management-workspaces .legend-deleted {
+      border-left: 8px solid #ff460d; }
+    .neos.neos-module.neos-module-management-workspaces .legend-created {
+      border-left: 8px solid #00a338; }
+    .neos.neos-module.neos-module-management-workspaces .legend-moved {
+      border-left: 8px solid #00b5ff; }
+    .neos.neos-module.neos-module-management-workspaces .legend-hidden {
+      border-left: 8px solid #fff; }
+    .neos.neos-module.neos-module-management-workspaces td.actions {
+      width: 144px; }
+      .neos.neos-module.neos-module-management-workspaces td.actions button {
+        display: inline-block; }
+    .neos.neos-module.neos-module-management-workspaces tfoot {
+      font-size: 11.9px;
+      color: #5b5b5b; }
+      .neos.neos-module.neos-module-management-workspaces tfoot .legend {
+        margin-left: 15px;
+        text-align: center;
+        padding-right: 4px; }
+    .neos.neos-module.neos-module-management-workspaces .neos-change-stats {
+      width: 100px;
+      height: 40px;
+      position: relative;
+      display: inline-block; }
+      .neos.neos-module.neos-module-management-workspaces .neos-change-stats span {
+        display: inline-block;
+        height: 8px;
+        position: relative;
+        overflow: hidden; }
+      .neos.neos-module.neos-module-management-workspaces .neos-change-stats .new {
+        background-color: #00a338; }
+      .neos.neos-module.neos-module-management-workspaces .neos-change-stats .changed {
+        background-color: #ff8700; }
+      .neos.neos-module.neos-module-management-workspaces .neos-change-stats .removed {
+        background-color: #ff460d; }
+      .neos.neos-module.neos-module-management-workspaces .neos-change-stats .unchanged {
+        background-color: #3f3f3f;
+        width: 100%; }
+    .neos.neos-module.neos-module-management-workspaces ins, .neos.neos-module.neos-module-management-workspaces ins a {
+      color: #00a338;
+      text-decoration: none; }
+    .neos.neos-module.neos-module-management-workspaces del, .neos.neos-module.neos-module-management-workspaces del a {
+      color: #9d261d;
+      text-decoration: none; }
+    .neos.neos-module.neos-menu-panel-sticky .neos-footer.fixedsticky-on {
+      width: calc(100% - 54px); }
+    .neos.neos-module > .neos-module-wrap {
+      position: relative;
+      background: #222;
+      padding: 80px 54px 40px 54px; }
+    .neos.neos-module h1,
+    .neos.neos-module h2,
+    .neos.neos-module h3,
+    .neos.neos-module h4,
+    .neos.neos-module h5,
+    .neos.neos-module h6 {
+      text-rendering: optimizelegibility; }
+    .neos.neos-module p {
+      line-height: 1.6em; }
+    .neos.neos-module a {
+      color: #00b5ff; }
+      .neos.neos-module a, .neos.neos-module a:hover {
+        color: #fff;
+        text-decoration: none; }
+    .neos.neos-module .neos-button {
+      color: #fff; }
+    .neos.neos-module label {
+      font-size: 14px; }
+    .neos.neos-module #neos-notifications-inline {
+      display: none; }
+    .neos.neos-module form.neos-inline {
+      display: inline-block; }
+    .neos.neos-module .neos-help-block {
+      margin-top: 8px;
+      margin-bottom: 16px; }
+      .neos.neos-module .neos-help-block em {
+        padding: 2px 4px;
+        color: #007fb2;
+        background-color: #323232;
+        border: 1px solid #3f3f3f;
+        white-space: nowrap; }
+    .neos.neos-module.neos-module-user-usersettings .neos-content #electronicAddresses input[type="text"], .neos.neos-module.neos-module-administration-users .neos-content #electronicAddresses input[type="text"] {
+      width: 100%; }
+    .neos.neos-module.neos-module-user-usersettings .neos-content #electronicAddresses input[type="radio"], .neos.neos-module.neos-module-administration-users .neos-content #electronicAddresses input[type="radio"] {
+      margin: 0; }
+    .neos.neos-module.neos-module-user-usersettings .neos-content i.fa-user, .neos.neos-module.neos-module-administration-users .neos-content i.fa-user {
+      margin-right: 11px; }
+    .neos.neos-module.neos-module-user-usersettings .neos-search-bar button.neos-button, .neos.neos-module.neos-module-administration-users .neos-search-bar button.neos-button {
+      border-right: 1px solid #222; }
+    .neos.neos-module.neos-module-user-usersettings .neos-search-bar a.neos-button, .neos.neos-module.neos-module-administration-users .neos-search-bar a.neos-button {
+      border-left: 1px solid #222; }
+    .neos.neos-module .neos-breadcrumb {
+      border-radius: 0;
+      background-color: transparent;
+      padding: 0;
+      border-bottom: 1px solid #3f3f3f; }
+      .neos.neos-module .neos-breadcrumb a {
+        color: #fff;
+        line-height: 40px;
+        text-shadow: none; }
+        .neos.neos-module .neos-breadcrumb a.active {
+          color: #00b5ff; }
+        .neos.neos-module .neos-breadcrumb a:hover, .neos.neos-module .neos-breadcrumb a:active, .neos.neos-module .neos-breadcrumb a:focus {
+          color: #fff;
+          text-decoration: none; }
+        .neos.neos-module .neos-breadcrumb a i {
+          line-height: 20px;
+          padding-right: 5px; }
+    .neos.neos-module .neos-content {
+      padding: 0; }
+      .neos.neos-module .neos-content.fluid-container h1 {
+        margin-left: 20px; }
+      .neos.neos-module .neos-content.neos-well {
+        background-color: #777;
+        border-color: #666;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.2) inset;
+        border-radius: 0;
+        padding: 0px; }
+        .neos.neos-module .neos-content.neos-well h1 {
+          padding: 10px 50px 0px 50px; }
+        .neos.neos-module .neos-content.neos-well p {
+          color: #3f3f3f; }
+      .neos.neos-module .neos-content .widget {
+        border-radius: 0; }
+    .neos.neos-module fieldset {
+      padding-bottom: 32px; }
+    .neos.neos-module legend {
+      border: none;
+      padding-top: 16px;
+      margin-bottom: 0; }
+    .neos.neos-module select,
+    .neos.neos-module input[type="text"],
+    .neos.neos-module input[type="password"],
+    .neos.neos-module input[type="datetime"],
+    .neos.neos-module input[type="datetime-local"],
+    .neos.neos-module input[type="date"],
+    .neos.neos-module input[type="month"],
+    .neos.neos-module input[type="time"],
+    .neos.neos-module input[type="week"],
+    .neos.neos-module input[type="number"],
+    .neos.neos-module input[type="range"],
+    .neos.neos-module input[type="date"],
+    .neos.neos-module input[type="email"],
+    .neos.neos-module input[type="url"],
+    .neos.neos-module input[type="search"],
+    .neos.neos-module input[type="tel"],
+    .neos.neos-module input[type="color"],
+    .neos.neos-module input[type="number"],
+    .neos.neos-module .neos-uneditable-input {
+      height: 40px;
+      line-height: 36px;
+      border: 2px solid #3f3f3f;
+      background-color: #3f3f3f;
+      color: #fff;
+      font-family: 'Noto Sans', sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 14px;
+      padding: 0 14px;
+      margin: 0;
+      box-sizing: border-box;
+      box-shadow: none;
+      transition: none;
+      border-radius: 0px; }
+      .neos.neos-module select:focus,
+      .neos.neos-module input[type="text"]:focus,
+      .neos.neos-module input[type="password"]:focus,
+      .neos.neos-module input[type="datetime"]:focus,
+      .neos.neos-module input[type="datetime-local"]:focus,
+      .neos.neos-module input[type="date"]:focus,
+      .neos.neos-module input[type="month"]:focus,
+      .neos.neos-module input[type="time"]:focus,
+      .neos.neos-module input[type="week"]:focus,
+      .neos.neos-module input[type="number"]:focus,
+      .neos.neos-module input[type="range"]:focus,
+      .neos.neos-module input[type="date"]:focus,
+      .neos.neos-module input[type="email"]:focus,
+      .neos.neos-module input[type="url"]:focus,
+      .neos.neos-module input[type="search"]:focus,
+      .neos.neos-module input[type="tel"]:focus,
+      .neos.neos-module input[type="color"]:focus,
+      .neos.neos-module input[type="number"]:focus,
+      .neos.neos-module .neos-uneditable-input:focus {
+        background-color: #fff;
+        border: 2px solid #fff;
+        color: #252525;
+        outline: none;
+        box-shadow: none; }
+      .neos.neos-module select.neos-modified,
+      .neos.neos-module input[type="text"].neos-modified,
+      .neos.neos-module input[type="password"].neos-modified,
+      .neos.neos-module input[type="datetime"].neos-modified,
+      .neos.neos-module input[type="datetime-local"].neos-modified,
+      .neos.neos-module input[type="date"].neos-modified,
+      .neos.neos-module input[type="month"].neos-modified,
+      .neos.neos-module input[type="time"].neos-modified,
+      .neos.neos-module input[type="week"].neos-modified,
+      .neos.neos-module input[type="number"].neos-modified,
+      .neos.neos-module input[type="range"].neos-modified,
+      .neos.neos-module input[type="date"].neos-modified,
+      .neos.neos-module input[type="email"].neos-modified,
+      .neos.neos-module input[type="url"].neos-modified,
+      .neos.neos-module input[type="search"].neos-modified,
+      .neos.neos-module input[type="tel"].neos-modified,
+      .neos.neos-module input[type="color"].neos-modified,
+      .neos.neos-module input[type="number"].neos-modified,
+      .neos.neos-module .neos-uneditable-input.neos-modified {
+        border: 2px solid #00a338; }
+    .neos.neos-module textarea {
+      border: 2px solid #3f3f3f;
+      background-color: #3f3f3f;
+      color: #fff;
+      font-family: 'Noto Sans', sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 14px;
+      padding: 0 14px;
+      margin: 0;
+      box-sizing: border-box;
+      box-shadow: none;
+      transition: none;
+      border-radius: 0px; }
+      .neos.neos-module textarea:focus {
+        background-color: #fff;
+        border: 2px solid #fff;
+        color: #252525;
+        outline: none;
+        box-shadow: none; }
+      .neos.neos-module textarea.neos-modified {
+        border: 2px solid #00a338; }
+    .neos.neos-module .neos-select {
+      position: relative;
+      background-color: #3f3f3f; }
+      .neos.neos-module .neos-select:focus {
+        outline: none; }
+        .neos.neos-module .neos-select:focus:after {
+          color: #252525; }
+      .neos.neos-module .neos-select:before {
+        display: block;
+        content: "";
+        position: absolute;
+        width: 1px;
+        height: 24px;
+        top: 8px;
+        right: 41px;
+        background-color: #fff;
+        opacity: 0.15; }
+      .neos.neos-module .neos-select:after {
+        content: "\f0d7";
+        display: block;
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 40px;
+        line-height: 40px;
+        text-align: center; }
+      .neos.neos-module .neos-select select {
+        appearance: none;
+        -webkit-border-radius: 0px;
+        -o-appearance: window;
+        -moz-appearance: window;
+        background-color: transparent;
+        line-height: 1;
+        padding: 7px 14px;
+        width: 100%;
+        position: relative;
+        z-index: 1; }
+        .neos.neos-module .neos-select select:focus {
+          color: #fff;
+          background-color: transparent;
+          border-color: transparent; }
+      .neos.neos-module .neos-select option {
+        appearance: none;
+        -webkit-border-radius: 0px;
+        background-color: #3f3f3f; }
+    .neos.neos-module .neos-footer {
+      position: sticky;
+      height: 72px;
+      background-color: #141414;
+      margin: 40px -54px -40px;
+      border-top: 1px solid #3f3f3f;
+      padding: 16px;
+      font-size: 0;
+      bottom: 0;
+      z-index: 100;
+      overflow: hidden;
+      box-sizing: border-box;
+      /* When position: sticky is supported but native behavior is ignored */ }
+      .neos.neos-module .neos-footer:after {
+        content: "";
+        display: table;
+        clear: both; }
+      .neos.neos-module .neos-footer.fixedsticky-on {
+        width: 100%;
+        position: -webkit-sticky;
+        position: -moz-sticky;
+        position: -ms-sticky;
+        position: -o-sticky;
+        position: sticky;
+        margin-bottom: 0; }
+        .fixedsticky-withoutfixedfixed .neos.neos-module .neos-footer.fixedsticky-on,
+        .fixed-supported .neos.neos-module .neos-footer.fixedsticky-on {
+          position: fixed; }
+      .fixedsticky-withoutfixedfixed .neos.neos-module .neos-footer.fixedsticky-off,
+      .fixed-supported .neos.neos-module .neos-footer.fixedsticky-off {
+        position: static; }
+      .neos.neos-module .neos-footer.fixedsticky-on + .fixedsticky-dummy {
+        display: block; }
+      @media screen and (max-width: 1024px) and (max-height: 768px) {
+        .neos.neos-module .neos-footer {
+          padding: 0; } }
+      .neos.neos-module .neos-footer .neos-button {
+        margin-right: 8px; }
+      .neos.neos-module .neos-footer .neos-modal .neos-button {
+        margin-right: 0; }
+    .neos.neos-module .fixedsticky-dummy {
+      display: none; }
+    .neos.neos-module .neos-checkbox,
+    .neos.neos-module .neos-radio {
+      position: relative;
+      display: inline-block;
+      overflow: hidden;
+      min-height: 22px;
+      min-width: 22px;
+      line-height: 22px;
+      vertical-align: middle;
+      padding: 0 !important; }
+      .neos.neos-module .neos-checkbox.neos-inline,
+      .neos.neos-module .neos-radio.neos-inline {
+        margin-bottom: 8px;
+        margin-right: 32px; }
+        .neos.neos-module .neos-checkbox.neos-inline + .neos-inline,
+        .neos.neos-module .neos-radio.neos-inline + .neos-inline {
+          margin-left: 0;
+          margin-right: 32px; }
+      .neos.neos-module .neos-checkbox input,
+      .neos.neos-module .neos-radio input {
+        position: absolute;
+        left: -9999px;
+        vertical-align: top; }
+        .neos.neos-module .neos-checkbox input + span,
+        .neos.neos-module .neos-radio input + span {
+          width: 22px;
+          height: 22px;
+          margin-right: 8px;
+          overflow: hidden;
+          float: left;
+          position: relative; }
+          .neos.neos-module .neos-checkbox input + span::before,
+          .neos.neos-module .neos-radio input + span::before {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 20px;
+            height: 20px;
+            background-color: #3f3f3f;
+            border: 1px solid #adadad;
+            color: #5b5b5b;
+            cursor: pointer;
+            content: "\f00c";
+            line-height: 20px;
+            text-align: center; }
+        .neos.neos-module .neos-checkbox input:checked + span::before,
+        .neos.neos-module .neos-radio input:checked + span::before {
+          background-color: #39c6ff;
+          border: 1px solid #39c6ff;
+          text-align: center;
+          color: #fff; }
+        .neos.neos-module .neos-checkbox input:checked:hover + span::before,
+        .neos.neos-module .neos-radio input:checked:hover + span::before {
+          background-color: #3f3f3f; }
+        .neos.neos-module .neos-checkbox input[type='radio'] + span::before,
+        .neos.neos-module .neos-radio input[type='radio'] + span::before {
+          content: "";
+          border-radius: 50%; }
+        .neos.neos-module .neos-checkbox input[type='radio'] + span::after,
+        .neos.neos-module .neos-radio input[type='radio'] + span::after {
+          content: "";
+          position: absolute;
+          background: #5b5b5b;
+          border-radius: 50%;
+          width: 8px;
+          height: 8px;
+          left: 7px;
+          top: 7px; }
+        .neos.neos-module .neos-checkbox input[type='radio']:checked + span::after,
+        .neos.neos-module .neos-radio input[type='radio']:checked + span::after {
+          background: #fff; }
+        .neos.neos-module .neos-checkbox input:hover + span::before,
+        .neos.neos-module .neos-radio input:hover + span::before {
+          border-color: #39c6ff; }
+        .neos.neos-module .neos-checkbox input[disabled] + span,
+        .neos.neos-module .neos-radio input[disabled] + span {
+          opacity: .35;
+          cursor: not-allowed; }
+          .neos.neos-module .neos-checkbox input[disabled] + span::before,
+          .neos.neos-module .neos-radio input[disabled] + span::before {
+            border-color: #adadad; }
+    .neos.neos-module label.neos-inline + label:not(.neos-inline) {
+      margin-top: 12px; }
+    .neos.neos-module table.table-bordered {
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+      border-top: 1px solid #3f3f3f;
+      border-bottom: 1px solid #3f3f3f; }
+      .neos.neos-module table.table-bordered tr,
+      .neos.neos-module table.table-bordered th {
+        border-radius: 0; }
+      .neos.neos-module table.table-bordered th,
+      .neos.neos-module table.table-bordered td {
+        border-left: 1px solid #3f3f3f; }
+    .neos.neos-module table.neos-table td:first-child,
+    .neos.neos-module table.neos-table th:first-child {
+      padding-left: 16px !important; }
+    .neos.neos-module table.neos-table td:last-child,
+    .neos.neos-module table.neos-table th:last-child {
+      padding-right: 16px !important; }
+    .neos.neos-module table.neos-table td.neos-action,
+    .neos.neos-module table.neos-table th.neos-action {
+      padding-left: 0 !important;
+      padding-right: 0 !important; }
+    .neos.neos-module table.neos-table tr.neos-folder td {
+      background: #222;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      border-top: 1px solid #323232; }
+      .neos.neos-module table.neos-table tr.neos-folder td i[class*="icon"] {
+        height: 40px;
+        line-height: 40px;
+        padding: 0 16px;
+        margin: 0;
+        text-align: center;
+        font-size: 10px;
+        vertical-align: middle; }
+        .neos.neos-module table.neos-table tr.neos-folder td i[class*="icon"]:hover {
+          background: #00b5ff; }
+    .neos.neos-module table.neos-table th.check,
+    .neos.neos-module table.neos-table td.check {
+      padding-right: 8px !important; }
+    .neos.neos-module table.neos-table .neos-label {
+      background-color: #3f3f3f;
+      box-shadow: 0 0 3px 2px rgba(0, 0, 0, 0.1);
+      font-weight: normal;
+      letter-spacing: 0.05em;
+      padding: 2px 0.5em; }
+    .neos.neos-module table.neos-info-table {
+      width: 100%;
+      margin-bottom: 32px; }
+      .neos.neos-module table.neos-info-table thead th {
+        padding: 0 16px !important;
+        height: 40px;
+        font-weight: bold; }
+      .neos.neos-module table.neos-info-table tbody th,
+      .neos.neos-module table.neos-info-table tbody td {
+        height: auto;
+        vertical-align: top;
+        line-height: 20px;
+        padding: 10px 16px !important;
+        border-top: 1px solid #323232; }
+      .neos.neos-module table.neos-info-table tbody th {
+        font-weight: bold;
+        text-align: left;
+        width: 30%; }
+        .neos.neos-module table.neos-info-table tbody th span {
+          font-weight: normal;
+          color: #eee;
+          font-size: 0.9em; }
+      .neos.neos-module table.neos-info-table tbody tr:first-child th,
+      .neos.neos-module table.neos-info-table tbody tr:first-child td {
+        border-top: 0; }
+    .neos.neos-module table td {
+      border-top: 1px solid #222; }
+    .neos.neos-module table th {
+      text-shadow: none; }
+    .neos.neos-module table td,
+    .neos.neos-module table th {
+      height: 40px;
+      padding: 0 16px;
+      line-height: 40px;
+      box-sizing: border-box; }
+      .neos.neos-module table td:first-child,
+      .neos.neos-module table th:first-child {
+        padding-left: 32px !important; }
+      .neos.neos-module table td:last-child,
+      .neos.neos-module table th:last-child {
+        padding-right: 32px !important; }
+      .neos.neos-module table td.neos-action,
+      .neos.neos-module table th.neos-action {
+        padding-left: 0 !important;
+        padding-right: 0 !important; }
+      .neos.neos-module table td i,
+      .neos.neos-module table th i {
+        vertical-align: baseline;
+        text-align: center; }
+    .neos.neos-module table td > .neos-button,
+    .neos.neos-module table td > form > .neos-button,
+    .neos.neos-module table td div.neos-pull-right > .neos-button,
+    .neos.neos-module table td div.neos-pull-right > form .neos-button {
+      background-color: #323232; }
+      .neos.neos-module table td > .neos-button:not([disabled]):hover, .neos.neos-module table td > .neos-button:not([disabled]):active, .neos.neos-module table td > .neos-button:not([disabled]).neos-active, .neos.neos-module table td > .neos-button:not([disabled]).neos-pressed, .neos.neos-module table td > .neos-button:not(.neos-disabled):hover, .neos.neos-module table td > .neos-button:not(.neos-disabled):active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td > form > .neos-button:not([disabled]):hover,
+      .neos.neos-module table td > form > .neos-button:not([disabled]):active,
+      .neos.neos-module table td > form > .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td > form > .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td > form > .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td > form > .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td > form > .neos-button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td > form > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]):hover,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]):active,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]):hover,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]):active,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled).neos-pressed {
+        background-color: #00b5ff; }
+      .neos.neos-module table td > .neos-button.neos-button-success,
+      .neos.neos-module table td > form > .neos-button.neos-button-success,
+      .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success {
+        background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-success:hover, .neos.neos-module table td > .neos-button.neos-button-success:active,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:active {
+          background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed {
+          background-color: #00a338; }
+      .neos.neos-module table td > .neos-button.neos-button-warning,
+      .neos.neos-module table td > form > .neos-button.neos-button-warning,
+      .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning {
+        background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-warning:hover, .neos.neos-module table td > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:active {
+          background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed {
+          background-color: #ff8700; }
+      .neos.neos-module table td > .neos-button.neos-button-danger,
+      .neos.neos-module table td > form > .neos-button.neos-button-danger,
+      .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger {
+        background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-danger:hover, .neos.neos-module table td > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:active {
+          background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed {
+          background-color: #ff460d; }
+      .neos.neos-module table td > .neos-button.neos-button-primary,
+      .neos.neos-module table td > form > .neos-button.neos-button-primary,
+      .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary {
+        background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-primary:hover, .neos.neos-module table td > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:active {
+          background-color: #323232; }
+        .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed {
+          background-color: #00b5ff; }
+    .neos.neos-module legend + table,
+    .neos.neos-module legend + .neos-alert {
+      margin-top: 20px;
+      -webkit-margin-top-collapse: separate; }
+  .neos #neos-notification-container.neos-notification-top {
+    position: fixed;
+    z-index: 999999;
+    top: 0;
+    left: 50%;
+    width: 512px;
+    padding-top: 8px;
+    font-family: 'Noto Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    transform: translate(-50%, 0); }
+    .neos #neos-notification-container.neos-notification-top > .neos-notification {
+      color: white;
+      font-size: 14px;
+      position: relative;
+      width: 512px;
+      margin: 0 auto 4px;
+      word-wrap: break-word;
+      overflow: hidden;
+      box-sizing: border-box;
+      box-shadow: 0 0 14px rgba(0, 0, 0, 0.15); }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification::before {
+        content: '';
+        display: block;
+        position: absolute;
+        left: 40px;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        background: rgba(255, 255, 255, 0.25); }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-error {
+        background-color: #ff460d; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-success {
+        background-color: #00a338; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-warning {
+        background-color: #ff8700; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification.neos-notification-info {
+        background-color: #00b5ff; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-title {
+        display: none; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification i {
+        height: 40px;
+        line-height: 40px !important;
+        width: 40px;
+        text-align: center;
+        font-size: 16px;
+        padding: 0;
+        margin: 0;
+        font-family: FontAwesome;
+        font-weight: 900;
+        font-style: normal;
+        text-decoration: inherit;
+        -webkit-font-smoothing: antialiased;
+        position: absolute;
+        top: 0;
+        left: 0; }
+        .neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button {
+          color: white;
+          height: 40px;
+          line-height: 40px;
+          width: 40px;
+          text-align: center;
+          left: auto;
+          right: 0;
+          cursor: pointer;
+          font-size: 18px; }
+          .neos #neos-notification-container.neos-notification-top > .neos-notification i.neos-close-button:hover {
+            background-color: rgba(255, 255, 255, 0.25); }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content .neos-expand-content {
+        display: none;
+        padding: 16px 49px; }
+        .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content .neos-expand-content pre {
+          padding: 16px 0;
+          font-family: "Lucida Console", Monaco, monospace;
+          background-color: transparent;
+          border: none;
+          color: #fff;
+          border-radius: 0;
+          white-space: pre-wrap; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content.expandable .neos-notification-heading {
+        cursor: pointer;
+        color: #fff; }
+        .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content.expandable .neos-notification-heading::after {
+          content: "›";
+          font-size: 26px;
+          font-weight: normal;
+          display: inline-block;
+          position: relative;
+          rotate: 90deg;
+          top: 5px;
+          left: 16px;
+          line-height: 0; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content.expandable.expanded .neos-notification-heading::after {
+        rotate: -90deg;
+        left: 10px; }
+      .neos #neos-notification-container.neos-notification-top > .neos-notification .neos-notification-content .neos-notification-heading {
+        padding: 12px 49px 12px;
+        margin-bottom: 0;
+        color: white;
+        font-weight: 400;
+        font-size: 14px; }
+
+body.neos-backend {
+  transition-property: margin;
+  transition-duration: 0.2s; }
+
+body.neos-controls {
+  margin-top: 82px;
+  margin-left: 0; }
+  body.neos-controls #neos-top-bar {
+    display: flex; }
+
+body.neos-edit-preview-panel-open {
+  margin-top: 192px; }
+
+body.neos-menu-panel-open.neos-menu-panel-sticky {
+  margin-left: 54px; }
+
+body.neos-navigate-panel-open {
+  margin-left: 321px; }
+
+body.neos-menu-panel-open.neos-menu-panel-sticky.neos-navigate-panel-open {
+  margin-left: 375px; }
+
+body.neos-inspector-panel-open {
+  margin-right: 321px; }
+
+body.neos-full-screen {
+  margin-top: 0 !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important; }
+  body.neos-full-screen .neos #neos-top-bar,
+  body.neos-full-screen .neos #neos-context-bar,
+  body.neos-full-screen .neos #neos-inspector {
+    display: block !important; }
+  body.neos-full-screen .neos #neos-top-bar {
+    top: -41px; }
+  body.neos-full-screen .neos #neos-inspector-button {
+    top: -42px; }
+  body.neos-full-screen .neos #neos-menu-button {
+    top: -40px; }
+  body.neos-full-screen .neos #neos-context-bar {
+    top: -41px;
+    box-shadow: none;
+    display: block;
+    padding-left: 0;
+    padding-right: 0; }
+  body.neos-full-screen .neos #neos-edit-preview-panel {
+    top: -111px; }
+  body.neos-full-screen .neos #neos-inspector {
+    right: -321px;
+    overflow: hidden; }
+  body.neos-full-screen .neos .neos-menu-panel,
+  body.neos-full-screen .neos #neos-navigate-panel {
+    left: -321px !important; }
+  body.neos-full-screen .neos-full-screen-close {
+    display: block !important;
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.25);
+    z-index: 9999; }
+    body.neos-full-screen .neos-full-screen-close .neos-button {
+      width: 40px;
+      line-height: 44px;
+      padding: 0; }
+      body.neos-full-screen .neos-full-screen-close .neos-button i {
+        margin-top: 1px; }
+
+body.neos-preview-mode .neos-contentelement {
+  outline: none !important; }
+
+body.neos-preview-mode div.neos-inline-editable {
+  outline: none !important;
+  background: none !important; }
+
+body.neos-preview-mode .neos-handle,
+body.neos-preview-mode .neos-status-indicator {
+  display: none !important; }
+
+body.neos-preview-mode #aloha-floatingmenu-shadow,
+body.neos-preview-mode .aloha-floatingmenu,
+body.neos-preview-mode .x-shadow,
+body.neos-preview-mode .neos-contentelement-overlay,
+body.neos-preview-mode button.neos-create-new-content,
+body.neos-preview-mode .neos-contentelement-hidden {
+  display: none !important; }
+
+body.neos-preview-mode .neos-contentelement-active {
+  outline: none !important;
+  outline-offset: 0px; }
+  body.neos-preview-mode .neos-contentelement-active > .neos-contentelement-handle-container {
+    visibility: hidden; }
+
+body.neos-preview-mode .neos.neos-empty-contentcollection-overlay,
+body.neos-preview-mode .neos .neos-overlay-component,
+body.neos-preview-mode .neos .neos-handle-container,
+body.neos-preview-mode .neos .neos-modal-backdrop {
+  display: none; }
+
+.neos-nprogress-busy body {
+  cursor: wait !important; }
+
+#neos-document-metadata {
+  display: none; }
+
+.neos-rendering-exception {
+  word-wrap: break-word; }
+
+#neos-shortcut {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #323232;
+  z-index: 9999;
+  font-family: 'Noto Sans', sans-serif;
+  -webkit-font-smoothing: antialiased; }
+  #neos-shortcut p {
+    position: relative;
+    margin: 0 auto;
+    width: 500px;
+    height: 60px;
+    top: 50%;
+    margin-top: -30px;
+    color: #fff;
+    font-size: 22px;
+    line-height: 1.4;
+    text-align: center; }
+    #neos-shortcut p a {
+      color: #00b5ff;
+      text-decoration: none; }
+      #neos-shortcut p a:hover {
+        color: #39c6ff; }
+

--- a/Neos.Neos/Resources/Public/Styles/Welcome.css
+++ b/Neos.Neos/Resources/Public/Styles/Welcome.css
@@ -24,3 +24,4 @@
 
 .neos-error-details-toggle--closed .neos-error-details-toggle__body {
   height: 0; }
+

--- a/Neos.Neos/webpack.config.js
+++ b/Neos.Neos/webpack.config.js
@@ -50,6 +50,9 @@ const stylesConfig = {
         Lite: [
           './Resources/Private/Styles/Lite.scss',
         ],
+        Minimal: [
+          './Resources/Private/Styles/Minimal.scss',
+        ],
         Login: [
             './Resources/Private/Styles/Login.scss',
         ],

--- a/Neos.Neos/webpack.config.js
+++ b/Neos.Neos/webpack.config.js
@@ -47,6 +47,9 @@ const stylesConfig = {
         Main: [
           './Resources/Private/Styles/Neos.scss',
         ],
+        Lite: [
+          './Resources/Private/Styles/Lite.scss',
+        ],
         Login: [
             './Resources/Private/Styles/Login.scss',
         ],


### PR DESCRIPTION
The old stylesheets from pre-react times override a lot of basic styles for backend modules.
This makes it hard to implement custom styles there or use our react ui components.

With this change it's possible to configure a "Lite" and a "Minimal" variant of the Neos backend stylesheet via the module configuration.

The old "Main" stylesheet variant is kept for compatibility reasons.

The "Lite" stylesheet should be used with almost all modules and will also be used for the core modules. It also provides all relevant Neos CSS variables and is about 50% smaller than the old one.

The "Minimal" stylesheet should be used for modules that bring their own styles. For example modules that use the Neos react-components library. It also provides all relevant Neos CSS variables and is about 70% smaller than the old one.

Example:

```
  Neos:
    modules:
      management: # Or any other module group
        submodules:
          myModule:
            controller: \My\Site\Controller\MyModuleController
            label: 'My module'
            description: 'My module'
            icon: 'fas fa-camera'
            privilegeTarget: 'My.Site:ManageMyModule'
            mainStylesheet: 'Lite' # Or 'Minimal', default is 'Main'
```