### PR TITLE
FEATURE: Freely position content collections

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -33,25 +33,30 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
 
 	attributes = Neos.Fusion:DataStructure
 
-	# The following is used to automatically append class attribute with "neos-contentcollection" needed for editing.
-	# You can disable the following line with:
-	# prototype(Neos.Neos:ContentCollection) {
-	#   attributes.class.@process.collectionClass >
-	# }
-	# in your site's Fusion if you don't need that behavior.
-	attributes.class.@process.collectionClass = Neos.Fusion:Case {
-		@context.collectionClass = 'neos-contentcollection'
+  # The following is used to automatically append class and data attribute needed for editing.
+  # You can disable the following line with:
+  # prototype(Neos.Neos:ContentCollection) {
+  #   attributes.class.@process.collectionClass >
+  # }
+  # in your site's Fusion if you don't need that behavior.
+  attributes {
+    class.@process.collectionClass = Neos.Fusion:Case {
+      @context.collectionClass = 'neos-contentcollection'
 
-		classIsString {
-			condition = ${Type.isString(value)}
-			renderer = ${String.trim(value + ' ' + collectionClass)}
-		}
+      classIsString {
+        condition = ${Type.isString(value)}
+        renderer = ${String.trim(value + ' ' + collectionClass)}
+      }
 
-		classIsArray {
-			condition = ${Type.isArray(value)}
-			renderer = ${Array.push(value, collectionClass)}
-		}
-	}
+      classIsArray {
+        condition = ${Type.isArray(value)}
+        renderer = ${Array.push(value, collectionClass)}
+      }
+    }
+
+    data-__neos-insertion-anchor = true
+    data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${node.context.inBackend && node.context.currentRenderingMode.edit}
+  }
 
 	nodePath = 'to-be-set-by-user'
 


### PR DESCRIPTION
Together with https://github.com/neos/neos-ui/pull/2609 and https://github.com/neos/neos-ui/pull/2667
this change allows to have a `Neos.Neos:Content` nodetype
that is also a `Neos.Neos:ContentCollection` and have one
or more wrapping tags around the Fusion `Neos.Neos:ContentCollection`.

Without the change in the UI new nodes would have been added into
the outer div instead of the collections div.

**What I did**

Add anchor attribute introduced in https://github.com/neos/neos-ui/pull/2609 by default
to the ContentCollection prototype.

**How to verify it**

Use the following prototype and add a new node. See test in https://github.com/neos/neos-ui/pull/2667

Example:
```
prototype(My.Vendor:Content.ItemContainer) < prototype(Neos.Neos:ContentComponent) {
    renderer = afx`
        <div class="container">
            <div class="outer-wrap">
                <Neos.Neos:ContentCollection
                    attributes.class="item-wrap"
                />
            </div>
        </div>
    `
}
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed 
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
