### PR TITLE
BUGFIX: Adjust user menu dropdown width

### DIFF
--- a/Neos.Neos/Resources/Private/Styles/Foundation/_dropdowns.scss
+++ b/Neos.Neos/Resources/Private/Styles/Foundation/_dropdowns.scss
@@ -41,11 +41,10 @@
 .neos-dropdown-menu {
 	position: absolute;
 	top: 100%;
-	left: 0;
 	z-index: $zindexDropdown;
 	display: none; // none by default, but block on "open" of the menu
 	float: left;
-	min-width: 160px;
+	min-width: 100%;
 	padding: 0;
 	margin: 1px 0 0;
 	list-style: none;

--- a/Neos.Neos/Resources/Public/Styles/Includes-built.css
+++ b/Neos.Neos/Resources/Public/Styles/Includes-built.css
@@ -7142,11 +7142,11 @@ readers do not read off random characters that represent icons */
 .neos .neos-dropdown-menu {
   position: absolute;
   top: 100%;
-  left: 0;
+  min-width: 100%;
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 160px;
+  min-width: 100%;
   padding: 0;
   margin: 1px 0 0;
   list-style: none;
@@ -17360,7 +17360,7 @@ disabled look for disabled choices in the results dropdown
  *
  * http://docs.jquery.com/UI/Autocomplete#theming
  */
-.ui-autocomplete { position: absolute; cursor: default; }	
+.ui-autocomplete { position: absolute; cursor: default; }
 
 /* workarounds */
 * html .ui-autocomplete { width:1px; } /* without this, the menu expands to 100% in IE6 */
@@ -17416,8 +17416,8 @@ disabled look for disabled choices in the results dropdown
 .ui-button { display: inline-block; position: relative; padding: 0; margin-right: .1em; text-decoration: none !important; cursor: pointer; text-align: center; zoom: 1; overflow: visible; } /* the overflow property removes extra width in IE */
 .ui-button-icon-only { width: 2.2em; } /* to make room for the icon, a width needs to be set here */
 button.ui-button-icon-only { width: 2.4em; } /* button elements seem to need a little more width */
-.ui-button-icons-only { width: 3.4em; } 
-button.ui-button-icons-only { width: 3.7em; } 
+.ui-button-icons-only { width: 3.4em; }
+button.ui-button-icons-only { width: 3.7em; }
 
 /*button text element */
 .ui-button .ui-button-text { display: block; line-height: 1.4;  }
@@ -17453,7 +17453,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
  */
 .ui-dialog { position: absolute; padding: .2em; width: 300px; overflow: hidden; }
 .ui-dialog .ui-dialog-titlebar { padding: .4em 1em; position: relative;  }
-.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 
+.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; }
 .ui-dialog .ui-dialog-titlebar-close { position: absolute; right: .3em; top: 50%; width: 19px; margin: -10px 0 0 0; padding: 1px; height: 18px; }
 .ui-dialog .ui-dialog-titlebar-close span { display: block; margin: 1px; }
 .ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus { padding: 0; }
@@ -17525,7 +17525,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 .ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
 .ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
 .ui-datepicker select.ui-datepicker-month-year {width: 100%;}
-.ui-datepicker select.ui-datepicker-month, 
+.ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year { width: 49%;}
 .ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
 .ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }

--- a/Neos.Neos/Resources/Public/Styles/Neos.css
+++ b/Neos.Neos/Resources/Public/Styles/Neos.css
@@ -7142,11 +7142,10 @@ readers do not read off random characters that represent icons */
 .neos .neos-dropdown-menu {
   position: absolute;
   top: 100%;
-  left: 0;
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 160px;
+  min-width: 100%;
   padding: 0;
   margin: 1px 0 0;
   list-style: none;


### PR DESCRIPTION
Limit the minimum width of the dropdown to the width of the trigger button
and make it possible to become wider and float from right side of the trigger button to the left.

Fixes: #3297
