### PR TITLE
Bugfix: Use controller context to get FlashMessageContainer

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -777,7 +777,7 @@ class AssetController extends ActionController
     {
         foreach ($this->arguments->getValidationResults()->getFlattenedErrors() as $propertyPath => $errors) {
             foreach ($errors as $error) {
-                $this->flashMessageContainer->addMessage($error);
+                $this->controllerContext->getFlashMessageContainer()->addMessage($error);
             }
         }
 

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -248,7 +248,7 @@ class SitesController extends AbstractModuleController
         $generatorService = $this->objectManager->get(GeneratorService::class);
         $generatorService->generateSitePackage($packageKey, $siteName);
 
-        $this->flashMessageContainer->addMessage(new Message(sprintf('Site Packages "%s" was created.', htmlspecialchars($packageKey))));
+        $this->controllerContext->getFlashMessageContainer()->addMessage(new Message(sprintf('Site Packages "%s" was created.', htmlspecialchars($packageKey))));
         $this->forward('importSite', null, null, ['packageKey' => $packageKey]);
     }
 


### PR DESCRIPTION
Remove left over of rewrite FlashMessages.
See: https://github.com/neos/flow-development-collection/pull/1061