### PR TITLE
BUGFIX: Allow Neos.Media package to be installed without Neos

### DIFF
--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -10,7 +10,7 @@ Neos:
     mvc:
       routes:
         Neos.Media:
-          position: 'before Neos.Neos'
+          position: 'start'
 
   Media:
     # Enable asynchronous thumbnails

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -9,8 +9,7 @@ Neos:
             listener: Neos\Media\Domain\EventListener\ImageEventListener
     mvc:
       routes:
-        Neos.Media:
-          position: 'start'
+        Neos.Media: true
 
   Media:
     # Enable asynchronous thumbnails

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -428,6 +428,9 @@ Neos:
           variables:
             # Set this to an empty string if you prefer URLs without the ".html" suffix
             'defaultUriSuffix': '.html'
+        # Move Neos.Media routes before default Neos routes so that they have priority
+        'Neos.Media':
+          position: 'before Neos.Neos'
 
     security:
       authentication:


### PR DESCRIPTION
Moves the `Neos.Neos` reference from the `Neos.Media` routing configuration
to the Neos package.

**NOTE:** This removes the `Neos.Media` route positioning, so that it depends solely on the package
loading order.

To set the position explicitly, this configuration can be overridden with a few lines of `Settings.yaml`, for example:

```yaml
Neos:
  Flow:
    mvc:
      routes:
        'Neos.Media':
          position: 'after Some.Package'
```

Fixes: #3258