### PR TITLE
TASK: Set text/html as default content type in Fusion

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -3,6 +3,12 @@
 prototype(Neos.Neos:Page) >
 prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
 
+  httpResponseHead {
+    headers {
+      'Content-Type' = 'text/html'
+    }
+  }
+
   doctype = '<!DOCTYPE html>'
   doctype.@position = 'start 100'
 


### PR DESCRIPTION
While experimenting with PSR-15 middlewares I found out that no content type is returned from the Fusion rendering step when using the Neos default page prototype.
This keeps those middlewares from applying their effects as they do not know what kind of content they get.

This can be easily fixed in custom packages, but it makes sense to just have this as default for the future.