### PR TITLE
BUGFIX: Adjust fusion tests to match the InvalidPositionException

### DIFF
--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -14,6 +14,7 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\DataStructureImplementation;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for the Fusion Concat object
@@ -21,14 +22,24 @@ use Neos\Fusion\FusionObjects\DataStructureImplementation;
 class DataStructureImplementationTest extends UnitTestCase
 {
     /**
+     * @var Runtime|MockObject
+     */
+    private $mockRuntime;
+
+
+    public function setUp(): void
+    {
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
      * @test
      */
-    public function evaluateWithEmptyArrayRendersEmptyArray()
+    public function evaluateWithEmptyArrayRendersEmptyArray(): void
     {
-        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
         $path = 'datastructure/test';
         $fusionObjectName = 'Neos.Fusion:DataStructure';
-        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        $renderer = new DataStructureImplementation($this->mockRuntime, $path, $fusionObjectName);
         $result = $renderer->evaluate();
         self::assertSame($result, []);
     }
@@ -36,7 +47,7 @@ class DataStructureImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElements()
+    public function positionalSubElements(): array
     {
         return [
             [
@@ -98,43 +109,17 @@ class DataStructureImplementationTest extends UnitTestCase
     }
 
     /**
-     * @return array
-     */
-    public function positionalSubElementsThatShouldFailByInvalidPositions()
-    {
-        return [
-            [
-                'Position after adds before end if named element not present',
-                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
-                ['/first', '/second', '/third']
-            ],
-            [
-                'Position before adds after start if named element not present',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
-                ['/first', '/second', '/third']
-            ],
-        ];
-    }
-
-    /**
      * @test
      * @dataProvider positionalSubElements
-     *
-     * @param string $message
-     * @param array $subElements
-     * @param array $expectedKeyOrder
      */
-    public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
+    public function evaluateRendersKeysSortedByPositionMetaProperty(string $message, array $subElements, array $expectedKeyOrder): void
     {
-        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-
-        $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
+        $this->mockRuntime->method('evaluate')->willReturnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;
-        }));
+        });
 
-        $path = '';
         $fusionObjectName = 'Neos.Fusion:DataStructure';
-        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        $renderer = new DataStructureImplementation($this->mockRuntime, '', $fusionObjectName);
         foreach ($subElements as $key => $value) {
             $renderer[$key] = $value;
         }
@@ -144,32 +129,35 @@ class DataStructureImplementationTest extends UnitTestCase
     }
 
     /**
+     * @return array
+     */
+    public function positionalSubElementsThatShouldFailByInvalidPositions(): array
+    {
+        return [
+            [
+                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
+            ],
+            [
+                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
+            ],
+        ];
+    }
+
+    /**
      * @test
      * @dataProvider positionalSubElementsThatShouldFailByInvalidPositions
      *
-     * @param string $message
      * @param array $subElements
-     * @param array $expectedKeyOrder
      */
-    public function evaluateRendersKeysSortedByPositionMetaPropertyThatShouldFail($message, $subElements, $expectedKeyOrder)
+    public function evaluateThrowsExceptionIfKeysSortedByPositionMetaPropertyContainsInvalidValues(array $subElements): void
     {
-        try {
-            $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-
-            $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
-                $renderedPaths[] = $path;
-            }));
-
-            $path = '';
-            $fusionObjectName = 'Neos.Fusion:DataStructure';
-            $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
-            foreach ($subElements as $key => $value) {
-                $renderer[$key] = $value;
-            }
-            $renderer->evaluate();
-            self::fail('Expected InvalidPositionException exception not thrown');
-        } catch (\Exception $exception) {
-            self::assertEquals($exception->getCode(), 1345126502);
+        $fusionObjectName = 'Neos.Fusion:DataStructure';
+        $renderer = new DataStructureImplementation($this->mockRuntime, '', $fusionObjectName);
+        foreach ($subElements as $key => $value) {
+            $renderer[$key] = $value;
         }
+        $this->expectExceptionCode(1345126502);
+
+        $renderer->evaluate();
     }
 }


### PR DESCRIPTION
Invalid positions has been skipped silently. Since https://github.com/neos/flow-development-collection/pull/2214 this leads to an InvalidPositionException.

This change adjusts the tests, so that the expected errors are also respected in the tests.

Related: https://github.com/neos/flow-development-collection/pull/2214