### PR TITLE
PHP 7.4 compatibility: Remove curly brace string offset access

### DIFF
--- a/Neos.Diff/Classes/Renderer/Html/HtmlArrayRenderer.php
+++ b/Neos.Diff/Classes/Renderer/Html/HtmlArrayRenderer.php
@@ -124,7 +124,7 @@ class HtmlArrayRenderer extends AbstractRenderer
     {
         $start = 0;
         $limit = min(strlen($fromLine), strlen($toLine));
-        while ($start < $limit && $fromLine{$start} == $toLine{$start}) {
+        while ($start < $limit && $fromLine[$start] == $toLine[$start]) {
             ++$start;
         }
         $end = -1;


### PR DESCRIPTION
**What I did**
I changed string offset access from curly-braces to brackets
