### PR TITLE
BUGFIX: Re-Enable formerly unsupported editors for NodeCreationDialog

### DIFF
--- a/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
@@ -130,13 +130,6 @@ class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
             $editorOptions = Arrays::arrayMergeRecursiveOverrule($this->editorDefaultConfiguration[$editor]['editorOptions'], $editorOptions);
         }
 
-        // The following editors don't (completely) work in the Creation Dialog so they are disabled
-        // TODO should be adjusted if fixed. See https://github.com/neos/neos-ui/issues/1034
-        $unsupportedEditors = ['Neos.Neos/Inspector/Editors/ImageEditor', 'Neos.Neos/Inspector/Editors/AssetEditor', 'Neos.Neos/Inspector/Editors/RichTextEditor', 'Neos.Neos/Inspector/Editors/CodeEditor'];
-        if (\in_array($editor, $unsupportedEditors, true)) {
-            $convertedConfiguration['ui']['help']['message'] = sprintf('The "%s" editor is currently not supported in the Creation Dialog', $editor);
-            $editorOptions['disabled'] = true;
-        }
         $convertedConfiguration['ui']['editor'] = $editor;
         $convertedConfiguration['ui']['editorOptions'] = $editorOptions;
         return $convertedConfiguration;

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -198,43 +198,4 @@ class CreationDialogPostprocessorTest extends UnitTestCase
 
         self::assertSame($expectedElements, $configuration['ui']['creationDialog']['elements']);
     }
-
-    /**
-     * @test
-     */
-    public function processDisablesUnsupportedEditors(): void
-    {
-        $configuration = [
-            'properties' => [
-                'somePropertyName' => [
-                    'ui' => [
-                        'showInCreationDialog' => true,
-                        'inspector' => [
-                            'editor' => 'Neos.Neos/Inspector/Editors/ImageEditor',
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $this->creationDialogPostprocessor->process($this->mockNodeType, $configuration, []);
-
-        $expectedElements = [
-            'somePropertyName' => [
-                'type' => 'string',
-                'ui' => [
-                    'label' => 'somePropertyName',
-                    'help' => [
-                        'message' => 'The "Neos.Neos/Inspector/Editors/ImageEditor" editor is currently not supported in the Creation Dialog',
-                    ],
-                    'editor' => 'Neos.Neos/Inspector/Editors/ImageEditor',
-                    'editorOptions' => [
-                        'disabled' => true,
-                    ]
-                ],
-            ],
-        ];
-
-        self::assertSame($expectedElements, $configuration['ui']['creationDialog']['elements']);
-    }
 }


### PR DESCRIPTION
Hi there,

this PR accompanies https://github.com/neos/neos-ui/pull/2870 and re-enables editor functionalities that were disabled in https://github.com/neos/neos-development-collection/commit/029572e38c163a5475c0ed3a8a29a988a60e4f4c#diff-5dcd744af0bf44e044a96b272818323abc9ed49d284f5e40ff33f62b440ff801R91 ff. due to a lack of support for secondary editor views in the NodeCreationDialog.
