### PR TITLE
BUGFIX: Avoid possible exception during sitemap rendering

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -174,6 +174,10 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
      */
     protected function getNodeInDimensions(array $dimensions, array $targetDimensions)
     {
+        if ($this->currentNode === null) {
+            return null;
+        }
+
         $q = new FlowQuery([$this->currentNode]);
 
         return $q->context([


### PR DESCRIPTION
hen rendering the XML sitemap with Neos.Seo sometimes an exception
occurs:

    No operation which satisfies the runtime constraints found for
    "context"

See https://github.com/neos/neos-development-collection/issues/2968
for more details.

This change should fix that by returning null early, if there is no
"current" node.

Fixes #2968