### PR TITLE
Fix doc comments in Node and NodeInterface

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -408,7 +408,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the path of this node
      *
      * @return string
-     * @deprecated with version 4.3, use TraversableNode::findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findNodePath() instead.
      */
     public function getPath()
     {
@@ -431,7 +431,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * Returns the name of this node
      *
      * @return string
-     * @deprecated with version 4.3, use TraversableNode::getNodeName() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::getNodeName() instead.
      */
     public function getName()
     {

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
@@ -81,7 +81,7 @@ interface NodeInterface
      * Returns the name of this node
      *
      * @return string
-     * @deprecated with version 4.3, use TraversableNode::getNodeName() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::getNodeName() instead.
      */
     public function getName();
 
@@ -294,7 +294,7 @@ interface NodeInterface
      * Example: /sites/mysitecom/homepage/about
      *
      * @return string The absolute node path
-     * @deprecated with version 4.3, use TraversableNode::findNodePath() instead.
+     * @deprecated with version 4.3, use TraversableNodeInterface::findNodePath() instead.
      */
     public function getPath();
 


### PR DESCRIPTION
Tweaks some doc comments that were introduced with #3187 and referred to a non-existing class `TraversableNode`