### PR TITLE
BUGFIX: Ensure node query by identifier uses strings

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1599,6 +1599,8 @@ class NodeDataRepository extends Repository
      */
     protected function addIdentifierConstraintToQueryBuilder(QueryBuilder $queryBuilder, $identifier)
     {
+        // TODO: We should add type hints in next major because this query becomes really SLOW if you use an integer here.
+        $identifier = (string)$identifier;
         $queryBuilder->andWhere('n.identifier = :identifier')
             ->setParameter('identifier', $identifier);
     }


### PR DESCRIPTION
Due to how the query is handled using an integer node identifier in a query by identifier 
will not break but result in severe performance problems as the query will not use 
the index for identifier anymore. Casting to string prevents that.

To expose the problem you can simply try to run such a query with an integer instead 
of a string and you will see extreme performance degradation.
Not giving numbers because it depends on the amount of nodes but it is VERY noticeable.
