### PR TITLE
BUGFIX: Don’t override default button style in modules

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -93,7 +93,7 @@
 
 <f:section name="Sidebar">
     <form action="{f:uri.action(action: 'index')}" method="get" class="neos-search">
-        <button type="submit" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
+        <button type="submit" class="neos-button" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
         <div>
             <input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}" value="{searchTerm}"{f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')} />
         </div>
@@ -144,7 +144,7 @@
                         </f:link.action>
                         <div class="neos-sidelist-edit-actions">
                             <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
-                            <button type="submit" class="neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
+                            <button type="submit" class="neos-button neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                         </div>
                     </li>
                 </f:for>
@@ -214,7 +214,7 @@
                     </f:link.action>
                     <div class="neos-sidelist-edit-actions">
                         <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
-                        <button class="neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="fas fa-trash"></i></button>
+                        <button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="fas fa-trash"></i></button>
                     </div>
                 </li>
             </f:for>

--- a/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
+++ b/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
@@ -20,7 +20,7 @@
               value: 'Content')}
             </f:link.action>
           </h2>
-          <button type="button" class="neos-menu-panel-toggle" role="button">
+          <button type="button" class="neos-button neos-menu-panel-toggle" role="button">
             <i class="fas fa-chevron-circle-down"></i>
           </button>
         </div>
@@ -74,7 +74,7 @@
           module.label)}
         </neos:link.module>
       </h2>
-      <button type="button" class="neos-menu-panel-toggle" role="button">
+      <button type="button" class="neos-button neos-menu-panel-toggle" role="button">
         <i class="fas fa-chevron-circle-down"></i>
       </button>
     </div>

--- a/Neos.Neos/Resources/Private/Styles/Foundation/_buttons.scss
+++ b/Neos.Neos/Resources/Private/Styles/Foundation/_buttons.scss
@@ -7,7 +7,6 @@
 // --------------------------------------------------
 
 // Core
-button,
 .neos-button {
 	display: inline-block;
 	padding: 0 $defaultMargin;

--- a/Neos.Neos/Resources/Private/Styles/Modules/_Modules.scss
+++ b/Neos.Neos/Resources/Private/Styles/Modules/_Modules.scss
@@ -389,8 +389,26 @@
 		}
 
 		&.neos-table {
+			td {
+				border-top: 1px solid $grayDark;
+			}
+
+			th {
+				text-shadow: none;
+			}
+
 			td,
 			th {
+				height: $unit;
+				padding: 0 $defaultMargin;
+				line-height: $unit;
+				box-sizing: border-box;
+
+				i {
+					vertical-align: baseline;
+					text-align: center;
+				}
+
 				&:first-child {
 					padding-left: $defaultMargin !important;
 				}
@@ -481,40 +499,6 @@
 						border-top: 0;
 					}
 				}
-			}
-		}
-
-		td {
-			border-top: 1px solid $grayDark;
-		}
-
-		th {
-			text-shadow: none;
-		}
-
-		td,
-		th {
-			height: $unit;
-			padding: 0 $defaultMargin;
-			line-height: $unit;
-			box-sizing: border-box;
-
-			&:first-child {
-				padding-left: $wideMargin !important;
-			}
-
-			&:last-child {
-				padding-right: $wideMargin !important;
-			}
-
-			&.neos-action {
-				padding-left: 0 !important;
-				padding-right: 0 !important;
-			}
-
-			i {
-				vertical-align: baseline;
-				text-align: center;
 			}
 		}
 

--- a/Neos.Neos/Resources/Private/Styles/Neos.scss
+++ b/Neos.Neos/Resources/Private/Styles/Neos.scss
@@ -31,6 +31,10 @@
 
 	// Components: Buttons & Alerts
 	@import "Foundation/buttons";
+	// Override standard button style for backwards compatibility
+	button {
+		@extend .neos-button;
+	}
 	@import "Foundation/button-groups";
 
 	// Components: Nav

--- a/Neos.Neos/Resources/Public/Styles/Lite.css
+++ b/Neos.Neos/Resources/Public/Styles/Lite.css
@@ -32,8 +32,6 @@
  */
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .neos-close,
@@ -132,8 +130,6 @@
 
 .fa.fa-pull-left,
 .fas.fa-pull-left,
-.neos button.fa-pull-left[class^="fa-"],
-.neos button.fa-pull-left[class*=" fa-"],
 .neos .fa-pull-left.neos-button[class^="fa-"],
 .neos .fa-pull-left.neos-button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .fa-pull-left.neos-close,
@@ -154,8 +150,6 @@
 
 .fa.fa-pull-right,
 .fas.fa-pull-right,
-.neos button.fa-pull-right[class^="fa-"],
-.neos button.fa-pull-right[class*=" fa-"],
 .neos .fa-pull-right.neos-button[class^="fa-"],
 .neos .fa-pull-right.neos-button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .fa-pull-right.neos-close,
