### PR TITLE
FEATURE: Add option to disable the creation of redirects for assets

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -318,7 +318,7 @@ class AssetController extends ActionController
         $this->view->assignMultiple([
             'asset' => $asset,
             'maximumFileUploadSize' => $maximumFileUploadSize,
-            'redirectPackageEnabled' => $this->packageManager->isPackageAvailable('Neos.RedirectHandler'),
+            'createAssetRedirectsOptionEnabled' => $this->packageManager->isPackageAvailable('Neos.RedirectHandler') && $this->settings['features']['createAssetRedirectsOption']['enable'],
             'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($maximumFileUploadSize)
         ]);
     }

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -19,10 +19,13 @@ Neos:
         - 'resource://Neos.Media.Browser/Public/Styles/MediaBrowser.css'
         - 'resource://Neos.Media.Browser/Public/Styles/Main.css'
 
-      # By default, disable the beta feature "variants tab":
       features:
+         # By default, disable the beta feature "variants tab":
         variantsTab:
           enable: false
+        # By default, enable the option to create redirects for replaced asset resources
+        createAssetRedirectsOption:
+          enable: true
 
   Flow:
     security:

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -26,7 +26,7 @@
                             <span></span> {neos:backend.translate(id: 'replace.options.keepOriginalFilename', arguments: {0: asset.resource.filename}, package: 'Neos.Media.Browser')}
                         </label>
                     </div>
-                    <f:if condition="{redirectPackageEnabled}">
+                    <f:if condition="{createAssetRedirectsOptionEnabled}">
                         <div>
                             <label class="neos-checkbox neos-inline">
                                 <f:form.checkbox name="options[generateRedirects]" value="1" checked="true"/>


### PR DESCRIPTION
This feature adds a config parameter for the media browser to disable the option to create redirects for replaced assets resources. Might be useful for some projects, where these kind of redirects don't make any sense and therefore should be disabled by default.

<img width="987" alt="createAssetRedirectsOption" src="https://user-images.githubusercontent.com/36864084/79948497-46602400-8474-11ea-8859-46ef0a391eb2.png">
