### PR TITLE
!!! FEATURE: Add getIconUri & getDescription to AssetSourceInterface

### DIFF
--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetSourceInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetSourceInterface.php
@@ -38,19 +38,17 @@ interface AssetSourceInterface
 
     /**
      * Returns the resource path to the icon of the asset source
-     * !! Will be added to the interface with Neos 6.0
      *
      * @return string
      */
-    // public function getIcon(): string;
+    public function getIconUri(): string;
 
     /**
      * Returns the description of the asset source
-     * !! Will be added to the interface with Neos 6.0
      *
      * @return string
      */
-    // public function getDescription(): string;
+    public function getDescription(): string;
 
     /**
      * @return AssetProxyRepositoryInterface

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetSource.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetSource.php
@@ -154,7 +154,6 @@ final class NeosAssetSource implements AssetSourceInterface
     }
 
     /**
-     * !! Will be added to the interface with Neos 6.0
      *
      * @return string
      */

--- a/Neos.Neos/Documentation/Appendixes/ReleaseNotes/520.rst
+++ b/Neos.Neos/Documentation/Appendixes/ReleaseNotes/520.rst
@@ -74,11 +74,11 @@ Allows a `position` to be specified in the NodeType `postprocessors` configurati
 
 FEATURE: Icons and description for asset sources
 ================================================
-Icons and descriptions can now be provided by the asset source. 
+Icons and descriptions can now be provided by the asset source.
 The icon makes the asset source easier to identify while the description can provide further information or a link to the asset source as required by some free asset source API guidelines.
 
-To make your AssetSources compatible with Neos 6.x add the methods
-* `public function getIcon(): string`
+To make your AssetSources compatible with Neos 7.x add the methods
+* `public function getIconUri(): string`
 * `public function getDescription(): string;`
 
 to your asset source.


### PR DESCRIPTION
Extends the `Neos\Media\Domain\Model\AssetSource\ AssetSourceInterface` by the two methods `getIconUri()` and `getDescription()`.

This is a breaking change if you created a custom Asset source (implementing the `AssetSourceInterface`) and didn't implement these methods yet.

Related to #3137