### PR TITLE
FEATURE: Allow users to log in without access to the content module

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/BackendController.php
+++ b/Neos.Neos/Classes/Controller/Backend/BackendController.php
@@ -83,7 +83,7 @@ class BackendController extends ActionController
      */
     public function indexAction(): void
     {
-        $redirectionUri = $this->backendRedirectionService->getAfterLoginRedirectionUri($this->request);
+        $redirectionUri = $this->backendRedirectionService->getAfterLoginRedirectionUri($this->controllerContext);
         if ($redirectionUri === null) {
             $redirectionUri = $this->uriBuilder->uriFor('index', [], 'Login', 'Neos.Neos');
         }

--- a/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
+++ b/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
@@ -116,7 +116,7 @@ class MenuHelper
      * @param ControllerContext $controllerContext
      * @return array
      */
-    public function buildModuleList(ControllerContext $controllerContext)
+    public function buildModuleList(ControllerContext $controllerContext): array
     {
         $modules = [];
         foreach ($this->settings['modules'] as $moduleName => $moduleConfiguration) {
@@ -144,14 +144,15 @@ class MenuHelper
                     if (isset($submoduleConfiguration['privilegeTarget']) && !$this->privilegeManager->isPrivilegeTargetGranted($submoduleConfiguration['privilegeTarget'])) {
                         continue;
                     }
-                    $submodules[] = $this->collectModuleData($controllerContext, $submoduleName, $submoduleConfiguration, $moduleName . '/' . $submoduleName);
+                    $submodules[$submoduleName] = $this->collectModuleData($controllerContext, $submoduleName, $submoduleConfiguration, $moduleName . '/' . $submoduleName);
                 }
             }
-            $modules[] = array_merge(
+            $modules[$moduleName] = array_merge(
                 $this->collectModuleData($controllerContext, $moduleName, $moduleConfiguration, $moduleName),
                 ['group' => $moduleName, 'submodules' => $submodules]
             );
         }
+
         return $modules;
     }
 

--- a/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
+++ b/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
@@ -13,6 +13,7 @@ namespace Neos\Neos\Controller\Backend;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Neos\Security\Authorization\Privilege\ModulePrivilege;
 use Neos\Neos\Security\Authorization\Privilege\ModulePrivilegeSubject;
