### PR TITLE
TASK: Extend the warning for the EmberUI

### DIFF
--- a/Neos.Neos/Documentation/Contribute/Code/EmberUI.rst
+++ b/Neos.Neos/Documentation/Contribute/Code/EmberUI.rst
@@ -3,7 +3,7 @@ Legacy Ember UI - Development
 ===================
 
 .. warning::
-  This applies for the legacy Ember Neos UI. Learn more about our `current ReactJS UI in the docs <https://docs.neos.io/cms/contributing-to-neos/neos-ui>`_.
+  This applies for the legacy Ember Neos UI. Learn more about our `current ReactJS UI in the docs <https://docs.neos.io/cms/contributing-to-neos/neos-ui>`_. The EmberUI has been partially removed since Neos 5.0 and the last pieces (Notification API and Translation API) will follow soon!
 
 Setting up your machine for Neos UI development
 ===============================================


### PR DESCRIPTION
The most parts of the EmberUI has been already removed. So we should mention that.

Releates: #2531
