### PR TITLE
TASK: Set default quality for pngs when using vips

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -232,6 +232,7 @@ class ImageService
         }
         $defaultOptions['jpeg_quality'] = $quality;
         $defaultOptions['webp_quality'] = $quality;
+        $defaultOptions['png_quality'] = $quality;
         // png_compression_level should be an integer between 0 and 9 and inverse to the quality level given. So quality 100 should result in compression 0.
         $defaultOptions['png_compression_level'] = (9 - ceil($quality * 9 / 100));
 


### PR DESCRIPTION
The vips-imagine integration actually uses `png_quality` to set the
resulting png quality instead of falling back to quality.

See https://github.com/rokka-io/imagine-vips/blob/master/lib/Imagine/Vips/Image.php#L979

GD and Imagick ignore the option.
This leads to much smaller file size without loosing quality in comparison to IM and GD.

**What I did**

Set `png_quality` as the other format qualities.

**How to verify it**

Install and configure Vips in any Neos project and recreate png thumbnails. Compare file sizes.
Or use (non-news) test script https://gist.github.com/Sebobo/94dd8ea909d2ed6ae813b7df70c20dc1
