### PR TITLE
BUGFIX: Keep configured creationDialog elements

### DIFF
--- a/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
@@ -75,7 +75,7 @@ class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
         if (!isset($configuration['properties'])) {
             return;
         }
-        $creationDialogElements = [];
+        $creationDialogElements = $configuration['ui']['creationDialog']['elements'] ?? [];
         foreach ($configuration['properties'] as $propertyName => $propertyConfiguration) {
             if (!isset($propertyConfiguration['ui']['showInCreationDialog']) || $propertyConfiguration['ui']['showInCreationDialog'] !== true) {
                 continue;


### PR DESCRIPTION
Keep configured creationDialog elements to keep dialog fields for NodeTemplates.

Fixes: #2882