### PR TITLE
BUGFIX: TransientNodeCache must be able to return null

### DIFF
--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/TransientNodeCache.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/TransientNodeCache.php
@@ -28,7 +28,7 @@ class TransientNodeCache
      * @param callable $getter
      * @return NodeInterface
      */
-    public function cache(string $nodeIdentifier, callable $getter): NodeInterface
+    public function cache(string $nodeIdentifier, callable $getter): ?NodeInterface
     {
         if (array_key_exists($nodeIdentifier, $this->nodes)) {
             return $this->nodes[$nodeIdentifier];


### PR DESCRIPTION
This is an important bugfix because right now non existing nodes will result in a fatal error 
due to the type hint, when the $getter() actually doesn't resolve a node but null, which can happen.
The current behavior is therefore broken for many installations.

Relate #2301