### PR TITLE
BUGFIX: Fix path to Styles/<Lite.css>

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -7,7 +7,7 @@
 	<link
 		rel="stylesheet"
 		type="text/css"
-		href="{f:uri.resource(package: 'Neos.Neos', path: '/Styles/{f:if(condition: moduleConfiguration.mainStylesheet, then: moduleConfiguration.mainStylesheet, else: settings.moduleConfiguration.mainStylesheet)}')}.css?bust={neos:backend.cssBuiltVersion()}"
+		href="{f:uri.resource(package: 'Neos.Neos', path: 'Styles/{f:if(condition: moduleConfiguration.mainStylesheet, then: moduleConfiguration.mainStylesheet, else: settings.moduleConfiguration.mainStylesheet)}')}.css?bust={neos:backend.cssBuiltVersion()}"
 	/>
 
 	<f:if condition="{moduleConfiguration.additionalResources.styleSheets}">


### PR DESCRIPTION
**What I did**
Remove the `/` in front of the Path for the resource.

**How to verify it**
Open Neos backend, e.g. User Manager and inspect the path in the HTML head for Lite.css

Closes #2996