### PR TITLE
BUGFIX: getAssetProxy failed for local assets

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -25,6 +25,7 @@ use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceConnectionExceptionInterface;
+use Neos\Media\Domain\Model\AssetSource\Neos\NeosAssetSource;
 use Neos\Media\Domain\Repository\ImportedAssetRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Service\AssetService;
@@ -498,10 +499,15 @@ class Asset implements AssetInterface
             $this->systemLogger->notice(sprintf('Asset %s: Invalid asset source "%s"', $this->getIdentifier(), $this->getAssetSourceIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
             return null;
         }
-        $importedAsset = $this->importedAssetRepository->findOneByLocalAssetIdentifier($this->getIdentifier());
-        if ($importedAsset === null) {
-            $this->systemLogger->notice(sprintf('Asset %s: Imported asset not found for asset source %s (%s)', $this->getIdentifier(), $assetSource->getIdentifier(), $assetSource->getLabel()), LogEnvironment::fromMethodName(__METHOD__));
-            return null;
+
+        if (!$assetSource instanceof NeosAssetSource) {
+            $importedAsset = $this->importedAssetRepository->findOneByLocalAssetIdentifier($this->getIdentifier());
+            if ($importedAsset === null) {
+                $this->systemLogger->notice(sprintf('Asset %s: Imported asset not found for asset source %s (%s)', $this->getIdentifier(), $assetSource->getIdentifier(), $assetSource->getLabel()), LogEnvironment::fromMethodName(__METHOD__));
+                return null;
+            }
+        } else {
+            $importedAsset = null;
         }
 
         try {

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -124,6 +124,16 @@ class AssetTest extends AbstractTest
     /**
      * @test
      */
+    public function getAssetProxyReturnsAssetProxyForLocalAssets()
+    {
+        $asset = $this->buildAssetObject();
+        $asset->setAssetSourceIdentifier('neos');
+        $this->assertNotNull($asset->getAssetProxy());
+    }
+
+    /**
+     * @test
+     */
     public function getAssetProxyReturnsNullIfAssetSourceIdentifierPointsToNonExistingAssetSource()
     {
         $asset = $this->buildAssetObject();

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -15,6 +15,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Repository;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
@@ -147,6 +148,11 @@ class AssetTest extends AbstractTest
     public function getAssetProxyReturnsNullIfNoCorrespondingImportedAssetExists()
     {
         $asset = $this->buildAssetObject();
+        $asset->setAssetSourceIdentifier('test-source');
+
+        $mockExternalAssetSource = $this->getMockBuilder(AssetSourceInterface::class)->disableOriginalConstructor()->getMock();
+        $this->inject($asset, 'assetSources', ['test-source' => $mockExternalAssetSource]);
+
         $mockImportedAssetRepository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->setMethods(['findOneByLocalAssetIdentifier'])->getMock();
         $this->inject($asset, 'importedAssetRepository', $mockImportedAssetRepository);
 


### PR DESCRIPTION
With 836d739fa4f92b3c87c0fcaccd54f2909e188773 a condition was added that prevented getting an AssetProxy for assets in the Neos AssetSource. But they all have one and therefore the query for an imported AssetProxy is not skipped for local assets.

**What I did**

Return AssetProxy for local assets.

**How I did it**

Check if the AssetSource is Neos itself.

**How to verify it**

Added functional test
