### PR TITLE
!!! BUGFIX: Speed up node move actions

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -610,7 +610,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_BEFORE);
         if ($referenceNode->getParentPath() !== $this->getParentPath()) {
             $this->setPath(NodePaths::addNodePathSegment($referenceNode->getParentPath(), $name));
-            $this->nodeDataRepository->persistEntities();
         } else {
             if (!$this->isNodeDataMatchingContext()) {
                 $this->materializeNodeData();
@@ -658,7 +657,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_AFTER);
         if ($referenceNode->getParentPath() !== $this->getParentPath()) {
             $this->setPath(NodePaths::addNodePathSegment($referenceNode->getParentPath(), $name));
-            $this->nodeDataRepository->persistEntities();
         } else {
             if (!$this->isNodeDataMatchingContext()) {
                 $this->materializeNodeData();
@@ -704,7 +702,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
 
         $this->emitBeforeNodeMove($this, $referenceNode, NodeDataRepository::POSITION_LAST);
         $this->setPath(NodePaths::addNodePathSegment($referenceNode->getPath(), $name));
-        $this->nodeDataRepository->persistEntities();
 
         $this->nodeDataRepository->setNewIndex($this->nodeData, NodeDataRepository::POSITION_LAST);
         $this->context->getFirstLevelNodeCache()->flush();

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -14,9 +14,11 @@ namespace Neos\ContentRepository\Domain\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\UnitOfWork;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Utility\Algorithms;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -924,8 +926,35 @@ class NodeData extends AbstractNodeData
                     $this->addOrUpdate($movedNodeData);
 
                     $shadowNodeData = $sourceNodeData;
-                    $shadowNodeData->setRemoved(true);
+
+                    /**
+                     * WARNING: we need to call MovedTo BEFORE calling setRemoved(), as OTHERWISE, the following happens:
+                     *
+                     * 1) {@see NodeData::setRemoved()} calls {@see NodeData::addOrUpdate()}, which then triggers
+                     *    {@see NodeDataRepository::remove()}.
+                     * 1a) In the {@see UnitOfWork::doRemove()}, the entity is marked with {@see UnitOfWork::STATE_REMOVED}.
+                     * 2) {@see NodeData::setMovedTo()} calls  {@see NodeData::addOrUpdate()}, which then triggers
+                     *    {@see NodeDataRepository::update()}.
+                     * 2a) In the {@see UnitOfWork::doPersist()}, the entity is marked as {@see UnitOfWork::STATE_MANAGED}
+                     *     AGAIN (it was marked as removed beforehand). NOTE: Doctrine does NOT call
+                     *     {@see UnitOfWork::scheduleForDirtyCheck()}, which it would call if the entity was already in
+                     *     STATE_MANAGED. We rely on this scheduleForDirtyCheck to be called, because we use DEFERRED_EXPLICIT
+                     *     as default Flow change tracking policy.
+                     * 3) When THEN calling {@see PersistenceManagerInterface::persistAll()}, which triggers a
+                     *    {@see UnitOfWork::commit()}, which triggers {@see UnitOfWork::computeChangeSets()}.
+                     * 3a) Because the scheduleForDirtyCheck has NOT been called in step 2a, `$this->scheduledForSynchronization[$className]`
+                     *     returns FALSE
+                     * 3b) thus, we DO NOT PERSIST OUR ENTITY CHANGE!
+                     *
+                     * WORKAROUND:
+                     * - before marking a NodeData object as removed, do all other changes (like setMovedTo). Because then,
+                     *   {@see NodeData::addOrUpdate()} will NOT call {@see NodeDataRepository::remove()} - and thus we do not
+                     *   trigger the described behavior.
+                     *
+                     * We reported this as Doctrine bug https://github.com/doctrine/orm/issues/8231
+                     */
                     $shadowNodeData->setMovedTo($movedNodeData);
+                    $shadowNodeData->setRemoved(true);
                     $this->addOrUpdate($shadowNodeData);
                 } else {
                     // A shadow node that references this node data already exists, so we just move the current node data

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1234,13 +1234,10 @@ class NodeDataRepository extends Repository
      */
     public function persistEntities()
     {
-        foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
-            if ($className === $this->entityClassName) {
-                $this->entityManager->flush($entities);
-                $this->emitRepositoryObjectsPersisted();
-                break;
-            }
-        }
+        // Flush all entities to circumvent an issue in Doctrine 2.x which reevaluates all changes
+        // for each change again when called individually leading to n^2 changeset calculations.
+        $this->entityManager->flush();
+        $this->emitRepositoryObjectsPersisted();
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1056,7 +1056,8 @@ class NodeDataRepository extends Repository
                 $queryBuilder->expr()->orx()
                     ->add($queryBuilder->expr()->eq('n.parentPathHash', ':parentPathHash'))
                     ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'))
-                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath')))
+                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath'))
+            )
                 ->setParameter('parentPathHash', md5($pathStartingPoint))
                 ->setParameter('pathHash', md5($pathStartingPoint))
                 ->setParameter('parentPath', rtrim($pathStartingPoint, '/') . '/%');
@@ -1320,12 +1321,16 @@ class NodeDataRepository extends Repository
                         if ($position === false) {
                             $position = PHP_INT_MAX;
                         }
-                        $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min($dimensionPositions[$dimensionName],
-                            $position) : $position;
+                        $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min(
+                            $dimensionPositions[$dimensionName],
+                            $position
+                        ) : $position;
                     }
                 } else {
-                    $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min($dimensionPositions[$dimensionName],
-                            PHP_INT_MAX) : PHP_INT_MAX;
+                    $dimensionPositions[$dimensionName] = isset($dimensionPositions[$dimensionName]) ? min(
+                        $dimensionPositions[$dimensionName],
+                        PHP_INT_MAX
+                    ) : PHP_INT_MAX;
                 }
             }
             $dimensionPositions[] = $workspacePosition;
