### PR TITLE
BUGFIX: Correct bug in migration of ContentCollectionConstraints

### DIFF
--- a/Neos.Neos/Migrations/Code/Version20201108113821.php
+++ b/Neos.Neos/Migrations/Code/Version20201108113821.php
@@ -37,7 +37,7 @@ class Version20201108113821 extends AbstractMigration
 
                     // transform constraints of nodes derived from Neos.Neos:ContentCollection
                     if (isset($nodeType['superTypes'])
-                        && in_array('Neos.Neos:ContentCollection', $nodeType['superTypes'])
+                        && array_key_exists('Neos.Neos:ContentCollection', $nodeType['superTypes'])
                         && isset($nodeType['constraints'])
                     ) {
                         $this->transformContentCollectionConstraints($nodeType['constraints']);


### PR DESCRIPTION
The adjustments were applied to all nodes with constraints because the existence of the superType "Neos.Neos:ContentCollection" was not properly checked. 

The fixed migration was introduced in #3163