### PR TITLE
BUGIX: Fix drag-n-drop upload of assets in media browser

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -324,10 +324,11 @@
     <script type="text/javascript">
         var uploadUrl = '<f:uri.action action="upload" additionalParams="{__csrfToken: \"{f:security.csrfToken()}\"}" absolute="true" />';
         var maximumFileUploadSize = {maximumFileUploadSize};
-
+<![CDATA[
         if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail) {
             window.parent.NeosMediaBrowserCallbacks.refreshThumbnail();
         }
+]]>
     </script>
     <f:form action="tagAsset" id="tag-asset-form" format="json">
         <f:form.hidden name="asset[__identity]" id="tag-asset-form-asset" />


### PR DESCRIPTION
This fixes parsing of the Fluid template on PHP 7.3+ so the upload
URL is correctly set.

Fixes #2906
Fixes #3096
