### PR TITLE
BUGFIX: Respect fallback rule "strictness" in FusionView

### DIFF
--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -16,7 +16,6 @@ namespace Neos\Neos\View;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\ActionResponse;
-use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Mvc\View\AbstractView;
 use Neos\Fusion\Exception\RuntimeException;
 use Neos\Neos\Domain\Service\FusionService;
@@ -25,8 +24,6 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Service\ContentContextFactory;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Flow\I18n\Locale;
-use Neos\Flow\I18n\Service;
 use Neos\Flow\Security\Context;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Mvc\ActionRequest;
@@ -34,8 +31,10 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Controller\Arguments;
 
-class FusionExceptionView extends AbstractView implements ViewInterface
+class FusionExceptionView extends AbstractView
 {
+    use FusionViewI18nTrait;
+
     /**
      * This contains the supported options, their default values, descriptions and types.
      * @var array
@@ -55,12 +54,6 @@ class FusionExceptionView extends AbstractView implements ViewInterface
      * @Flow\Inject
      */
     protected $objectManager;
-
-    /**
-     * @Flow\Inject
-     * @var Service
-     */
-    protected $i18nService;
 
     /**
      * @var FusionService
@@ -129,12 +122,7 @@ class FusionExceptionView extends AbstractView implements ViewInterface
 
         $fusionRuntime = $this->getFusionRuntime($currentSiteNode, $controllerContext);
 
-        $dimensions = $currentSiteNode->getContext()->getDimensions();
-        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== []) {
-            $currentLocale = new Locale($dimensions['language'][0]);
-            $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
-            $this->i18nService->getConfiguration()->setFallbackRule(['strict' => false, 'order' => array_reverse($dimensions['language'])]);
-        }
+        $this->setFallbackRuleFromDimension($currentSiteNode);
 
         $fusionRuntime->pushContextArray(array_merge(
             $this->variables,

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -14,8 +14,6 @@ namespace Neos\Neos\View;
 use function GuzzleHttp\Psr7\parse_response;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\I18n\Locale;
-use Neos\Flow\I18n\Service;
 use Neos\Flow\Mvc\View\AbstractView;
 use Neos\Neos\Domain\Service\FusionService;
 use Neos\Neos\Exception;
@@ -30,11 +28,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class FusionView extends AbstractView
 {
-    /**
-     * @Flow\Inject
-     * @var Service
-     */
-    protected $i18nService;
+    use FusionViewI18nTrait;
 
     /**
      * This contains the supported options, their default values, descriptions and types.
@@ -82,13 +76,7 @@ class FusionView extends AbstractView
         $currentSiteNode = $this->getCurrentSiteNode();
         $fusionRuntime = $this->getFusionRuntime($currentSiteNode);
 
-        $dimensions = $currentNode->getContext()->getDimensions();
-        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== []) {
-            $currentLocale = new Locale($dimensions['language'][0]);
-            $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
-            array_shift($dimensions['language']);
-            $this->i18nService->getConfiguration()->setFallbackRule(['strict' => true, 'order' => $dimensions['language']]);
-        }
+        $this->setFallbackRuleFromDimension($currentNode);
 
         $fusionRuntime->pushContextArray([
             'node' => $currentNode,

--- a/Neos.Neos/Classes/View/FusionViewI18nTrait.php
+++ b/Neos.Neos/Classes/View/FusionViewI18nTrait.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\View;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
+use Neos\Flow\I18n\Locale;
+
+trait FusionViewI18nTrait
+{
+    /**
+     * @Flow\Inject
+     * @var \Neos\Flow\I18n\Service
+     */
+    protected $i18nService;
+
+    /**
+     * If a content dimension named "language" exists, it is used to set the locale fallback
+     * chain order for rendering based on that.
+     *
+     * This overrides the fallback order from Neos.Flow.i18n.fallbackRule.order - the strict
+     * flag is kept from the settings!
+     *
+     * @param TraversableNodeInterface $currentSiteNode
+     * @return void
+     * @throws InvalidLocaleIdentifierException
+     */
+    protected function setFallbackRuleFromDimension(TraversableNodeInterface $currentSiteNode): void
+    {
+        $dimensions = $currentSiteNode->getContext()->getDimensions();
+        if (array_key_exists('language', $dimensions) && $dimensions['language'] !== []) {
+            $currentLocale = new Locale($dimensions['language'][0]);
+            $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
+            array_shift($dimensions['language']);
+            $this->i18nService->getConfiguration()->setFallbackRule([
+                'strict' => $this->i18nService->getConfiguration()->getFallbackRule()['strict'],
+                'order' => $dimensions['language']
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
When Neos finds a content dimension named "language" it uses that
dimension to set the locale fallback order for rendering in the
`FusionView`.

In Neos 5.0 that rule was switched to "strict" mode, meaning the order
was used without falling back to implicit parents in locales. This
broke translations in case the "language" dimension was configured with
e.g. `de_DE` or `en_US` - for those cases translations were never used if
the respective XLIFF files were in `de` (or `en`) folders.

This change makes the `FusionView` use the strict flag from the settings,
giving back control to the user (in case non-strict is really needed).
At the same time it makes translations work as would be expected in
most cases, by using e.g. `de_DE` first, but falling back to `de` later.

Fixes #2963