@@ -4529,8 +4523,6 @@ readers do not read off random characters that represent icons */
 
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .neos-close,
@@ -6171,7 +6163,6 @@ q:after {
   .neos .neos-thumbnail .neos-caption {
     padding: 9px;
     color: #555; }
-  .neos button,
   .neos .neos-button {
     display: inline-block;
     padding: 0 16px;
@@ -6194,70 +6185,44 @@ q:after {
     box-shadow: none;
     box-sizing: border-box;
     transition: all 0 ease 0; }
-    .neos button.neos-button-small,
     .neos .neos-button.neos-button-small {
       height: 24px;
       line-height: 24px;
       font-size: 12px;
       padding: 0 8px; }
-    .neos button:not([disabled]):hover, .neos button:not([disabled]):active, .neos button:not([disabled]).neos-active, .neos button:not([disabled]).neos-pressed, .neos button:not(.neos-disabled):hover, .neos button:not(.neos-disabled):active, .neos button:not(.neos-disabled).neos-active, .neos button:not(.neos-disabled).neos-pressed,
-    .neos .neos-button:not([disabled]):hover,
-    .neos .neos-button:not([disabled]):active,
-    .neos .neos-button:not([disabled]).neos-active,
-    .neos .neos-button:not([disabled]).neos-pressed,
-    .neos .neos-button:not(.neos-disabled):hover,
-    .neos .neos-button:not(.neos-disabled):active,
-    .neos .neos-button:not(.neos-disabled).neos-active,
-    .neos .neos-button:not(.neos-disabled).neos-pressed {
+    .neos .neos-button:not([disabled]):hover, .neos .neos-button:not([disabled]):active, .neos .neos-button:not([disabled]).neos-active, .neos .neos-button:not([disabled]).neos-pressed, .neos .neos-button:not(.neos-disabled):hover, .neos .neos-button:not(.neos-disabled):active, .neos .neos-button:not(.neos-disabled).neos-active, .neos .neos-button:not(.neos-disabled).neos-pressed {
       color: #fff;
       background-color: #00b5ff;
       text-decoration: none; }
-    .neos button:focus,
     .neos .neos-button:focus {
       outline: thin dotted #333;
       outline: 5px auto -webkit-focus-ring-color;
       outline-offset: -2px;
       outline: 1px dotted #fff;
       outline-offset: 0; }
-    .neos button.neos-disabled, .neos button[disabled],
-    .neos .neos-button.neos-disabled,
-    .neos .neos-button[disabled] {
+    .neos .neos-button.neos-disabled, .neos .neos-button[disabled] {
       cursor: not-allowed;
       opacity: .65; }
-    .neos button.neos-button-primary,
     .neos .neos-button.neos-button-primary {
       background-color: #00b5ff; }
-      .neos button.neos-button-primary:focus,
       .neos .neos-button.neos-button-primary:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-success,
     .neos .neos-button.neos-button-success {
       background-color: #00a338; }
-      .neos button.neos-button-success:hover, .neos button.neos-button-success:active,
-      .neos .neos-button.neos-button-success:hover,
-      .neos .neos-button.neos-button-success:active {
+      .neos .neos-button.neos-button-success:hover, .neos .neos-button.neos-button-success:active {
         background-color: #00a338; }
-      .neos button.neos-button-success:focus,
       .neos .neos-button.neos-button-success:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-warning,
     .neos .neos-button.neos-button-warning {
       background-color: #ff8700; }
-      .neos button.neos-button-warning:hover, .neos button.neos-button-warning:active,
-      .neos .neos-button.neos-button-warning:hover,
-      .neos .neos-button.neos-button-warning:active {
+      .neos .neos-button.neos-button-warning:hover, .neos .neos-button.neos-button-warning:active {
         background-color: #ff8700; }
-      .neos button.neos-button-warning:focus,
       .neos .neos-button.neos-button-warning:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-danger,
     .neos .neos-button.neos-button-danger {
       background-color: #ff460d; }
-      .neos button.neos-button-danger:hover, .neos button.neos-button-danger:active,
-      .neos .neos-button.neos-button-danger:hover,
-      .neos .neos-button.neos-button-danger:active {
+      .neos .neos-button.neos-button-danger:hover, .neos .neos-button.neos-button-danger:active {
         background-color: #ff460d; }
-      .neos button.neos-button-danger:focus,
       .neos .neos-button.neos-button-danger:focus {
         outline: 1px dotted #fff; }
   .neos a.neos-button {

--- a/Neos.Neos/Resources/Public/Styles/Lite.css
+++ b/Neos.Neos/Resources/Public/Styles/Lite.css
@@ -8511,16 +8511,30 @@ q:after {
       .neos.neos-module table.table-bordered th,
       .neos.neos-module table.table-bordered td {
         border-left: 1px solid #3f3f3f; }
-    .neos.neos-module table.neos-table td:first-child,
-    .neos.neos-module table.neos-table th:first-child {
-      padding-left: 16px !important; }
-    .neos.neos-module table.neos-table td:last-child,
-    .neos.neos-module table.neos-table th:last-child {
-      padding-right: 16px !important; }
-    .neos.neos-module table.neos-table td.neos-action,
-    .neos.neos-module table.neos-table th.neos-action {
-      padding-left: 0 !important;
-      padding-right: 0 !important; }
+    .neos.neos-module table.neos-table td {
+      border-top: 1px solid #222; }
+    .neos.neos-module table.neos-table th {
+      text-shadow: none; }
+    .neos.neos-module table.neos-table td,
+    .neos.neos-module table.neos-table th {
+      height: 40px;
+      padding: 0 16px;
+      line-height: 40px;
+      box-sizing: border-box; }
+      .neos.neos-module table.neos-table td i,
+      .neos.neos-module table.neos-table th i {
+        vertical-align: baseline;
+        text-align: center; }
+      .neos.neos-module table.neos-table td:first-child,
+      .neos.neos-module table.neos-table th:first-child {
+        padding-left: 16px !important; }
+      .neos.neos-module table.neos-table td:last-child,
+      .neos.neos-module table.neos-table th:last-child {
+        padding-right: 16px !important; }
+      .neos.neos-module table.neos-table td.neos-action,
+      .neos.neos-module table.neos-table th.neos-action {
+        padding-left: 0 !important;
+        padding-right: 0 !important; }
     .neos.neos-module table.neos-table tr.neos-folder td {
       background: #222;
       padding-left: 0 !important;
@@ -8570,30 +8584,6 @@ q:after {
       .neos.neos-module table.neos-info-table tbody tr:first-child th,
       .neos.neos-module table.neos-info-table tbody tr:first-child td {
         border-top: 0; }
-    .neos.neos-module table td {
-      border-top: 1px solid #222; }
-    .neos.neos-module table th {
-      text-shadow: none; }
-    .neos.neos-module table td,
-    .neos.neos-module table th {
-      height: 40px;
-      padding: 0 16px;
-      line-height: 40px;
-      box-sizing: border-box; }
-      .neos.neos-module table td:first-child,
-      .neos.neos-module table th:first-child {
-        padding-left: 32px !important; }
-      .neos.neos-module table td:last-child,
-      .neos.neos-module table th:last-child {
-        padding-right: 32px !important; }
-      .neos.neos-module table td.neos-action,
-      .neos.neos-module table th.neos-action {
-        padding-left: 0 !important;
-        padding-right: 0 !important; }
-      .neos.neos-module table td i,
-      .neos.neos-module table th i {
-        vertical-align: baseline;
-        text-align: center; }
     .neos.neos-module table td > .neos-button,
     .neos.neos-module table td > form > .neos-button,
     .neos.neos-module table td div.neos-pull-right > .neos-button,

--- a/Neos.Neos/Resources/Public/Styles/Main.css
+++ b/Neos.Neos/Resources/Public/Styles/Main.css
@@ -8854,16 +8854,30 @@ readers do not read off random characters that represent icons */
       .neos.neos-module table.table-bordered th,
       .neos.neos-module table.table-bordered td {
         border-left: 1px solid #3f3f3f; }
-    .neos.neos-module table.neos-table td:first-child,
-    .neos.neos-module table.neos-table th:first-child {
-      padding-left: 16px !important; }
-    .neos.neos-module table.neos-table td:last-child,
-    .neos.neos-module table.neos-table th:last-child {
-      padding-right: 16px !important; }
-    .neos.neos-module table.neos-table td.neos-action,
-    .neos.neos-module table.neos-table th.neos-action {
-      padding-left: 0 !important;
-      padding-right: 0 !important; }
+    .neos.neos-module table.neos-table td {
+      border-top: 1px solid #222; }
+    .neos.neos-module table.neos-table th {
+      text-shadow: none; }
+    .neos.neos-module table.neos-table td,
+    .neos.neos-module table.neos-table th {
+      height: 40px;
+      padding: 0 16px;
+      line-height: 40px;
+      box-sizing: border-box; }
+      .neos.neos-module table.neos-table td i,
+      .neos.neos-module table.neos-table th i {
+        vertical-align: baseline;
+        text-align: center; }
+      .neos.neos-module table.neos-table td:first-child,
+      .neos.neos-module table.neos-table th:first-child {
+        padding-left: 16px !important; }
+      .neos.neos-module table.neos-table td:last-child,
+      .neos.neos-module table.neos-table th:last-child {
+        padding-right: 16px !important; }
+      .neos.neos-module table.neos-table td.neos-action,
+      .neos.neos-module table.neos-table th.neos-action {
+        padding-left: 0 !important;
+        padding-right: 0 !important; }
     .neos.neos-module table.neos-table tr.neos-folder td {
       background: #222;
       padding-left: 0 !important;
@@ -8913,30 +8927,6 @@ readers do not read off random characters that represent icons */
       .neos.neos-module table.neos-info-table tbody tr:first-child th,
       .neos.neos-module table.neos-info-table tbody tr:first-child td {
         border-top: 0; }
-    .neos.neos-module table td {
-      border-top: 1px solid #222; }
-    .neos.neos-module table th {
-      text-shadow: none; }
-    .neos.neos-module table td,
-    .neos.neos-module table th {
-      height: 40px;
-      padding: 0 16px;
-      line-height: 40px;
-      box-sizing: border-box; }
-      .neos.neos-module table td:first-child,
-      .neos.neos-module table th:first-child {
-        padding-left: 32px !important; }
-      .neos.neos-module table td:last-child,
-      .neos.neos-module table th:last-child {
-        padding-right: 32px !important; }
-      .neos.neos-module table td.neos-action,
-      .neos.neos-module table th.neos-action {
-        padding-left: 0 !important;
-        padding-right: 0 !important; }
-      .neos.neos-module table td i,
-      .neos.neos-module table th i {
-        vertical-align: baseline;
-        text-align: center; }
     .neos.neos-module table td > .neos-button, .neos.neos-module table td > button,
     .neos.neos-module table td > form > .neos-button,
     .neos.neos-module table td > form > button,

--- a/Neos.Neos/Resources/Public/Styles/Main.css
+++ b/Neos.Neos/Resources/Public/Styles/Main.css
@@ -32,10 +32,10 @@
  */
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
+.neos button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
+.neos button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .neos-close,
 .neos .neos-modal-content .neos-modal-header .neos-close,
 .neos ul.neos-tree-container .neos-tree-node.neos-hidden span + span:after,
@@ -136,10 +136,10 @@
 
 .fa.fa-pull-left,
 .fas.fa-pull-left,
-.neos button.fa-pull-left[class^="fa-"],
-.neos button.fa-pull-left[class*=" fa-"],
 .neos .fa-pull-left.neos-button[class^="fa-"],
+.neos button.fa-pull-left[class^="fa-"],
 .neos .fa-pull-left.neos-button[class*=" fa-"],
+.neos button.fa-pull-left[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .fa-pull-left.neos-close,
 .neos .neos-modal-content .neos-modal-header .fa-pull-left.neos-close,
 .neos ul.neos-tree-container .neos-tree-node.neos-hidden span + span.fa-pull-left:after,
@@ -162,10 +162,10 @@
 
 .fa.fa-pull-right,
 .fas.fa-pull-right,
-.neos button.fa-pull-right[class^="fa-"],
-.neos button.fa-pull-right[class*=" fa-"],
 .neos .fa-pull-right.neos-button[class^="fa-"],
+.neos button.fa-pull-right[class^="fa-"],
 .neos .fa-pull-right.neos-button[class*=" fa-"],
+.neos button.fa-pull-right[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .fa-pull-right.neos-close,
 .neos .neos-modal-content .neos-modal-header .fa-pull-right.neos-close,
 .neos ul.neos-tree-container .neos-tree-node.neos-hidden span + span.fa-pull-right:after,
@@ -4541,10 +4541,10 @@ readers do not read off random characters that represent icons */
 
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
+.neos button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
+.neos button[class*=" fa-"],
 .neos .neos-modal .neos-modal-header .neos-close,
 .neos .neos-modal-content .neos-modal-header .neos-close,
 .neos ul.neos-tree-container .neos-tree-node.neos-hidden span + span:after,
@@ -5404,9 +5404,11 @@ readers do not read off random characters that represent icons */
       border: 1px solid #ccc; }
     .neos .neos-input-append .neos-add-on,
     .neos .neos-input-append .neos-button,
+    .neos .neos-input-append button,
     .neos .neos-input-append .neos-button-group > .neos-dropdown-toggle,
     .neos .neos-input-prepend .neos-add-on,
     .neos .neos-input-prepend .neos-button,
+    .neos .neos-input-prepend button,
     .neos .neos-input-prepend .neos-button-group > .neos-dropdown-toggle {
       vertical-align: top;
       border-radius: 0; }
@@ -5415,41 +5417,51 @@ readers do not read off random characters that represent icons */
       background-color: #3dff80;
       border-color: #00a338; }
   .neos .neos-input-prepend .neos-add-on,
-  .neos .neos-input-prepend .neos-button {
+  .neos .neos-input-prepend .neos-button,
+  .neos .neos-input-prepend button {
     margin-right: -1px; }
   .neos .neos-input-prepend .neos-add-on:first-child,
-  .neos .neos-input-prepend .neos-button:first-child {
+  .neos .neos-input-prepend .neos-button:first-child,
+  .neos .neos-input-prepend button:first-child {
     border-radius: 4px 0 0 4px; }
   .neos .neos-input-append input,
   .neos .neos-input-append select,
   .neos .neos-input-append .neos-uneditable-input {
     border-radius: 4px 0 0 4px; }
-    .neos .neos-input-append input + .neos-button-group .neos-button:last-child,
+    .neos .neos-input-append input + .neos-button-group .neos-button:last-child, .neos .neos-input-append input + .neos-button-group button:last-child,
     .neos .neos-input-append select + .neos-button-group .neos-button:last-child,
-    .neos .neos-input-append .neos-uneditable-input + .neos-button-group .neos-button:last-child {
+    .neos .neos-input-append select + .neos-button-group button:last-child,
+    .neos .neos-input-append .neos-uneditable-input + .neos-button-group .neos-button:last-child,
+    .neos .neos-input-append .neos-uneditable-input + .neos-button-group button:last-child {
       border-radius: 0 4px 4px 0; }
   .neos .neos-input-append .neos-add-on,
   .neos .neos-input-append .neos-button,
+  .neos .neos-input-append button,
   .neos .neos-input-append .neos-button-group {
     margin-left: -1px; }
   .neos .neos-input-append .neos-add-on:last-child,
   .neos .neos-input-append .neos-button:last-child,
+  .neos .neos-input-append button:last-child,
   .neos .neos-input-append .neos-button-group:last-child > .neos-dropdown-toggle {
     border-radius: 0 4px 4px 0; }
   .neos .neos-input-prepend.neos-input-append input,
   .neos .neos-input-prepend.neos-input-append select,
   .neos .neos-input-prepend.neos-input-append .neos-uneditable-input {
     border-radius: 0; }
-    .neos .neos-input-prepend.neos-input-append input + .neos-button-group .neos-button,
+    .neos .neos-input-prepend.neos-input-append input + .neos-button-group .neos-button, .neos .neos-input-prepend.neos-input-append input + .neos-button-group button,
     .neos .neos-input-prepend.neos-input-append select + .neos-button-group .neos-button,
-    .neos .neos-input-prepend.neos-input-append .neos-uneditable-input + .neos-button-group .neos-button {
+    .neos .neos-input-prepend.neos-input-append select + .neos-button-group button,
+    .neos .neos-input-prepend.neos-input-append .neos-uneditable-input + .neos-button-group .neos-button,
+    .neos .neos-input-prepend.neos-input-append .neos-uneditable-input + .neos-button-group button {
       border-radius: 0 4px 4px 0; }
   .neos .neos-input-prepend.neos-input-append .neos-add-on:first-child,
-  .neos .neos-input-prepend.neos-input-append .neos-button:first-child {
+  .neos .neos-input-prepend.neos-input-append .neos-button:first-child,
+  .neos .neos-input-prepend.neos-input-append button:first-child {
     margin-right: -1px;
     border-radius: 4px 0 0 4px; }
   .neos .neos-input-prepend.neos-input-append .neos-add-on:last-child,
-  .neos .neos-input-prepend.neos-input-append .neos-button:last-child {
+  .neos .neos-input-prepend.neos-input-append .neos-button:last-child,
+  .neos .neos-input-prepend.neos-input-append button:last-child {
     margin-left: -1px;
     border-radius: 0 4px 4px 0; }
   .neos .neos-input-prepend.neos-input-append .neos-button-group:first-child {
@@ -5467,11 +5479,11 @@ readers do not read off random characters that represent icons */
     border-radius: 0; }
   .neos .neos-form-search .neos-input-append .neos-search-query {
     border-radius: 14px 0 0 14px; }
-  .neos .neos-form-search .neos-input-append .neos-button {
+  .neos .neos-form-search .neos-input-append .neos-button, .neos .neos-form-search .neos-input-append button {
     border-radius: 0 14px 14px 0; }
   .neos .neos-form-search .neos-input-prepend .neos-search-query {
     border-radius: 0 14px 14px 0; }
-  .neos .neos-form-search .neos-input-prepend .neos-button {
+  .neos .neos-form-search .neos-input-prepend .neos-button, .neos .neos-form-search .neos-input-prepend button {
     border-radius: 14px 0 0 14px; }
   .neos .neos-form-search input,
   .neos .neos-form-search textarea,
@@ -5595,7 +5607,7 @@ readers do not read off random characters that represent icons */
       padding: 0 !important; }
       .neos .neos-table .neos-action .neos-modal, .neos .neos-table .neos-action .neos-modal-content {
         white-space: normal; }
-    .neos .neos-table .neos-button {
+    .neos .neos-table .neos-button, .neos .neos-table button {
       margin-top: 0;
       vertical-align: top; }
     .neos .neos-table tbody + tbody {
@@ -6041,8 +6053,7 @@ readers do not read off random characters that represent icons */
   .neos .neos-thumbnail .neos-caption {
     padding: 9px;
     color: #555; }
-  .neos button,
-  .neos .neos-button {
+  .neos .neos-button, .neos button {
     display: inline-block;
     padding: 0 16px;
     margin: 0;
@@ -6064,71 +6075,45 @@ readers do not read off random characters that represent icons */
     box-shadow: none;
     box-sizing: border-box;
     transition: all 0 ease 0; }
-    .neos button.neos-button-small,
-    .neos .neos-button.neos-button-small {
+    .neos .neos-button.neos-button-small, .neos button.neos-button-small {
       height: 24px;
       line-height: 24px;
       font-size: 12px;
       padding: 0 8px; }
-    .neos button:not([disabled]):hover, .neos button:not([disabled]):active, .neos button:not([disabled]).neos-active, .neos button:not([disabled]).neos-pressed, .neos button:not(.neos-disabled):hover, .neos button:not(.neos-disabled):active, .neos button:not(.neos-disabled).neos-active, .neos button:not(.neos-disabled).neos-pressed,
-    .neos .neos-button:not([disabled]):hover,
-    .neos .neos-button:not([disabled]):active,
-    .neos .neos-button:not([disabled]).neos-active,
-    .neos .neos-button:not([disabled]).neos-pressed,
-    .neos .neos-button:not(.neos-disabled):hover,
-    .neos .neos-button:not(.neos-disabled):active,
-    .neos .neos-button:not(.neos-disabled).neos-active,
-    .neos .neos-button:not(.neos-disabled).neos-pressed {
+    .neos .neos-button:not([disabled]):hover, .neos button:not([disabled]):hover, .neos .neos-button:not([disabled]):active, .neos button:not([disabled]):active, .neos .neos-button:not([disabled]).neos-active, .neos button:not([disabled]).neos-active, .neos .neos-button:not([disabled]).neos-pressed, .neos button:not([disabled]).neos-pressed, .neos .neos-button:not(.neos-disabled):hover, .neos button:not(.neos-disabled):hover, .neos .neos-button:not(.neos-disabled):active, .neos button:not(.neos-disabled):active, .neos .neos-button:not(.neos-disabled).neos-active, .neos button:not(.neos-disabled).neos-active, .neos .neos-button:not(.neos-disabled).neos-pressed, .neos button:not(.neos-disabled).neos-pressed {
       color: #fff;
       background-color: #00b5ff;
       text-decoration: none; }
-    .neos button:focus,
-    .neos .neos-button:focus {
+    .neos .neos-button:focus, .neos button:focus {
       outline: thin dotted #333;
       outline: 5px auto -webkit-focus-ring-color;
       outline-offset: -2px;
       outline: 1px dotted #fff;
       outline-offset: 0; }
-    .neos button.neos-disabled, .neos button[disabled],
-    .neos .neos-button.neos-disabled,
-    .neos .neos-button[disabled] {
+    .neos .neos-button.neos-disabled, .neos button.neos-disabled, .neos .neos-button[disabled], .neos button[disabled] {
       cursor: not-allowed;
       opacity: .65; }
-    .neos button.neos-button-primary,
-    .neos .neos-button.neos-button-primary {
+    .neos .neos-button.neos-button-primary, .neos button.neos-button-primary {
       background-color: #00b5ff; }
-      .neos button.neos-button-primary:focus,
-      .neos .neos-button.neos-button-primary:focus {
+      .neos .neos-button.neos-button-primary:focus, .neos button.neos-button-primary:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-success,
-    .neos .neos-button.neos-button-success {
+    .neos .neos-button.neos-button-success, .neos button.neos-button-success {
       background-color: #00a338; }
-      .neos button.neos-button-success:hover, .neos button.neos-button-success:active,
-      .neos .neos-button.neos-button-success:hover,
-      .neos .neos-button.neos-button-success:active {
+      .neos .neos-button.neos-button-success:hover, .neos button.neos-button-success:hover, .neos .neos-button.neos-button-success:active, .neos button.neos-button-success:active {
         background-color: #00a338; }
-      .neos button.neos-button-success:focus,
-      .neos .neos-button.neos-button-success:focus {
+      .neos .neos-button.neos-button-success:focus, .neos button.neos-button-success:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-warning,
-    .neos .neos-button.neos-button-warning {
+    .neos .neos-button.neos-button-warning, .neos button.neos-button-warning {
       background-color: #ff8700; }
-      .neos button.neos-button-warning:hover, .neos button.neos-button-warning:active,
-      .neos .neos-button.neos-button-warning:hover,
-      .neos .neos-button.neos-button-warning:active {
+      .neos .neos-button.neos-button-warning:hover, .neos button.neos-button-warning:hover, .neos .neos-button.neos-button-warning:active, .neos button.neos-button-warning:active {
         background-color: #ff8700; }
-      .neos button.neos-button-warning:focus,
-      .neos .neos-button.neos-button-warning:focus {
+      .neos .neos-button.neos-button-warning:focus, .neos button.neos-button-warning:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-danger,
-    .neos .neos-button.neos-button-danger {
+    .neos .neos-button.neos-button-danger, .neos button.neos-button-danger {
       background-color: #ff460d; }
-      .neos button.neos-button-danger:hover, .neos button.neos-button-danger:active,
-      .neos .neos-button.neos-button-danger:hover,
-      .neos .neos-button.neos-button-danger:active {
+      .neos .neos-button.neos-button-danger:hover, .neos button.neos-button-danger:hover, .neos .neos-button.neos-button-danger:active, .neos button.neos-button-danger:active {
         background-color: #ff460d; }
-      .neos button.neos-button-danger:focus,
-      .neos .neos-button.neos-button-danger:focus {
+      .neos .neos-button.neos-button-danger:focus, .neos button.neos-button-danger:focus {
         outline: 1px dotted #fff; }
   .neos a.neos-button {
     color: #fff; }
@@ -6148,14 +6133,16 @@ readers do not read off random characters that represent icons */
     font-size: 0;
     margin-top: 10px;
     margin-bottom: 10px; }
-    .neos .neos-button-toolbar > .neos-button + .neos-button,
+    .neos .neos-button-toolbar > .neos-button + .neos-button, .neos .neos-button-toolbar > button + .neos-button, .neos .neos-button-toolbar > .neos-button + button, .neos .neos-button-toolbar > button + button,
     .neos .neos-button-toolbar > .neos-button-group + .neos-button,
-    .neos .neos-button-toolbar > .neos-button + .neos-button-group {
+    .neos .neos-button-toolbar > .neos-button-group + button,
+    .neos .neos-button-toolbar > .neos-button + .neos-button-group,
+    .neos .neos-button-toolbar > button + .neos-button-group {
       margin-left: 5px; }
-  .neos .neos-button-group > .neos-button {
+  .neos .neos-button-group > .neos-button, .neos .neos-button-group > button {
     position: relative;
     border-radius: 0; }
-  .neos .neos-button-group > .neos-button + .neos-button {
+  .neos .neos-button-group > .neos-button + .neos-button, .neos .neos-button-group > button + .neos-button, .neos .neos-button-group > .neos-button + button, .neos .neos-button-group > button + button {
     margin-left: -1px; }
   .neos .neos-button-group > .neos-button-mini {
     font-size: 10.5px; }
@@ -6163,19 +6150,22 @@ readers do not read off random characters that represent icons */
     font-size: 11.9px; }
   .neos .neos-button-group > .neos-button-large {
     font-size: 17.5px; }
-  .neos .neos-button-group > .neos-button:first-child {
+  .neos .neos-button-group > .neos-button:first-child, .neos .neos-button-group > button:first-child {
     margin-left: 0; }
-  .neos .neos-button-group > .neos-button.neos-large:first-child {
+  .neos .neos-button-group > .neos-button.neos-large:first-child, .neos .neos-button-group > button.neos-large:first-child {
     margin-left: 0; }
-  .neos .neos-button-group > .neos-button:hover,
+  .neos .neos-button-group > .neos-button:hover, .neos .neos-button-group > button:hover,
   .neos .neos-button-group > .neos-button:focus,
+  .neos .neos-button-group > button:focus,
   .neos .neos-button-group > .neos-button:active,
-  .neos .neos-button-group > .neos-button.neos-active {
+  .neos .neos-button-group > button:active,
+  .neos .neos-button-group > .neos-button.neos-active,
+  .neos .neos-button-group > button.neos-active {
     z-index: 2; }
   .neos .neos-button-group .neos-dropdown-toggle:active,
   .neos .neos-button-group.neos-open .neos-dropdown-toggle {
     outline: 0; }
-  .neos .neos-button-group > .neos-button + .neos-dropdown-toggle {
+  .neos .neos-button-group > .neos-button + .neos-dropdown-toggle, .neos .neos-button-group > button + .neos-dropdown-toggle {
     padding-left: 8px;
     padding-right: 8px;
     box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -6209,7 +6199,7 @@ readers do not read off random characters that represent icons */
     background-color: #2f96b4; }
   .neos .neos-button-group.neos-open .neos-button-inverse.neos-dropdown-toggle {
     background-color: #222; }
-  .neos .neos-button .neos-caret {
+  .neos .neos-button .neos-caret, .neos button .neos-caret {
     margin-top: 8px;
     margin-left: 0; }
   .neos .neos-button-large .neos-caret {
@@ -6233,17 +6223,17 @@ readers do not read off random characters that represent icons */
     border-bottom-color: #fff; }
   .neos .neos-button-group-vertical {
     display: inline-block; }
-  .neos .neos-button-group-vertical > .neos-button {
+  .neos .neos-button-group-vertical > .neos-button, .neos .neos-button-group-vertical > button {
     display: block;
     float: none;
     max-width: 100%;
     border-radius: 0; }
-  .neos .neos-button-group-vertical > .neos-button + .neos-button {
+  .neos .neos-button-group-vertical > .neos-button + .neos-button, .neos .neos-button-group-vertical > button + .neos-button, .neos .neos-button-group-vertical > .neos-button + button, .neos .neos-button-group-vertical > button + button {
     margin-left: 0;
     margin-top: -1px; }
-  .neos .neos-button-group-vertical > .neos-button:first-child {
+  .neos .neos-button-group-vertical > .neos-button:first-child, .neos .neos-button-group-vertical > button:first-child {
     border-radius: 4px 4px 0 0; }
-  .neos .neos-button-group-vertical > .neos-button:last-child {
+  .neos .neos-button-group-vertical > .neos-button:last-child, .neos .neos-button-group-vertical > button:last-child {
     border-radius: 0 0 4px 4px; }
   .neos .neos-button-group-vertical > .neos-button-large:first-child {
     border-radius: 6px 6px 0 0; }
@@ -6345,7 +6335,7 @@ readers do not read off random characters that represent icons */
         content: "";
         display: table;
         clear: both; }
-      .neos .neos-modal .neos-modal-footer .neos-button, .neos .neos-modal-content .neos-modal-footer .neos-button {
+      .neos .neos-modal .neos-modal-footer .neos-button, .neos .neos-modal-content .neos-modal-footer .neos-button, .neos .neos-modal .neos-modal-footer button, .neos .neos-modal-content .neos-modal-footer button {
         margin-left: 8px;
         margin-bottom: 0; }
   .neos .neos-modal-centered {
@@ -6649,8 +6639,9 @@ readers do not read off random characters that represent icons */
     background-color: #00b5ff; }
   .neos .neos-badge-inverse {
     background-color: #222; }
-  .neos .neos-button .neos-label,
-  .neos .neos-button .neos-badge {
+  .neos .neos-button .neos-label, .neos button .neos-label,
+  .neos .neos-button .neos-badge,
+  .neos button .neos-badge {
     position: relative;
     top: -1px; }
   .neos .neos-pull-right {
@@ -7758,7 +7749,7 @@ readers do not read off random characters that represent icons */
           font-size: 14px; }
   .neos .neos-user-menu.neos-button-group {
     font-size: 14px; }
-    .neos .neos-user-menu.neos-button-group .neos-button {
+    .neos .neos-user-menu.neos-button-group .neos-button, .neos .neos-user-menu.neos-button-group button {
       background: none;
       padding: 0 16px; }
   .neos .neos-menu-button {
@@ -8112,17 +8103,17 @@ readers do not read off random characters that represent icons */
         font-size: 14px;
         line-height: 40px;
         padding-left: 16px; }
-      .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button {
+      .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button, .neos #neos-navigate-panel .neos-node-tree-toolbar button {
         float: right;
         width: 40px;
         color: #fff;
         background-color: transparent;
         text-align: center; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button i {
+        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button i, .neos #neos-navigate-panel .neos-node-tree-toolbar button i {
           margin-left: -3px; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled], .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled]:hover {
+        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled], .neos #neos-navigate-panel .neos-node-tree-toolbar button[disabled], .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button[disabled]:hover, .neos #neos-navigate-panel .neos-node-tree-toolbar button[disabled]:hover {
           color: #5b5b5b; }
-        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button.neos-pressed, .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button:hover {
+        .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button.neos-pressed, .neos #neos-navigate-panel .neos-node-tree-toolbar button.neos-pressed, .neos #neos-navigate-panel .neos-node-tree-toolbar .neos-button:hover, .neos #neos-navigate-panel .neos-node-tree-toolbar button:hover {
           color: #00b5ff; }
       .neos #neos-navigate-panel .neos-node-tree-toolbar #neos-node-tree-search {
         overflow: hidden;
@@ -8517,7 +8508,7 @@ readers do not read off random characters that represent icons */
       .neos.neos-module a, .neos.neos-module a:hover {
         color: #fff;
         text-decoration: none; }
-    .neos.neos-module .neos-button {
+    .neos.neos-module .neos-button, .neos.neos-module button {
       color: #fff; }
     .neos.neos-module label {
       font-size: 14px; }
@@ -8540,7 +8531,7 @@ readers do not read off random characters that represent icons */
       margin: 0; }
     .neos.neos-module.neos-module-user-usersettings .neos-content i.fa-user, .neos.neos-module.neos-module-administration-users .neos-content i.fa-user {
       margin-right: 11px; }
-    .neos.neos-module.neos-module-user-usersettings .neos-search-bar button.neos-button, .neos.neos-module.neos-module-administration-users .neos-search-bar button.neos-button {
+    .neos.neos-module.neos-module-user-usersettings .neos-search-bar button.neos-button, .neos.neos-module.neos-module-user-usersettings .neos-search-bar button, .neos.neos-module.neos-module-administration-users .neos-search-bar button.neos-button, .neos.neos-module.neos-module-administration-users .neos-search-bar button {
       border-right: 1px solid #222; }
     .neos.neos-module.neos-module-user-usersettings .neos-search-bar a.neos-button, .neos.neos-module.neos-module-administration-users .neos-search-bar a.neos-button {
       border-left: 1px solid #222; }
@@ -8762,9 +8753,9 @@ readers do not read off random characters that represent icons */
       @media screen and (max-width: 1024px) and (max-height: 768px) {
         .neos.neos-module .neos-footer {
           padding: 0; } }
-      .neos.neos-module .neos-footer .neos-button {
+      .neos.neos-module .neos-footer .neos-button, .neos.neos-module .neos-footer button {
         margin-right: 8px; }
-      .neos.neos-module .neos-footer .neos-modal .neos-button, .neos.neos-module .neos-footer .neos-modal-content .neos-button {
+      .neos.neos-module .neos-footer .neos-modal .neos-button, .neos.neos-module .neos-footer .neos-modal-content .neos-button, .neos.neos-module .neos-footer .neos-modal button, .neos.neos-module .neos-footer .neos-modal-content button {
         margin-right: 0; }
     .neos.neos-module .fixedsticky-dummy {
       display: none; }
@@ -8946,144 +8937,255 @@ readers do not read off random characters that represent icons */
       .neos.neos-module table th i {
         vertical-align: baseline;
         text-align: center; }
-    .neos.neos-module table td > .neos-button,
+    .neos.neos-module table td > .neos-button, .neos.neos-module table td > button,
     .neos.neos-module table td > form > .neos-button,
+    .neos.neos-module table td > form > button,
     .neos.neos-module table td div.neos-pull-right > .neos-button,
-    .neos.neos-module table td div.neos-pull-right > form .neos-button {
+    .neos.neos-module table td div.neos-pull-right > button,
+    .neos.neos-module table td div.neos-pull-right > form .neos-button,
+    .neos.neos-module table td div.neos-pull-right > form button {
       background-color: #323232; }
-      .neos.neos-module table td > .neos-button:not([disabled]):hover, .neos.neos-module table td > .neos-button:not([disabled]):active, .neos.neos-module table td > .neos-button:not([disabled]).neos-active, .neos.neos-module table td > .neos-button:not([disabled]).neos-pressed, .neos.neos-module table td > .neos-button:not(.neos-disabled):hover, .neos.neos-module table td > .neos-button:not(.neos-disabled):active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td > .neos-button:not([disabled]):hover, .neos.neos-module table td > button:not([disabled]):hover, .neos.neos-module table td > .neos-button:not([disabled]):active, .neos.neos-module table td > button:not([disabled]):active, .neos.neos-module table td > .neos-button:not([disabled]).neos-active, .neos.neos-module table td > button:not([disabled]).neos-active, .neos.neos-module table td > .neos-button:not([disabled]).neos-pressed, .neos.neos-module table td > button:not([disabled]).neos-pressed, .neos.neos-module table td > .neos-button:not(.neos-disabled):hover, .neos.neos-module table td > button:not(.neos-disabled):hover, .neos.neos-module table td > .neos-button:not(.neos-disabled):active, .neos.neos-module table td > button:not(.neos-disabled):active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-active, .neos.neos-module table td > button:not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button:not(.neos-disabled).neos-pressed, .neos.neos-module table td > button:not(.neos-disabled).neos-pressed,
       .neos.neos-module table td > form > .neos-button:not([disabled]):hover,
+      .neos.neos-module table td > form > button:not([disabled]):hover,
       .neos.neos-module table td > form > .neos-button:not([disabled]):active,
+      .neos.neos-module table td > form > button:not([disabled]):active,
       .neos.neos-module table td > form > .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td > form > button:not([disabled]).neos-active,
       .neos.neos-module table td > form > .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td > form > button:not([disabled]).neos-pressed,
       .neos.neos-module table td > form > .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td > form > button:not(.neos-disabled):hover,
       .neos.neos-module table td > form > .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td > form > button:not(.neos-disabled):active,
       .neos.neos-module table td > form > .neos-button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td > form > button:not(.neos-disabled).neos-active,
       .neos.neos-module table td > form > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td > form > button:not(.neos-disabled).neos-pressed,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]):hover,
+      .neos.neos-module table td div.neos-pull-right > button:not([disabled]):hover,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]):active,
+      .neos.neos-module table td div.neos-pull-right > button:not([disabled]):active,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td div.neos-pull-right > button:not([disabled]).neos-active,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > button:not([disabled]).neos-pressed,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td div.neos-pull-right > button:not(.neos-disabled):hover,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td div.neos-pull-right > button:not(.neos-disabled):active,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td div.neos-pull-right > button:not(.neos-disabled).neos-active,
       .neos.neos-module table td div.neos-pull-right > .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > button:not(.neos-disabled).neos-pressed,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]):hover,
+      .neos.neos-module table td div.neos-pull-right > form button:not([disabled]):hover,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]):active,
+      .neos.neos-module table td div.neos-pull-right > form button:not([disabled]):active,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]).neos-active,
+      .neos.neos-module table td div.neos-pull-right > form button:not([disabled]).neos-active,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not([disabled]).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > form button:not([disabled]).neos-pressed,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled):hover,
+      .neos.neos-module table td div.neos-pull-right > form button:not(.neos-disabled):hover,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled):active,
+      .neos.neos-module table td div.neos-pull-right > form button:not(.neos-disabled):active,
       .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled).neos-active,
-      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled).neos-pressed {
+      .neos.neos-module table td div.neos-pull-right > form button:not(.neos-disabled).neos-active,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button:not(.neos-disabled).neos-pressed,
+      .neos.neos-module table td div.neos-pull-right > form button:not(.neos-disabled).neos-pressed {
         background-color: #00b5ff; }
-      .neos.neos-module table td > .neos-button.neos-button-success,
+      .neos.neos-module table td > .neos-button.neos-button-success, .neos.neos-module table td > button.neos-button-success,
       .neos.neos-module table td > form > .neos-button.neos-button-success,
+      .neos.neos-module table td > form > button.neos-button-success,
       .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success,
-      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success {
+      .neos.neos-module table td div.neos-pull-right > button.neos-button-success,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success,
+      .neos.neos-module table td div.neos-pull-right > form button.neos-button-success {
         background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-success:hover, .neos.neos-module table td > .neos-button.neos-button-success:active,
+        .neos.neos-module table td > .neos-button.neos-button-success:hover, .neos.neos-module table td > button.neos-button-success:hover, .neos.neos-module table td > .neos-button.neos-button-success:active, .neos.neos-module table td > button.neos-button-success:active,
         .neos.neos-module table td > form > .neos-button.neos-button-success:hover,
+        .neos.neos-module table td > form > button.neos-button-success:hover,
         .neos.neos-module table td > form > .neos-button.neos-button-success:active,
+        .neos.neos-module table td > form > button.neos-button-success:active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:hover,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:active {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:active {
           background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > button.neos-button-success:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > button.neos-button-success:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed, .neos.neos-module table td > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > button.neos-button-success:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td > form > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-success:not([disabled]):not(.neos-disabled).neos-pressed {
           background-color: #00a338; }
-      .neos.neos-module table td > .neos-button.neos-button-warning,
+      .neos.neos-module table td > .neos-button.neos-button-warning, .neos.neos-module table td > button.neos-button-warning,
       .neos.neos-module table td > form > .neos-button.neos-button-warning,
+      .neos.neos-module table td > form > button.neos-button-warning,
       .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning,
-      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning {
+      .neos.neos-module table td div.neos-pull-right > button.neos-button-warning,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning,
+      .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning {
         background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-warning:hover, .neos.neos-module table td > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td > .neos-button.neos-button-warning:hover, .neos.neos-module table td > button.neos-button-warning:hover, .neos.neos-module table td > .neos-button.neos-button-warning:active, .neos.neos-module table td > button.neos-button-warning:active,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:hover,
+        .neos.neos-module table td > form > button.neos-button-warning:hover,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td > form > button.neos-button-warning:active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:hover,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:active {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:active {
           background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > button.neos-button-warning:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > button.neos-button-warning:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed, .neos.neos-module table td > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td > form > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-warning:not([disabled]):not(.neos-disabled).neos-pressed {
           background-color: #ff8700; }
-      .neos.neos-module table td > .neos-button.neos-button-danger,
+      .neos.neos-module table td > .neos-button.neos-button-danger, .neos.neos-module table td > button.neos-button-danger,
       .neos.neos-module table td > form > .neos-button.neos-button-danger,
+      .neos.neos-module table td > form > button.neos-button-danger,
       .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger,
-      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger {
+      .neos.neos-module table td div.neos-pull-right > button.neos-button-danger,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger,
+      .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger {
         background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-danger:hover, .neos.neos-module table td > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td > .neos-button.neos-button-danger:hover, .neos.neos-module table td > button.neos-button-danger:hover, .neos.neos-module table td > .neos-button.neos-button-danger:active, .neos.neos-module table td > button.neos-button-danger:active,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:hover,
+        .neos.neos-module table td > form > button.neos-button-danger:hover,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td > form > button.neos-button-danger:active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:hover,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:active {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:active {
           background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > button.neos-button-danger:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > button.neos-button-danger:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed, .neos.neos-module table td > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td > form > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-danger:not([disabled]):not(.neos-disabled).neos-pressed {
           background-color: #ff460d; }
-      .neos.neos-module table td > .neos-button.neos-button-primary,
+      .neos.neos-module table td > .neos-button.neos-button-primary, .neos.neos-module table td > button.neos-button-primary,
       .neos.neos-module table td > form > .neos-button.neos-button-primary,
+      .neos.neos-module table td > form > button.neos-button-primary,
       .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary,
-      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary {
+      .neos.neos-module table td div.neos-pull-right > button.neos-button-primary,
+      .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary,
+      .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary {
         background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-primary:hover, .neos.neos-module table td > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td > .neos-button.neos-button-primary:hover, .neos.neos-module table td > button.neos-button-primary:hover, .neos.neos-module table td > .neos-button.neos-button-primary:active, .neos.neos-module table td > button.neos-button-primary:active,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:hover,
+        .neos.neos-module table td > form > button.neos-button-primary:hover,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td > form > button.neos-button-primary:active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:hover,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:active {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:hover,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:active {
           background-color: #323232; }
-        .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > button.neos-button-primary:not([disabled]):not(.neos-disabled):hover, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > button.neos-button-primary:not([disabled]):not(.neos-disabled):active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active, .neos.neos-module table td > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed, .neos.neos-module table td > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td > form > button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td > form > button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td > form > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td > form > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td > form > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
         .neos.neos-module table td div.neos-pull-right > .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:not([disabled]):not(.neos-disabled):hover,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:not([disabled]):not(.neos-disabled):active,
         .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
-        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed {
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-active,
+        .neos.neos-module table td div.neos-pull-right > form .neos-button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed,
+        .neos.neos-module table td div.neos-pull-right > form button.neos-button-primary:not([disabled]):not(.neos-disabled).neos-pressed {
           background-color: #00b5ff; }
     .neos.neos-module legend + table,
     .neos.neos-module legend + .neos-alert {
@@ -9143,10 +9245,10 @@ readers do not read off random characters that represent icons */
       content: ""; }
     .neos .widget .widget-footer:after {
       clear: both; }
-    .neos .widget .widget-footer .neos-button-group .neos-button {
+    .neos .widget .widget-footer .neos-button-group .neos-button, .neos .widget .widget-footer .neos-button-group button {
       margin-bottom: 0;
       margin-left: 5px; }
-    .neos .widget .widget-footer .neos-button-group .neos-button + .neos-button {
+    .neos .widget .widget-footer .neos-button-group .neos-button + .neos-button, .neos .widget .widget-footer .neos-button-group button + .neos-button, .neos .widget .widget-footer .neos-button-group .neos-button + button, .neos .widget .widget-footer .neos-button-group button + button {
       margin-left: -1px; }
   .neos .neos-button-group.neos-open .neos-dropdown-toggle {
     box-shadow: 0px 0px 0px transparent; }
@@ -9289,7 +9391,7 @@ readers do not read off random characters that represent icons */
         -webkit-text-fill-color: #252525; }
   .neos .neos-login-dialog .neos-modal-body {
     padding: 16px; }
-  .neos .neos-login-dialog .neos-button {
+  .neos .neos-login-dialog .neos-button, .neos .neos-login-dialog button {
     width: 100%; }
   .neos .neos-login-dialog .neos-tooltip {
     left: -4px;
@@ -9369,18 +9471,18 @@ readers do not read off random characters that represent icons */
     border: 1px solid #3f3f3f;
     border-top: none;
     box-shadow: 1px 2px 5px #222; }
-    .neos .neos-position-selector-position .neos-button {
+    .neos .neos-position-selector-position .neos-button, .neos .neos-position-selector-position button {
       width: 38px;
       height: 40px;
       color: #fff;
       border: none; }
-      .neos .neos-position-selector-position .neos-button.neos-active {
+      .neos .neos-position-selector-position .neos-button.neos-active, .neos .neos-position-selector-position button.neos-active {
         color: #00b5ff;
         background-color: inherit; }
-      .neos .neos-position-selector-position .neos-button.neos-disabled {
+      .neos .neos-position-selector-position .neos-button.neos-disabled, .neos .neos-position-selector-position button.neos-disabled {
         color: #5b5b5b !important;
         opacity: 1; }
-      .neos .neos-position-selector-position .neos-button:hover:not(.neos-disabled) {
+      .neos .neos-position-selector-position .neos-button:hover:not(.neos-disabled), .neos .neos-position-selector-position button:hover:not(.neos-disabled) {
         color: #00b5ff;
         background-color: inherit; }
   .neos .neos-help-message-button:active, .neos .neos-help-message-button:focus {
@@ -9508,11 +9610,11 @@ body.neos-full-screen {
     right: 16px;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.25);
     z-index: 9999; }
-    body.neos-full-screen .neos-full-screen-close .neos-button {
+    body.neos-full-screen .neos-full-screen-close .neos-button, body.neos-full-screen .neos-full-screen-close .neos button, .neos body.neos-full-screen .neos-full-screen-close button {
       width: 40px;
       line-height: 44px;
       padding: 0; }
-      body.neos-full-screen .neos-full-screen-close .neos-button i {
+      body.neos-full-screen .neos-full-screen-close .neos-button i, body.neos-full-screen .neos-full-screen-close .neos button i, .neos body.neos-full-screen .neos-full-screen-close button i {
         margin-top: 1px; }
 
 body.neos-preview-mode .neos-contentelement {

--- a/Neos.Neos/Resources/Public/Styles/Minimal.css
+++ b/Neos.Neos/Resources/Public/Styles/Minimal.css
@@ -32,8 +32,6 @@
  */
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
@@ -126,8 +124,6 @@
 
 .fa.fa-pull-left,
 .fas.fa-pull-left,
-.neos button.fa-pull-left[class^="fa-"],
-.neos button.fa-pull-left[class*=" fa-"],
 .neos .fa-pull-left.neos-button[class^="fa-"],
 .neos .fa-pull-left.neos-button[class*=" fa-"],
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-left::before,
@@ -143,8 +139,6 @@
 
 .fa.fa-pull-right,
 .fas.fa-pull-right,
-.neos button.fa-pull-right[class^="fa-"],
-.neos button.fa-pull-right[class*=" fa-"],
 .neos .fa-pull-right.neos-button[class^="fa-"],
 .neos .fa-pull-right.neos-button[class*=" fa-"],
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span.fa-pull-right::before,
@@ -4513,8 +4507,6 @@ readers do not read off random characters that represent icons */
 
 .fa,
 .fas,
-.neos button[class^="fa-"],
-.neos button[class*=" fa-"],
 .neos .neos-button[class^="fa-"],
 .neos .neos-button[class*=" fa-"],
 .neos #neos-top-bar #neos-user-actions .neos-dropdown-menu .neos-checkbox input + span::before,
@@ -4848,7 +4840,6 @@ q:after {
         color: #ccc; }
     .neos .neos-breadcrumb .neos-active {
       color: #3f3f3f; }
-  .neos button,
   .neos .neos-button {
     display: inline-block;
     padding: 0 16px;
@@ -4871,70 +4862,44 @@ q:after {
     box-shadow: none;
     box-sizing: border-box;
     transition: all 0 ease 0; }
-    .neos button.neos-button-small,
     .neos .neos-button.neos-button-small {
       height: 24px;
       line-height: 24px;
       font-size: 12px;
       padding: 0 8px; }
-    .neos button:not([disabled]):hover, .neos button:not([disabled]):active, .neos button:not([disabled]).neos-active, .neos button:not([disabled]).neos-pressed, .neos button:not(.neos-disabled):hover, .neos button:not(.neos-disabled):active, .neos button:not(.neos-disabled).neos-active, .neos button:not(.neos-disabled).neos-pressed,
-    .neos .neos-button:not([disabled]):hover,
-    .neos .neos-button:not([disabled]):active,
-    .neos .neos-button:not([disabled]).neos-active,
-    .neos .neos-button:not([disabled]).neos-pressed,
-    .neos .neos-button:not(.neos-disabled):hover,
-    .neos .neos-button:not(.neos-disabled):active,
-    .neos .neos-button:not(.neos-disabled).neos-active,
-    .neos .neos-button:not(.neos-disabled).neos-pressed {
+    .neos .neos-button:not([disabled]):hover, .neos .neos-button:not([disabled]):active, .neos .neos-button:not([disabled]).neos-active, .neos .neos-button:not([disabled]).neos-pressed, .neos .neos-button:not(.neos-disabled):hover, .neos .neos-button:not(.neos-disabled):active, .neos .neos-button:not(.neos-disabled).neos-active, .neos .neos-button:not(.neos-disabled).neos-pressed {
       color: #fff;
       background-color: #00b5ff;
       text-decoration: none; }
-    .neos button:focus,
     .neos .neos-button:focus {
       outline: thin dotted #333;
       outline: 5px auto -webkit-focus-ring-color;
       outline-offset: -2px;
       outline: 1px dotted #fff;
       outline-offset: 0; }
-    .neos button.neos-disabled, .neos button[disabled],
-    .neos .neos-button.neos-disabled,
-    .neos .neos-button[disabled] {
+    .neos .neos-button.neos-disabled, .neos .neos-button[disabled] {
       cursor: not-allowed;
       opacity: .65; }
-    .neos button.neos-button-primary,
     .neos .neos-button.neos-button-primary {
       background-color: #00b5ff; }
-      .neos button.neos-button-primary:focus,
       .neos .neos-button.neos-button-primary:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-success,
     .neos .neos-button.neos-button-success {
       background-color: #00a338; }
-      .neos button.neos-button-success:hover, .neos button.neos-button-success:active,
-      .neos .neos-button.neos-button-success:hover,
-      .neos .neos-button.neos-button-success:active {
+      .neos .neos-button.neos-button-success:hover, .neos .neos-button.neos-button-success:active {
         background-color: #00a338; }
-      .neos button.neos-button-success:focus,
       .neos .neos-button.neos-button-success:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-warning,
     .neos .neos-button.neos-button-warning {
       background-color: #ff8700; }
-      .neos button.neos-button-warning:hover, .neos button.neos-button-warning:active,
-      .neos .neos-button.neos-button-warning:hover,
-      .neos .neos-button.neos-button-warning:active {
+      .neos .neos-button.neos-button-warning:hover, .neos .neos-button.neos-button-warning:active {
         background-color: #ff8700; }
-      .neos button.neos-button-warning:focus,
       .neos .neos-button.neos-button-warning:focus {
         outline: 1px dotted #fff; }
-    .neos button.neos-button-danger,
     .neos .neos-button.neos-button-danger {
       background-color: #ff460d; }
-      .neos button.neos-button-danger:hover, .neos button.neos-button-danger:active,
-      .neos .neos-button.neos-button-danger:hover,
-      .neos .neos-button.neos-button-danger:active {
+      .neos .neos-button.neos-button-danger:hover, .neos .neos-button.neos-button-danger:active {
         background-color: #ff460d; }
-      .neos button.neos-button-danger:focus,
       .neos .neos-button.neos-button-danger:focus {
         outline: 1px dotted #fff; }
   .neos a.neos-button {

--- a/Neos.Neos/Resources/Public/Styles/Minimal.css
+++ b/Neos.Neos/Resources/Public/Styles/Minimal.css
@@ -6156,16 +6156,30 @@ q:after {
       .neos.neos-module table.table-bordered th,
       .neos.neos-module table.table-bordered td {
         border-left: 1px solid #3f3f3f; }
-    .neos.neos-module table.neos-table td:first-child,
-    .neos.neos-module table.neos-table th:first-child {
-      padding-left: 16px !important; }
-    .neos.neos-module table.neos-table td:last-child,
-    .neos.neos-module table.neos-table th:last-child {
-      padding-right: 16px !important; }
-    .neos.neos-module table.neos-table td.neos-action,
-    .neos.neos-module table.neos-table th.neos-action {
-      padding-left: 0 !important;
-      padding-right: 0 !important; }
+    .neos.neos-module table.neos-table td {
+      border-top: 1px solid #222; }
+    .neos.neos-module table.neos-table th {
+      text-shadow: none; }
+    .neos.neos-module table.neos-table td,
+    .neos.neos-module table.neos-table th {
+      height: 40px;
+      padding: 0 16px;
+      line-height: 40px;
+      box-sizing: border-box; }
+      .neos.neos-module table.neos-table td i,
+      .neos.neos-module table.neos-table th i {
+        vertical-align: baseline;
+        text-align: center; }
+      .neos.neos-module table.neos-table td:first-child,
+      .neos.neos-module table.neos-table th:first-child {
+        padding-left: 16px !important; }
+      .neos.neos-module table.neos-table td:last-child,
+      .neos.neos-module table.neos-table th:last-child {
+        padding-right: 16px !important; }
+      .neos.neos-module table.neos-table td.neos-action,
+      .neos.neos-module table.neos-table th.neos-action {
+        padding-left: 0 !important;
+        padding-right: 0 !important; }
     .neos.neos-module table.neos-table tr.neos-folder td {
       background: #222;
       padding-left: 0 !important;
@@ -6215,30 +6229,6 @@ q:after {
       .neos.neos-module table.neos-info-table tbody tr:first-child th,
       .neos.neos-module table.neos-info-table tbody tr:first-child td {
         border-top: 0; }
-    .neos.neos-module table td {
-      border-top: 1px solid #222; }
-    .neos.neos-module table th {
-      text-shadow: none; }
-    .neos.neos-module table td,
-    .neos.neos-module table th {
-      height: 40px;
-      padding: 0 16px;
-      line-height: 40px;
-      box-sizing: border-box; }
-      .neos.neos-module table td:first-child,
-      .neos.neos-module table th:first-child {
-        padding-left: 32px !important; }
-      .neos.neos-module table td:last-child,
-      .neos.neos-module table th:last-child {
-        padding-right: 32px !important; }
-      .neos.neos-module table td.neos-action,
-      .neos.neos-module table th.neos-action {
-        padding-left: 0 !important;
-        padding-right: 0 !important; }
-      .neos.neos-module table td i,
-      .neos.neos-module table th i {
-        vertical-align: baseline;
-        text-align: center; }
     .neos.neos-module table td > .neos-button,
     .neos.neos-module table td > form > .neos-button,
     .neos.neos-module table td div.neos-pull-right > .neos-button,


### PR DESCRIPTION
The standard module stylesheet applied a lot of
styles to `<button>`. With this change this only
happens when using the backwards compatible
„Full“ stylesheet as the Lite and Minimal (introduced with 5.2) 
shouldn’t interfere with the modules styles.