### PR TITLE
!!! BUGFIX: Set the default for new shortcut nodes to "parent"

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.Shortcut.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Shortcut.yaml
@@ -14,7 +14,7 @@
   properties:
     targetMode:
       type: string
-      defaultValue: 'firstChildNode'
+      defaultValue: 'parentNode'
       ui:
         label: i18n
         reloadPageIfChanged: true


### PR DESCRIPTION
Currently the default is firstChidNode which leads to error
when adding a new shortcut, as there will never be a
child node in this case while targeting the parent
in this case

Related: #3256