### PR TITLE
BUGFIX: Don’t skip childnodes when discarding nodes

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -403,7 +403,9 @@ class WorkspacesController extends AbstractModuleController
                 $this->addFlashMessage($this->translator->translateById('workspaces.selectedChangesHaveBeenPublished', [], null, null, 'Modules', 'Neos.Neos'));
             break;
             case 'discard':
-                $this->publishingService->discardNodes($nodes);
+                foreach ($nodes as $node) {
+                    $this->publishingService->discardNode($node);
+                }
                 $this->addFlashMessage($this->translator->translateById('workspaces.selectedChangesHaveBeenDiscarded', [], null, null, 'Modules', 'Neos.Neos'));
             break;
             default:

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -403,6 +403,8 @@ class WorkspacesController extends AbstractModuleController
                 $this->addFlashMessage($this->translator->translateById('workspaces.selectedChangesHaveBeenPublished', [], null, null, 'Modules', 'Neos.Neos'));
             break;
             case 'discard':
+                // not using $this->publishingService->discardNodes($nodes); here to
+                // actually use discardNode() from the Neos.Neos PublishingService
                 foreach ($nodes as $node) {
                     $this->publishingService->discardNode($node);
                 }


### PR DESCRIPTION
Previously autocreated childnodes like ContentCollections
were ignored when discarding nodes via the workspace module.

When deleting a node and discarding the change the auto created children would 
then stay deleted in the database and the backend would show no content/errors.
The only way to fix this again is to go to the database and remove the broken nodes.

The behaviour is now the same as for publishing nodes and the direct child nodes are
included in the discard if the node has auto-created child nodes or is a document.

Resolves: #3274

**What I did**

The Neos publishing service already has the methods that respects child nodes and 
this was already used for publishing. My change does the same for discarding.

**How to verify it**

See #3274

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
