### PR TITLE
BUGFIX: Make getThumbnail() return type nullable

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -109,7 +109,7 @@ class ThumbnailService
      * @return ImageInterface
      * @throws \Exception
      */
-    public function getThumbnail(AssetInterface $asset, ThumbnailConfiguration $configuration): ImageInterface
+    public function getThumbnail(AssetInterface $asset, ThumbnailConfiguration $configuration): ?ImageInterface
     {
         // Enforce format conversions if needed. This replaces the actual
         // thumbnail-configuration with one that also enforces the target format


### PR DESCRIPTION
If the thumbnail strategy failed to generate a valid thumbnail, null
is returned. This needs to be allowed.
