### PR TITLE
BUGFIX: Replace baseUri in cache identifiers

### DIFF
--- a/Neos.Fusion/Classes/Eel/BaseUriHelper.php
+++ b/Neos.Fusion/Classes/Eel/BaseUriHelper.php
@@ -1,0 +1,58 @@
+<?php
+namespace Neos\Fusion\Eel;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Http\BaseUriProvider;
+use Neos\Flow\Http\Helper\RequestInformationHelper;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * This is a purely internal helper to provide baseUris for Caching.
+ * It will be moved to a more sensible package in the future so do
+ * not rely on the classname for now.
+ *
+ * @internal
+ */
+class BaseUriHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var BaseUriProvider
+     */
+    protected $baseUriProvider;
+
+    /**
+     * @param ServerRequestInterface|null $fallbackRequest
+     * @return UriInterface
+     * @throws \Exception
+     */
+    public function getConfiguredBaseUriOrFallbackToCurrentRequest(ServerRequestInterface $fallbackRequest = null): UriInterface
+    {
+        try {
+            $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+        } catch (\Exception $e) {
+            // We are avoiding an exception here in favor of trying more fallback variants.
+        }
+
+        if (isset($baseUri)) {
+            return $baseUri;
+        }
+
+        if ($fallbackRequest === null) {
+            throw new \Exception('Could not determine baseUri for current process and no fallback HTTP request was given, maybe running in a CLI command.', 1581002260);
+        }
+
+        return RequestInformationHelper::generateBaseUri($fallbackRequest);
+    }
+
+    /**
+     * @param string $methodName
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -47,3 +47,4 @@ Neos:
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       File: 'Neos\Eel\Helper\FileHelper'
       q: 'Neos\Eel\FlowQuery\FlowQuery::q'
+      BaseUri: 'Neos\Fusion\Eel\BaseUriHelper'

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -177,5 +177,5 @@ prototype(Neos.Fusion:ResourceUri) {
 #
 prototype(Neos.Fusion:GlobalCacheIdentifiers) < prototype(Neos.Fusion:RawArray) {
 	format = ${request.format}
-	baseUri = ${String.toString(request.httpRequest.baseUri)}
+	baseUri = ${String.toString(BaseUri.getConfiguredBaseUriOrFallbackToCurrentRequest(request.httpRequest))}
 }


### PR DESCRIPTION
Since Flow 6.0 the httpRequest.baseUri is gone and we
need to replace it in the cache identifiers to avoid wrong
cache behavior.
