### PR TITLE
TASK: update documentation link for formatCldr formats

### DIFF
--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -469,7 +469,7 @@ Date.formatCldr(date, cldrFormat, locale)
 Format a date to a string with a given cldr format
 
 * ``date`` (integer|string|\DateTime)
-* ``cldrFormat`` (string) Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
+* ``cldrFormat`` (string) Format string in CLDR format (see http://cldr.unicode.org/translation/date-time-1/date-time)
 * ``locale`` (null|string, *optional*) String locale - example (de|en|ru_RU)
 
 **Return** (string)


### PR DESCRIPTION
The link given in the documentation leads to a 404, I have set the correct link

