### PR TITLE
BUGFIX: Flush content cache on image variant change

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -343,6 +343,9 @@ class AssetService
     /**
      * Signals that a resource on an asset has been replaced
      *
+     * Note: when an asset resource is replaced, the assetUpdated signal is sent anyway
+     * and can be used instead.
+     *
      * @param AssetInterface $asset
      * @return void
      * @Flow\Signal

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -18,6 +18,7 @@ use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\AssetVariantInterface;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Neos\Domain\Model\Dto\AssetUsageInNodeProperties;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -270,6 +271,14 @@ class ContentCacheFlusher
      */
     public function registerAssetChange(AssetInterface $asset)
     {
+        // In Nodes only assets are referenced, never asset variants directly. When an asset
+        // variant is updated, it is passed as $asset, but since it is never "used" by any node
+        // no flushing of corresponding entries happens. Thus we instead us the original asset
+        // of the variant.
+        if ($asset instanceof AssetVariantInterface) {
+            $asset = $asset->getOriginalAsset();
+        }
+
         if (!$asset->isInUse()) {
             return;
         }

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -85,7 +85,6 @@ class Package extends BasePackage
         });
 
         $dispatcher->connect(AssetService::class, 'assetUpdated', ContentCacheFlusher::class, 'registerAssetChange', false);
-        $dispatcher->connect(AssetService::class, 'assetResourceReplaced', ContentCacheFlusher::class, 'registerAssetChange', false);
 
         $dispatcher->connect(ContentController::class, 'assetUploaded', SiteService::class, 'assignUploadedAssetToSiteAssetCollection');
 


### PR DESCRIPTION
If you access an image property in a node and render an ImageVariant
from it via Fusion using an image variant preset, the cache is now
flushed if the image variant is changed afterwards, e.g. when changing
the crop in the media management module.

Fixes #2897
