### PR TITLE
[BUGFIX] FusionObjects: LazyProps expects object

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -4,6 +4,7 @@ namespace Neos\Fusion\FusionObjects\Helpers;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\Runtime;
+use Neos\Fusion\FusionObjects\ComponentImplementation;
 
 /**
  * @Flow\Proxy(false)
@@ -34,7 +35,7 @@ final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
     private $keys;
 
     /**
-     * @var object
+     * @var ComponentImplementation
      */
     private $fusionObject;
 
@@ -43,8 +44,16 @@ final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
      */
     private $effectiveContext;
 
+    /**
+     * LazyProps constructor.
+     * @param ComponentImplementation $fusionObject
+     * @param string $parentPath
+     * @param Runtime $runtime
+     * @param array $keys
+     * @param array $effectiveContext
+     */
     public function __construct(
-        object $fusionObject,
+        ComponentImplementation $fusionObject,
         string $parentPath,
         Runtime $runtime,
         array $keys,


### PR DESCRIPTION
LazyProps expects the Class `object` and not
ComponentImplementation due to Class Configuration

**What I did**

I changed the Class-Names cause they are not correct in PHP 7.1.x and added PHPdoc-Comment

**Checklist**

- [x ] Code follows the PSR-2 coding style
- [x ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
