### PR TITLE
BUGFIX: Use autorotate filter to apply resize adjustments properly to images with exif-orientations

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -456,6 +456,9 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
             throw new \InvalidArgumentException('Invalid mode specified', 1574686891);
         }
 
+        $autorotateFilter = new \Imagine\Filter\Basic\Autorotate();
+        $autorotateFilter->apply($image);
+
         $imageSize = $image->getSize();
         $requestedDimensions = $this->calculateDimensions($imageSize);
 

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -169,7 +169,7 @@ class ImageService
                 $adjustmentsApplied = true;
             }
         }
-        
+
         $additionalOptions = $this->getOptionsMergedWithDefaults($additionalOptions);
 
         if ($adjustmentsApplied === true) {
@@ -260,6 +260,10 @@ class ImageService
         } else {
             try {
                 $imagineImage = $this->imagineService->read($resource->getStream());
+
+                $autorotateFilter = new \Imagine\Filter\Basic\Autorotate();
+                $autorotateFilter->apply($imagineImage);
+
                 $sizeBox = $imagineImage->getSize();
                 $imageSize = ['width' => $sizeBox->getWidth(), 'height' => $sizeBox->getHeight()];
             } catch (\Exception $e) {


### PR DESCRIPTION
The autorotate is applied before calculating the resize dimensions to work with correct size values.

How to test:
- Go to the media module
- Upload an image with exif orientation like https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_6.jpg
- Look at the generated thumbnails (without this change the thumbnail is rotated 90°)

Resolves: #3148 