### PR TITLE
BUGFIX: Don't use AbstractValidator::$result in PasswordValidator

### DIFF
--- a/Neos.Neos/Classes/Validation/Validator/PasswordValidator.php
+++ b/Neos.Neos/Classes/Validation/Validator/PasswordValidator.php
@@ -74,7 +74,7 @@ class PasswordValidator extends AbstractValidator
 
         if ($stringLengthValidatorResult->hasErrors() === true) {
             foreach ($stringLengthValidatorResult->getErrors() as $error) {
-                $this->result->addError($error);
+                $this->addError($error, $error->getCode());
             }
         }
     }


### PR DESCRIPTION
PasswordValidator was using the property $result of AbstractValidaor. That caused an Error 500 since Flow 6, because AbstractValidator::$result is private now.


**What I did**
Changed to AbstractValidator::addError() method

**How to verify it**
Use The PasswordValidator with a minimumLength and try to produce a validation-error.