### PR TITLE
TASK: Throw fusion exception with explanation also for afx parser errors

### DIFF
--- a/Neos.Fusion.Afx/Classes/Dsl/AfxDslImplementation.php
+++ b/Neos.Fusion.Afx/Classes/Dsl/AfxDslImplementation.php
@@ -16,6 +16,7 @@ use Neos\Fusion;
 use Neos\Fusion\Core\DslInterface;
 use Neos\Fusion\Afx\Service\AfxService;
 use Neos\Fusion\Afx\Exception\AfxException;
+use Neos\Fusion\Afx\Parser\AfxParserException;
 
 /**
  * Class Fusion AFX Dsl
@@ -37,6 +38,8 @@ class AfxDslImplementation implements DslInterface
         try {
             return AfxService::convertAfxToFusion($code);
         } catch (AfxException $afxException) {
+            throw new Fusion\Exception(sprintf('Error during AFX-transpilation: %s', $afxException->getMessage()));
+        } catch (AfxParserException $afxException) {
             throw new Fusion\Exception(sprintf('Error during AFX-parsing: %s', $afxException->getMessage()));
         }
     }


### PR DESCRIPTION
Previously only AfxExceptions were converted to fusion exceptions which hid valuable information about the error source from the user. This change will also catch for AfxParserExceptions and convert those to Fusion\Exceptions

This is non critical as the fusion side will catch this aswell but it should help to create error messages that are slightly easier to understand.

This replaces pr: https://github.com/neos/fusion-afx/pull/35 after moving afx to the neos development collection