### PR TITLE
FEATURE: Configurable Asset Constraints

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
@@ -15,8 +15,11 @@ namespace Neos\Media\Browser\Controller;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Mvc\Exception\StopActionException;
+use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Media\Browser\Domain\Session\BrowserState;
 use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Model\Dto\AssetConstraints;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\TagRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
@@ -54,6 +57,12 @@ class AssetCollectionController extends ActionController
      */
     protected $tagRepository;
 
+    protected function initializeView(ViewInterface $view)
+    {
+        $view->assign('constraints', $this->request->hasArgument('constraints') ? AssetConstraints::fromArray($this->request->getArgument('constraints')) : AssetConstraints::create());
+        parent::initializeView($view);
+    }
+
     /**
      * @param string $title
      * @return void
@@ -64,7 +73,7 @@ class AssetCollectionController extends ActionController
     {
         $this->assetCollectionRepository->add(new AssetCollection($title));
         $this->addFlashMessage('collectionHasBeenCreated', '', Message::SEVERITY_OK, [htmlspecialchars($title)]);
-        $this->redirect('index', 'Asset', 'Neos.Media.Browser');
+        $this->redirectToAssetIndex();
     }
 
     /**
@@ -87,7 +96,7 @@ class AssetCollectionController extends ActionController
     {
         $this->assetCollectionRepository->update($assetCollection);
         $this->addFlashMessage('collectionHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($assetCollection->getTitle())]);
-        $this->redirect('index', 'Asset', 'Neos.Media.Browser');
+        $this->redirectToAssetIndex();
     }
 
     /**
@@ -106,6 +115,20 @@ class AssetCollectionController extends ActionController
         }
         $this->assetCollectionRepository->remove($assetCollection);
         $this->addFlashMessage('collectionHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars($assetCollection->getTitle())]);
-        $this->redirect('index', 'Asset', 'Neos.Media.Browser');
+        $this->redirectToAssetIndex();
+    }
+
+    /**
+     * Overridden redirect method that points to the "index" action of the "Asset" controller and adds constraints arguments from the current request
+     *
+     * @param array $arguments
+     * @throws StopActionException
+     */
+    private function redirectToAssetIndex(array $arguments = []): void
+    {
+        if (!isset($arguments['constraints']) && $this->request->hasArgument('constraints')) {
+            $arguments['constraints'] = $this->request->getArgument('constraints');
+        }
+        $this->redirect('index', 'Asset', 'Neos.Media.Browser', $arguments);
     }
 }

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -957,7 +957,7 @@ class AssetController extends ActionController
     }
 
     /**
-     * Overridden redirect method that adds "constraints" arguments from the current request
+     * Custom redirect method that adds "constraints" arguments from the current request
      *
      * @param array $arguments
      * @throws StopActionException | NoSuchArgumentException
@@ -971,7 +971,7 @@ class AssetController extends ActionController
     }
 
     /**
-     * Overridden forward method that adds "constraints" arguments from the current request
+     * Custom forward method that adds "constraints" arguments from the current request
      *
      * @param string $actionName
      * @param string $controllerName

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -38,12 +38,12 @@ use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyRepositoryInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceConnectionExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
-use Neos\Media\Domain\Model\AssetSource\AssetTypeFilter;
 use Neos\Media\Domain\Model\AssetSource\Neos\NeosAssetProxy;
 use Neos\Media\Domain\Model\AssetSource\SupportsCollectionsInterface;
 use Neos\Media\Domain\Model\AssetSource\SupportsSortingInterface;
 use Neos\Media\Domain\Model\AssetSource\SupportsTaggingInterface;
 use Neos\Media\Domain\Model\AssetVariantInterface;
+use Neos\Media\Domain\Model\Dto\AssetConstraints;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Model\VariantSupportInterface;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
@@ -152,6 +152,11 @@ class AssetController extends ActionController
     protected $imageProfilesConfiguration;
 
     /**
+     * @var AssetConstraints
+     */
+    private $assetConstraints;
+
+    /**
      * @return void
      */
     public function initializeObject(): void
@@ -168,6 +173,21 @@ class AssetController extends ActionController
     }
 
     /**
+     * @throws NoSuchArgumentException
+     */
+    protected function initializeAction(): void
+    {
+        parent::initializeAction();
+
+        if ($this->request->hasArgument('constraints')) {
+            $this->assetConstraints = AssetConstraints::fromArray($this->request->getArgument('constraints'));
+        } else {
+            $this->assetConstraints = AssetConstraints::create();
+        }
+        $this->assetSources = $this->assetConstraints->applyToAssetSources($this->assetSources);
+    }
+
+    /**
      * Set common variables on the view
      *
      * @param ViewInterface $view
@@ -179,11 +199,13 @@ class AssetController extends ActionController
             'view' => $this->browserState->get('view'),
             'sortBy' => $this->browserState->get('sortBy'),
             'sortDirection' => $this->browserState->get('sortDirection'),
-            'filter' => $this->browserState->get('filter'),
+            'filter' => (string)$this->assetConstraints->applyToAssetTypeFilter($this->browserState->get('filter')),
+            'filterOptions' => $this->assetConstraints->getAllowedAssetTypeFilterOptions(),
             'activeTag' => $this->browserState->get('activeTag'),
             'activeAssetCollection' => $this->browserState->get('activeAssetCollection'),
             'assetSources' => $this->assetSources,
-            'variantsTabFeatureEnabled' => $this->settings['features']['variantsTab']['enable']
+            'variantsTabFeatureEnabled' => $this->settings['features']['variantsTab']['enable'],
+            'constraints' => $this->assetConstraints,
         ]);
     }
 
@@ -205,6 +227,8 @@ class AssetController extends ActionController
      */
     public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
+        $assetSourceIdentifier = $this->assetConstraints->applyToAssetSourceIdentifiers($assetSourceIdentifier);
+
         // First, apply all options given to indexAction() and save them in the BrowserState object.
         // Note that the order of these apply*() method calls plays a role, because they may depend on previous results:
         $this->applyActiveAssetSourceToBrowserState($assetSourceIdentifier);
