### PR TITLE
FEATURE: Add keyRenderer to render the key in the result map

### DIFF
--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Map.fusion
@@ -33,3 +33,10 @@ map.iteration = Neos.Fusion:Map {
 		test = ${element + '-' + iteration.index + '-' + iteration.cycle + '-' + iteration.isFirst + '-' + iteration.isLast + '-' + iteration.isOdd + '-' + iteration.isEven}
 	}
 }
+
+map.keyRenderer = Neos.Fusion:Map {
+  items = ${items}
+  itemName = 'element'
+  itemRenderer = ${'value-' + element}
+  keyRenderer = ${'key-' + element}
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -53,6 +53,17 @@ class MapTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function resultKeysCanBeRendered(): void
+    {
+        $view = $this->buildView();
+        $view->assign('items', ['foo' => 'element1', 'bar' => 'element2']);
+        $view->setFusionPath('map/keyRenderer');
+        self::assertEquals(['key-element1' => 'value-element1', 'key-element2' => 'value-element2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function basicCollectionWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -200,7 +200,8 @@ Render each item in ``items`` using ``itemRenderer`` and return the result as an
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
-:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
+:itemRenderer: (mixed, **required**) The renderer definition (simple value, expression or object) will be called once for every collection element to render the item (if ``itemRenderer`` cannot be rendered the path ``content`` is used as fallback for convenience in afx)
+:keyRenderer: (mixed, **optional**) The renderer definition (simple value, expression or object) will be called once for every collection element to render the key in the result collection.
 
 .. _Neos_Fusion__Reduce:
 


### PR DESCRIPTION
This adds a new fusionPath `keyRenderer` to render
the key of the resulting collection of `Neos.Fusion:Map`

Example:

```
keyRenderer = Neos.Fusion:Map {
  items = ${items}
  itemName = 'element'
  itemRenderer = ${'value-' + element}
  keyRenderer = ${'key-' + element}
}
```

will render:

```
['key-element1' => 'value-element1', 'key-element2' => 'value-element2']
```