### PR TITLE
BUGFIX: Respect arguments value as defined in Neos.Neos:NodeUri

### DIFF
--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -93,7 +93,7 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function getAdditionalParams()
     {
-        return $this->fusionValue('additionalParams');
+        return array_merge($this->fusionValue('additionalParams'), $this->fusionValue('arguments'));
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
@@ -1,9 +1,9 @@
 # Renders an URI pointing to a node
 #
 prototype(Neos.Neos:NodeUri) {
-	@class = 'Neos\\Neos\\Fusion\\NodeUriImplementation'
-	additionalParams = Neos.Fusion:RawArray
-	arguments = Neos.Fusion:RawArray
-	argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
-	@exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
+  @class = 'Neos\\Neos\\Fusion\\NodeUriImplementation'
+  additionalParams = Neos.Fusion:RawArray
+  arguments = Neos.Fusion:RawArray
+  argumentsToBeExcludedFromQueryString = Neos.Fusion:RawArray
+  @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }


### PR DESCRIPTION
The prototype Neos.Neos:NodeUri defines `arguments = Neos.Fusion:RawArray`
but this value is never processed in the PHP implementation.
Instead, the additionalParams is processed and passed to
the parameter `arguments` of the NodeLiking service.

Now both parameters are used. `additionalParams` should be deprecated.
