### PR TITLE
BUGFIX: Respect already defined attributes in Neos.Neos:ConvertUris

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -156,10 +156,10 @@ class ConvertUrisImplementation extends AbstractFusionObject
                     $target = $resourceLinkTarget;
                 }
                 if ($isExternalLink && $setNoOpener) {
-                    $linkText = ConvertUrisImplementation::_setAttribute('rel', 'noopener', $linkText, true);
+                    $linkText = self::setAttribute('rel', 'noopener', $linkText, true);
                 }
                 if (is_string($target) && strlen($target) !== 0) {
-                    return ConvertUrisImplementation::_setAttribute('target', $target, $linkText);
+                    return self::setAttribute('target', $target, $linkText);
                 }
                 return $linkText;
             },
@@ -178,7 +178,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
      * @param boolean $multipleArguments
      * @return string
      */
-    private static function _setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
+    private static function setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
     {
         // The attribute is already set
         if (\preg_match_all('~\s+' . $attribute . '="(.*?)~i', $content, $matches)) {

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -117,7 +117,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         }, $text);
 
         if ($unresolvedUris !== []) {
-            $processedContent = preg_replace('/<a(?: [^>]*)? href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
+            $processedContent = preg_replace('/<a(?:\s+[^>]*)?\s+href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
             $processedContent = preg_replace(LinkingService::PATTERN_SUPPORTED_URIS, '', $processedContent);
         }
 
@@ -142,7 +142,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
         $processedContent = \preg_replace_callback(
-            '~<a .*?href="(.*?)".*?>~i',
+            '~<a\s+.*?href="(.*?)".*?>~i',
             static function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $setNoOpener) {
                 [$linkText, $linkHref] = $matches;
                 $uriHost = \parse_url($linkHref, PHP_URL_HOST);

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -181,7 +181,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
     private static function _setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
     {
         // The attribute is already set
-        if (\preg_match_all('~ ' . $attribute . '="(.*?)~i', $content, $matches)) {
+        if (\preg_match_all('~\s+' . $attribute . '="(.*?)~i', $content, $matches)) {
             // If multiple arguments are not allowed or the value is already set, leave the attribute as it is
             if (!$multipleArguments || \preg_match('~' . $attribute . '=".*?' . $value . '.*?"~i', $content)) {
                 return $content;

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Neos\Fusion;
 
 /*

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Fusion;
 
 /*
@@ -180,7 +181,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
     private static function _setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
     {
         // The attribute is already set
-        if (\preg_match_all('~' . $attribute . '="(.*?)~i', $content, $matches)) {
+        if (\preg_match_all('~ ' . $attribute . '="(.*?)~i', $content, $matches)) {
             // If multiple arguments are not allowed or the value is already set, leave the attribute as it is
             if (!$multipleArguments || \preg_match('~' . $attribute . '=".*?' . $value . '.*?"~i', $content)) {
                 return $content;

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -83,7 +83,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
             throw new Exception(sprintf('The current node must be an instance of NodeInterface, given: "%s".', gettype($text)), 1382624087);
         }
 
-        if ($node->getContext()->getWorkspace()->getName() !== 'live' && !($this->fusionValue('forceConversion'))) {
+        if (!($this->fusionValue('forceConversion')) && $node->getContext()->getWorkspace()->getName() !== 'live') {
             return $text;
         }
 

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -155,10 +155,10 @@ class ConvertUrisImplementation extends AbstractFusionObject
                     $target = $resourceLinkTarget;
                 }
                 if ($isExternalLink && $setNoOpener) {
-                    $linkText = ConvertUrisImplementation::setAttribute('rel', 'noopener', $linkText, true);
+                    $linkText = ConvertUrisImplementation::_setAttribute('rel', 'noopener', $linkText, true);
                 }
                 if ($target && is_string($target)) {
-                    return ConvertUrisImplementation::setAttribute('target', $target, $linkText);
+                    return ConvertUrisImplementation::_setAttribute('target', $target, $linkText);
                 }
                 return $linkText;
             },
@@ -177,7 +177,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
      * @param boolean $multipleArguments
      * @return string
      */
-    static function setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
+    private static function _setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
     {
         // The attribute is already set
         if (\preg_match_all('~' . $attribute . '="(.*?)~i', $content, $matches)) {

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -156,7 +156,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
                     $target = $resourceLinkTarget;
                 }
                 if ($isExternalLink && $setNoOpener) {
-                    $linkText = self::setAttribute('rel', 'noopener', $linkText, true);
+                    $linkText = self::setAttribute('rel', 'noopener', $linkText);
                 }
                 if (is_string($target) && strlen($target) !== 0) {
                     return self::setAttribute('target', $target, $linkText);
@@ -172,18 +172,17 @@ class ConvertUrisImplementation extends AbstractFusionObject
     /**
      * Set or add value to the a attribute
      *
-     * @param string $attribute
-     * @param string $value
-     * @param string $content
-     * @param boolean $multipleArguments
+     * @param string $attribute The attribute, ('target' or 'rel')
+     * @param string $value The value of the attribute to add
+     * @param string $content The content to parse
      * @return string
      */
-    private static function setAttribute(string $attribute, string $value, string $content, bool $multipleArguments = false): string
+    private static function setAttribute(string $attribute, string $value, string $content): string
     {
         // The attribute is already set
         if (\preg_match_all('~\s+' . $attribute . '="(.*?)~i', $content, $matches)) {
-            // If multiple arguments are not allowed or the value is already set, leave the attribute as it is
-            if (!$multipleArguments || \preg_match('~' . $attribute . '=".*?' . $value . '.*?"~i', $content)) {
+            // If the attribute is target or the value is already set, leave the attribute as it is
+            if ($attribute === 'target' || \preg_match('~' . $attribute . '=".*?' . $value . '.*?"~i', $content)) {
                 return $content;
             }
             // Add the attribute to the list

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -158,7 +158,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
                 if ($isExternalLink && $setNoOpener) {
                     $linkText = ConvertUrisImplementation::_setAttribute('rel', 'noopener', $linkText, true);
                 }
-                if ($target && is_string($target)) {
+                if (is_string($target) && strlen($target) !== 0) {
                     return ConvertUrisImplementation::_setAttribute('target', $target, $linkText);
                 }
                 return $linkText;

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertUris.fusion
@@ -9,6 +9,7 @@ prototype(Neos.Neos:ConvertUris) {
 	externalLinkTarget = '_blank'
 	resourceLinkTarget = '_blank'
 	absolute = false
+	forceConversion = false
 	# Sets the rel="noopener" attribute to external links, which is good practice.
 	setNoOpener = true
 }

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Tests\Unit\Fusion;
 
 /*
@@ -189,15 +190,15 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $self = $this;
         $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveNodeUri')->will($this->returnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
             if ($nodeUri === 'node://' . $nodeIdentifier1) {
-                return 'http://replaced/uri/01';
+                return 'http://localhost/replaced/uri/01';
             } elseif ($nodeUri === 'node://' . $nodeIdentifier2) {
-                return 'http://replaced/uri/02';
+                return 'http://localhost/replaced/uri/02';
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
         }));
 
-        $expectedResult = 'This string contains a node URI: http://replaced/uri/01 and two <a href="http://replaced/uri/02">node</a> <a href="http://replaced/uri/01">links</a>.';
+        $expectedResult = 'This string contains a node URI: http://localhost/replaced/uri/01 and two <a href="http://localhost/replaced/uri/02">node</a> <a href="http://localhost/replaced/uri/01">links</a>.';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -217,15 +218,15 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $self = $this;
         $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveNodeUri')->will($this->returnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
             if ($nodeUri === 'node://' . $nodeIdentifier1) {
-                return 'http://replaced/uri/01';
+                return 'http://localhost/replaced/uri/01';
             } elseif ($nodeUri === 'node://' . $nodeIdentifier2) {
-                return 'http://replaced/uri/02';
+                return 'http://localhost/replaced/uri/02';
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
         }));
 
-        $expectedResult = 'This string contains a node URI: http://replaced/uri/01 and two <a href="http://replaced/uri/02">node</a> <a href="http://replaced/uri/01">links</a>.';
+        $expectedResult = 'This string contains a node URI: http://localhost/replaced/uri/01 and two <a href="http://localhost/replaced/uri/02">node</a> <a href="http://localhost/replaced/uri/01">links</a>.';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -273,7 +274,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             }
         }));
 
-        $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example2</a>';
+        $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a target="top" rel="noopener" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example2</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -301,7 +302,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             return 'http://localhost/_Resources/01';
         }));
 
-        $expectedResult = 'This string contains two asset links and an external link: one with a target set <a target="' . $resourceLinkTarget . '" rel="noopener" href="http://localhost/_Resources/01">example</a> and one without a target <a target="' . $resourceLinkTarget . '" rel="noopener" href="http://localhost/_Resources/01">example2</a> and an external link <a href="http://www.example.org">example3</a>';
+        $expectedResult = 'This string contains two asset links and an external link: one with a target set <a target="top" href="http://localhost/_Resources/01">example</a> and one without a target <a target="' . $resourceLinkTarget . '" href="http://localhost/_Resources/01">example2</a> and an external link <a rel="noopener" href="http://www.example.org">example3</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -341,7 +342,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             return 'http://localhost/_Resources/01';
         }));
 
-        $expectedResult = 'and an external link inside another tag beginning with a <article> test <a target="' . $resourceLinkTarget . '" rel="noopener" href="http://localhost/_Resources/01">example1</a></article>';
+        $expectedResult = 'and an external link inside another tag beginning with a <article> test <a target="' . $resourceLinkTarget . '" href="http://localhost/_Resources/01">example1</a></article>';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -274,7 +274,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             }
         }));
 
-        $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a target="top" rel="noopener" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example2</a>';
+        $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a rel="noopener" target="top" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example2</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
         $this->assertSame($expectedResult, $actualResult);
     }


### PR DESCRIPTION
* The `rel` value get merged with existent`rel` attributes
* If a value already exists, it will not get overridden. Example `<a href="https://external.site" target="external">` the target stays `external`
* When you set the external target to something different (e.g. `'external'`) or disable it with false, the `rel` attribute will still be set
* If you have `data-target` set, this will not be overwritten

Fixes: #2942