### PR TITLE
BUGFIX: Only return users for Neos Backend from `UserService::getCurrentUser()`

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -231,13 +231,15 @@ class UserService
     /**
      * Returns the currently logged in user, if any
      *
+     * @param string $authenticationProviderName
      * @return User The currently logged in user, or null
      * @api
      */
-    public function getCurrentUser()
+    public function getCurrentUser($authenticationProviderName = null)
     {
         if ($this->securityContext->canBeInitialized() === true) {
-            $account = $this->securityContext->getAccount();
+            $authenticationProviderName = $authenticationProviderName ?: $this->defaultAuthenticationProviderName;
+            $account = $this->securityContext->getAccountByAuthenticationProviderName($authenticationProviderName);
             if ($account !== null) {
                 return $this->getUser(
                     $account->getAccountIdentifier(),


### PR DESCRIPTION
Fixes #3088 
Related to #2981