### PR TITLE
FEATURE: Reduce backend load time with nodetype schema cache

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/SchemaController.php
+++ b/Neos.Neos/Classes/Controller/Backend/SchemaController.php
@@ -60,7 +60,8 @@ class SchemaController extends ActionController
         $vieSchema = $this->nodeTypeSchemaCache->get($cacheIdentifier);
         if (!$vieSchema) {
             $vieSchema = json_encode($this->vieSchemaBuilder->generateVieSchema());
-            $this->nodeTypeSchemaCache->set($cacheIdentifier, $vieSchema);
+            $this->nodeTypeSchemaCache->flushByTag('vie');
+            $this->nodeTypeSchemaCache->set($cacheIdentifier, $vieSchema, ['vie']);
         }
         return $vieSchema;
     }
@@ -81,7 +82,8 @@ class SchemaController extends ActionController
         $nodeTypeSchema = $this->nodeTypeSchemaCache->get($cacheIdentifier);
         if (!$nodeTypeSchema) {
             $nodeTypeSchema = json_encode($this->nodeTypeSchemaBuilder->generateNodeTypeSchema());
-            $this->nodeTypeSchemaCache->set($cacheIdentifier, $nodeTypeSchema);
+            $this->nodeTypeSchemaCache->flushByTag('nodeType');
+            $this->nodeTypeSchemaCache->set($cacheIdentifier, $nodeTypeSchema, ['nodeType']);
         }
         return $nodeTypeSchema;
     }

--- a/Neos.Neos/Classes/Controller/Backend/SchemaController.php
+++ b/Neos.Neos/Classes/Controller/Backend/SchemaController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Neos\Controller\Backend;
 
 /*
@@ -11,7 +13,9 @@ namespace Neos\Neos\Controller\Backend;
  * source code.
  */
 
+use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Component\SetHeaderComponent;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Neos\Service\NodeTypeSchemaBuilder;
 use Neos\Neos\Service\VieSchemaBuilder;
@@ -34,15 +38,31 @@ class SchemaController extends ActionController
     protected $nodeTypeSchemaBuilder;
 
     /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $nodeTypeSchemaCache;
+
+    /**
      * Generate and renders the JSON schema for the node types for VIE.
      * Schema format example: http://schema.rdfs.org/all.json
      *
      * @return string
      */
-    public function vieSchemaAction()
+    public function vieSchemaAction(): string
     {
+        $version = $this->request->hasArgument('version') ? $this->request->getArgument('version') : '';
+        $cacheIdentifier = 'vieSchema_' . $version;
+
         $this->response->setContentType('application/json');
-        return json_encode($this->vieSchemaBuilder->generateVieSchema());
+        $this->response->setComponentParameter(SetHeaderComponent::class, 'Cache-Control', 'max-age=' . (3600 * 24 * 7));
+
+        $vieSchema = $this->nodeTypeSchemaCache->get($cacheIdentifier);
+        if (!$vieSchema) {
+            $vieSchema = json_encode($this->vieSchemaBuilder->generateVieSchema());
+            $this->nodeTypeSchemaCache->set($cacheIdentifier, $vieSchema);
+        }
+        return $vieSchema;
     }
 
     /**
@@ -50,9 +70,19 @@ class SchemaController extends ActionController
      *
      * @return string
      */
-    public function nodeTypeSchemaAction()
+    public function nodeTypeSchemaAction(): string
     {
+        $version = $this->request->hasArgument('version') ? $this->request->getArgument('version') : '';
+        $cacheIdentifier = 'nodeTypeSchema_' . $version;
+
         $this->response->setContentType('application/json');
-        return json_encode($this->nodeTypeSchemaBuilder->generateNodeTypeSchema());
+        $this->response->setComponentParameter(SetHeaderComponent::class, 'Cache-Control', 'max-age=' . (3600 * 24 * 7));
+
+        $nodeTypeSchema = $this->nodeTypeSchemaCache->get($cacheIdentifier);
+        if (!$nodeTypeSchema) {
+            $nodeTypeSchema = json_encode($this->nodeTypeSchemaBuilder->generateNodeTypeSchema());
+            $this->nodeTypeSchemaCache->set($cacheIdentifier, $nodeTypeSchema);
+        }
+        return $nodeTypeSchema;
     }
 }

--- a/Neos.Neos/Configuration/Caches.yaml
+++ b/Neos.Neos/Configuration/Caches.yaml
@@ -10,6 +10,10 @@ Neos_Neos_XliffToJsonTranslations:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
 
+Neos_Neos_NodeType_Schema:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend
+
 Neos_Neos_LoginTokenCache:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\SimpleFileBackend

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -58,6 +58,16 @@ Neos\Neos\Service\XliffService:
           1:
             value: Neos_Neos_XliffToJsonTranslations
 
+Neos\Neos\Controller\Backend\SchemaController:
+  properties:
+    nodeTypeSchemaCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Neos_Neos_NodeType_Schema
+
 Neos\Neos\Controller\Backend\BackendController:
   properties:
     loginTokenCache:


### PR DESCRIPTION
This prevents the generation of the nodetype schema on every backend reload.

Load times for Neos instances with lots of nodetypes
are reduced by several seconds depending on the setup.
Also the response has a cache header to allow the browser to keep the result longer.

This also helps in development context as the `version` parameter changes when the nodetypes change. Therefore changing Fusion and reloading is faster ;)

**What I did**

Cache the generated nodetype and vie schema

**How I did it**

Use the same caching behaviour as is already used for the xliff translations.

**How to verify it**

Load the backend twice and check response times.
The difference in projects with many nodetypes is much larger.
