### PR TITLE
FEATURE: third parameter "sortFlags" for FlowQuery sort()

### DIFF
--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -70,6 +70,12 @@ class SortOperation extends AbstractOperation
             throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort direction (ASC or DESC)', 1467881105);
         }
 
+        // Check sort flags
+        $sortOptions = [];
+        if (isset($arguments[2]) && !empty($arguments[2])) {
+            $sortOptions = str_split(strtoupper($arguments[2]));
+        }
+
         $sortedNodes = [];
         $sortSequence = [];
         $nodesByIdentifier = [];
@@ -91,10 +97,39 @@ class SortOperation extends AbstractOperation
         }
 
         // Create the sort sequence
+        $sortFlags = SORT_REGULAR;
+        foreach ($sortOptions as $sortOpt) {
+            // see https://www.php.net/manual/en/function.sort
+            // no flag - SORT_REGULAR
+            // 'N' - SORT_NUMERIC
+            // 'S' - SORT_STRING
+            // 'L' - SORT_LOCALE_STRING
+            // 'T' - SORT_NATURAL
+            // 'I' - SORT_FLAG_CASE (use as last option with SORT_STRING, SORT_LOCALE_STRING or SORT_NATURAL)
+            switch ($sortOpt) {
+                case 'I':
+                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL)) {
+                        $sortFlags |= SORT_FLAG_CASE;
+                    }
+                    break;
+                case 'N':
+                    $sortFlags = SORT_NUMERIC;
+                    break;
+                case 'S':
+                    $sortFlags = SORT_STRING;
+                    break;
+                case 'L':
+                    $sortFlags = SORT_LOCALE_STRING;
+                    break;
+                case 'T':
+                    $sortFlags = SORT_NATURAL;
+                    break;
+            }
+        }
         if ($sortOrder === 'DESC') {
-            arsort($sortSequence);
+            arsort($sortSequence, $sortFlags);
         } elseif ($sortOrder === 'ASC') {
-            asort($sortSequence);
+            asort($sortSequence, $sortFlags);
         }
 
         // Build the sorted context that is returned

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -74,11 +74,7 @@ class SortOperation extends AbstractOperation
         $sortOptions = [];
         $sortOptions = [];
         if (isset($arguments[2]) && !empty($arguments[2])) {
-            if (gettype($arguments[2]) == "string") {
-                $args[] = $arguments[2];
-            } else {
-                $args = $arguments[2];
-            }
+            $args = is_array($arguments[2]) ? $arguments[2] : [$arguments[2]];
             foreach ($args as $arg) {
                 if (!in_array(strtoupper($arg), ['SORT_REGULAR', 'SORT_NUMERIC', 'SORT_STRING', 'SORT_LOCALE_STRING', 'SORT_NATURAL', 'SORT_FLAG_CASE'])) {
                     throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort option (see https://www.php.net/manual/en/function.sort)', 1591107722);

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -105,28 +105,8 @@ class SortOperation extends AbstractOperation
         }
 
         // Create the sort sequence
-        $sortFlags = SORT_REGULAR;
-        foreach ($sortOptions as $sortOpt) {
-            switch (strtoupper($sortOpt)) {
-                case 'SORT_FLAG_CASE':
-                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL)) {
-                        $sortFlags |= SORT_FLAG_CASE;
-                    }
-                    break;
-                case 'SORT_NUMERIC':
-                    $sortFlags = SORT_NUMERIC;
-                    break;
-                case 'SORT_STRING':
-                    $sortFlags = SORT_STRING;
-                    break;
-                case 'SORT_LOCALE_STRING':
-                    $sortFlags = SORT_LOCALE_STRING;
-                    break;
-                case 'SORT_NATURAL':
-                    $sortFlags = SORT_NATURAL;
-                    break;
-            }
-        }
+        $sortFlags = array_sum(array_map('constant', $sortOptions));
+        $sortFlags = $sortFlags === 0 ? SORT_REGULAR : $sortFlags;
         if ($sortOrder === 'DESC') {
             arsort($sortSequence, $sortFlags);
         } elseif ($sortOrder === 'ASC') {

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -70,10 +70,16 @@ class SortOperation extends AbstractOperation
             throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort direction (ASC or DESC)', 1467881105);
         }
 
-        // Check sort flags
+        // Check sort options
         $sortOptions = [];
         if (isset($arguments[2]) && !empty($arguments[2])) {
-            $sortOptions = str_split(strtoupper($arguments[2]));
+            foreach ($arguments[2] as $arg) {
+                if (!in_array(strtoupper($arg), ['SORT_REGULAR', 'SORT_NUMERIC', 'SORT_STRING', 'SORT_LOCALE_STRING', 'SORT_NATURAL', 'SORT_FLAG_CASE'])) {
+                    throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort option (see https://www.php.net/manual/en/function.sort)',1591107722);
+                } else {
+                    $sortOptions[] = $arg;
+                }
+            }
         }
 
         $sortedNodes = [];
@@ -99,29 +105,21 @@ class SortOperation extends AbstractOperation
         // Create the sort sequence
         $sortFlags = SORT_REGULAR;
         foreach ($sortOptions as $sortOpt) {
-            // see https://www.php.net/manual/en/function.sort
-            // no flag - SORT_REGULAR
-            // 'N' - SORT_NUMERIC
-            // 'S' - SORT_STRING
-            // 'L' - SORT_LOCALE_STRING
-            // 'T' - SORT_NATURAL
-            // 'I' - SORT_FLAG_CASE (use as last option with SORT_STRING, SORT_LOCALE_STRING or SORT_NATURAL)
-            switch ($sortOpt) {
-                case 'I':
-                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL)) {
+            switch (strtoupper($sortOpt)) {
+                case 'SORT_FLAG_CASE':
+                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL))
                         $sortFlags |= SORT_FLAG_CASE;
-                    }
                     break;
-                case 'N':
+                case 'SORT_NUMERIC':
                     $sortFlags = SORT_NUMERIC;
                     break;
-                case 'S':
+                case 'SORT_STRING':
                     $sortFlags = SORT_STRING;
                     break;
-                case 'L':
+                case 'SORT_LOCALE_STRING':
                     $sortFlags = SORT_LOCALE_STRING;
                     break;
-                case 'T':
+                case 'SORT_NATURAL':
                     $sortFlags = SORT_NATURAL;
                     break;
             }

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -72,7 +72,6 @@ class SortOperation extends AbstractOperation
 
         // Check sort options
         $sortOptions = [];
