### PR TITLE
FEATURE: Fusion match object

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/MatchImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MatchImplementation.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion\Exception as FusionException;
+
+/**
+ * Implementation class for matching strings in Fusion and return the matched value
+ */
+class MatchImplementation extends AbstractFusionObject
+{
+    public function getSubject(): string
+    {
+        return (string)($this->fusionValue('__meta/subject') ?? '');
+    }
+
+    public function getDefault(): ?string
+    {
+        return $this->fusionValue('__meta/default');
+    }
+
+    /**
+     * Tries to find a matching value for the subject and returns it
+     *
+     * @return mixed
+     * @throws FusionException
+     */
+    public function evaluate()
+    {
+        $subject = $this->getSubject();
+        $result = $this->fusionValue($subject);
+
+        if ($result !== null) {
+            return $result;
+        }
+
+        $default = $this->getDefault();
+        if ($default !== null) {
+            return $default;
+        }
+
+        throw new FusionException('Unhandled match', 1616578975);
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Match.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Match.fusion
@@ -1,0 +1,12 @@
+##
+# Provides match functionality similar to `match` in PHP 8 https://www.php.net/manual/tr/control-structures.match.php
+#
+# cssClass = Neos.Fusion:Match {
+#     @subject = ${q(node).property('layout')}
+#     @default = 'my-module--centered'
+#     left = 'my-module--left'
+#     right = 'my-module--right'
+# }
+prototype(Neos.Fusion:Match) {
+  @class = 'Neos\\Fusion\\FusionObjects\\MatchImplementation'
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -1,3 +1,5 @@
+include: Match.fusion
+
 prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
 prototype(Neos.Fusion:Join).@class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Match.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Match.fusion
@@ -1,0 +1,29 @@
+prototype(Neos.Fusion:Match) {
+  @class = 'Neos\\Fusion\\FusionObjects\\MatchImplementation'
+}
+
+match.empty = Neos.Fusion:Match {
+  @subject = ''
+  @default = 'empty'
+  left = 'module--left'
+  right = 'module--right'
+}
+
+match.foundMatch = Neos.Fusion:Match {
+  @subject = 'left'
+  left = 'module--left'
+  right = 'module--right'
+}
+
+match.default = Neos.Fusion:Match {
+  @subject = 'foo'
+  @default = 'module--centered'
+  left = 'module--left'
+  right = 'module--right'
+}
+
+match.errorWithoutMatch = Neos.Fusion:Match {
+  @subject = 'foo'
+  left = 'module--left'
+  right = 'module--right'
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Debug object
+ *
+ */
+class MatchTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function matchEmptyValue()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('match/empty');
+        $result = $view->render();
+        self::assertEquals('empty', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function matchSimple()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('match/foundMatch');
+        $result = $view->render();
+        self::assertEquals('module--left', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function matchDefault()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('match/default');
+        $result = $view->render();
+        self::assertEquals('module--centered', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function errorWithoutMatch()
+    {
+        $this->expectExceptionMessage('Unhandled match');
+        $view = $this->buildView();
+        $view->setFusionPath('match/errorWithoutMatch');
+        $view->render();
+    }
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -449,6 +449,27 @@ Example::
 
 .. note:: Most of the time this can be simplified by directly assigning the value instead of using the ``Value`` object.
 
+.. _Neos_Fusion__Match:
+
+Neos.Fusion:Match
+-----------------
+
+Matches the given subject to a value
+
+:@subject: (string, **required**) The subject to match
+:@default: (mixed) The default to return when no match was found
+:[key]: (mixed) Definition list, the keys will be matched to the subject and their value returned.
+
+Example::
+
+	myValue = Neos.Fusion:Match {
+	  @subject = 'hello'
+	  @default = 'World?'
+		hello = 'Hello World'
+		bye = 'Goodbye world'
+	}
+
+.. note:: This can be used to simplify many usages of :ref:`Neos_Fusion__Case` when the subject is a string.
 
 .. _Neos_Fusion__RawArray:
 


### PR DESCRIPTION
This change adds a new Fusion object to replace many situations where the Case object was used just to return a value based on a string.

The idea is based on the new match method in PHP 8 https://www.php.net/manual/tr/control-structures.match.php.

Resolves: #3318

**What I did**

Added a new Fusion object that returns the value for a key that matches the given subject or optionally a default if no match was found.

**How to verify it**

Run included tests.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
