### PR TITLE
BUGFIX: Make child nodes of hidden parents inaccessible

### DIFF
--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -579,7 +579,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     {
         $contextProperties = [
             'workspaceName' => $workspaceName,
-            'invisibleContentShown' => true,
+            'invisibleContentShown' => ($workspaceName !== 'live'),
             'inaccessibleContentShown' => ($workspaceName !== 'live'),
             'dimensions' => $dimensionsAndDimensionValues
         ];


### PR DESCRIPTION
Since a couple of months child nodes of hidden nodes are accessible (outside the Neos backend). This change restores the initial behavior and makes sure that accessing child nodes from hidden nodes will lead to a 404 response.

resolves: https://github.com/neos/neos-development-collection/issues/2983
