### PR TITLE
BUGFIX: Aspected convertObjectToIdentityArray should return an array

### DIFF
--- a/Neos.Neos/Classes/Routing/NodeIdentityConverterAspect.php
+++ b/Neos.Neos/Classes/Routing/NodeIdentityConverterAspect.php
@@ -38,7 +38,7 @@ class NodeIdentityConverterAspect
     {
         $objectArgument = $joinPoint->getMethodArgument('object');
         if ($objectArgument instanceof NodeInterface) {
-            return $objectArgument->getContextPath();
+            return ['__identity' => $objectArgument->getContextPath()];
         } else {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         }


### PR DESCRIPTION
This will create an error with typehints as with the changes in Flow 7.0