### PR TITLE
FEATURE: Improve Neos.Neos:ConvertUris

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -147,7 +147,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
         $processedContent = preg_replace_callback(
             '~<a .*?href="(.*?)".*?>~i',
-            function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $relAttributeValue, $linkType) {
+            function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $relAttributeValue) {
                 list($linkText, $linkHref) = $matches;
                 $uriHost = parse_url($linkHref, PHP_URL_HOST);
                 $target = null;

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
@@ -15,6 +15,6 @@ prototype(Neos.Neos:ConvertUris) {
   # The value of the rel attribute for external links
   relAttributeValue = 'noopener'
 
-  # Deprectated with Neos 6.0 and will be removed with Neos 7.0
+  # Deprecated with Neos 6.0 and will be removed with Neos 7.0
   setNoOpener = true
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
@@ -3,12 +3,18 @@
 # replaces all occurrences of "node://<UUID>" by proper URIs.
 #
 prototype(Neos.Neos:ConvertUris) {
-	@class = 'Neos\\Neos\\Fusion\\ConvertUrisImplementation'
-	value = ${value}
-	node = ${node}
-	externalLinkTarget = '_blank'
-	resourceLinkTarget = '_blank'
-	absolute = false
-	# Sets the rel="noopener" attribute to external links, which is good practice.
-	setNoOpener = true
+  @class = 'Neos\\Neos\\Fusion\\ConvertUrisImplementation'
+  value = ${value}
+  node = ${node}
+  externalLinkTarget = '_blank'
+  resourceLinkTarget = '_blank'
+  absolute = false
+
+  # Set the rel attribute to to external links, which is good practice.
+  setRelAttribute = true
+  # The value of the rel attribute for external links
+  relAttributeValue = 'noopener'
+
+  # Deprectated with Neos 6.0 and will be removed with Neos 7.0
+  setNoOpener = true
 }


### PR DESCRIPTION
## Improvements

* You can set the value of the `rel` attribute (e.g. `nofollow noopener`)
* The `rel` value get merged with existent `rel` attributes
* When you set the external target to something different (e.g. `'external`) or disable it with `false`, the `rel` attribute will still be set