### PR TITLE
FEATURE: Make login controller view configurable using Views.yaml

### DIFF
--- a/Neos.Neos/Classes/Controller/LoginController.php
+++ b/Neos.Neos/Classes/Controller/LoginController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Controller;
 
 /*
@@ -19,7 +20,6 @@ use Neos\Flow\Http\Cookie;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
 use Neos\Flow\Mvc\View\JsonView;
-use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Session\SessionInterface;
@@ -229,7 +229,7 @@ class LoginController extends AbstractAuthenticationController
         switch ($this->request->getFormat()) {
             case 'json':
                 $this->view->assign('value', ['success' => true]);
-            break;
+                break;
             default:
                 if ($possibleRedirectionUri !== null) {
                     $this->redirectToUri($possibleRedirectionUri);

--- a/Neos.Neos/Classes/Controller/LoginController.php
+++ b/Neos.Neos/Classes/Controller/LoginController.php
@@ -260,17 +260,4 @@ class LoginController extends AbstractAuthenticationController
         $sessionCookie = new Cookie($this->sessionName, $sessionIdentifier);
         $this->response->setCookie($sessionCookie);
     }
-
-    /**
-     * Simply sets the Fusion path pattern on the view.
-     *
-     * @param ViewInterface $view
-     * @return void
-     */
-    protected function initializeView(ViewInterface $view)
-    {
-        parent::initializeView($view);
-        /** @var FusionView $view */
-        $view->setFusionPathPattern('resource://Neos.Neos/Private/Fusion/Backend');
-    }
 }

--- a/Neos.Neos/Configuration/Views.yaml
+++ b/Neos.Neos/Configuration/Views.yaml
@@ -1,0 +1,6 @@
+-
+  requestFilter: 'isPackage("Neos.Neos") && isController("Login") && isAction("index") && isFormat("html")'
+  viewObjectName: 'Neos\Fusion\View\FusionView'
+  options:
+    fusionPathPatterns:
+      - 'resource://Neos.Neos/Private/Fusion/Backend'


### PR DESCRIPTION
The login controller view was not configurable using a `Views.yaml` (as was the case for Neos 3 & 4.)
This is fixed by adding a `Views.yaml` and removing `initializeView()` from `LoginController`.

Now the Login screen can be customized again by creating custom Fusion for rendering it (see
`Neos.Neos/Resources/Private/Fusion/Backend` for inspiration) and adjusting the path used
through `Views.yaml`, e.g.

    -
      requestFilter: 'isPackage("Neos.Neos") && isController("Login") && isAction("index") && isFormat("html")'
      options:
        fusionPathPatterns:
          - 'resource://Acme.Com/Private/Fusion/NeosLogin'

Resolves: #3041