### PR TITLE
FEATURE: Introduce NodeTypePresetPostprocessor

### DIFF
--- a/Neos.Neos/Classes/NodeTypePostprocessor/DefaultPropertyEditorPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/DefaultPropertyEditorPostprocessor.php
@@ -1,0 +1,92 @@
+<?php
+namespace Neos\Neos\NodeTypePostprocessor;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Utility\Arrays;
+use Neos\Neos\Exception;
+
+/**
+ * Add default editor configurations for properties based on type and editor
+ */
+class DefaultPropertyEditorPostprocessor implements NodeTypePostprocessorInterface
+{
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="userInterface.inspector.dataTypes")
+     */
+    protected $dataTypesDefaultConfiguration;
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="userInterface.inspector.editors")
+     */
+    protected $editorDefaultConfiguration;
+
+    /**
+     * @param NodeType $nodeType (uninitialized) The node type to process
+     * @param array $configuration input configuration
+     * @param array $options The processor options
+     * @return void
+     */
+    public function process(NodeType $nodeType, array &$configuration, array $options): void
+    {
+        $nodeTypeName = $nodeType->getName();
+        if (isset($configuration['properties']) && is_array($configuration['properties'])) {
+            foreach ($configuration['properties'] as $propertyName => &$propertyConfiguration) {
+                if (!isset($propertyConfiguration['type'])) {
+                    continue;
+                }
+
+                $type = $propertyConfiguration['type'];
+
+                if (!isset($this->dataTypesDefaultConfiguration[$type])) {
+                    continue;
+                }
+
+                if (!isset($propertyConfiguration['ui']['inspector'])) {
+                    continue;
+                }
+
+                $defaultConfigurationFromDataType = $this->dataTypesDefaultConfiguration[$type];
+
+                // FIRST STEP: Figure out which editor should be used
+                // - Default: editor as configured from the data type
+                // - Override: editor as configured from the property configuration.
+                if (isset($propertyConfiguration['ui']['inspector']['editor'])) {
+                    $editor = $propertyConfiguration['ui']['inspector']['editor'];
+                } elseif (isset($defaultConfigurationFromDataType['editor'])) {
+                    $editor = $defaultConfigurationFromDataType['editor'];
+                } else {
+                    throw new Exception('Could not find editor for ' . $propertyName . ' in node type ' . $nodeTypeName, 1436809123);
+                }
+
+                // SECOND STEP: Build up the full inspector configuration by merging:
+                // - take configuration from editor defaults
+                // - take configuration from dataType
+                // - take configuration from properties (NodeTypes)
+                $mergedInspectorConfiguration = [];
+                if (isset($this->editorDefaultConfiguration[$editor])) {
+                    $mergedInspectorConfiguration = $this->editorDefaultConfiguration[$editor];
+                }
+
+                $mergedInspectorConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedInspectorConfiguration, $defaultConfigurationFromDataType);
+                $mergedInspectorConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedInspectorConfiguration, $propertyConfiguration['ui']['inspector']);
+                $propertyConfiguration['ui']['inspector'] = $mergedInspectorConfiguration;
+                $propertyConfiguration['ui']['inspector']['editor'] = $editor;
+            }
+        }
+    }
+}

