### PR TITLE
BUGFIX: Use Neos config when overriding FrontendRoutePartHandler

### DIFF
--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -64,7 +64,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     protected $siteRepository;
 
     /**
-     * @Flow\InjectConfiguration("routing.supportEmptySegmentForDimensions")
+     * @Flow\InjectConfiguration("routing.supportEmptySegmentForDimensions", package="Neos.Neos")
      * @var boolean
      */
     protected $supportEmptySegmentForDimensions;


### PR DESCRIPTION
When overriding the FrontendRouterPartHandler with a custom implementation but inheriting from it the configuration was not read from Neos.Neos but from the package that did the override.
This causes the setting to always be false and makes the routing not work properly when
having empty segments for dimensions. This is then quite difficult to debug.

Custom implementations can still decide to override the config and read it from somewhere else if required.