### PR TITLE
BUGFIX: Fix LinkingService for CLI mode

### DIFF
--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -320,7 +320,7 @@ class LinkingService
             $site = $this->siteRepository->findOneByNodeName($siteNodeName);
         }
 
-        $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+        $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest($request->getHttpRequest());
         if ($site->hasActiveDomains()) {
             $requestUriHost = $baseUri->getHost();
             $activeHostPatterns = $site->getActiveDomains()->map(static function (Domain $domain) {
@@ -353,9 +353,10 @@ class LinkingService
         if ($primaryDomain === null) {
             throw new NeosException(sprintf('Cannot link to a site "%s" since it has no active domains.', $site->getName()), 1460443524);
         }
-        $requestUri = $controllerContext->getRequest()->getHttpRequest()->getUri();
+        $httpRequest = $controllerContext->getRequest()->getHttpRequest();
+        $requestUri = $httpRequest->getUri();
         // TODO: Should probably directly use \Neos\Flow\Http\Helper\RequestInformationHelper::getRelativeRequestPath() and even that is tricky.
-        $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+        $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest($httpRequest);
         $port = $primaryDomain->getPort() ?: $requestUri->getPort();
         return sprintf(
             '%s://%s%s%s',


### PR DESCRIPTION
Specifies the HTTP request from the ControllerContext as
fallback for the `BaseUriProvider` in order to prevent an
exception when trying to create Node URIs on the CLI.

Note: This requires https://github.com/neos/flow-development-collection/pull/2158

Fixes: #3128
Related: https://github.com/neos/flow-development-collection/issues/2084