### PR TITLE
BUGFIX: Set ``alt`` attribute per default for ``Neos.Neos:ImageTag``

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageUri.fusion
@@ -39,6 +39,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
 
 	tagName = 'img'
 	attributes {
+		alt = ''
 		src = Neos.Neos:ImageUri {
 			asset = ${asset}
 			width = ${width}


### PR DESCRIPTION
Add alt attribute (empty by default) for full HTML conformance with validity checkers.
See https://www.w3.org/wiki/HTML/Usage/TextAlternatives

Bonus effect: Since screen readers will read the full file name when no
alt attribute is set at all, this will improve accessibility.
It is recommended to provide meaningful alternative texts for non-decorative images.