### PR TITLE
BUGFIX: Prevent error in route cache aspect

### DIFF
--- a/Neos.Neos/Classes/Routing/Aspects/RouteCacheAspect.php
+++ b/Neos.Neos/Classes/Routing/Aspects/RouteCacheAspect.php
@@ -47,7 +47,16 @@ class RouteCacheAspect
     public function addCurrentNodeIdentifier(JoinPointInterface $joinPoint)
     {
         $values = $joinPoint->getMethodArgument('values');
-        if (!isset($values['node']) || strpos($values['node'], '@') === false) {
+
+        if (!isset($values['node'])) {
+            return;
+        }
+
+        if (is_array($values['node']) && isset($values['node']['__contextNodePath'])) {
+            $values['node'] = $values['node']['__contextNodePath'];
+        }
+
+        if (strpos($values['node'], '@') === false) {
             return;
         }
 
@@ -90,7 +99,15 @@ class RouteCacheAspect
 
         $values = $joinPoint->getMethodArgument('routeValues');
 
-        if (isset($values['node']) && strpos($values['node'], '@') !== false) {
+        if (!isset($values['node'])) {
+            return $tags;
+        }
+
+        if (is_array($values['node']) && isset($values['node']['__contextNodePath'])) {
+            $values['node'] = $values['node']['__contextNodePath'];
+        }
+
+        if (strpos($values['node'], '@') !== false) {
             // Build context explicitly without authorization checks because the security context isn't available yet
             // anyway and any Entity Privilege targeted on Workspace would fail at this point:
             $this->securityContext->withoutAuthorizationChecks(function () use ($values, &$tags) {


### PR DESCRIPTION
Allow array wrapped node context paths
similar to the adjusted implementation
in `FrontendNodeRoutePartHandler->resolveValue`.

Resolves: #3276 

**What I did**

Check if node is an array and extract context path.
The behaviour is now the same as in `FrontendNodeRoutePartHandler->resolveValue`.

**How to verify it**

I had a Fluid template with a paginate widget that threw an exception without this change.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
