### PR TITLE
TASK: Use square brackets to access characters in string

### DIFF
--- a/Neos.Diff/Classes/Renderer/Html/HtmlArrayRenderer.php
+++ b/Neos.Diff/Classes/Renderer/Html/HtmlArrayRenderer.php
@@ -124,7 +124,7 @@ class HtmlArrayRenderer extends AbstractRenderer
     {
         $start = 0;
         $limit = min(strlen($fromLine), strlen($toLine));
-        while ($start < $limit && $fromLine{$start} == $toLine{$start}) {
+        while ($start < $limit && $fromLine[$start] == $toLine[$start]) {
             ++$start;
         }
         $end = -1;


### PR DESCRIPTION
Using curly braces for string character access leads to deprecation warnings with PHP 7.4.
I am not sure if it should go to a 5.x or even the 4.2 branch. Should be no problem, as the file has not changed since quite some time.