### PR TITLE
BUGFIX: Prevent black shapes in document thumbnails

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -85,9 +85,6 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $resource = $this->resourceManager->importResourceFromContent($im->getImageBlob(), $filenameWithoutExtension . '.png');
             $im->destroy();
 
-            $resource = $this->resourceManager->importResourceFromContent($im->getImageBlob(), $filenameWithoutExtension . '.png');
-            $im->destroy();
-
             $thumbnail->setResource($resource);
             $thumbnail->setWidth($width);
             $thumbnail->setHeight($height);

--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -64,6 +64,15 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $im->setImageFormat('png');
             $im->setImageBackgroundColor('white');
             $im->setImageCompose(\Imagick::COMPOSITE_OVER);
+            
+            if (method_exists($im, 'mergeImageLayers')) {
+                // Replace flattenImages in imagick 3.3.0
+                // @see https://pecl.php.net/package/imagick/3.3.0RC2
+                $im = $im->mergeImageLayers(\Imagick::LAYERMETHOD_MERGE);
+            } else {
+                $im->flattenImages();
+            }
+
             if (defined('\Imagick::ALPHACHANNEL_OFF')) {
                 // ImageMagick >= 7.0, Imagick >= 3.4.3RC1
                 // @see https://pecl.php.net/package/imagick/3.4.3RC1
@@ -71,15 +80,10 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             } else {
                 $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
             }
-            $im->thumbnailImage($width, $height, true);
 
-            if (method_exists($im, 'mergeImageLayers')) {
-                // Replace flattenImages in imagick 3.3.0
-                // @see https://pecl.php.net/package/imagick/3.3.0RC2
-                $im->mergeImageLayers(\Imagick::LAYERMETHOD_MERGE);
-            } else {
-                $im->flattenImages();
-            }
+            $im->thumbnailImage($width, $height, true);
+            $resource = $this->resourceManager->importResourceFromContent($im->getImageBlob(), $filenameWithoutExtension . '.png');
+            $im->destroy();
 
             $resource = $this->resourceManager->importResourceFromContent($im->getImageBlob(), $filenameWithoutExtension . '.png');
             $im->destroy();


### PR DESCRIPTION
**What I did**
Tested with the following imagick versions:

- V. 6.7.8
- V. 6.9
- V. 7.0
**How I did it**

See below
**How to verify it**

You can verifiy it by running this small code local:

```php
<?php
$filePath = 'pdf.pdf[0]';
$width = 500;
$height = 500;

$im = new \Imagick();
$im->setResolution(120, 120);
$im->readImage($filePath);
$im->setImageFormat('png');
$im->setImageBackgroundColor('white');
$im->setImageCompose(\Imagick::COMPOSITE_OVER);

if (method_exists($im, 'mergeImageLayers')) {
    // Replace flattenImages in imagick 3.3.0
    // @see https://pecl.php.net/package/imagick/3.3.0RC2
    $im = $im->mergeImageLayers(\Imagick::LAYERMETHOD_MERGE);
} else {
    $im->flattenImages();
}

if (defined('\Imagick::ALPHACHANNEL_OFF')) {
    // ImageMagick >= 7.0, Imagick >= 3.4.3RC1
    // @see https://pecl.php.net/package/imagick/3.4.3RC1
    $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OFF);
} else {
    $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
}

$im->thumbnailImage($width, $height, true);

$im->writeImage('thumb.png');
$im->destroy();
```
**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
