### PR TITLE
BUGFIX: Access tags of asset in media list view

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -85,7 +85,7 @@
             'deleteAssetLabel': '{neos:backend.translate(id: \'deleteAsset\', package: \'Neos.Media.Browser\')}'
         }">
             <f:for each="{paginatedAssetProxies}" as="assetProxy" iteration="iterator">
-                <tr class="asset draggable-asset{f:if(condition: '{assetProxy.tags -> f:count()} === 0', then: ' neos-media-untagged')}"
+                <tr class="asset draggable-asset{f:if(condition: '{assetProxy.asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}"
                     data-asset-identifier="{assetProxy.identifier}"
                     data-local-asset-identifier="{assetProxy.localAssetIdentifier}"
                     data-asset-source-identifier="{assetProxy.assetSource.identifier}"
@@ -109,7 +109,7 @@
                     <td>{assetProxy.fileSize -> f:format.bytes()}</td>
                     <td><span class="neos-label">{assetProxy.mediaType}</span></td>
                     <td class="tags">
-                        <f:for each="{assetProxy.tags}" as="tag">
+                        <f:for each="{assetProxy.asset.tags}" as="tag">
                             <span class="neos-label">{tag.label}</span>
                         </f:for>
                     </td>


### PR DESCRIPTION
This uses `assetProxy.asset.tags` instead of just `assetProxy.tags`
as a simple way to fix the display of assigned tags in the media
browser list view.

Fixes neos/neos-development-collection#2350