-        $sortOptions = [];
         if (isset($arguments[2]) && !empty($arguments[2])) {
             $args = is_array($arguments[2]) ? $arguments[2] : [$arguments[2]];
             foreach ($args as $arg) {

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -75,7 +75,7 @@ class SortOperation extends AbstractOperation
         if (isset($arguments[2]) && !empty($arguments[2])) {
             $args = is_array($arguments[2]) ? $arguments[2] : [$arguments[2]];
             foreach ($args as $arg) {
-                if (!in_array(strtoupper($arg), ['SORT_REGULAR', 'SORT_NUMERIC', 'SORT_STRING', 'SORT_LOCALE_STRING', 'SORT_NATURAL', 'SORT_FLAG_CASE'])) {
+                if (!in_array(strtoupper($arg), ['SORT_REGULAR', 'SORT_NUMERIC', 'SORT_STRING', 'SORT_LOCALE_STRING', 'SORT_NATURAL', 'SORT_FLAG_CASE'], true)) {
                     throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort option (see https://www.php.net/manual/en/function.sort)', 1591107722);
                 } else {
                     $sortOptions[] = $arg;

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -72,10 +72,16 @@ class SortOperation extends AbstractOperation
 
         // Check sort options
         $sortOptions = [];
+        $sortOptions = [];
         if (isset($arguments[2]) && !empty($arguments[2])) {
-            foreach ($arguments[2] as $arg) {
+            if (gettype($arguments[2]) == "string") {
+                $args[] = $arguments[2];
+            } else {
+                $args = $arguments[2];
+            }
+            foreach ($args as $arg) {
                 if (!in_array(strtoupper($arg), ['SORT_REGULAR', 'SORT_NUMERIC', 'SORT_STRING', 'SORT_LOCALE_STRING', 'SORT_NATURAL', 'SORT_FLAG_CASE'])) {
-                    throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort option (see https://www.php.net/manual/en/function.sort)',1591107722);
+                    throw new \Neos\Eel\FlowQuery\FlowQueryException('Please provide a valid sort option (see https://www.php.net/manual/en/function.sort)', 1591107722);
                 } else {
                     $sortOptions[] = $arg;
                 }

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -113,8 +113,9 @@ class SortOperation extends AbstractOperation
         foreach ($sortOptions as $sortOpt) {
             switch (strtoupper($sortOpt)) {
                 case 'SORT_FLAG_CASE':
-                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL))
+                    if ($sortFlags & (SORT_STRING | SORT_LOCALE_STRING | SORT_NATURAL)) {
                         $sortFlags |= SORT_FLAG_CASE;
+                    }
                     break;
                 case 'SORT_NUMERIC':
                     $sortFlags = SORT_NUMERIC;

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/Fixtures/SortableNodes.xml
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/Fixtures/SortableNodes.xml
@@ -51,6 +51,36 @@
         </variant>
       </node>
 
+      <node identifier="c381f64d-4269-429a-9c21-6d846115addc" nodeName="text-4">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
+          <dimensions/>
+          <accessRoles __type="array"/>
+          <creationDateTime __type="object" __classname="DateTime">2016-08-06T13:04:23+02:00</creationDateTime>
+          <lastModificationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:57+02:00</lastModificationDateTime>
+          <lastPublicationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:56+02:00</lastPublicationDateTime>
+          <properties>
+            <uriPathSegment __type="string">example4</uriPathSegment>
+            <title __type="string">aaaaaa</title>
+            <text __type="string">5 Füchse sind gar keine Rudeltiere!</text>
+          </properties>
+        </variant>
+      </node>
+
+      <node identifier="c381f64d-4269-429a-9c21-6d846115addb" nodeName="text-5">
+        <variant sortingIndex="400" workspace="live" nodeType="Acme.Demo:Text" version="1" removed="" hidden="" hiddenInIndex="">
+          <dimensions/>
+          <accessRoles __type="array"/>
+          <creationDateTime __type="object" __classname="DateTime">2016-08-06T13:04:23+02:00</creationDateTime>
+          <lastModificationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:57+02:00</lastModificationDateTime>
+          <lastPublicationDateTime __type="object" __classname="DateTime">2016-08-06T13:26:56+02:00</lastPublicationDateTime>
+          <properties>
+            <uriPathSegment __type="string">example5</uriPathSegment>
+            <title __type="string">mmmmmm</title>
+            <text __type="string">12 Füchse sind gar keine Rudeltiere!</text>
+          </properties>
+        </variant>
+      </node>
+
     </nodes>
   </site>
 </root>

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
@@ -208,10 +208,10 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), [])
         ];
         $correctOrder = [
-            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
-            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), [])
         ];
         $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
@@ -183,4 +183,61 @@ class SortOperationTest extends FunctionalTestCase
 
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
+
+    /**
+     * @test
+     */
+    public function invalidSortOptionCausesException()
+    {
+        $this->expectException(FlowQueryException::class);
+        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery([]);
+        $operation = new SortOperation();
+        $operation->evaluate($flowQuery, ['title', 'ASC', 'SORT_BAR']);
+    }
+
+    /**
+     * @test
+     */
+    public function sortByStringNaturalCaseAscending()
+    {
+        $nodesToSort = [
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), [])
+        ];
+        $correctOrder = [
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), [])
+        ];
+        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $operation = new SortOperation();
+        $operation->evaluate($flowQuery, ['title', 'ASC', ['SORT_NATURAL', 'SORT_FLAG_CASE']]);
+
+        self::assertEquals($correctOrder, $flowQuery->getContext());
+    }
+
+    /**
+     * @test
+     */
+    public function sortByNumericDescending()
+    {
+        $nodesToSort = [
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
+        ];
+        $correctOrder = [
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
+            $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
+        ];
+        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $operation = new SortOperation();
+        $operation->evaluate($flowQuery, ['text', 'DESC', 'SORT_NUMERIC']);
+
+        self::assertEquals($correctOrder, $flowQuery->getContext());
+    }
 }


### PR DESCRIPTION
On enabling Psmb/FlatNav I stumbled over the FlowQuery sort operation having the demand for case insensitive sort.

Here's the solution: a third optional `sort()` parameter for sortOptions.

The FlowQuery `sort()` is executed utilizing PHP `arsort()`. According to the sort flags of `arsort()` (see [https://www.php.net/manual/en/function.sort](https://www.php.net/manual/en/function.sort)) the sort options are:

```
'SORT_REGULAR'
'SORT_NUMERIC'
'SORT_STRING'
'SORT_LOCALE_STRING'
'SORT_NATURAL'
'SORT_FLAG_CASE' (use as last option with SORT_STRING, SORT_LOCALE_STRING or SORT_NATURAL)
```
A single sort option can be supplied as string. Multiple sort options are supplied as array.

Other than the above listed sort options shall throw an error.

Omitting the third parameter leaves FlowQuery `sort()` in `SORT_REGULAR` sort mode.

How to use (example for Psmb/FlatNav) in `Settings.yaml`:
```
      frontendConfiguration:
        Psmb_FlatNav:
          presets:
            tree:
              type: tree
              label: tree
              icon: tree
            pressTags:
              label: 'Press Tags'
              icon: icon-hashtag
              type: flat
              query: 'q(node).find("[instanceof My.Site:Document.PressTag]").sort("title", "ASC", ["SORT_NATURAL", "SORT_FLAG_CASE"]).get()'
              ...
            numberTags:
              label: 'Number Tags'
              icon: arrow-circle-up
              type: flat
              query: 'q(node).find("[instanceof My.Site:Document.NumberTag]").sort("title", "ASC", "SORT_NUMERIC").get()'
              ...
```
In the line `query:` of `pressTags:` you can see FlowQuery `sort()`in action:
```
    sort("title", "ASC", ["SORT_NATURAL", "SORT_FLAG_CASE"])
```
with sort flags `["SORT_NATURAL", "SORT_FLAG_CASE"]` passed as array for natural, case insensitive sort.

The line `query:`of `numberTags:` has a single sort option `"SORT_NUMERIC"` passed as string:
```
    sort("title", "ASC", "SORT_NUMERIC")
```
