### PR TITLE
BUGFIX: Have NeosAssetProxy return resource on getImportStream

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
@@ -1,7 +1,7 @@
 {namespace m=Neos\Media\ViewHelpers}
 {namespace neos=Neos\Neos\ViewHelpers}
 <div class="neos-preview-image" id="neos-preview-image">
-    <a href="{assetProxy.importStream}" target="_blank">
+    <a href="{assetProxy.originalUri}" target="_blank">
         <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
     </a>
 </div>

--- a/Neos.Media.Browser/Resources/Private/Partials/ContentPdfPreview.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ContentPdfPreview.html
@@ -1,20 +1,20 @@
 {namespace neos=Neos\Neos\ViewHelpers}
-<div class="neos-preview-image" id="neos-preview-pdf" data-asset-preview-url="{assetProxy.importStream}">
+<div class="neos-preview-image" id="neos-preview-pdf" data-asset-preview-url="{assetProxy.originalUri}">
   <canvas id="pdf-canvas"></canvas>
 </div>
 <div class="neos-preview-actions">
   <div class="neos-preview-action-pager">
-    <a class="neos-button" id="neos-preview-button-previous" href="{assetProxy.importStream}" target="_blank">
+    <a class="neos-button" id="neos-preview-button-previous" href="{assetProxy.originalUri}" target="_blank">
       <i class="fas fa-arrow-left"></i>
     </a>
-    <a class="neos-button" id="neos-preview-button-next" href="{assetProxy.importStream}" target="_blank">
+    <a class="neos-button" id="neos-preview-button-next" href="{assetProxy.originalUri}" target="_blank">
       <i class="fas fa-arrow-right"></i>
     </a>
   </div>
   <div class="neos-preview-page-cursor">
     <span id="neos-preview-pdf-page"></span>/<span id="neos-preview-pdf-page-count"></span>
   </div>
-  <a class="neos-button neos-preview-action-download" href="{assetProxy.importStream}" target="_blank">
+  <a class="neos-button neos-preview-action-download" href="{assetProxy.originalUri}" target="_blank">
     <i class="fas fa-download"></i> {neos:backend.translate(id: 'download', package: 'Neos.Media.Browser')}
   </a>
 </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -179,7 +179,7 @@
 <f:section name="ContentImage">
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
-        <a href="{assetProxy.importStream}" target="_blank">
+        <a href="{assetProxy.originalUri}" target="_blank">
             <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
         </a>
     </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -39,7 +39,7 @@
                             </f:if>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.filename', package: 'Neos.Media.Browser')}</th>
-                                <td><a href="{assetProxy.importStream}" target="_blank">{assetProxy.filename}</a></td>
+                                <td><a href="{assetProxy.originalUri}" target="_blank">{assetProxy.filename}</a></td>
                             </tr>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.lastModified', package: 'Neos.Media.Browser')}</th>
@@ -85,7 +85,7 @@
 <f:section name="ContentImage">
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
-        <a href="{assetProxy.importStream}" target="_blank">
+        <a href="{assetProxy.originalUri}" target="_blank">
             <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
         </a>
     </div>

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxy/ProvidesOriginalUriInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxy/ProvidesOriginalUriInterface.php
@@ -5,7 +5,7 @@ namespace Neos\Media\Domain\Model\AssetSource\AssetProxy;
  * This file is part of the Neos.Media package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
-  *
+ *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this
  * source code.

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxy/ProvidesOriginalUriInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxy/ProvidesOriginalUriInterface.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Media\Domain\Model\AssetSource\AssetProxy;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+  *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Interface for an Asset Proxy which provides an URI to the original binary data
+ */
+interface ProvidesOriginalUriInterface
+{
+    /**
+     * @return null|UriInterface
+     */
+    public function getOriginalUri(): ?UriInterface;
+}

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxy.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxy.php
@@ -18,13 +18,14 @@ use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
+use Neos\Media\Domain\Model\AssetSource\AssetProxy\ProvidesOriginalUriInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Exception\AssetServiceException;
 use Neos\Media\Exception\ThumbnailServiceException;
 use Psr\Http\Message\UriInterface;
 
-final class NeosAssetProxy implements AssetProxyInterface
+final class NeosAssetProxy implements AssetProxyInterface, ProvidesOriginalUriInterface
 {
     /**
      * @var NeosAssetSource
@@ -174,10 +175,18 @@ final class NeosAssetProxy implements AssetProxyInterface
     /**
      * @return null|UriInterface
      */
-    public function getImportStream(): ?UriInterface
+    public function getOriginalUri(): ?UriInterface
     {
         $uriString = $this->resourceManager->getPublicPersistentResourceUri($this->asset->getResource());
         return $uriString !== false ? new Uri($uriString) : null;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getImportStream()
+    {
+        return $this->asset->getResource()->getStream();
     }
 
     /**


### PR DESCRIPTION
The `AssetProxyInterface` declares `getImportStream()` must return
`resource`. The `NeosAssetProxy` returns `?UriInterface` there, which
breaks the contract.

In some places `getImportStream()` is used to access the original URI
(see #2190), but for other proxies, the resulting link target is
`Resource id #x` since the resource is cast to string and used as is.

This fixes the issue by making `getImportStream()` in `NeosAssetProxy`
return `resource` as expected and add (back) `getOriginalUri()` to the
proxy. The URI can be used for a download.

An additional `ProvidesOriginalUriInterface` is added, which can be
implemented by asset sources at will.

Fixes #2918
