### PR TITLE
BUGFIX: Remove alpha channel for newer Imagick versions

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -64,10 +64,8 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $im->setImageFormat('png');
             $im->setImageBackgroundColor('white');
             $im->setImageCompose(\Imagick::COMPOSITE_OVER);
-            if (defined('\Imagick::ALPHACHANNEL_OFF')) {
-                // ImageMagick >= 7.0, Imagick >= 3.4.3RC1
-                // @see https://pecl.php.net/package/imagick/3.4.3RC1
-                $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OFF);
+            if (defined('\Imagick::ALPHACHANNEL_REMOVE')) {
+                $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
             } else {
                 $im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_RESET);
             }


### PR DESCRIPTION
The ALPHACHANNEL_OFF constant for the newer Image magick version seems not to work.
The PDFs still have transparent background instead of white ones.

So this patch is using ALPHACHANNEL_REMOVE instead.

Fixes: #2954

**How to verify it**
* download https://www.neos.io/_Resources/Persistent/3aae952ccb0ec3d72e1c4d357ec33fe5d0c66052/20170125_CIC36_Form_Neos_Foundation_CIC_signed.pdf
* go to the media module and upload the file. Background should be white.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