@@ -466,7 +490,7 @@ class AssetController extends ActionController
     {
         $this->assetRepository->update($asset);
         $this->addFlashMessage('assetHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
-        $this->redirect('index');
+        $this->redirectToIndex();
     }
 
     /**
@@ -497,7 +521,7 @@ class AssetController extends ActionController
             $this->assetRepository->add($asset);
         }
         $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
-        $this->redirect('index');
+        $this->redirectToIndex();
     }
 
     /**
@@ -594,12 +618,12 @@ class AssetController extends ActionController
         $usageReferences = $this->assetService->getUsageReferences($asset);
         if (count($usageReferences) > 0) {
             $this->addFlashMessage('deleteRelatedNodes', '', Message::SEVERITY_WARNING, [], 1412422767);
-            $this->redirect('index');
+            $this->redirectToIndex();
         }
 
         $this->assetRepository->remove($asset);
         $this->addFlashMessage('assetHasBeenDeleted', '', Message::SEVERITY_OK, [$asset->getLabel()], 1412375050);
-        $this->redirect('index');
+        $this->redirectToIndex();
     }
 
     /**
@@ -626,7 +650,7 @@ class AssetController extends ActionController
                 [$sourceMediaType['type'], $resource->getMediaType()],
                 1462308179
             );
-            $this->redirect('index');
+            $this->redirectToIndex();
         }
 
         try {
@@ -639,7 +663,7 @@ class AssetController extends ActionController
 
         $assetLabel = (method_exists($asset, 'getLabel') ? $asset->getLabel() : $resource->getFilename());
         $this->addFlashMessage('assetHasBeenReplaced', '', Message::SEVERITY_OK, [htmlspecialchars($assetLabel)]);
-        $this->redirect('index');
+        $this->redirectToIndex();
     }
 
     /**
@@ -651,7 +675,7 @@ class AssetController extends ActionController
      */
     public function relatedNodesAction(AssetInterface $asset): void
     {
-        $this->forward('relatedNodes', 'Usage', 'Neos.Media.Browser', ['asset' => $asset]);
+        $this->forwardWithConstraints('relatedNodes', 'Usage', ['asset' => $asset]);
     }
 
     /**
@@ -663,7 +687,7 @@ class AssetController extends ActionController
      */
     public function createTagAction(string $label): void
     {
-        $this->forward('create', 'Tag', 'Neos.Media.Browser', ['label' => $label]);
+        $this->forwardWithConstraints('create', 'Tag', ['label' => $label]);
     }
 
     /**
@@ -673,7 +697,7 @@ class AssetController extends ActionController
      */
     public function editTagAction(Tag $tag): void
     {
-        $this->forward('edit', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
+        $this->forwardWithConstraints('edit', 'Tag', ['tag' => $tag]);
     }
 
     /**
@@ -683,7 +707,7 @@ class AssetController extends ActionController
      */
     public function updateTagAction(Tag $tag): void
     {
-        $this->forward('update', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
+        $this->forwardWithConstraints('update', 'Tag', ['tag' => $tag]);
     }
 
     /**
@@ -693,7 +717,7 @@ class AssetController extends ActionController
      */
     public function deleteTagAction(Tag $tag): void
     {
-        $this->forward('delete', 'Tag', 'Neos.Media.Browser', ['tag' => $tag]);
+        $this->forwardWithConstraints('delete', 'Tag', ['tag' => $tag]);
     }
 
     /**
@@ -705,7 +729,7 @@ class AssetController extends ActionController
      */
     public function createAssetCollectionAction($title): void
     {
-        $this->forward('create', 'AssetCollection', 'Neos.Media.Browser', ['title' => $title]);
+        $this->forwardWithConstraints('create', 'AssetCollection', ['title' => $title]);
     }
 
     /**
@@ -715,7 +739,7 @@ class AssetController extends ActionController
      */
     public function editAssetCollectionAction(AssetCollection $assetCollection): void
     {
-        $this->forward('edit', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
+        $this->forwardWithConstraints('edit', 'AssetCollection', ['assetCollection' => $assetCollection]);
     }
 
     /**
@@ -725,7 +749,7 @@ class AssetController extends ActionController
      */
     public function updateAssetCollectionAction(AssetCollection $assetCollection): void
     {
-        $this->forward('update', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
+        $this->forwardWithConstraints('update', 'AssetCollection', ['assetCollection' => $assetCollection]);
     }
 
     /**
@@ -735,7 +759,7 @@ class AssetController extends ActionController
      */
     public function deleteAssetCollectionAction(AssetCollection $assetCollection): void
     {
-        $this->forward('delete', 'AssetCollection', 'Neos.Media.Browser', ['assetCollection' => $assetCollection]);
+        $this->forwardWithConstraints('delete', 'AssetCollection', ['assetCollection' => $assetCollection]);
     }
 
     /**
@@ -804,9 +828,10 @@ class AssetController extends ActionController
             $this->browserState->set('filter', $filter);
         }
 
-        foreach (['view', 'sortBy', 'sortDirection', 'filter'] as $optionName) {
+        foreach (['view', 'sortBy', 'sortDirection'] as $optionName) {
             $this->view->assign($optionName, $this->browserState->get($optionName));
         }
+        $this->view->assign('filter', (string)$this->assetConstraints->applyToAssetTypeFilter($this->browserState->get('filter')));
     }
 
     /**
@@ -918,7 +943,7 @@ class AssetController extends ActionController
      */
     private function applyAssetTypeFilterFromBrowserState(AssetProxyRepositoryInterface $assetProxyRepository): void
     {
-        $assetProxyRepository->filterByType(new AssetTypeFilter($this->browserState->get('filter')));
+        $assetProxyRepository->filterByType($this->assetConstraints->applyToAssetTypeFilter($this->browserState->get('filter')));
     }
 
     /**
@@ -929,5 +954,35 @@ class AssetController extends ActionController
         if ($assetProxyRepository instanceof SupportsCollectionsInterface) {
             $assetProxyRepository->filterByCollection($this->getActiveAssetCollectionFromBrowserState());
         }
+    }
+
+    /**
+     * Overridden redirect method that adds "constraints" arguments from the current request
+     *
+     * @param array $arguments
+     * @throws StopActionException | NoSuchArgumentException
+     */
+    private function redirectToIndex(array $arguments = []): void
+    {
+        if (!isset($arguments['constraints']) && $this->request->hasArgument('constraints')) {
+            $arguments['constraints'] = $this->request->getArgument('constraints');
+        }
+        $this->redirect('index', null, null, $arguments);
+    }
+
+    /**
+     * Overridden forward method that adds "constraints" arguments from the current request
+     *
+     * @param string $actionName
+     * @param string $controllerName
+     * @param array $arguments
+     * @throws ForwardException | NoSuchArgumentException
+     */
+    private function forwardWithConstraints(string $actionName, string $controllerName, array $arguments = []): void
+    {
+        if (!isset($arguments['constraints']) && $this->request->hasArgument('constraints')) {
+            $arguments['constraints'] = $this->request->getArgument('constraints');
+        }
+        $this->forward($actionName, $controllerName, null, $arguments);
     }
 }

--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -12,7 +12,6 @@ namespace Neos\Media\Browser\Controller;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceAwareInterface;

--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -14,6 +14,7 @@ namespace Neos\Media\Browser\Controller;
 use Neos\Flow\Annotations as Flow;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceAwareInterface;
 use Neos\Media\Domain\Model\ImportedAsset;
 use Neos\Media\Domain\Model\Tag;
@@ -54,19 +55,19 @@ class ImageController extends AssetController
      */
     public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
-        $this->view->assign('disableFilter', true);
+        $this->view->assign('filterOptions', []);
         parent::indexAction($view, $sortBy, $sortDirection, 'Image', $tagMode, $tag, $searchTerm, $collectionMode, $assetCollection, $assetSourceIdentifier);
     }
 
     /**
      * @param string $assetSourceIdentifier
      * @param string $assetProxyIdentifier
-     * @param Asset $asset
+     * @param AssetInterface $asset
      * @return void
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
-    public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, Asset $asset = null): void
+    public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, AssetInterface $asset = null): void
     {
         if ($assetSourceIdentifier !== null && $assetProxyIdentifier !== null) {
             parent::editAction($assetSourceIdentifier, $assetProxyIdentifier);

--- a/Neos.Media.Browser/Resources/Private/Partials/ConstraintsHiddenFields.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ConstraintsHiddenFields.html
@@ -1,0 +1,6 @@
+<f:for each="{constraints.allowedAssetSourceIdentifiers}" as="assetSourceIdentifier" iteration="iteration">
+    <f:form.hidden name="constraints[assetSources][{iteration.index}]" value="{assetSourceIdentifier}" />
+</f:for>
+<f:for each="{constraints.allowedMediaTypes}" as="mediaType" iteration="iteration">
+    <f:form.hidden name="constraints[mediaTypes][{iteration.index}]" value="{mediaType}" />
+</f:for>

--- a/Neos.Media.Browser/Resources/Private/Partials/ListView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ListView.html
@@ -123,13 +123,13 @@
                                     <f:if condition="!{activeAssetSource.readOnly}">
                                         <f:then>
                                             <li>
-                                                <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-edit icon-white"></i> {editLabel}
                                                 </f:link.action>
                                             </li>
                                             <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
                                                 <li>
-                                                    <f:link.action action="replaceAssetResource" arguments="{assetSourceIdentifier: activeAssetSource.identifier, asset: assetProxy.asset}" data="{asset-identifier: '{assetProxy.identifier}'}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                    <f:link.action action="replaceAssetResource" arguments="{assetSourceIdentifier: activeAssetSource.identifier, asset: assetProxy.asset}" addQueryString="true" title="{replaceAssetResourceLabel}" data="{asset-identifier: '{assetProxy.identifier}', neos-toggle: 'tooltip', placement: 'left'}">
                                                         <i class="fas fa-random icon-white"></i> {replaceAssetResourceLabel}
                                                     </f:link.action>
                                                 </li>
@@ -142,7 +142,7 @@
                                         </f:then>
                                         <f:else>
                                             <li>
-                                                <f:link.action action="show" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{viewAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="show" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true" title="{viewAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-eye icon-white"></i> {viewLabel}
                                                 </f:link.action>
                                             </li>

--- a/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ThumbnailView.html
@@ -15,7 +15,7 @@
                 <li class="asset">
                     <f:if condition="!{activeAssetSource.readOnly}">
                         <f:then>
-                            <f:link.action action="edit" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
+                            <f:link.action action="edit" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container draggable-asset {f:if(condition: '{assetProxy.asset.tags -> f:count()} === 0', then: ' neos-media-untagged')}">
                                     <f:if condition="{assetProxy.thumbnailUri}">
                                         <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
@@ -25,7 +25,7 @@
                             </f:link.action>
                         </f:then>
                         <f:else>
-                            <f:link.action action="show" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
+                            <f:link.action action="show" class="neos-thumbnail" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true" data="{asset-identifier: '{assetProxy.identifier}', local-asset-identifier: '{assetProxy.localAssetIdentifier}', asset-source-identifier: '{assetProxy.assetSource.identifier}'}">
                                 <div class="neos-img-container">
                                     <f:if condition="{assetProxy.thumbnailUri}">
                                         <f:then><img src="{assetProxy.thumbnailUri}" alt="" width="250" height="250"/></f:then>
@@ -45,13 +45,13 @@
                                 <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
                                     <ul>
                                         <li>
-                                            <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                            <f:link.action action="edit" arguments="{assetSourceIdentifier: activeAssetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true" title="{editAssetLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                 <i class="fas fa-edit icon-white"></i> {editLabel}
                                             </f:link.action>
                                         </li>
                                         <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
                                             <li>
-                                                <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" title="{replaceAssetResourceLabel}" data="{neos-toggle: 'tooltip', placement: 'left'}">
+                                                <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" title="{replaceAssetResourceLabel}" addQueryString="true" data="{neos-toggle: 'tooltip', placement: 'left'}">
                                                     <i class="fas fa-random icon-white"></i> {replaceLabel}
                                                 </f:link.action>
                                             </li>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -18,7 +18,7 @@
                     <a href="#" role="tab">Overview</a>
                 </li>
                 <li role="presentation">
-                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'edit'}">Variants</f:link.action>
+                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'edit'}" addQueryString="true">Variants</f:link.action>
                 </li>
             </ul>
             </f:if>
@@ -111,7 +111,7 @@
                                         </tbody>
                                     </table>
                                     <f:if condition="{assetProxy.asset.inUse}">
-                                        <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset}" class="neos-button">
+                                        <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset}" addQueryString="true" class="neos-button">
                                             {neos:backend.translate(id: 'relatedNodes', quantity: '{assetProxy.asset.usageCount}', arguments: {0: assetProxy.asset.usageCount}, package: 'Neos.Media.Browser')}
                                         </f:link.action>
                                     </f:if>
@@ -122,10 +122,10 @@
                             </div>
                         </div>
                         <div class="neos-footer">
-                            <f:link.action action="index" class="neos-button neos-action-cancel">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+                            <f:link.action action="index" addQueryString="true" class="neos-button neos-action-cancel">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
                             <f:if condition="!{assetSource.readOnly}">
                                 <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ReplaceAssetResource">
-                                    <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" class="neos-button" title="{neos:backend.translate(id: 'replaceAssetResource', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', container: 'body'}">
+                                    <f:link.action action="replaceAssetResource" arguments="{asset: assetProxy.asset}" addQueryString="true" class="neos-button" title="{neos:backend.translate(id: 'replaceAssetResource', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', container: 'body'}">
                                         {neos:backend.translate(id: 'replaceAssetResource', package: 'Neos.Media.Browser')}
                                     </f:link.action>
                                 </f:security.ifAccess>
@@ -159,7 +159,7 @@
                                     </div>
                                     <div class="neos-modal-footer">
                                         <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                                        <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'delete', arguments: {asset: assetProxy.asset})}" class="neos-button neos-button-mini neos-button-danger">
+                                        <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'delete', arguments: {asset: assetProxy.asset}, addQueryString: true)}" class="neos-button neos-button-mini neos-button-danger">
                                             {neos:backend.translate(id: 'message.confirmDelete', package: 'Neos.Media.Browser')}
                                         </button>
                                     </div>
@@ -167,8 +167,11 @@
                             </div>
                             <div class="neos-modal-backdrop neos-in"></div>
                         </div>
+                        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
                     </f:form>
-                    <f:form action="index" id="postHelper" method="post"></f:form>
+                    <f:form action="index" id="postHelper" method="post">
+                        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+                    </f:form>
                 </div>
             </div>
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -10,37 +10,25 @@
             <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: {0: searchTerm}, package: 'Neos.Media.Browser')}</f:if>
         </span>
         <f:if condition="!{activeAssetSource.readOnly}">
-        <f:link.action action="new"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
+        <f:link.action action="new" addQueryString="true"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
         </f:if>
     </div>
     <div class="neos-view-options">
-        <f:if condition="{disableFilter}">
-            <f:else>
-                <div class="neos-dropdown" id="neos-filter-menu">
+        <f:if condition="{filterOptions}">
+            <div class="neos-dropdown" id="neos-filter-menu">
                 <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
                     <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#" data-neos-toggle="dropdown" data-target="#neos-filter-menu">
                         <i class="fas fa-filter"></i>
                     </a>
                 </span>
-                    <ul class="neos-dropdown-menu neos-pull-right" role="menu">
+                <ul class="neos-dropdown-menu neos-pull-right" role="menu">
+                    <f:for each="{filterOptions}" as="filterValue">
                         <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action>
+                            <f:render section="FilterLink.{filterValue}" />
                         </li>
-                        <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action>
-                        </li>
-                        <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action>
-                        </li>
-                        <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action>
-                        </li>
-                        <li>
-                            <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="TRUE" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action>
-                        </li>
-                    </ul>
-                </div>
-            </f:else>
+                    </f:for>
+                </ul>
+            </div>
         </f:if>
         <f:if condition="{activeAssetSourceSupportsSorting}">
             <f:then>
@@ -61,19 +49,19 @@
                 <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
                 <ul>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="TRUE" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                 </ul>
                 <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
                 <ul>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                     <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="TRUE" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
                     </li>
                 </ul>
             </div>
@@ -82,29 +70,29 @@
         </f:if>
         <f:if condition="{view} === 'Thumbnail'">
             <f:then>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
             </f:then>
             <f:else>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail'}" addQueryString="TRUE" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
             </f:else>
         </f:if>
     </div>
 </f:section>
 
 <f:section name="Sidebar">
-    <form action="{f:uri.action(action: 'index')}" method="get" class="neos-search">
+    <f:form action="index" addQueryString="true" method="get" class="neos-search">
         <button type="submit" class="neos-button" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
         <div>
             <input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}" value="{searchTerm}"{f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')} />
         </div>
-    </form>
+    </f:form>
     <f:if condition="{assetSources -> f:count()} > 1">
     <div class="neos-media-aside-group">
         <h2>{neos:backend.translate(id: 'mediaSources', package: 'Neos.Media.Browser')}</h2>
         <ul class="neos-media-aside-list">
             <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
                 <li>
-                    <f:link.action action="index" title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier}">
+                    <f:link.action action="index" title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier}" addQueryString="true">
                       <f:if condition="{assetSource.iconUri}"><img class="neos-media-assetsource-icon" src="{assetSource.iconUri}" /></f:if>
 											{assetSource.label}
                     </f:link.action>
@@ -131,19 +119,19 @@
             <f:if condition="{assetCollections -> f:count()}">
             <ul class="neos-media-aside-list">
                 <li>
-                    <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}">
+                    <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}" addQueryString="true">
                         {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
                         <span class="count">{allCollectionsCount}</span>
                     </f:link.action>
                 </li>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
-                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
                             {assetCollection.object.title}
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <div class="neos-sidelist-edit-actions">
-                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" addQueryString="true" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                             <button type="submit" class="neos-button neos-button-danger" data-modal="delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-label="{assetCollection.object.title}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                         </div>
                     </li>
@@ -166,11 +154,12 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteAssetCollection" class="neos-inline">
+                            <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
                                 <f:form.hidden name="assetCollection" id="modal-form-object" />
                                 <button type="submit" class="neos-button neos-button-danger">
                                     {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                                 </button>
+                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
                             </f:form>
                         </div>
                     </div>
@@ -179,9 +168,10 @@
             </div>
         </f:if>
         <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
-            <f:form action="createAssetCollection" id="neos-assetcollections-create-form">
+            <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
                 <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
                 <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
+                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
             </f:form>
         </f:security.ifAccess>
         </f:if>
@@ -195,25 +185,25 @@
         </h2>
         <ul class="neos-media-aside-list">
             <li class="neos-media-list-all">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}">
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}" addQueryString="true">
                     {neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
                     <span class="count">{allCount}</span>
                 </f:link.action>
             </li>
             <li class="neos-media-list-untagged">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}">
+                <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}" addQueryString="true">
                     {neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
                     <span class="count">{untaggedCount}</span>
                 </f:link.action>
             </li>
             <f:for each="{tags}" as="tag">
                 <li>
-                    <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+                    <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object}" addQueryString="true" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
                         {tag.object.label}
                         <span class="count">{tag.count}</span>
                     </f:link.action>
                     <div class="neos-sidelist-edit-actions">
-                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" addQueryString="true" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
                         <button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-modal="delete-tag-modal" data-object-identifier="{tag.object -> f:format.identifier()}" data-label="{tag.object.label}"><i class="fas fa-trash"></i></button>
                     </div>
                 </li>
@@ -235,11 +225,12 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteTag" class="neos-inline">
+                            <f:form action="deleteTag" addQueryString="true" class="neos-inline">
                                 <f:form.hidden name="tag" id="modal-form-object" />
                                 <button type="submit" class="neos-button neos-button-danger">
                                     {neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}
                                 </button>
+                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
                             </f:form>
                         </div>
                     </div>
@@ -247,9 +238,10 @@
                 <div class="neos-modal-backdrop neos-in"></div>
             </div>
         </ul>
-        <f:form action="createTag" id="neos-tags-create-form">
+        <f:form action="createTag" addQueryString="true" id="neos-tags-create-form">
             <f:form.textfield name="label" placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}" /><br /><br />
             <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createTag', package: 'Neos.Media.Browser')}</button>
+            <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
         </f:form>
     </div>
     </f:if>
@@ -259,8 +251,9 @@
     <f:if condition="!{activeAssetSource.readOnly}">
     <div id="dropzone" class="neos-upload-area">
         <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
-        <f:form method="post" action="create" object="{asset}" objectName="asset" enctype="multipart/form-data">
-            <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}" />
+        <f:form method="post" action="create" addQueryString="true" object="{asset}" objectName="asset" enctype="multipart/form-data">
+            <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}" />
+            <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
         </f:form>
     </div>
     <div id="uploader">
@@ -299,11 +292,12 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="delete" method="post" class="neos-inline">
+                            <f:form action="delete" addQueryString="true" method="post" class="neos-inline">
                                 <f:form.hidden name="asset" id="modal-form-object" />
                                 <button type="submit" class="neos-button neos-button-mini neos-button-danger">
                                     {neos:backend.translate(id: 'message.confirmDelete', package: 'Neos.Media.Browser')}
                                 </button>
+                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
                             </f:form>
                         </div>
                     </div>
@@ -323,18 +317,18 @@
     <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/jquery-ui/js/jquery-ui-1.10.3.custom.js')}"></script>
     <f:if condition="!{activeAssetSource.readOnly}">
     <script type="text/javascript">
-        var uploadUrl = "{f:uri.action(action: 'upload', additionalParams: {__csrfToken: '{f:security.csrfToken()}'}, absolute: true) -> f:format.raw()}";
+        var uploadUrl = "{f:uri.action(action: 'upload', addQueryString: true, additionalParams: {__csrfToken: '{f:security.csrfToken()}'}, absolute: true) -> f:format.raw()}";
         var maximumFileUploadSize = {maximumFileUploadSize};
 
         if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail) {
             window.parent.NeosMediaBrowserCallbacks.refreshThumbnail();
         }
     </script>
-    <f:form action="tagAsset" id="tag-asset-form" format="json">
+    <f:form action="tagAsset" addQueryString="true" id="tag-asset-form" format="json">
         <f:form.hidden name="asset[__identity]" id="tag-asset-form-asset" />
         <f:form.hidden name="tag[__identity]" id="tag-asset-form-tag" />
     </f:form>
-    <f:form action="addAssetToCollection" id="link-asset-to-assetcollection-form" format="json">
+    <f:form action="addAssetToCollection" addQueryString="true" id="link-asset-to-assetcollection-form" format="json">
         <f:form.hidden name="asset[__identity]" id="link-asset-to-assetcollection-form-asset" />
         <f:form.hidden name="assetCollection[__identity]" id="link-asset-to-assetcollection-form-assetcollection" />
     </f:form>
@@ -344,3 +338,9 @@
     </f:if>
     <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/select.js')}"></script>
 </f:section>
+
+<f:section name="FilterLink.All"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="true" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Image"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Document"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Video"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Audio"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action></f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/New.html
@@ -11,7 +11,7 @@
                     <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
                         {neos:backend.translate(id: 'chooseFile', package: 'Neos.Media.Browser')} <i class="fas fa-file"></i>
                     </label>
-                    <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required'}"/>
+                    <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}"/>
                 </span>
                 <label for="title">{neos:backend.translate(id: 'field.title', package: 'Neos.Media.Browser')}</label>
                 <f:form.textfield property="title" id="title" placeholder="{neos:backend.translate(id: 'field.title', package: 'Neos.Media.Browser')}"/>
@@ -40,7 +40,8 @@
             </div>
         </fieldset>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" addQueryString="true" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+            <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
             <f:form.submit id="import" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}"/>
         </div>
     </f:form>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/ReplaceAssetResource.html
@@ -16,7 +16,7 @@
                     </p>
                     <span class="neos-file-input">
                         <label class="neos-button neos-button-primary" for="resource" title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'replaceAsset.chooseNewFile', package: 'Neos.Media.Browser')} <i class="fas fa-file"></i></label>
-                        <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required'}"/>
+                        <f:form.upload id="resource" name="resource" additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}"/>
                     </span>
                 </fieldset>
                 <fieldset>
@@ -40,7 +40,7 @@
                     <f:if condition="{asset.inUse}">
                         <f:then>
                             <p class="neos-buffer-below"><i class="fas fa-exclamation-sign"></i> {neos:backend.translate(id: 'replace.usageCount', arguments: {usageCount: asset.usageCount}, package: 'Neos.Media.Browser')}</p>
-                            <f:link.action action="relatedNodes" arguments="{asset:asset}" class="neos-button">
+                            <f:link.action action="relatedNodes" arguments="{asset:asset}" addQueryString="true" class="neos-button">
                                 {neos:backend.translate(id: 'replace.allUsages', package: 'Neos.Media.Browser')}
                             </f:link.action>
                         </f:then>
@@ -59,6 +59,7 @@
             <a href="javascript:window.history.back(1);" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
             <f:form.submit id="replace" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'replaceAssetResource', package: 'Neos.Media.Browser')}"/>
         </div>
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
     </f:form>
 </f:section>
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -11,7 +11,7 @@
                     <a href="#" role="tab">Overview</a>
                 </li>
                 <li role="presentation">
-                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'show'}">Variants</f:link.action>
+                    <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier, overviewAction: 'show'}" addQueryString="true">Variants</f:link.action>
                 </li>
             </ul>
         </f:if>
@@ -78,7 +78,7 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'back', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" class="neos-button" addQueryString="true">{neos:backend.translate(id: 'back', package: 'Neos.Neos')}</f:link.action>
         </div>
 </f:section>
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Variants.html
@@ -8,10 +8,10 @@
 
     <ul class="neos-nav neos-nav-tabs" role="tablist">
         <li role="presentation">
-            <f:link.action action="{overviewAction}" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}">Overview</f:link.action>
+            <f:link.action action="{overviewAction}" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true">Overview</f:link.action>
         </li>
         <li role="presentation" class="neos-active">
-            <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}">Variants</f:link.action>
+            <f:link.action action="variants" arguments="{assetSourceIdentifier: assetProxy.assetSource.identifier, assetProxyIdentifier: assetProxy.identifier}" addQueryString="true">Variants</f:link.action>
         </li>
     </ul>
 
@@ -21,7 +21,9 @@
         <script id="variants-information" type="application/json">{variantsInformation -> f:format.json() -> f:format.raw()}</script>
         <script id="original-information" type="application/json">{originalInformation -> f:format.json() -> f:format.raw()}</script>
     </div>
-    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="true"></f:form>
+    <f:form action="update" controller="ImageVariant" package="Neos.Media.Browser" format="json" id="postHelper" method="post" useParentRequest="true">
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+    </f:form>
 </f:section>
 
 <f:section name="Scripts">

--- a/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/AssetCollection/Edit.html
@@ -26,7 +26,7 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" controller="Asset" class="neos-button" addQueryString="true">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
             <a data-toggle="modal" href="#collection-{assetCollection -> f:format.identifier()}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'delete', package: 'Neos.Neos')}</a>
             <f:form.submit id="save" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'save', package: 'Neos.Neos')}"/>
             <div class="neos-hide" id="collection-{assetCollection -> f:format.identifier()}">
@@ -46,7 +46,7 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', controller: 'Asset', arguments: {assetCollection: assetCollection})}" class="neos-button neos-button-mini neos-button-danger">
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteAssetCollection', controller: 'Asset', arguments: {assetCollection: assetCollection}, addQueryString: true)}" class="neos-button neos-button-mini neos-button-danger">
                                 {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                             </button>
                         </div>
@@ -55,6 +55,9 @@
                 <div class="neos-modal-backdrop neos-in"></div>
             </div>
         </div>
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
     </f:form>
-    <f:form action="index" id="postHelper" method="post"></f:form>
+    <f:form action="index" id="postHelper" method="post">
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+    </f:form>
 </f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Tag/Edit.html
@@ -27,7 +27,7 @@
             </div>
         </div>
         <div class="neos-footer">
-            <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
+            <f:link.action action="index" controller="Asset" addQueryString="true" class="neos-button">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</f:link.action>
             <a class="neos-button neos-button-danger" data-toggle="modal" href="#tag-{tag -> f:format.identifier()}">{neos:backend.translate(id: 'delete', package: 'Neos.Neos')}</a>
             <f:form.submit id="save" class="neos-button neos-button-primary" value="{neos:backend.translate(id: 'save', package: 'Neos.Neos')}"/>
             <div class="neos-hide" id="tag-{tag -> f:format.identifier()}">
@@ -47,13 +47,16 @@
                         </div>
                         <div class="neos-modal-footer">
                             <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', controller: 'Asset', arguments: {tag: tag})}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
+                            <button type="submit" form="postHelper" formaction="{f:uri.action(action: 'deleteTag', controller: 'Asset', arguments: {tag: tag}, addQueryString: true)}" class="neos-button neos-button-danger">{neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}</button>
                         </div>
                     </div>
                 </div>
                 <div class="neos-modal-backdrop neos-in"></div>
             </div>
         </div>
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
     </f:form>
-    <f:form action="index" id="postHelper" method="post"></f:form>
+    <f:form action="index" id="postHelper" method="post">
+        <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+    </f:form>
 </f:section>

--- a/Neos.Media.Browser/Resources/Public/JavaScript/upload.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/upload.js
@@ -7,6 +7,9 @@
             multipart: true,
             url: uploadUrl,
             max_file_size: maximumFileUploadSize,
+            filters: {
+                mime_types : $('#resource').attr('accept')
+            },
             file_data_name: $('#resource').attr('name'),
             drop_element: 'dropzone'
         });

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetTypeFilter.php
@@ -16,7 +16,7 @@ final class AssetTypeFilter implements \JsonSerializable
     /**
      * @var string
      */
-    private $assetType = 'All';
+    private $assetType;
 
     /**
      * AssetType constructor.
@@ -25,10 +25,18 @@ final class AssetTypeFilter implements \JsonSerializable
      */
     public function __construct(string $assetType)
     {
-        if (!in_array($assetType, ['All', 'Image', 'Document', 'Video', 'Audio'])) {
-            throw new \InvalidArgumentException(sprintf('Invalid asset type "%s".', $assetType), 1524130064);
+        if (!in_array($assetType, self::getAllowedValues(), true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid asset type "%s", allowed values are: "%s".', $assetType, implode('", "', self::getAllowedValues())), 1524130064);
         }
         $this->assetType = $assetType;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAllowedValues(): array
+    {
+        return ['All', 'Image', 'Document', 'Video', 'Audio'];
     }
 
     /**
@@ -50,7 +58,7 @@ final class AssetTypeFilter implements \JsonSerializable
     /**
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->assetType;
     }

--- a/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
+++ b/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+namespace Neos\Media\Domain\Model\Dto;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
+use Neos\Media\Domain\Model\AssetSource\AssetTypeFilter;
+
+/**
+ * Constraints for the Assets that can't be changed by the user while navigating the Media module / endpoints (other than filters)
+ *
+ * @Flow\Proxy(false)
+ */
+final class AssetConstraints
+{
+    private const PATTERN_MEDIA_TYPE = '/^(?P<type>(?:[\.!#%&\'\`\^~\$\*\+\-\|\w]+))\/(?P<subtype>(?:[\.!#%&\'\`\^~\$\*\+\-\|\w]+))$/i';
+
+    /**
+     * @var string[]
+     */
+    private $allowedAssetSourceIdentifiers;
+
+    /**
+     * @var string[]
+     */
+    private $allowedMediaTypes;
+
+    /**
+     * @internal
+     * @var string[]
+     */
+    private $allowedAssetTypes;
+
+    /**
+     * @param string[] $allowedAssetSourceIdentifiers Empty array means all allowed!
+     * @param string[] $allowedMediaTypes Empty array means all allowed!
+     */
+    private function __construct(array $allowedAssetSourceIdentifiers = [], array $allowedMediaTypes = [])
+    {
+        $this->allowedAssetSourceIdentifiers = $allowedAssetSourceIdentifiers;
+        $this->allowedMediaTypes = $allowedMediaTypes;
+        $this->allowedAssetTypes = array_unique(array_map(static function(string $mediaType) {
+            if (preg_match(self::PATTERN_MEDIA_TYPE, $mediaType, $matches) === 0) {
+                throw new \InvalidArgumentException(sprintf('Failed to parse media type "%s"', $mediaType), 1594727068);
+            }
+            $type = strtolower($matches['type']) ?? '';
+            if (in_array($type, ['image', 'audio', 'video'], true)) {
+                return ucfirst($type);
+            }
+            return 'Document';
+        }, $this->allowedMediaTypes));
+    }
+
+    /**
+     * Create an empty instance (without any active constraints)
+     *
+     * @return self
+     */
+    public static function create(): self
+    {
+        return new self([], []);
+    }
+
+    /**
+     * @param array $array Keys: "assetSources", "mediaTypes"
+     * @return self
+     */
+    public static function fromArray(array $array): self
+    {
+        if (isset($array['assetSources'])) {
+            if (!is_array($array['assetSources'])) {
+                throw new \InvalidArgumentException(sprintf('"assetSources" must be an array, given: %s', gettype($array['assetSources'])), 1594372054);
+            }
+            $allowedAssetSourceIdentifiers = $array['assetSources'];
+            unset($array['assetSources']);
+        }
+        if (isset($array['mediaTypes'])) {
+            if (!is_array($array['mediaTypes'])) {
+                throw new \InvalidArgumentException(sprintf('"mediaTypes" must be a array, given: %s', gettype($array['mediaTypes'])), 1594372096);
+            }
+            $allowedMediaTypes = $array['mediaTypes'];
+            unset($array['mediaTypes']);
+        }
+        if ($array !== []) {
+            throw new \InvalidArgumentException(sprintf('Unsupported asset constraint(s): "%s"', implode('", "', array_keys($array))), 1594633851);
+        }
+
+        return new self($allowedAssetSourceIdentifiers ?? [], $allowedMediaTypes ?? []);
+    }
+
+    /**
+     * @param array $allowedAssetSourceIdentifiers
+     * @return self
+     */
+    public function withAssetSourceConstraint(array $allowedAssetSourceIdentifiers): self
+    {
+        return new self($allowedAssetSourceIdentifiers, $this->allowedMediaTypes);
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutAssetSourceConstraint(): self
+    {
+        return new self([], $this->allowedMediaTypes);
+    }
+
+    /**
+     * @param string[] $allowedMediaType
+     * @return self
+     */
+    public function withMediaTypeConstraint(array $allowedMediaType): self
+    {
+        return new self($this->allowedAssetSourceIdentifiers, $allowedMediaType);
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutAssetTypeConstraint(): self
+    {
+        return new self($this->allowedAssetSourceIdentifiers, []);
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAssetSourceConstraint(): bool
+    {
+        return $this->allowedAssetSourceIdentifiers !== [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedAssetSourceIdentifiers(): array
+    {
+        return $this->allowedAssetSourceIdentifiers;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasMediaTypeConstraint(): bool
+    {
+        return $this->allowedMediaTypes !== [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedMediaTypes(): array
+    {
+        return $this->allowedMediaTypes;
+    }
+
+    /**
+     * Returns the allowed media types as a string that can be used for "accept" attributes in file upload HTML elements
+     *
+     * @return string comma separated list of allowed media types or an empty string if no media type constraints are active
+     */
+    public function getMediaTypeAcceptAttribute(): string
+    {
+        return implode(',', $this->allowedMediaTypes);
+    }
+
+    /**
+     * Filters the given $assetSources according to the active asset source constraints
+     * If no asset source constraints is active, the original array is returned
+     *
+     * @param AssetSourceInterface[] $assetSources
+     * @return AssetSourceInterface[]
+     */
+    public function applyToAssetSources(array $assetSources): array
+    {
+        if (!$this->hasAssetSourceConstraint()) {
+            return $assetSources;
+        }
+        return array_filter($assetSources, function(AssetSourceInterface $assetSource) {
+            return in_array($assetSource->getIdentifier(), $this->allowedAssetSourceIdentifiers, true);
+        });
+    }
+
+    /**
+     * Verifies the given $assetSourceIdentifier against the asset source constraint:
+     * If no asset source constraint is set or the given $assetSourceIdentifier matches one of the allowedAssetSourceIdentifiers, the input is un-altered
+     * Otherwise the first allowed allowedAssetSourceIdentifier is returned
+     *
+     * @param string|null $assetSourceIdentifier
+     * @return string|null
+     */
+    public function applyToAssetSourceIdentifiers(?string $assetSourceIdentifier): ?string
+    {
+        if (!$this->hasAssetSourceConstraint() || in_array($assetSourceIdentifier, $this->allowedAssetSourceIdentifiers, true)) {
+            return $assetSourceIdentifier;
+        }
+        return $this->allowedAssetSourceIdentifiers[array_key_first($this->allowedAssetSourceIdentifiers)] ?? null;
+    }
+
+    /**
+     * Verifies the given $assetType against the media type constraint:
+     * If no media type constraint is set or the given $assetType matches one of the allowed asset types, the input is un-altered
+     * Otherwise the first allowed asset type is returned
+     *
+     * @param string|null $assetType
+     * @return AssetTypeFilter
+     */
+    public function applyToAssetTypeFilter(string $assetType = null): AssetTypeFilter
+    {
+        if (!$this->hasMediaTypeConstraint() || in_array($assetType, $this->allowedAssetTypes, true)) {
+            return new AssetTypeFilter($assetType ?? 'All');
+        }
+        return new AssetTypeFilter($this->allowedAssetTypes[array_key_first($this->allowedAssetTypes)]);
+    }
+
+    /**
+     * Returns an array with all supported asset type filter values according to the active media type constraints
+     * If no media type constraint is set, all options are returned including the special "All": ("All", "Image", "Video", ...)
+     * Otherwise only the allowed asset types are returned ("Video", "Image").
+     * If only one asset type is allowed, an empty array is returned because a filter with only one option is useless
+     *
+     * @return array
+     */
+    public function getAllowedAssetTypeFilterOptions(): array
+    {
+        $allAllowedFilterValues = AssetTypeFilter::getAllowedValues();
+        if (!$this->hasMediaTypeConstraint()) {
+            return $allAllowedFilterValues;
+        }
+        $filteredValues = array_intersect($this->allowedAssetTypes, $allAllowedFilterValues);
+        return count($filteredValues) > 1 ? $filteredValues : [];
+    }
+}

--- a/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
+++ b/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
@@ -39,7 +39,7 @@ final class AssetConstraints
     {
         $this->allowedAssetSourceIdentifiers = $allowedAssetSourceIdentifiers;
         $this->allowedMediaTypes = $allowedMediaTypes;
-        $this->allowedAssetTypes = array_unique(array_map(static function(string $mediaType) {
+        $this->allowedAssetTypes = array_unique(array_map(static function (string $mediaType) {
             if (preg_match(self::PATTERN_MEDIA_TYPE, $mediaType, $matches) === 0) {
                 throw new \InvalidArgumentException(sprintf('Failed to parse media type "%s"', $mediaType), 1594727068);
             }
@@ -176,7 +176,7 @@ final class AssetConstraints
         if (!$this->hasAssetSourceConstraint()) {
             return $assetSources;
         }
-        return array_filter($assetSources, function(AssetSourceInterface $assetSource) {
+        return array_filter($assetSources, function (AssetSourceInterface $assetSource) {
             return in_array($assetSource->getIdentifier(), $this->allowedAssetSourceIdentifiers, true);
         });
     }

--- a/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
@@ -1,0 +1,282 @@
+<?php
+namespace Neos\Media\Tests\Unit\Domain\Model\Dto;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
+use Neos\Media\Domain\Model\Dto\AssetConstraints;
+
+/**
+ * Test case for the AssetConstraints DTO
+ */
+class AssetConstraintsTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function createCreatesInstanceWithoutConstraints(): void
+    {
+        $constraints = AssetConstraints::create();
+        self::assertFalse($constraints->hasAssetSourceConstraint());
+        self::assertFalse($constraints->hasMediaTypeConstraint());
+    }
+
+    public function fromArrayDataProvider(): array
+    {
+        return [
+            ['input' => [], 'expectedAllowedAssetSourceIdentifiers' => [], 'expectedAllowedMediaTypes' => []],
+            ['input' => ['assetSources' => ['identifier1']], 'expectedAllowedAssetSourceIdentifiers' => ['identifier1'], 'expectedAllowedMediaTypes' => []],
+            ['input' => ['assetSources' => ['identifier1', 'identifier2']], 'expectedAllowedAssetSourceIdentifiers' => ['identifier1', 'identifier2'], 'expectedAllowedMediaTypes' => []],
+            ['input' => ['mediaTypes' => ['image/*']], 'expectedAllowedAssetSourceIdentifiers' => [], 'expectedAllowedMediaTypes' => ['image/*']],
+            ['input' => ['mediaTypes' => ['application/*', 'audio/*']], 'expectedAllowedAssetSourceIdentifiers' => [], 'expectedAllowedMediaTypes' => ['application/*', 'audio/*']],
+            ['input' => ['mediaTypes' => ['application/*'], 'assetSources' => ['identifier1', 'identifier2']], 'expectedAllowedAssetSourceIdentifiers' => ['identifier1', 'identifier2'], 'expectedAllowedMediaTypes' => ['application/*']],
+        ];
+    }
+
+    /**
+     * @param array $input
+     * @param array $expectedAllowedAssetSourceIdentifiers
+     * @param array $expectedAllowedMediaTypes
+     * @test
+     * @dataProvider fromArrayDataProvider
+     */
+    public function fromArrayTests(array $input, array $expectedAllowedAssetSourceIdentifiers, array $expectedAllowedMediaTypes): void
+    {
+        $constraints = AssetConstraints::fromArray($input);
+        self::assertSame($expectedAllowedAssetSourceIdentifiers, $constraints->getAllowedAssetSourceIdentifiers());
+        self::assertSame($expectedAllowedMediaTypes, $constraints->getAllowedMediaTypes());
+    }
+
+    public function invalidFromArrayDataProvider(): array
+    {
+        return [
+            [['unknown-constraint' => 'foo']],
+            [['assetSources' => 'no-array']],
+            [['assetSources' => 123]],
+            [['mediaTypes' => 'no-array']],
+            [['mediaTypes' => 123]],
+            [['mediaTypes' => ['invalid-media-type']]],
+            [['assetSources' => ['valid'], 'mediaTypes' => ['invalid']]],
+            [['assetSources' => 'invalid', 'mediaTypes' => ['image/*']]],
+            [['assetSources' => ['valid'], 'unknown-constraint' => 'foo']],
+            [['mediaTypes' => ['image/*'], 'unknown-constraint' => 'foo']],
+        ];
+    }
+
+    /**
+     * @param array $input
+     * @test
+     * @dataProvider invalidFromArrayDataProvider
+     */
+    public function invalidFromArrayTests(array $input): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        AssetConstraints::fromArray($input);
+    }
+
+    /**
+     * @test
+     */
+    public function withAssetSourceConstraintAllowsToChangeAssetSourceIdentifiers(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id1'], 'mediaTypes' => ['image/*']]);
+        $constraints = $constraints->withAssetSourceConstraint(['id2']);
+        self::assertSame(['id2'], $constraints->getAllowedAssetSourceIdentifiers());
+        self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
+    }
+
+    /**
+     * @test
+     */
+    public function withoutAssetSourceConstraintClearsAssetSourceIdentifiers(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id1', 'id2'], 'mediaTypes' => ['image/*']]);
+        $constraints = $constraints->withoutAssetSourceConstraint();
+        self::assertFalse($constraints->hasAssetSourceConstraint());
+        self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
+    }
+
+    /**
+     * @test
+     */
+    public function withMediaTypeConstraintAllowsToChangeAllowedMediaTypes(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id1']]);
+        $constraints = $constraints->withMediaTypeConstraint(['image/*']);
+        self::assertSame(['id1'], $constraints->getAllowedAssetSourceIdentifiers());
+        self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
+    }
+
+    /**
+     * @test
+     */
+    public function withoutAssetTypeConstraintClearsAllowedMediaTypes(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id1'], 'mediaTypes' => ['image/*']]);
+        $constraints = $constraints->withoutAssetTypeConstraint();
+        self::assertSame(['id1'], $constraints->getAllowedAssetSourceIdentifiers());
+        self::assertFalse($constraints->hasMediaTypeConstraint());
+    }
+
+    /**
+     * @test
+     */
+    public function getMediaTypeAcceptAttributeReturnsAnEmptyStringIfNoAssetConstraintsAreSet(): void
+    {
+        $constraints = AssetConstraints::create();
+        self::assertSame('', $constraints->getMediaTypeAcceptAttribute());
+    }
+
+    /**
+     * @test
+     */
+    public function getMediaTypeAcceptAttributeReturnsACommaSeparatedListOfAllActiveMediaTypeConstraints(): void
+    {
+        $constraints = AssetConstraints::create()->withMediaTypeConstraint(['image/*', 'audio/wav']);
+        self::assertSame('image/*,audio/wav', $constraints->getMediaTypeAcceptAttribute());
+    }
+
+    /**
+     * @test
+     */
+    public function applyToAssetSourcesDoesNotHaveAnyEffectWhenNoAssetSourceConstraintsAreActive(): void
+    {
+        $constraints = AssetConstraints::create();
+        $mockAssetSources = [
+            $this->getMockBuilder(AssetSourceInterface::class)->getMock(),
+            $this->getMockBuilder(AssetSourceInterface::class)->getMock(),
+        ];
+        $resultingAssetSources = $constraints->applyToAssetSources($mockAssetSources);
+        self::assertSame($mockAssetSources, $resultingAssetSources);
+    }
+
+    /**
+     * @test
+     */
+    public function applyToAssetSourcesFiltersDisallowedAssetSources(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id1']]);
+
+        $mockAssetSource1 = $this->getMockBuilder(AssetSourceInterface::class)->getMock();
+        $mockAssetSource1->method('getIdentifier')->willReturn('id1');
+
+        $mockAssetSource2 = $this->getMockBuilder(AssetSourceInterface::class)->getMock();
+        $mockAssetSource2->method('getIdentifier')->willReturn('id2');
+
+        $mockAssetSources = [
+            $mockAssetSource1,
+            $mockAssetSource2,
+        ];
+        $resultingAssetSources = $constraints->applyToAssetSources($mockAssetSources);
+        self::assertSame([$mockAssetSource1], $resultingAssetSources);
+    }
+
+
+    /**
+     * @test
+     */
+    public function applyToAssetSourcesFiltersAllAssetSourcesIfThereIsNoMatch(): void
+    {
+        $constraints = AssetConstraints::fromArray(['assetSources' => ['id3']]);
+
+        $mockAssetSource1 = $this->getMockBuilder(AssetSourceInterface::class)->getMock();
+        $mockAssetSource1->method('getIdentifier')->willReturn('id1');
+
+        $mockAssetSource2 = $this->getMockBuilder(AssetSourceInterface::class)->getMock();
+        $mockAssetSource2->method('getIdentifier')->willReturn('id2');
+
+        $mockAssetSources = [
+            $mockAssetSource1,
+            $mockAssetSource2,
+        ];
+        $resultingAssetSources = $constraints->applyToAssetSources($mockAssetSources);
+        self::assertSame([], $resultingAssetSources);
+    }
+
+    public function applyToAssetSourceIdentifiersDataProvider(): array
+    {
+        return [
+            ['allowedAssetSourceIdentifiers' => [], 'assetSourceIdentifier' => null, 'expectedResult' => null],
+            ['allowedAssetSourceIdentifiers' => [], 'assetSourceIdentifier' => 'some-id', 'expectedResult' => 'some-id'],
+            ['allowedAssetSourceIdentifiers' => ['some-id'], 'assetSourceIdentifier' => 'some-id', 'expectedResult' => 'some-id'],
+            ['allowedAssetSourceIdentifiers' => ['some-allowed-id'], 'assetSourceIdentifier' => 'some-disallowed-id', 'expectedResult' => 'some-allowed-id'],
+            ['allowedAssetSourceIdentifiers' => ['some-allowed-id', 'some-other-allowed-id'], 'assetSourceIdentifier' => 'some-disallowed-id', 'expectedResult' => 'some-allowed-id'],
+            ['allowedAssetSourceIdentifiers' => ['some-allowed-id', 'some-other-allowed-id'], 'assetSourceIdentifier' => 'some-allowed-id', 'expectedResult' => 'some-allowed-id'],
+            ['allowedAssetSourceIdentifiers' => ['some-allowed-id', 'some-other-allowed-id'], 'assetSourceIdentifier' => 'some-other-allowed-id', 'expectedResult' => 'some-other-allowed-id'],
+        ];
+    }
+
+    /**
+     * @param array $allowedAssetSourceIdentifiers
+     * @param string|null $assetSourceIdentifier
+     * @param string|null $expectedResult
+     * @test
+     * @dataProvider applyToAssetSourceIdentifiersDataProvider
+     */
+    public function applyToAssetSourceIdentifiersTests(array $allowedAssetSourceIdentifiers, string $assetSourceIdentifier = null, string $expectedResult = null): void
+    {
+        $constraints = AssetConstraints::create()->withAssetSourceConstraint($allowedAssetSourceIdentifiers);
+        self::assertSame($expectedResult, $constraints->applyToAssetSourceIdentifiers($assetSourceIdentifier));
+    }
+
+    public function applyToAssetTypeFilterDataProvider(): array
+    {
+        return [
+            ['mediaTypes' => [], 'assetType' => null, 'expectedResult' => 'All'],
+            ['mediaTypes' => [], 'assetType' => 'All', 'expectedResult' => 'All'],
+            ['mediaTypes' => [], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['mediaTypes' => ['image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => null, 'expectedResult' => 'Audio'],
+            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Video', 'expectedResult' => 'Audio'],
+            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'All', 'expectedResult' => 'Audio'],
+        ];
+    }
+
+    /**
+     * @param array $allowedMediaTypes
+     * @param string|null $assetType
+     * @param string $expectedResult
+     * @test
+     * @dataProvider applyToAssetTypeFilterDataProvider
+     */
+    public function applyToAssetTypeFilterTests(array $allowedMediaTypes, ?string $assetType, string $expectedResult): void
+    {
+        $constraints = AssetConstraints::create()->withMediaTypeConstraint($allowedMediaTypes);
+        self::assertSame($expectedResult, (string)$constraints->applyToAssetTypeFilter($assetType));
+    }
+
+    public function getAllowedAssetTypeFilterOptionsDataProvider(): array
+    {
+        return [
+            ['mediaTypes' => [], 'expectedResult' => ['All', 'Image', 'Document', 'Video', 'Audio']],
+            ['mediaTypes' => ['image/*'], 'expectedResult' => []],
+            ['mediaTypes' => ['unknown/media-type'], 'expectedResult' => []],
+            ['mediaTypes' => ['video/*', 'image/*'], 'expectedResult' => ['Video', 'Image']],
+            ['mediaTypes' => ['video/*', 'image/jpeg', 'image/gif'], 'expectedResult' => ['Video', 'Image']],
+            ['mediaTypes' => ['unknown/media-type', 'video/*'], 'expectedResult' => ['Document', 'Video']],
+        ];
+    }
+
+    /**
+     * @param array $allowedMediaTypes
+     * @param array $expectedResult
+     * @test
+     * @dataProvider getAllowedAssetTypeFilterOptionsDataProvider
+     */
+    public function getAllowedAssetTypeFilterOptionsTests(array $allowedMediaTypes, array $expectedResult): void
+    {
+        $constraints = AssetConstraints::create()->withMediaTypeConstraint($allowedMediaTypes);
+        self::assertSame($expectedResult, $constraints->getAllowedAssetTypeFilterOptions());
+    }
+}

--- a/Neos.Neos/Classes/Controller/Service/AssetProxiesController.php
+++ b/Neos.Neos/Classes/Controller/Service/AssetProxiesController.php
@@ -18,7 +18,6 @@ use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\FluidAdaptor\View\TemplateView;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
-use Neos\Media\Domain\Model\AssetSource\AssetTypeFilter;
 use Neos\Media\Domain\Model\Dto\AssetConstraints;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Service\AssetSourceService;

--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -600,9 +600,10 @@ image format must be ``16:9``::
         inspector:
           group: 'document'
           editorOptions:
-            accept: 'image/png'
             features:
               crop: true
+            constraints:
+              mediaTypes: ['image/png']
             crop:
               aspectRatio:
                 forceCrop: true
@@ -622,7 +623,8 @@ to choose a custom aspect ratio, set ``crop.aspectRatio.allowCustom`` to ``true`
         inspector:
           group: 'document'
           editorOptions:
-            accept: 'image/png'
+            constraints:
+              mediaTypes: ['image/png']
             features:
               crop: true
             crop:
@@ -648,7 +650,18 @@ Options Reference:
 	Defaults to the maximum allowed upload size configured in php.ini
 
 ``accept`` (string)
-  Set the accepted mime type for this editor. If non is given it falls back to ``image/*``.
+  DEPRECATED. Use ``constraints.mediaTypes`` instead
+
+``constraints``
+
+	``mediaTypes`` (array)
+		If set, the media browser and file upload will be limited to assets with the specified media type. Default ``['image/*']``
+		Example: ``['image/png', 'image/jpeg']``
+		Note: Due to technical limitations the media browser currently ignores the media sub type, so ``image/png`` has the same effect as ``image/*``
+
+	``assetSources`` (array)
+		If set, the media browser will be limited to assets of the specified asset source. Default: ``[]`` (all asset sources)
+		Example: ``['neos', 'custom_asset_source]``
 
 ``features``
 
@@ -733,8 +746,19 @@ Conversely, if multiple assets shall be uploaded, use ``array<Neos\Media\Domain\
 
 Options Reference:
 
-``accept``
-  Set the accepted mime type for this editor. If non is given all files are allowed.
+``accept`` (string)
+  DEPRECATED. Use ``constraints.mediaTypes`` instead
+
+``constraints``
+
+	``mediaTypes`` (array)
+		If set, the media browser, file search and file upload will be limited to assets with the specified media type. Default ``[]`` (all media types)
+		Example: ``['application/msword', 'application/pdf']``
+		Note: Due to technical limitations the media browser currently ignores the media sub type, so ``application/pdf`` has the same effect as ``application/*``.
+
+	``assetSources`` (array)
+		If set, the media browser and file search will be limited to assets of the specified asset source. Default: ``[]`` (all asset sources)
+		Example: ``['neos', 'custom_asset_source]``
 
 ``features``
 


### PR DESCRIPTION
Extends the Media Browser and Asset proxy search endpoint so
that it supports *constraints* that filter the asset lists
(on top of the user-specified filters).

This makes it possible to constraint asset source(s) and
media type(s) per node type property.

Example:

    'Some.Node:Type':
      properties:
        'asset':
          type: 'Neos\Media\Domain\Model\Asset'
          ui:
            inspector:
              group: 'asset'
              editorOptions:
                constraints:
                  mediaTypes: ['audio/*']
                  assetSources: ['neos', 'wikipedia_de']

(restricts the asset editor to only allow audio files of the `neos` or `wikipedia_de`
asset source when using the media browser modal, searchbox or file upload).

Resolves: #2984