### PR TITLE
BUGFIX: Respect super types in CreateNodePrivilege

### DIFF
--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilege.php
@@ -62,7 +62,7 @@ class CreateNodePrivilege extends AbstractNodePrivilege
             return parent::matchesSubject($nodePrivilegeSubject);
         }
 
-        if ($subject->hasCreationNodeType() && $this->matchesNodeType($subject->getCreationNodeType())) {
+        if (!$subject->hasCreationNodeType() || $this->matchesNodeType($subject->getCreationNodeType())) {
             return parent::matchesSubject($subject);
         }
         return false;


### PR DESCRIPTION
Fixes the `createdNodeIsOfType()` matcher so that it works respects
the inheritance chain:

  privilegeTargets:
    'Neos\ContentRepository\Security\Authorization\Privilege\Node\CreateNodePrivilege':
      'Cornelsen.Webkatalog:Nodes.DisableCreation':
        matcher: 'createdNodeIsOfType("Some.Package:Some.Mixin")'

Fixes: #2960