### PR TITLE
TASK: Remove use of resolveShortcuts argument

### DIFF
--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -233,7 +233,7 @@ class LinkingService
      * @param string $section
      * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
      * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = true
-     * @param boolean $resolveShortcuts @deprecated With Neos 6.0 this argument is no longer evaluated and will throw an exception if set to FALS
+     * @param boolean $resolveShortcuts @deprecated With Neos 6.0 this argument is no longer evaluated and log a message if set to FALSE
      * @return string The rendered URI
      * @throws NeosException if no URI could be resolved for the given node
      * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -149,7 +149,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
         $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
         $this->registerArgument('baseNodeName', 'string', 'The name of the base node inside the Fusion context to use for the ContentContext or resolving relative paths', false, 'documentNode');
         $this->registerArgument('nodeVariableName', 'string', 'The variable the node will be assigned to for the rendered child content', false, 'linkedNode');
-        $this->registerArgument('resolveShortcuts', 'boolean', 'INTERNAL Parameter - if false, shortcuts are not redirected to their target. Only needed on rare backend occasions when we want to link to the shortcut itself', false, true);
+        $this->registerArgument('resolveShortcuts', 'boolean', 'DEPRECATED Parameter - ignored', false, true);
     }
 
     /**
@@ -181,8 +181,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
                 $this->arguments['arguments'],
                 $this->arguments['section'],
                 $this->arguments['addQueryString'],
-                $this->arguments['argumentsToBeExcludedFromQueryString'],
-                $this->arguments['resolveShortcuts']
+                $this->arguments['argumentsToBeExcludedFromQueryString']
             );
             $this->tag->addAttribute('href', $uri);
         } catch (NeosException $exception) {

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -122,7 +122,7 @@ class NodeViewHelper extends AbstractViewHelper
         $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
         $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
         $this->registerArgument('baseNodeName', 'string', 'The name of the base node inside the Fusion context to use for the ContentContext or resolving relative paths', false, 'documentNode');
-        $this->registerArgument('resolveShortcuts', 'boolean', 'INTERNAL Parameter - if false, shortcuts are not redirected to their target. Only needed on rare backend occasions when we want to link to the shortcut itself.', false, true);
+        $this->registerArgument('resolveShortcuts', 'boolean', 'DEPRECATED Parameter - ignored', false, true);
     }
 
     /**
@@ -154,8 +154,7 @@ class NodeViewHelper extends AbstractViewHelper
                 $this->arguments['arguments'],
                 $this->arguments['section'],
                 $this->arguments['addQueryString'],
-                $this->arguments['argumentsToBeExcludedFromQueryString'],
-                $this->arguments['resolveShortcuts']
+                $this->arguments['argumentsToBeExcludedFromQueryString']
             );
         } catch (NeosException $exception) {
             $this->throwableStorage->logThrowable($exception);


### PR DESCRIPTION
The LinkingService.createNodeUri() no longer uses/accepts this
parameter…

See https://github.com/neos/neos-development-collection/pull/3168