### PR TITLE
TASK: Update code documentation for TraversableNodeInterface

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
@@ -384,6 +384,10 @@ interface NodeInterface
      *
      * @return NodeInterface The parent node or NULL if this is the root node
      * @deprecated with version 4.3, use findParentNode() instead.
+     *  Beware that findParentNode() is not fully equivalent to this method.
+     *  It has a different root node handling:
+     *    - findParentNode() throws an exception for the root node
+     *    - getParent() returns <code>null</code> for the root node
      */
     public function getParent();
 

--- a/Neos.ContentRepository/Classes/Domain/Projection/Content/TraversableNodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Projection/Content/TraversableNodeInterface.php
@@ -53,9 +53,9 @@ interface TraversableNodeInterface extends NodeInterface
 
     /**
      * Retrieves and returns the parent node from the node's subgraph.
-     * Returns null if this is a root node.
+     * If no parent node is present, an {@link NodeException} is thrown.
      *
-     * @return TraversableNodeInterface
+     * @return TraversableNodeInterface the parent node, never <code>null</code>
      * @throws NodeException If this node has no parent (i.e. is the root)
      */
     public function findParentNode(): TraversableNodeInterface;


### PR DESCRIPTION
Also improves deprecation warning for NodeInterface#getParent

1. The NodeInterface#getParent method is not fully equivalent to its deprecation replacement TraversableNodeInterface#findParentNode -> it should be at least mentioned on the deprecation waring, that those behaviors differ from each other
2. The comment on findParentNode was telling "two truths" about root node handling