@@ -1562,7 +1567,8 @@ class NodeDataRepository extends Repository
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->orX()
                     ->add($queryBuilder->expr()->eq('n.parentPathHash', ':parentPathHash'))
-                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath')))
+                    ->add($queryBuilder->expr()->like('n.parentPath', ':parentPath'))
+            )
                 ->setParameter('parentPathHash', md5($parentPath))
                 ->setParameter('parentPath', rtrim($parentPath, '/') . '/%');
         }
@@ -1583,7 +1589,8 @@ class NodeDataRepository extends Repository
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->orX()
                     ->add($queryBuilder->expr()->eq('n.pathHash', ':pathHash'))
-                    ->add($queryBuilder->expr()->like('n.path', ':path')))
+                    ->add($queryBuilder->expr()->like('n.path', ':path'))
+            )
                 ->setParameter('pathHash', md5($path))
                 ->setParameter('path', rtrim($path, '/') . '/%');
         }

--- a/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
@@ -229,7 +229,6 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $this->rootNode->getNode('foo/bar/baz')->moveInto($this->rootNode->getNode('foo'));
-        $this->persistenceManager->persistAll();
 
         $this->rootNode->getContext()->getWorkspace()->publish($this->groupWorkspace);
         $this->persistenceManager->persistAll();

--- a/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
@@ -260,7 +260,6 @@ class WorkspacesTest extends FunctionalTestCase
         $parentNode->createNode('child-node-a');
         $childNodeB = $parentNode->createNode('child-node-b');
         $childNodeB->createNode('child-node-c');
-        $this->persistenceManager->persistAll();
         $parentNode->getWorkspace()->publish($this->liveWorkspace);
 
         $this->saveNodesAndTearDownRootNodeAndRepository();

--- a/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
@@ -260,6 +260,7 @@ class WorkspacesTest extends FunctionalTestCase
         $parentNode->createNode('child-node-a');
         $childNodeB = $parentNode->createNode('child-node-b');
         $childNodeB->createNode('child-node-c');
+        $this->persistenceManager->persistAll();
         $parentNode->getWorkspace()->publish($this->liveWorkspace);
 
         $this->saveNodesAndTearDownRootNodeAndRepository();


### PR DESCRIPTION
Due to an issue in how Doctrine 2.x handles the computation of changesets when given
entities to commit it recomputed the changesets for all entities for every entity.
Leading to n^2 change computations.

In a large project this improved the moving of ~750 nodes from 1.7m to 8.5s.
In the demo site moving the "features" page from 4s to 1.65s. 
Publishing seems to be only slightly (~10%) faster to its different behaviour in the CR.

**What I did**

Which this change this behaviour is circumvented by commiting all
entities at once. Including entities which might not have been included
with the previous code but would have been persisted at the end of the request
anyway.

**What is breaking**
This change leads to all entities scheduled for persistence to actually persist when a node is changed, see following comparison timelines:

Old:
1. Create Entity, mark for insertion
2. change node
3. controller call is done / persistAll was called -> entity from step one is now persisted

New:
1. Create Entity, mark for insertion
2. change node (entity will be persisted at this point)
3. controller call is done / persistAll was called -> nothing happens anymore.

**How I did it**

Replace the repeated flush calls to the entity manager with a single one.

This should only lead to a behavioural change if custom code would modify a node
then move other nodes and expect the the first node was not persisted yet.

**How to verify it**

1. Move a large set of pages with subpages and nodes in the Neos backend. 
2. Check the request time of the `change` xhr request.
3. Apply this patch
4. Repeat steps 1 + 2 and compare

Example screenshots:

Before:

<img width="600" alt="before-change" src="https://user-images.githubusercontent.com/596967/87766599-b4b94600-c819-11ea-9777-0bbe11f84d3a.png">

After:

<img width="600" alt="after-change" src="https://user-images.githubusercontent.com/596967/87766608-b7b43680-c819-11ea-83f9-2fbf1993cda7.png">

