### PR TITLE
TASK: Relax version constraint and allow Neos.Fusion.Form 2.0

### DIFF
--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -14,7 +14,7 @@
         "neos/content-repository": "~5.2.0",
         "neos/fusion": "~5.2.0",
         "neos/fusion-afx": "^1.4",
-        "neos/fusion-form": "^1.0",
+        "neos/fusion-form": "^1.0 || ^2.0",
         "neos/fluid-adaptor": "~6.2.0",
         "behat/transliterator": "~1.0",
         "neos/media": "~5.2.0"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "neos/party": "*",
         "neos/twitter-bootstrap": "*",
         "neos/fusion-afx": "^1.4",
-        "neos/fusion-form": "^1.0",
+        "neos/fusion-form": "^1.0 || ^2.0",
         "neos/form": "*",
         "neos/kickstarter": "~6.2.0"
     },


### PR DESCRIPTION
Starting with Neos 5.2 the Neos Package required Neos.Fusion.Form `^1.0` instead of `*` which will not allow to use version 2.0+ of said package.

This change adjusts the constraint to `^1.0 || ^2.0` to allow projects to benefit from the Fusion.Form Runtime. 

Hint: When upmerged to master constraint should be adjusted to `^2.0`. If this is forgotten i will take care in a second pr.

Relates: https://github.com/neos/fusion-form/issues/42