### PR TITLE
BUGFIX: Require jQuery Version 3.5.1

### DIFF
--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -10,7 +10,7 @@ Neos:
     Browser:
       bodyClasses: 'neos neos-module media-browser'
       scripts:
-        - 'resource://Neos.Neos/Public/Library/jquery/jquery-2.0.3.js'
+        - 'resource://Neos.Neos/Public/Library/jquery/jquery-3.5.1.js'
         - 'resource://Neos.Twitter.Bootstrap/Public/2/js/bootstrap.min.js'
         - 'resource://Neos.Neos/Public/Library/bootstrap-components.js'
         - 'resource://Neos.Media.Browser/Public/JavaScript/media-browser.js'


### PR DESCRIPTION
After the https://github.com/neos/neos-development-collection/pull/3023 the image selector in the backend was broken.