### PR TITLE
BUGFIX: redirect-to-last-visited-page broken with Fusion LoginForm rewrite

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -97,7 +97,7 @@ prototype(Neos.Neos:Component.Login.Form) < prototype(Neos.Fusion:Component) {
   }
 
   renderer = afx`
-    <Neos.Fusion.Form:Form form.target.action="authenticate">
+    <Neos.Fusion.Form:Form form.target.action="authenticate" attributes.name="login">
         <Neos.Fusion.Form:Hidden field.name="lastVisitedNode" />
         <fieldset>
             <div class="neos-controls">


### PR DESCRIPTION
When rewriting the Login form to Neos.Fusion.Form, the `name` attribute of the form has been lost.
This broke the JS code which sets the `lastVisitedNode`.

**How to verify it**

- open some nested page in the frontend
- open the login form to the backend
- log in
- EXPECTED with this change: you get the exact same page in the backend
- WITHOUT this change: you get the homepage

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
