### PR TITLE
BUGFIX: Correctly set apply values for instantiated array objects

### DIFF
--- a/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
@@ -66,4 +66,14 @@ class ComponentTest extends AbstractFusionObjectTest
         $view->setFusionPath('component/lazyRenderer');
         self::assertEquals('Hello', $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function componentWrapperRenderer()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('component/wrapperRenderer');
+        self::assertEquals('Default content', $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Component.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Component.fusion
@@ -48,3 +48,24 @@ component.lazyRenderer = Neos.Fusion:Component {
 
   renderer = ${props.a}
 }
+
+component.wrapperRenderer = Neos.Fusion:Component {
+  title = 'Hello'
+
+  content = Neos.Fusion:Component {
+    renderer = Neos.Fusion:Case {
+      default {
+        @position = 'end'
+        condition = ${true}
+        renderer = 'Default content'
+      }
+    }
+  }
+
+  renderer = Neos.Fusion:Component {
+    // The wrapper pattern passes all props down to another component
+    @apply.props = ${props}
+
+    renderer = ${props.content}
+  }
+}


### PR DESCRIPTION
With the introduction of lazy evaluation the apply values are stored as
an array of (absolute) paths and popped accordingly to the evaluation
stack. When an object is instantiated only the effective apply values
for this object must be set (and not all currently set apply values).

Fixes #3003

**What I did**

Adjusted the code in Runtime to only set applicable (stored) apply values when instantiating an object.

**How I did it**

- Reproduced the error
- Analyzed the rendering of the broken case with some added debugging output
- Found the case where `Case` will be instantiated with wrong props and spotted the issue introduced with 0642115d529237bd30ae1502a78409e7739c4718
- Implemented a minimal functional test case that reproduces the error
- Implemented the fix by only setting the actual apply values for the Fusion object (we already remember these for popping them after leaving the evaluation stack) and not _everything_ ever `@apply`'d

**How to verify it**

- Check the new functional test without the change to Runtime, it exposes the error from #3003
- Add a NodeType like described in #3003 and check the rendering

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)