### PR TITLE
BUGFIX: Only allow content nodetypes in content collections

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
@@ -9,5 +9,5 @@
     inlineEditable: true
   constraints:
     nodeTypes:
-      'Neos.Neos:Document': false
-      '*': true
+      '*': false
+      'Neos.Neos:Content': true

--- a/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
+++ b/Neos.Neos/Tests/Functional/Fixtures/NodeStructure.xml
@@ -570,7 +570,7 @@
         <someSpecialProperty __type="string">xx</someSpecialProperty>
        </properties>
       </variant>
-      <node identifier="7b443d48-56f1-85a4-8f82-8d4f7342331f" nodeName="dummy42">
+      <node identifier="7b443d48-56f1-85a4-8f82-8d4f7342331f" nodeName="dummy46">
        <variant sortingIndex="200" workspace="live" nodeType="Acme.Demo:Text" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>
@@ -581,7 +581,7 @@
         </properties>
        </variant>
       </node>
-      <node identifier="9fa376af-a1b8-83ac-bedc-9ad83c8598bc" nodeName="dummy42a">
+      <node identifier="9fa376af-a1b8-83ac-bedc-9ad83c8598bc" nodeName="dummy46a">
        <variant sortingIndex="100" workspace="live" nodeType="Acme.Demo:Headline" version="2" removed="" hidden="" hiddenInIndex="">
         <dimensions>
          <language>en_US</language>

--- a/Neos.Neos/Tests/Functional/NodeRenamingTest.php
+++ b/Neos.Neos/Tests/Functional/NodeRenamingTest.php
@@ -54,12 +54,12 @@ class NodeRenamingTest extends AbstractNodeTest
         $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser');
         $teaserTestWorkspace->setName('teaser-new');
 
-        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy42a'), 'renaming was not successful in user workspace');
-        self::assertNotNull($this->nodeInTestWorkspace->getNode('teaser-new/dummy42a'), 'renaming was not successful in user workspace (2)');
+        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy46a'), 'renaming was not successful in user workspace');
+        self::assertNotNull($this->nodeInTestWorkspace->getNode('teaser-new/dummy46a'), 'renaming was not successful in user workspace (2)');
 
         self::assertNotNull($this->node->getNode('teaser'), 'the renamed teaser should not shine through in the live workspace for subelements (1) ');
-        self::assertNotNull($this->node->getNode('teaser/dummy42a'), 'the renamed teaser should not shine through in the live workspace for subelements (2)');
-        self::assertNull($this->node->getNode('teaser-new/dummy42a'));
+        self::assertNotNull($this->node->getNode('teaser/dummy46a'), 'the renamed teaser should not shine through in the live workspace for subelements (2)');
+        self::assertNull($this->node->getNode('teaser-new/dummy46a'));
     }
 
     /**
@@ -67,16 +67,16 @@ class NodeRenamingTest extends AbstractNodeTest
      */
     public function movedIntoInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
-        // move "teaser" into "main"
-        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser');
+        // move headline of "teaser" into "main"
+        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser/dummy46a');
         $teaserTestWorkspace->moveInto($this->nodeInTestWorkspace->getNode('main'));
 
-        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy42a'), 'moving not successful (1)');
-        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/teaser/dummy42a'), 'moving not successful (2)');
+        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy46a'), 'moving not successful (1)');
+        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/dummy46a'), 'moving not successful (2)');
 
         self::assertNotNull($this->node->getNode('teaser'), 'moving shined through into live workspace (1)');
-        self::assertNotNull($this->node->getNode('teaser/dummy42a'), 'moving shined through into live workspace (2)');
-        self::assertNull($this->node->getNode('main/teaser/dummy42a'), 'moving shined through into live workspace (3)');
+        self::assertNotNull($this->node->getNode('teaser/dummy46a'), 'moving shined through into live workspace (2)');
+        self::assertNull($this->node->getNode('main/dummy46a'), 'moving shined through into live workspace (3)');
     }
 
     /**
@@ -84,16 +84,16 @@ class NodeRenamingTest extends AbstractNodeTest
      */
     public function moveBeforeInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
-        // move "teaser" before "main/dummy42"
-        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser');
+        // move headline of "teaser" before "main/dummy42"
+        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser/dummy46a');
         $teaserTestWorkspace->moveBefore($this->nodeInTestWorkspace->getNode('main/dummy42'));
 
-        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy42a'), 'moving not successful (1)');
-        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/teaser/dummy42a'), 'moving not successful (2)');
+        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy46a'), 'moving not successful (1)');
+        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/dummy46a'), 'moving not successful (2)');
 
         self::assertNotNull($this->node->getNode('teaser'), 'moving shined through into live workspace (1)');
-        self::assertNotNull($this->node->getNode('teaser/dummy42a'), 'moving shined through into live workspace (2)');
-        self::assertNull($this->node->getNode('main/teaser/dummy42a'), 'moving shined through into live workspace (3)');
+        self::assertNotNull($this->node->getNode('teaser/dummy46a'), 'moving shined through into live workspace (2)');
+        self::assertNull($this->node->getNode('main/dummy46a'), 'moving shined through into live workspace (3)');
     }
 
     /**
@@ -101,15 +101,15 @@ class NodeRenamingTest extends AbstractNodeTest
      */
     public function moveAfterInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
-        // move "teaser" after "main/dummy42"
-        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser');
+        // move headline of "teaser" after "main/dummy42"
+        $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser/dummy46a');
         $teaserTestWorkspace->moveAfter($this->nodeInTestWorkspace->getNode('main/dummy42'));
 
-        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy42a'), 'moving not successful (1)');
-        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/teaser/dummy42a'), 'moving not successful (2)');
+        self::assertNull($this->nodeInTestWorkspace->getNode('teaser/dummy46a'), 'moving not successful (1)');
+        self::assertNotNull($this->nodeInTestWorkspace->getNode('main/dummy46a'), 'moving not successful (2)');
 
         self::assertNotNull($this->node->getNode('teaser'), 'moving shined through into live workspace (1)');
-        self::assertNotNull($this->node->getNode('teaser/dummy42a'), 'moving shined through into live workspace (2)');
-        self::assertNull($this->node->getNode('main/teaser/dummy42a'), 'moving shined through into live workspace (3)');
+        self::assertNotNull($this->node->getNode('teaser/dummy46a'), 'moving shined through into live workspace (2)');
+        self::assertNull($this->node->getNode('main/dummy46a'), 'moving shined through into live workspace (3)');
     }
 }


### PR DESCRIPTION
This change makes sure that only nodetypes that inherit from `Neos.Neos:Content` are addable to `Neos.Neos:ContentCollection` as the comment of the nodetype specifically mentions.

Without this other nodetypes are reported as valid child types when getting the configuration from the `NodeType` class.

This caused only a problem when interacting with nodetypes via PHP as the UI already made sure you could not add something else than Content.

Resolves: #2894 
