### PR TITLE
BUGFIX: Add missing return tag for the flow query operation

### DIFF
--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -50,6 +50,7 @@ class SortOperation extends AbstractOperation
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation.
      * @throws \Neos\Eel\FlowQuery\FlowQueryException
+     * @return void
      */
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {


### PR DESCRIPTION
Without this, the reference documentation can not be parsed. The Eel helper was not updated since version 4.3!!!
