### PR TITLE
TASK: Adjust Node and NodeInterface deprecation annotations

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -114,8 +114,10 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      *
      * Example: /sites/mysitecom/homepage/about@user-admin
      *
+     * NOTE: This method will probably be removed at some point. Code should never rely on the exact format of the context path
+     *       since that might change in the future.
+     *
      * @return string Node path with context information
-     * @deprecated with version 4.3 - Use the node's NodeAddress instead
      */
     public function getContextPath()
     {
@@ -405,8 +407,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the path of this node
      *
      * @return string
-     * @api
-     * @deprecated with version 4.3, use findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findNodePath() instead.
      */
     public function getPath()
     {
@@ -429,7 +430,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the name of this node
      *
      * @return string
-     * @deprecated with version 4.3, use getNodeName() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::getNodeName() instead.
      */
     public function getName()
     {
@@ -457,7 +458,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @return void
      * @throws NodeException
      * @throws NodeTypeNotFoundException
-     * @deprecated with version 4.3 - From 5.0 you will be able to use the ContentStream instead
      */
     public function setWorkspace(Workspace $workspace): void
     {
@@ -476,7 +476,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the workspace this node is contained in
      *
      * @return Workspace
-     * @deprecated with version 4.3 - From 5.0 you will be able to use the ContentStream instead
      */
     public function getWorkspace()
     {
@@ -503,7 +502,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @return void
      * @throws NodeException
      * @throws NodeTypeNotFoundException
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
      */
     public function setIndex($index): void
     {
@@ -523,7 +521,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * with the same parent node.
      *
      * @return integer
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
      */
     public function getIndex()
     {
@@ -534,7 +531,11 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the parent node of this node
      *
      * @return NodeInterface|null The parent node or NULL if this is the root node
-     * @deprecated with version 4.3, use findParentNode() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findParentNode() instead.
+     *  Beware that findParentNode() is not fully equivalent to this method.
+     *  It has a different root node handling:
+     *    - findParentNode() throws an exception for the root node
+     *    - getParent() returns <code>null</code> for the root node
      */
     public function getParent()
     {
@@ -557,7 +558,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the parent node path
      *
      * @return string Absolute node path of the parent node
-     * @deprecated with version 4.3, use findParentNode()->findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findParentNode()->findNodePath() instead.
      */
     public function getParentPath(): string
     {
@@ -1007,7 +1008,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      *
      * @param object $contentObject The content object
      * @return void
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      * @throws NodeTypeNotFoundException
      * @throws NodeException
      */
@@ -1027,7 +1028,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the content object of this node (if any).
      *
      * @return object
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      */
     public function getContentObject()
     {
@@ -1040,7 +1041,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @return void
      * @throws NodeTypeNotFoundException
      * @throws NodeException
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      */
     public function unsetContentObject(): void
     {
@@ -1206,7 +1207,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      *
      * @param string $path Path specifying the node, relative to this node
      * @return NodeInterface|null The specified node or NULL if no such node exists
-     * @deprecated with version 4.3 - use findNamedChildNode() instead - for absolute paths a new API will be added with 5.0
+     * @deprecated with version 4.3 - use TraversableNodeInterface::findNamedChildNode() instead
      */
     public function getNode($path): ?NodeInterface
     {
@@ -1227,7 +1228,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * node type. For now it is just the first child node.
      *
      * @return NodeInterface|null The primary child node or NULL if no such node exists
-     * @deprecated with version 4.3, without any replacement.
+     * @deprecated with version 4.3. use TraversableNodeInterface::findChildNodes() instead, the first result is considered the "primary child node"
      */
     public function getPrimaryChildNode(): ?NodeInterface
     {
@@ -1242,7 +1243,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @param integer $limit An optional limit for the number of nodes to find. Added or removed nodes can still change the number nodes!
      * @param integer $offset An optional offset for the query
      * @return array<\Neos\ContentRepository\Domain\Model\NodeInterface> An array of nodes or an empty array if no child nodes matched
-     * @deprecated with version 4.3, use findChildNodes() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findChildNodes() instead.
      */
     public function getChildNodes($nodeTypeFilter = null, $limit = null, $offset = null): array
     {
@@ -1278,7 +1279,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      *
      * @param string $nodeTypeFilter If specified, only nodes with that node type are considered
      * @return boolean true if this node has child nodes, otherwise false
-     * @deprecated with version 4.3, use findChildNodes() instead and count the result
+     * @deprecated with version 4.3, use TraversableNodeInterface::findChildNodes() instead and count the result
      */
     public function hasChildNodes($nodeTypeFilter = null): bool
     {
@@ -1333,7 +1334,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * If this node is a removed node.
      *
      * @return boolean
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve removed nodes
      */
     public function isRemoved(): bool
     {
@@ -1397,7 +1397,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the date and time before which this node will be automatically hidden.
      *
      * @return \DateTimeInterface Date before this node will be hidden
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function getHiddenBeforeDateTime(): ?\DateTimeInterface
     {
@@ -1429,7 +1428,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the date and time after which this node will be automatically hidden.
      *
      * @return \DateTimeInterface Date after which this node will be hidden
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function getHiddenAfterDateTime(): ?\DateTimeInterface
     {
@@ -1476,7 +1474,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @api
      * @throws NodeTypeNotFoundException
      * @throws NodeException
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function setAccessRoles(array $accessRoles): void
     {
@@ -1496,7 +1494,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the names of defined access roles
      *
      * @return array
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function getAccessRoles(): array
     {
@@ -1508,7 +1506,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * current security context.
      *
      * @return boolean
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function hasAccessRestrictions(): bool
     {
@@ -1522,7 +1520,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * taken into account.
      *
      * @return boolean
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function isVisible(): bool
     {
@@ -1544,7 +1541,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Tells if this node may be accessed according to the current security context.
      *
      * @return boolean
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function isAccessible(): bool
     {
@@ -1555,7 +1552,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the context this node operates in.
      *
      * @return Context
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement, but you can access the node's subGraph via getSubgraph()
+     * @internal This method is not meant to be called in userland code
      */
     public function getContext(): Context
     {
@@ -1725,7 +1722,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
 
     /**
      * @return NodeData
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
+     * @internal This is not meant to be used in userland code
      */
     public function getNodeData(): NodeData
     {
@@ -1747,7 +1744,6 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Return the assigned content dimensions of the node.
      *
      * @return array
-     * @deprecated with version 4.3 - will be replaced in 5.0 by getOriginDimensionSpacePoint() and getDimensionSpacePoint()
      */
     public function getDimensions(): array
     {
@@ -1845,7 +1841,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      *
      * @param NodeData $nodeData
      * @return void
-     * @deprecated with version 4.3 - will be removed with 5.0
+     * @internal This method is not meant to be called from userland
      */
     public function setNodeData(NodeData $nodeData): void
     {
@@ -1874,7 +1870,8 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * should not be deleted.
      *
      * @return boolean true if this node is auto-created by the parent.
-     * @deprecated with version 4.3 - will be replaced by isTethered with 5.0.
+     * @deprecated with version 4.3. This information should not be required usually. Otherwise it can be determined via:
+     * if (array_key_exists((string)$node->getNodeName(), $parent->getNodeType()->getAutoCreatedChildNodes()))
      */
     public function isAutoCreated(): bool
     {

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
@@ -17,10 +17,9 @@ use Neos\ContentRepository\Exception\NodeException;
 use Neos\ContentRepository\Exception\NodeExistsException;
 
 /**
- * Interface for a Node. This is the central interface for the Neos Content Repository
- * up to version 4.X; it will be REMOVED in version 5.0 and is replaced
- * by {@see Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface}.
+ * Interface for a Node. This is the central interface for the Neos Content Repository.
  *
+ * Note: This will be replaced by {@see Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface} at some point
  * @api
  */
 interface NodeInterface
@@ -82,8 +81,7 @@ interface NodeInterface
      * Returns the name of this node
      *
      * @return string
-     * @api
-     * @deprecated with version 4.3, use getNodeName() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::getNodeName() instead.
      */
     public function getName();
 
@@ -171,7 +169,7 @@ interface NodeInterface
      * @param object $contentObject The content object
      * @return void
      * @throws \InvalidArgumentException if the given contentObject is no object.
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      */
     public function setContentObject($contentObject);
 
@@ -179,7 +177,7 @@ interface NodeInterface
      * Returns the content object of this node (if any).
      *
      * @return object The content object or NULL if none was set
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      */
     public function getContentObject();
 
@@ -187,7 +185,7 @@ interface NodeInterface
      * Unsets the content object of this node.
      *
      * @return void
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
+     * @deprecated with version 4.3. Attaching entities to nodes never really worked. Instead you can reference objects as node properties via their identifier
      */
     public function unsetContentObject();
 
@@ -221,7 +219,6 @@ interface NodeInterface
      * Returns the current state of the hidden flag
      *
      * @return boolean
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function isHidden();
 
@@ -238,7 +235,6 @@ interface NodeInterface
      * Returns the date and time before which this node will be automatically hidden.
      *
      * @return \DateTimeInterface|null Date before this node will be hidden - or null if no hidden before date is set
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function getHiddenBeforeDateTime();
 
@@ -255,7 +251,6 @@ interface NodeInterface
      * Returns the date and time after which this node will be automatically hidden.
      *
      * @return \DateTimeInterface|null Date after which this node will be hidden - or null if no hidden after date is set
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function getHiddenAfterDateTime();
 
@@ -281,7 +276,7 @@ interface NodeInterface
      *
      * @param array $accessRoles
      * @return void
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function setAccessRoles(array $accessRoles);
 
@@ -289,7 +284,7 @@ interface NodeInterface
      * Returns the names of defined access roles
      *
      * @return array
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function getAccessRoles();
 
@@ -299,8 +294,7 @@ interface NodeInterface
      * Example: /sites/mysitecom/homepage/about
      *
      * @return string The absolute node path
-     * @api
-     * @deprecated with version 4.3, use findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findNodePath() instead.
      */
     public function getPath();
 
@@ -309,8 +303,10 @@ interface NodeInterface
      *
      * Example: /sites/mysitecom/homepage/about@user-admin
      *
+     * NOTE: This method will probably be removed at some point. Code should never rely on the exact format of the context path
+     *       since that might change in the future.
+     *
      * @return string Node path with context information
-     * @deprecated with version 4.3 - Use the node's NodeAddress instead
      */
     public function getContextPath();
 
@@ -331,7 +327,6 @@ interface NodeInterface
      *
      * @param Workspace $workspace
      * @return void
-     * @deprecated with version 4.3 - From 5.0 you will be able to use the ContentStream instead
      */
     public function setWorkspace(Workspace $workspace);
 
@@ -339,7 +334,6 @@ interface NodeInterface
      * Returns the workspace this node is contained in
      *
      * @return Workspace
-     * @deprecated with version 4.3 - From 5.0 you will be able to use the ContentStream instead
      */
     public function getWorkspace();
 
@@ -366,7 +360,6 @@ interface NodeInterface
      *
      * @param integer $index The new index
      * @return void
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
      */
     public function setIndex($index);
 
@@ -375,7 +368,6 @@ interface NodeInterface
      * with the same parent node.
      *
      * @return integer
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
      */
     public function getIndex();
 
@@ -383,7 +375,11 @@ interface NodeInterface
      * Returns the parent node of this node
      *
      * @return NodeInterface The parent node or NULL if this is the root node
-     * @deprecated with version 4.3, use findParentNode() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findParentNode() instead.
+     *  Beware that findParentNode() is not fully equivalent to this method.
+     *  It has a different root node handling:
+     *    - findParentNode() throws an exception for the root node
+     *    - getParent() returns <code>null</code> for the root node
      */
     public function getParent();
 
@@ -391,7 +387,7 @@ interface NodeInterface
      * Returns the parent node path
      *
      * @return string Absolute node path of the parent node
-     * @deprecated with version 4.3, use findParentNode()->findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findParentNode()->findNodePath() instead.
      */
     public function getParentPath();
 
@@ -439,7 +435,7 @@ interface NodeInterface
      *
      * @param string $path Path specifying the node, relative to this node
      * @return NodeInterface The specified node or NULL if no such node exists
-     * @deprecated with version 4.3 - use TraversableNodeInterface::findNamedChildNode() instead - for absolute paths a new API will be added with 5.0
+     * @deprecated with version 4.3 - use TraversableNodeInterface::findNamedChildNode() instead
      */
     public function getNode($path);
 
@@ -450,7 +446,7 @@ interface NodeInterface
      * node type. For now it is just the first child node.
      *
      * @return NodeInterface The primary child node or NULL if no such node exists
-     * @deprecated with version 4.3, without any replacement.
+     * @deprecated with version 4.3. use TraversableNodeInterface::findChildNodes() instead, the first result is considered the "primary child node"
      */
     public function getPrimaryChildNode();
 
@@ -462,7 +458,7 @@ interface NodeInterface
      * @param integer $limit An optional limit for the number of nodes to find. Added or removed nodes can still change the number nodes!
      * @param integer $offset An optional offset for the query
      * @return array<\Neos\ContentRepository\Domain\Model\NodeInterface> An array of nodes or an empty array if no child nodes matched
-     * @deprecated with version 4.3, use findChildNodes() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findChildNodes() instead.
      */
     public function getChildNodes($nodeTypeFilter = null, $limit = null, $offset = null);
 
@@ -471,7 +467,7 @@ interface NodeInterface
      *
      * @param string $nodeTypeFilter If specified, only nodes with that node type are considered
      * @return boolean true if this node has child nodes, otherwise false
-     * @deprecated with version 4.3, use findChildNodes() instead and count the result
+     * @deprecated with version 4.3, use TraversableNodeInterface::findChildNodes() instead and count the result
      */
     public function hasChildNodes($nodeTypeFilter = null);
 
@@ -496,7 +492,6 @@ interface NodeInterface
      * If this node is a removed node.
      *
      * @return boolean
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve removed nodes
      */
     public function isRemoved();
 
@@ -506,7 +501,6 @@ interface NodeInterface
      * taken into account.
      *
      * @return boolean
-     * @deprecated with version 4.3 - 5.0 will provide a new API with to retrieve visibility restrictions
      */
     public function isVisible();
 
@@ -514,7 +508,7 @@ interface NodeInterface
      * Tells if this node may be accessed according to the current security context.
      *
      * @return boolean
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function isAccessible();
 
@@ -523,7 +517,7 @@ interface NodeInterface
      * current security context.
      *
      * @return boolean
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement. Use a Policy to restrict access to nodes
+     * @deprecated with version 4.3. Use a Policy to restrict access to nodes
      */
     public function hasAccessRestrictions();
 
@@ -532,7 +526,6 @@ interface NodeInterface
      *
      * @param NodeType $nodeType
      * @return boolean true if the passed $nodeType is allowed as child node
-     * @deprecated with version 4.3 - There will be a new utility method with 5.0 (probably part of the NodeType API)
      */
     public function isNodeTypeAllowedAsChildNode(NodeType $nodeType);
 
@@ -601,7 +594,7 @@ interface NodeInterface
      * Return the NodeData representation of the node.
      *
      * @return NodeData
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement
+     * @internal This is not meant to be used in userland code
      */
     public function getNodeData();
 
@@ -609,7 +602,7 @@ interface NodeInterface
      * Return the context of the node
      *
      * @return Context
-     * @deprecated with version 4.3 - will be removed with 5.0 without replacement, but you can access the node's subgraph via TraversableNodeInterface::getSubgraph()
+     * @internal This method is not meant to be called in userland code
      */
     public function getContext();
 
@@ -617,7 +610,6 @@ interface NodeInterface
      * Return the assigned content dimensions of the node.
      *
      * @return array An array of dimensions to array of dimension values
-     * @deprecated with version 4.3 - will be replaced in 5.0 by getOriginDimensionSpacePoint() and getDimensionSpacePoint()
      */
     public function getDimensions();
 
@@ -635,7 +627,7 @@ interface NodeInterface
      * should not be deleted.
      *
      * @return boolean true if this node is auto-created by the parent.
-     * @deprecated with version 4.3 - will be removed with 5.0. This information should not be required usually. Otherwise it can be determined via:
+     * @deprecated with version 4.3. This information should not be required usually. Otherwise it can be determined via:
      * if (array_key_exists((string)$node->getNodeName(), $parent->getNodeType()->getAutoCreatedChildNodes()))
      */
     public function isAutoCreated();
@@ -647,7 +639,6 @@ interface NodeInterface
      * The resulting node instances might belong to a different context.
      *
      * @return array<NodeInterface> All node variants of this node (excluding the current node)
-     * @deprecated with version 4.3 - will be removed in 5.0 without replacement. But the subGraph can be used to determine other variants of a node
      */
     public function getOtherNodeVariants();
 }


### PR DESCRIPTION
* Reword the deprecation message in the interface doc comment
* For deprecated methods with a replacement (e.g. `getDepth()`):
  * Don't remove the method but keep the deprecation annotation
  * Remove any `@api` annotation from the method
* For deprecated methods without replacement (e.g. `getContextPath()`):
  * Don't remove the method
  * replace the `@deprecated` annotation by some comment

Related: #3137 