### PR TITLE
BUGFIX: Flush 1st level node caches after publishing

### DIFF
--- a/Neos.ContentRepository/Classes/Package.php
+++ b/Neos.ContentRepository/Classes/Package.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Booting\Sequence;
 use Neos\Flow\Core\Bootstrap;
@@ -43,6 +44,14 @@ class Package extends BasePackage
         $dispatcher->connect(Node::class, 'nodePathChanged', function () use ($bootstrap) {
             $contextFactory = $bootstrap->getObjectManager()->get(ContextFactoryInterface::class);
             /** @var Context $contextInstance */
+            foreach ($contextFactory->getInstances() as $contextInstance) {
+                $contextInstance->getFirstLevelNodeCache()->flush();
+            }
+        });
+
+        // this fixes https://github.com/neos/neos-development-collection/issues/3173
+        $dispatcher->connect(Workspace::class, 'afterNodePublishing', function () use ($bootstrap) {
+            $contextFactory = $bootstrap->getObjectManager()->get(ContextFactoryInterface::class);
             foreach ($contextFactory->getInstances() as $contextInstance) {
                 $contextInstance->getFirstLevelNodeCache()->flush();
             }


### PR DESCRIPTION
When a fresh variant is published outdated URLs may be generated if
the urlPathSegment was changed on the variant.

Fixes #3173
