### PR TITLE
FEATURE: Fusion debug to browser console

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/DebugConsoleImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugConsoleImplementation.php
@@ -1,0 +1,70 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A Fusion object for debugging fusion-values via the browser console
+ *
+ * //fusionPath value The variable to serialize and output to the console.
+ * //fusionPath title Optional custom title for the debug output.
+ * //fusionPath method Optional alternative method to call on the browser console.
+ * //fusionPath content When used as process the console script will be appended to it.
+ * @api
+ */
+class DebugConsoleImplementation extends DataStructureImplementation
+{
+    protected $ignoreProperties = ['__meta', 'title', 'method', 'value', 'content'];
+
+    public function getTitle(): string
+    {
+        return $this->fusionValue('title') ?: '';
+    }
+
+    public function getMethod(): string
+    {
+        return $this->fusionValue('method') ?: 'log';
+    }
+
+    public function getContent(): string
+    {
+        return $this->fusionValue('content') ?: '';
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->fusionValue('value') ?: '';
+    }
+
+    /**
+     * Appends a console script call to the output
+     */
+    public function evaluate(): string
+    {
+        $title = trim($this->getTitle());
+        $method = $this->getMethod();
+        $content = $this->getContent();
+
+        $arguments = parent::evaluate();
+        array_unshift($arguments, $this->getValue());
+
+        if ($title) {
+            $arguments[] = $this->getTitle();
+        }
+
+        $arguments = array_map('json_encode', $arguments);
+
+        return sprintf('%s<script>console.%s(%s)</script>', $content, $method, implode(', ', $arguments));
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/DebugConsole.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/DebugConsole.fusion
@@ -1,0 +1,14 @@
+##
+# This object will output the given value to the browser console.
+#
+# @process.debug = Neos.Fusion:Debug.Console {
+#     value = ${node.identifier}
+# }
+#
+prototype(Neos.Fusion:Debug.Console) {
+  @class = 'Neos\\Fusion\\FusionObjects\\DebugConsoleImplementation'
+  title = ${node ? node.label : (documentNode ? documentNode.label : '')}
+  method = 'log'
+  value = ''
+  content = ${value}
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -1,3 +1,5 @@
+include: DebugConsole.fusion
+
 prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
 prototype(Neos.Fusion:Join).@class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the DebugConsole object
+ *
+ */
+class DebugConsoleTest extends AbstractFusionObjectTest
+{
+
+    /**
+     * @test
+     */
+    public function debugEmptyValue()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debugConsole/empty');
+        $result = $view->render();
+        self::assertEquals('<script>console.log("")</script>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function debugNull()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debugConsole/null');
+        $result = $view->render();
+        self::assertEquals('<script>console.log("")</script>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function debugNullWithTitle()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debugConsole/nullWithTitle');
+        $result = $view->render();
+        self::assertEquals('<script>console.log("", "Title")</script>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function debugObject()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debugConsole/object');
+        $result = $view->render();
+        self::assertEquals('<script>console.log({"foo":"bar"})</script>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function debugMultipleValues()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('debugConsole/multipleValues');
+        $result = $view->render();
+        self::assertEquals('<script>console.log("a", "b", "c")</script>', $result);
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DebugConsole.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DebugConsole.fusion
@@ -1,0 +1,28 @@
+prototype(Neos.Fusion:DebugConsole) {
+  @class = 'Neos\\Fusion\\FusionObjects\\DebugConsoleImplementation'
+  title = ''
+  method = 'log'
+  value = ''
+  content = ${value}
+}
+
+debugConsole.empty = Neos.Fusion:DebugConsole
+
+debugConsole.null = Neos.Fusion:DebugConsole {
+  value = null
+}
+
+debugConsole.nullWithTitle = Neos.Fusion:DebugConsole {
+  title = 'Title'
+  value = null
+}
+
+debugConsole.object = Neos.Fusion:DebugConsole {
+  value = ${{ foo: 'bar' }}
+}
+
+debugConsole.multipleValues = Neos.Fusion:DebugConsole {
+  value = 'a'
+  b = 'b'
+  c = 'c'
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -308,6 +308,41 @@ Example::
 
   # the initial value is not changed, so you can define the Debug prototype anywhere in your Fusion code
 
+.. _Neos_Fusion__DebugConsole:
+
+Neos.Fusion:DebugConsole
+-----------------
+
+Wraps the given value with a script tag to print it to the browser console.
+When used as process the script tag is appended to the processed value.
+
+:title: (optional) Title for the debug output
+:value: (mixed) The value to print to the console
+:method: (string, optional) The method to call on the browser console object
+:[key]: (mixed) Other arguments to pass to the console method
+
+Example::
+
+  renderer.@process.debug = Neos.Fusion:Debug.Console {
+    title = 'My props'
+    value = ${props}
+    method = 'table'
+  }
+
+Multiple values::
+
+  renderer.@process.debug = Neos.Fusion:Debug.Console {
+    value = ${props.foo}
+    otherValue = ${props.other}
+    thirdValue = ${props.third}
+  }
+
+Color usage::
+
+  renderer.@process.debug = Neos.Fusion:Debug.Console {
+    value = ${'%c' + node.identifier}
+    color = 'color: red'
+  }
 
 .. _Neos_Fusion__Component:
 


### PR DESCRIPTION
With this new Fusion object it’s possible to debug to the browser console via an inserted script tag instead of showing a big dump that breaks the layout.

It optionally allows setting a title, method and additional arguments.

Resolves: #3319


**What I did**

Added a new Fusion object that returns a script tag with a script that calls the browser console and 
prints the given json serialized value.

**How to verify it**

Run the provided tests or add the following script to a visible Fusion component and play with it:

```
renderer.@process.debug = Neos.Fusion:Debug.Console {
    value = '%cfoo'
    method = 'table'
    color = 'color: green'
}
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
