### PR TITLE
BUGFIX: Fix headline in release notes (5.2)

### DIFF
--- a/Neos.Neos/Documentation/Appendixes/ReleaseNotes/520.rst
+++ b/Neos.Neos/Documentation/Appendixes/ReleaseNotes/520.rst
@@ -6,7 +6,6 @@ This is a planned feature release and includes the following new feature as well
 
 Update procedure includes updating dependencies and running `./flow doctrine:migrate` as for  most updates.
 
-================
 What has changed
 ================
 


### PR DESCRIPTION
The headline "What has changed" is one level to high, so it will generate the wrong menu on the sidebar.