### PR TITLE
BUGFIX: Variants tab does not use mainRequest in form when opened from inspector

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -436,7 +436,8 @@ class AssetController extends ActionController
                 'imageProfiles' => $this->imageProfilesConfiguration,
                 'overviewAction' => $overviewAction,
                 'originalInformation' => (new ImageMapper($asset))->getMappingResult(),
-                'variantsInformation' => $variantInformation
+                'variantsInformation' => $variantInformation,
+                'useParentRequest' => !$this->request->isMainRequest()
             ]);
         } catch (AssetNotFoundExceptionInterface | AssetSourceConnectionExceptionInterface $e) {
             $this->view->assign('connectionError', $e);

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -437,7 +437,7 @@ class AssetController extends ActionController
                 'overviewAction' => $overviewAction,
                 'originalInformation' => (new ImageMapper($asset))->getMappingResult(),
                 'variantsInformation' => $variantInformation,
-                'useParentRequest' => !$this->request->isMainRequest()
+                'isSubRequest' => !$this->request->isMainRequest()
             ]);
         } catch (AssetNotFoundExceptionInterface | AssetSourceConnectionExceptionInterface $e) {
             $this->view->assign('connectionError', $e);

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
@@ -21,7 +21,7 @@
         <script id="variants-information" type="application/json">{variantsInformation -> f:format.json() -> f:format.raw()}</script>
         <script id="original-information" type="application/json">{originalInformation -> f:format.json() -> f:format.raw()}</script>
     </div>
-    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="true"></f:form>
+    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="{useParentRequest}"></f:form>
 </f:section>
 
 <f:section name="Scripts">

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
@@ -21,7 +21,7 @@
         <script id="variants-information" type="application/json">{variantsInformation -> f:format.json() -> f:format.raw()}</script>
         <script id="original-information" type="application/json">{originalInformation -> f:format.json() -> f:format.raw()}</script>
     </div>
-    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="{useParentRequest}"></f:form>
+    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="{isSubRequest}"></f:form>
 </f:section>
 
 <f:section name="Scripts">


### PR DESCRIPTION
This adds a condition for using the parentRequest only if it is not the mainRequest already.

Fixes #3005