### PR TITLE
BUGFIX: Only use accounts that have Neos users attached

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -240,11 +240,6 @@ class UserService
             return null;
         }
 
-        $runtimeCacheIdentifier = 'sec-context-' . $this->securityContext->getContextHash();
-        if (array_key_exists($runtimeCacheIdentifier, $this->runtimeUserCache)) {
-            return $this->runtimeUserCache[$runtimeCacheIdentifier];
-        }
-
         $tokens = $this->securityContext->getAuthenticationTokens();
         $user = array_reduce($tokens, function ($foundUser, TokenInterface $token) {
             if ($foundUser !== null) {
@@ -264,7 +259,6 @@ class UserService
             return $user;
         }, null);
 
-        $this->runtimeUserCache[$runtimeCacheIdentifier] = $user;
         return $user;
     }
 


### PR DESCRIPTION
Since Neos 5.2.0 the use of frontend logins is broken. When logging in, an exception is thrown. The exact exception varies, but can be traced to `Unexpected user type "". An account with the identifier "…" exists, but the corresponding party is not a Neos User.` eventually.

This change fixes that by not using `getUser()` directly, but doing more checks and eventually just returning `null` if no Neos user can be found for the authenticated tokens.

Related: #2577
Fixes: #3088