### PR TITLE
BUGFIX: Fix cache identifier collision in `Neos_Fusion_ObjectTree` cache.

### DIFF
--- a/Neos.Fusion/Classes/Aspects/FusionCachingAspect.php
+++ b/Neos.Fusion/Classes/Aspects/FusionCachingAspect.php
@@ -34,7 +34,7 @@ class FusionCachingAspect
      */
     public function cacheGetMergedFusionObjectTree(JoinPointInterface $joinPoint)
     {
-        $fusionPathPatterns = $joinPoint->getProxy()->getOption('fusionPathPatterns');
+        $fusionPathPatterns = $joinPoint->getProxy()->getFusionPathPatterns();
         $cacheIdentifier = md5(serialize($fusionPathPatterns));
 
         if ($this->fusionCache->has($cacheIdentifier)) {

--- a/Neos.Fusion/Classes/View/FusionView.php
+++ b/Neos.Fusion/Classes/View/FusionView.php
@@ -178,9 +178,8 @@ class FusionView extends AbstractView
     protected function getMergedFusionObjectTree(): array
     {
         $parsedFusion = [];
-        $fusionPathPatterns = $this->getOption('fusionPathPatterns');
+        $fusionPathPatterns = $this->getFusionPathPatterns();
         foreach ($fusionPathPatterns as $fusionPathPattern) {
-            $fusionPathPattern = str_replace('@package', $this->getPackageKey(), $fusionPathPattern);
             if (is_dir($fusionPathPattern)) {
                 $fusionPathPattern .= '/Root.fusion';
             }
@@ -189,6 +188,24 @@ class FusionView extends AbstractView
             }
         }
         return $parsedFusion;
+    }
+
+    /**
+     * Get the currently configured fusion path patterns
+     * `@package` is replaced by the current package key
+     *
+     * @return array
+     */
+    public function getFusionPathPatterns(): array
+    {
+        $packageKey = $this->getPackageKey();
+        $fusionPathPatterns = array_map(
+            function ($fusionPathPattern) use ($packageKey) {
+                return str_replace('@package', $packageKey, $fusionPathPattern);
+            },
+            $this->getOption('fusionPathPatterns')
+        );
+        return $fusionPathPatterns;
     }
 
     /**


### PR DESCRIPTION
The `Neos_Fusion_ObjectTree` cache is used to store parsed fusion ASTs, the identifier is calculated from the configured fusionPathPatterns. Previously the string `@package` was replaced at runtime and thus became not part of the cache identifier calculation. That way two packages using the same fusionPathPatterns would end up with the same cacheIdentifier.

This change extracts the replacement of the `@package` into a separate method that is called from the CachingAspect.
That way if the package key is used in the current path pattern it becomes part of the cache identifier.

Resolves: #3288