--- a/Neos.Neos/Classes/NodeTypePostprocessor/IconNameMappingPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/IconNameMappingPostprocessor.php
@@ -1,0 +1,55 @@
+<?php
+namespace Neos\Neos\NodeTypePostprocessor;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Neos\Service\IconNameMappingService;
+use Neos\Utility\Arrays;
+
+/**
+ * Map all icon- prefixed icon names to the corresponding
+ * names in the used icon implementation
+ */
+class IconNameMappingPostprocessor implements NodeTypePostprocessorInterface
+{
+    /**
+     * @Flow\Inject
+     * @var IconNameMappingService
+     */
+    protected $iconNameMappingService;
+
+    /**
+     * @param NodeType $nodeType (uninitialized) The node type to process
+     * @param array $configuration input configuration
+     * @param array $options The processor options
+     * @return void
+     */
+    public function process(NodeType $nodeType, array &$configuration, array $options): void
+    {
+        if (isset($configuration['ui']['icon'])) {
+            $configuration['ui']['icon'] = $this->iconNameMappingService->convert($configuration['ui']['icon']);
+        }
+
+        $inspectorConfiguration = Arrays::getValueByPath($configuration, 'ui.inspector');
+        if (is_array($inspectorConfiguration)) {
+            foreach ($inspectorConfiguration as $elementTypeName => $elementTypeItems) {
+                foreach ($elementTypeItems as $elementName => $elementConfiguration) {
+                    if (isset($inspectorConfiguration[$elementTypeName][$elementName]['icon'])) {
+                        $configuration['ui']['inspector'][$elementTypeName][$elementName]['icon'] = $this->iconNameMappingService->convert($inspectorConfiguration[$elementTypeName][$elementName]['icon']);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Neos.Neos/Classes/NodeTypePostprocessor/NodeTypePresetPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/NodeTypePresetPostprocessor.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Neos\NodeTypePostprocessor;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Utility\Arrays;
+
+/**
+ * Apply presets from configuration to nodeTypes
+ */
+class NodeTypePresetPostprocessor implements NodeTypePostprocessorInterface
+{
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="nodeTypes.presets.properties")
+     */
+    protected $propertyPresetConfiguration;
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="nodeTypes.presets.childNodes")
+     */
+    protected $childNodePresetConfiguration;
+
+    /**
+     * @param NodeType $nodeType (uninitialized) The node type to process
+     * @param array $configuration input configuration
+     * @param array $options The processor options
+     * @return void
+     */
+    public function process(NodeType $nodeType, array &$configuration, array $options): void
+    {
+        if ($nodeType->hasConfiguration('properties')) {
+            foreach ($nodeType->getConfiguration('properties') as $propertyName => $propertyConfiguration) {
+                if ($preset = Arrays::getValueByPath($propertyConfiguration, 'options.preset')) {
+                    $presetConfiguration = Arrays::getValueByPath($this->propertyPresetConfiguration, $preset);
+                    if ($presetConfiguration) {
+                        $mergedPropertyConfiguration = Arrays::arrayMergeRecursiveOverrule(
+                            $presetConfiguration,
+                            $propertyConfiguration
+                        );
+                        $configuration['properties'][$propertyName] = $mergedPropertyConfiguration;
+                    }
+                }
+            }
+        }
+
+        if ($nodeType->hasConfiguration('childNodes')) {
+            foreach ($nodeType->getConfiguration('childNodes') as $propertyName => $propertyConfiguration) {
+                if ($preset = Arrays::getValueByPath($propertyConfiguration, 'options.preset')) {
+                    $presetConfiguration = Arrays::getValueByPath($this->childNodePresetConfiguration, $preset);
+                    if ($presetConfiguration) {
+                        $mergedPropertyConfiguration = Arrays::arrayMergeRecursiveOverrule(
+                            $presetConfiguration,
+                            $propertyConfiguration
+                        );
+                        $configuration['childNodes'][$propertyName] = $mergedPropertyConfiguration;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -6,8 +6,11 @@
     fusion:
       prototypeGenerator: ~
   postprocessors:
+    'NodeTypePresetPostprocessor':
+      position: 'before IconNameMappingPostprocessor'
+      postprocessor: 'Neos\Neos\NodeTypePostprocessor\NodeTypePresetPostprocessor'
     'IconNameMappingPostprocessor':
-      position: 'end'
+      position: 'before DefaultPropertyEditorPostprocessor'
       postprocessor: 'Neos\Neos\NodeTypePostprocessor\IconNameMappingPostprocessor'
     'DefaultPropertyEditorPostprocessor':
       position: 'end'

--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -5,6 +5,13 @@
   options:
     fusion:
       prototypeGenerator: ~
+  postprocessors:
+    'IconNameMappingPostprocessor':
+      position: 'end'
+      postprocessor: 'Neos\Neos\NodeTypePostprocessor\IconNameMappingPostprocessor'
+    'DefaultPropertyEditorPostprocessor':
+      position: 'end'
+      postprocessor: 'Neos\Neos\NodeTypePostprocessor\DefaultPropertyEditorPostprocessor'
   ui:
     inspector:
       tabs:


### PR DESCRIPTION
Introduce `NodeTypePresetPostprocessor` and extract `IconNameMappingPostprocessor` and `DefaultPropertyEditorPostprocessor` from `NodeTypeConfigurationEnrichmentAspect`.

This allows to configure nodeType presets via settings and apply them to nodeTypes via. Other than mixins this allows to ensure consistent configurations across differently named properties to ensure a consistent editor experience.

Note: This is mainly a core adaptation of the Sitegeist.Silhoettes package https://github.com/sitegeist/Sitegeist.Silhouettes.

The presets can be applied by definining the `options.preset` for childNodes or properties.

```
Neos:
  Neos:
    nodeTypes:

      presets:

        childNodes:
          vendor:
            defaultConstraints:
              constraints:
                'Neos.Neos:Content': true
                'Neos.NodeTypes.BaseMixins:TitleMixin': true

        properties:
          vendor:
            textBlock:
              type: string
              ui:
                inlineEditable
            type: string
            defaultValue: ''
            ui:
              inlineEditable: true
              inline:
                editorOptions:
                  placeholder: 'Vendor.Site:NodeTypes.Generic:text.placeholder'
                  autoparagraph: true
                  formatting:
                    strong: true
                    em: true
                    u: false
                    underline: false
```

Presets can then be applied to nodetypes via: 

```
'Vendor.Package:NodeTypeName':
  childNodes:
    column1:
      options:
        preset: 'vendor.defaultConstraints'    
    column2:
      options:
        preset: 'vendor.defaultConstraints'    
  properties:
    description:
      options:
        preset: 'vendor.textBlock'
```

Resolves: #3090

This also solves two thirds of #2867  (get rid of NodeTypeConfigurationEnrichmentAspect). The last part cannot be extracted that easily as it converts the magic value `i18n` to a key built from the NodeType it was defined on.