### PR TITLE
BUGFIX: set collection mode explicitly for custom collection links

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -126,7 +126,7 @@
                 </li>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
-                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
                             {assetCollection.object.title}
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>


### PR DESCRIPTION
**What I did**
I set the collection mode explicitly to 0 to correct the argument in the url for switching to a custom collection. This Fixes Issue https://github.com/neos/neos-development-collection/issues/3161 
**How I did it**
I adjusted the arguments in the link generation in the template for the index action. 
**How to verify it**
Switch to the All collection and than by clicking on an link for a custom collection the view switches to the selected collection. 
**Checklist**

- [ x] Code follows the PSR-2 coding style
- [ x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) with the bug (5.3)
