### PR TITLE
BUGFIX: Open delete dialog on edit user view

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Edit.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Edit.html
@@ -30,7 +30,7 @@
 	</f:form>
 	<f:form action="index" id="postHelper" method="post"></f:form>
 
-	<f:if condition="{currentUser} === {user}">
+	<f:if condition="{currentUser} !== {user}">
 		<div class="neos-hide" id="delete">
 			<div class="neos-modal-centered">
 				<div class="neos-modal-content">


### PR DESCRIPTION
On the edit view of the user management module it was not possible to delete the user caused by the missing confirmation dialog. This has not been open caused by a wrong if condition.

Fixes: #3310
