### PR TITLE
BUGFIX: Revert ContentCollection constraint change

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.ContentCollection.yaml
@@ -9,5 +9,5 @@
     inlineEditable: true
   constraints:
     nodeTypes:
-      '*': false
-      'Neos.Neos:Content': true
+      'Neos.Neos:Document': false
+      '*': true


### PR DESCRIPTION
This reverts commit b48660b28c1de596e74d4a95b8547d743b5199f1 as it’s breaking the „constraint“ best practices for node types and allows to many NodeTypes in existing projects suddenly.

As the previous fix is still necessary I will create a new PR for a next Neos version 5.3 or 6.0 depending on the final solution.

Without the fix the actual constraint to only allow Content NodeTypes is done by the Neos.Ui and NOT by our NodeType definition which causes an inconsistency when working with the CR via its API or when analysing the NodeType definitions.
