### PR TITLE
FEATURE: Allow the format `avif` for thumbnail generation.

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailConfiguration.php
@@ -75,7 +75,7 @@ class ThumbnailConfiguration
      * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
      * @param boolean $async Whether the thumbnail can be generated asynchronously
      * @param integer $quality Quality of the processed image
-     * @param string $format Format for the image, only jpg, jpeg, gif, png, wbmp, xbm, webp and bmp are supported.
+     * @param string $format Format for the image, only jpg, jpeg, gif, png, wbmp, xbm, webp, avif and bmp are supported.
      */
     public function __construct($width = null, $maximumWidth = null, $height = null, $maximumHeight = null, $allowCropping = false, $allowUpScaling = false, $async = false, $quality = null, $format = null)
     {

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -78,7 +78,7 @@ class ImageService
     /**
      * @var array<string>
      */
-    protected static $allowedFormats = ['jpg', 'jpeg', 'gif', 'png', 'wbmp', 'xbm', 'webp', 'bmp'];
+    protected static $allowedFormats = ['jpg', 'jpeg', 'gif', 'png', 'wbmp', 'xbm', 'webp', 'bmp', 'avif'];
 
     /**
      * @param array $settings


### PR DESCRIPTION
As with `webp` the format has to be supported by the library behind imagine aswell.
Currently `avif` is only supported by imagick > 7.0.10-25 and libheif > 1.7.0.

Resolves: #3132