### PR TITLE
FEATURE: Allow http image urls as login wallpapers

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -11,9 +11,23 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
     content = Neos.Fusion:Component {
       @apply.props = ${props}
 
-      backgroundImageSource = Neos.Fusion:ResourceUri {
+      backgroundImageSource = Neos.Fusion:Component {
         @if.set = ${this.path}
         path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.backgroundImage')}
+
+        renderer = Neos.Fusion:Case {
+          resourcePath {
+            condition = ${String.indexOf(props.path, 'resource://') == 0}
+            renderer = Neos.Fusion:ResourceUri {
+              path = ${props.path}
+            }
+          }
+
+          default {
+            condition = true
+            renderer = ${props.path}
+          }
+        }
       }
 
       headerComment = ${Configuration.setting('Neos.Neos.headerComment')}


### PR DESCRIPTION
Before this change only `resource://…` urls were supported.

**What I did**

Check whether the configured path is a resource uri or a simple url.

**How I did it**

Use Fusion case object and condition to check the type.

**How to verify it**

Set `https://source.unsplash.com/random` as background image and enjoy a nice random picture for every login.

**Checklist**

- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
