### PR TITLE
BUGFIX: Prevent exception when shortcut nodes can't be resolved

### DIFF
--- a/Neos.Neos/Classes/Routing/Exception/InvalidShortcutException.php
+++ b/Neos.Neos/Classes/Routing/Exception/InvalidShortcutException.php
@@ -1,0 +1,20 @@
+<?php
+namespace Neos\Neos\Routing\Exception;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Neos\Neos\Routing\Exception;
+
+/**
+ * An "invalid shortcut" exception that is thrown if a shortcut node can't be resolved to an URL
+ */
+class InvalidShortcutException extends Exception
+{
+}

--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -266,7 +266,12 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return false;
         }
 
-        $nodeOrUri = $this->resolveShortcutNode($node);
+        try {
+            $nodeOrUri = $this->resolveShortcutNode($node);
+        } catch (Exception\InvalidShortcutException $exception) {
+            $this->systemLogger->debug('FrontendNodeRoutePartHandler resolveValue(): ' . $exception->getMessage());
+            return false;
+        }
         if ($nodeOrUri instanceof UriInterface) {
             return new ResolveResult('', UriConstraints::fromUri($nodeOrUri), null);
         }
@@ -304,7 +309,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
     /**
      * @param NodeInterface $node
      * @return NodeInterface|Uri The original, unaltered $node if it's not a shortcut node. Otherwise the nodes shortcut target (a node or an URI for external & asset shortcuts)
-     * @throws NeosException
+     * @throws Exception\InvalidShortcutException
      */
     protected function resolveShortcutNode(NodeInterface $node)
     {
@@ -313,7 +318,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
             return new Uri($resolvedNode);
         }
         if (!$resolvedNode instanceof NodeInterface) {
-            throw new NeosException(sprintf('Could not resolve shortcut target for node "%s"', $node->getPath()), 1414771137);
+            throw new Exception\InvalidShortcutException(sprintf('Could not resolve shortcut target for node "%s"', $node->getPath()), 1414771137);
         }
         return $resolvedNode;
     }


### PR DESCRIPTION
Adjusts the `FrontendNodeRoutePartHandler`  such that it doesn't throw an
exception if the URL to a Shortcut node can't be resolved.

Instead the handler just won't handle this case, passing its handling on to the
next route (usually leading to a `NoMatchingRouteException` when no custom
route handles broken shortcuts).

Background:

When creating Shortcut nodes, the `mode` defaults to "first child node". If that new node
is published without a child node, the shortcut points to a non-existing node which
led to the exception.

Related: #3256