@@ -20,6 +21,7 @@ use Neos\Neos\Service\IconNameMappingService;
 use Neos\Utility\Arrays;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Utility\PositionalArraySorter;
 
 /**
  * A helper class for menu generation in backend controllers / view helpers
@@ -115,11 +117,15 @@ class MenuHelper
     /**
      * @param ControllerContext $controllerContext
      * @return array
+     * @throws \Neos\Flow\Http\Exception
+     * @throws MissingActionNameException
      */
     public function buildModuleList(ControllerContext $controllerContext): array
     {
+        $moduleSettings = (new PositionalArraySorter($this->settings['modules']))->toArray();
         $modules = [];
-        foreach ($this->settings['modules'] as $moduleName => $moduleConfiguration) {
+
+        foreach ($moduleSettings as $moduleName => $moduleConfiguration) {
             if (!$this->isModuleEnabled($moduleName)) {
                 continue;
             }
@@ -131,8 +137,9 @@ class MenuHelper
                 continue;
             }
             $submodules = [];
-            if (isset($moduleConfiguration['submodules'])) {
-                foreach ($moduleConfiguration['submodules'] as $submoduleName => $submoduleConfiguration) {
+            if (isset($moduleConfiguration['submodules']) && is_array($moduleConfiguration['submodules'])) {
+                $submoduleSettings = (new PositionalArraySorter($moduleConfiguration['submodules']))->toArray();
+                foreach ($submoduleSettings as $submoduleName => $submoduleConfiguration) {
                     $modulePath = $moduleName . '/' . $submoduleName;
                     if (!$this->isModuleEnabled($modulePath)) {
                         continue;

--- a/Neos.Neos/Classes/Service/BackendRedirectionService.php
+++ b/Neos.Neos/Classes/Service/BackendRedirectionService.php
@@ -107,12 +107,6 @@ class BackendRedirectionService
     protected $privilegeManager;
 
     /**
-     * @Flow\InjectConfiguration(package="Neos.Neos", path="userInterface.routeAfterLogin.values")
-     * @var bool
-     */
-    protected $routingValuesAfterLogin;
-
-    /**
      * @Flow\InjectConfiguration(package="Neos.Neos", path="moduleConfiguration.preferredStartModules")
      * @var string[]
      */
@@ -135,8 +129,6 @@ class BackendRedirectionService
         }
 
         $availableModules = $this->menuHelper->buildModuleList($controllerContext);
-        $availableModules = $this->addContentModuleDefinitionIfAccessible($availableModules, $controllerContext);
-
         $startModule = $this->determineStartModule($availableModules);
 
         $workspaceName = $this->userService->getPersonalWorkspaceName();
@@ -164,37 +156,6 @@ class BackendRedirectionService
         }
 
         return $firstModule;
-    }
-
-    /**
-     * @param array $modules
-     * @param ControllerContext $controllerContext
-     * @return array
-     * @throws MissingActionNameException
-     * @throws \Neos\Flow\Http\Exception
-     */
-    protected function addContentModuleDefinitionIfAccessible(array $modules, ControllerContext $controllerContext): array
-    {
-        if (!$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.Module.Content')) {
-            return $modules;
-        }
-
-        $workspaceName = $this->userService->getPersonalWorkspaceName();
-
-        $uriBuilder = $controllerContext->getUriBuilder();
-        $uriBuilder->setFormat('html');
-        $uriBuilder->setCreateAbsoluteUri(true);
-
-        $nodeToEdit = $this->getLastVisitedNode($workspaceName);
-        if ($nodeToEdit === null) {
-            $contentContext = $this->createContext($workspaceName);
-            $nodeToEdit = $contentContext->getCurrentSiteNode();
-        }
-
-        $arguments = array_merge(['node' => $nodeToEdit], $this->routingValuesAfterLogin);
-
-        $modules['content'] = ['uri' => $uriBuilder->uriFor($this->routingValuesAfterLogin['@action'], $arguments, $this->routingValuesAfterLogin['@controller'], $this->routingValuesAfterLogin['@package'])];
-        return $modules;
     }
 
     /**

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -106,9 +106,6 @@ privilegeTargets:
 
   'Neos\Neos\Security\Authorization\Privilege\ModulePrivilege':
 
-    'Neos.Neos:Backend.Module.Content':
-      matcher: 'content'
-
     'Neos.Neos:Backend.Module.User':
       matcher: 'user'
 
@@ -179,10 +176,6 @@ roles:
 
       -
         privilegeTarget: 'Neos.Neos:ContentPreview'
-        permission: GRANT
-
-      -
-        privilegeTarget: 'Neos.Neos:Backend.Module.Content'
         permission: GRANT
 
       -

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -33,8 +33,8 @@ privilegeTargets:
     # Content access and publishing
     #
 
-    'Neos.Neos:Backend.Module.Content':
-      matcher: 'method(Neos\Neos\Controller\Backend\SchemaController->(nodeTypeSchema|vieSchema)Action()) || method(Neos\Neos\Controller\Backend\MenuController->indexAction()) || method(Neos\Neos\Controller\Backend\SettingsController->editPreviewAction())'
+    'Neos.Neos:Backend.Content.Services':
+      matcher: 'method(Neos\Neos\Controller\Backend\SchemaController->(nodeTypeSchema|vieSchema)Action()) || method(Neos\Neos\Controller\Backend\SettingsController->editPreviewAction())'
 
     'Neos.Neos:Backend.PersonalWorkspaceReadAccess.NodeConverter':
       matcher: 'method(Neos\Neos\TypeConverter\NodeConverter->prepareContextProperties(workspaceName === current.userInformation.personalWorkspaceName))'
@@ -105,6 +105,9 @@ privilegeTargets:
   #
 
   'Neos\Neos\Security\Authorization\Privilege\ModulePrivilege':
+
+    'Neos.Neos:Backend.Module.Content':
+      matcher: 'content'
 
     'Neos.Neos:Backend.Module.User':
       matcher: 'user'
@@ -219,6 +222,10 @@ roles:
         permission: GRANT
 
       -
+        privilegeTarget: 'Neos.Neos:Backend.Content.Services'
+        permission: GRANT
+
+      -
         privilegeTarget: 'Neos.Neos:Backend.DataSource'
         permission: GRANT
 
@@ -249,6 +256,7 @@ roles:
       -
         privilegeTarget: 'Neos.Neos:Backend.Module.Management.History'
         permission: GRANT
+
 
   'Neos.Neos:RestrictedEditor':
     parentRoles: ['Neos.Neos:AbstractEditor']

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -66,15 +66,6 @@ Neos:
           collapsed: true
 
     userInterface:
-      # Sets the route after login. There will be one argument "node" set with the lastVisited or site node (and correct context)
-      # The below configuration sets this to the "old" UI route.
-      routeAfterLogin:
-        values:
-          '@package': 'Neos.Neos'
-          '@controller': 'Frontend\Node'
-          '@action': 'show'
-          '@format': 'html'
-
       # should minified JavaScript be loaded? For developing the Neos
       # Content Module, this should be set to false.
       loadMinifiedJavascript: true

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -309,6 +309,9 @@ Neos:
       # Use `Lite` for a reduced variant with a less aggressive reset and other non essential styles removed.
       # Use `Minimal` when your module provides its own styles and Neos only needs to show the top and bottom bar.
       mainStylesheet: 'Main'
+
+      preferredStartModules: [ 'content','user/usersettings' ]
+
     modules:
       management:
         label: 'Neos.Neos:Modules:management.label'

--- a/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
+++ b/Neos.Neos/Resources/Private/Partials/Backend/Menu.html
@@ -6,49 +6,7 @@
   ></button>
   <div class="neos-menu-panel">
     <div class="neos-menu-wrapper">
-      <div class="neos-menu-section" data-key="content">
-        <div class="neos-menu-section-header" aria-expanded="false">
-          <h2>
-            <f:link.action
-              package="Neos.Neos"
-              controller="Backend\Backend"
-              action="index"
-              title="{neos:backend.translate(id: 'contentView', value: 'Content View')}"
-              class="neos-menu-headline"
-            >
-              <i class="fas fa-file"></i> {neos:backend.translate(id: 'content',
-              value: 'Content')}
-            </f:link.action>
-          </h2>
-          <button type="button" class="neos-button neos-menu-panel-toggle" role="button">
-            <i class="fas fa-chevron-circle-down"></i>
-          </button>
-        </div>
-        <f:if condition="{sites}">
-          <div class="neos-menu-section-content">
-            <div class="neos-menu-list">
-              <f:for each="{sites}" as="site">
-                <f:if condition="{site.uri}">
-                  <f:then>
-                    <a href="{site.uri}" title="{site.nodeName}">
-                      <i class="fas fa-globe"></i> {site.name}
-                    </a>
-                  </f:then>
-                  <f:else>
-                    <span
-                      title="{site.nodeName}"
-                      class="neos-menu-item neos-disabled"
-                    >
-                      <i class="fas fa-globe"></i> {site.name}
-                    </span>
-                  </f:else>
-                </f:if>
-              </f:for>
-            </div>
-          </div>
-        </f:if>
-      </div>
-      <f:for each="{modules}" as="module">
+      <f:for each="{modules}" as="module" key="moduleKey">
         <f:if condition="{module.hideInMenu}">
           <f:else>
             <f:render section="moduleMenu" arguments="{_all}" />
@@ -63,21 +21,18 @@
   <div class="neos-menu-section" data-key="{module.modulePath}">
     <div class="neos-menu-section-header" aria-expanded="false">
       <h2>
-        <neos:link.module
-          path="{module.modulePath}"
-          class="neos-menu-headline"
-        >
-          <i
-            class="{f:if(condition: module.icon, then: module.icon, else: 'fas fa-puzzle-piece')}"
-          ></i>
-          {neos:backend.translate(id: module.label, source: 'Modules', value:
-          module.label)}
+        <neos:link.module path="{module.modulePath}" class="neos-menu-headline">
+          <i class="{f:if(condition: module.icon, then: module.icon, else: 'fas fa-puzzle-piece')}"></i>
+          {neos:backend.translate(id: module.label, source: 'Modules', value: module.label)}
         </neos:link.module>
       </h2>
       <button type="button" class="neos-button neos-menu-panel-toggle" role="button">
         <i class="fas fa-chevron-circle-down"></i>
       </button>
     </div>
+    <f:if condition="{moduleKey}=='content'">
+        <f:render section="siteSelector" arguments="{_all}" />
+    </f:if>
     <f:if condition="{module.submodules}">
       <div class="neos-menu-section-content">
         <div class="neos-menu-list">
@@ -105,4 +60,28 @@
     {neos:backend.translate(id: submodule.label, source: 'Modules', value:
     submodule.label)}
   </neos:link.module>
+</f:section>
+
+
+<f:section name="siteSelector">
+    <f:if condition="{sites}">
+        <div class="neos-menu-section-content">
+            <div class="neos-menu-list">
+                <f:for each="{sites}" as="site">
+                    <f:if condition="{site.uri}">
+                        <f:then>
+                            <a href="{site.uri}" title="{site.nodeName}">
+                                <i class="fas fa-globe"></i> {site.name}
+                            </a>
+                        </f:then>
+                        <f:else>
+                        <span title="{site.nodeName}" class="neos-menu-item neos-disabled">
+                          <i class="fas fa-globe"></i> {site.name}
+                        </span>
+                        </f:else>
+                    </f:if>
+                </f:for>
+            </div>
+        </div>
+    </f:if>
 </f:section>


### PR DESCRIPTION
Before, it was not possible to log in to the Neos backend without having access to the content module, as the user was automatically redirected to the content module.

With this feature, an available module is determined when a user logs in and the user is redirected to that module.

# High level features

- Users no longer need to have access to the content module to be able to log in
- There is a setting `Neos.Neos.moduleConfiguration.preferredStartModules` available to define the preferred start modules. The first module of that list, which a user has access to is chosen for the start module. If none of the listed modules can be accessed, the first module of the list of accessible modules of a user is chosen:
- The backend modules and sub modules can now be sorted using the positional array sorter

```
Neos:
  Neos:
    moduleConfiguration:
      preferredStartModules: [ 'content', 'user/usersettings' ]
```

## Details

- A user who has no access to the content module is redirected to the first (preferred) accessible content module
- A user who has access to the content module is still redirected to the content module by default
- A user without access to the content module does not see the available sites menu
- When the `preferredStartModule` is not `content`, the content module is still selectable

# Update notes

- This removes `Neos.Neos.userInterface.routeAfterLogin`, it can be dropped from custom configuration

Resolves: #2351
Depends on: https://github.com/neos/neos-ui/pull/2793