### PR TITLE
BUGFIX: pass copied node to emitAfterNodeCopy signal

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -794,7 +794,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
     {
         $this->emitBeforeNodeCopy($this, $referenceNode);
         $copiedNode = $this->copyIntoInternal($referenceNode, $nodeName, $this->getNodeType()->isAggregate());
-        $this->emitAfterNodeCopy($this, $referenceNode);
+        $this->emitAfterNodeCopy($copiedNode, $referenceNode);
 
         return $copiedNode;
     }


### PR DESCRIPTION
Pass copied node instead of current node instance to `emitAfterNodeCopy` signal.

This fixes #2994 