### PR TITLE
FEATURE: Add StaticResource helper to Fusion defaults

### DIFF
--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -43,6 +43,7 @@ Neos:
       Json: 'Neos\Eel\Helper\JsonHelper'
       Security: 'Neos\Eel\Helper\SecurityHelper'
       Translation: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
+      StaticResource: 'Neos\Flow\ResourceManagement\EelHelper\StaticResourceHelper'
       Type: 'Neos\Eel\Helper\TypeHelper'
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       File: 'Neos\Eel\Helper\FileHelper'


### PR DESCRIPTION
Add the StaticResource EEL Helper from https://github.com/neos/flow-development-collection/pull/2174 to the Fusion defaultContext. 

StaticResource.uri (packageKey, pathAndFilename, localize)
- (string) packageKey
- (string) pathAndFilename
- (boolean, optional) localize = false

StaticResource.content (packageKey, pathAndFilename, localize)
- (string) packageKey
- (string) pathAndFilename
- (boolean, optional) localize = false

This makes this helper available in afx:

```
  <!-- create static resource uri -->
  <link rel="stylesheet" href={StaticResource.uri('Neos.Demo', 'Public/Styles/Main.css')} media="all" />

  <!-- get static resource content -->
  <style>{StaticResource.content('Neos.Demo', 'Public/Styles/Main.css')}</style>
```

Resolves: #3133
