### PR TITLE
FEATURE: Add node label helper

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -48,6 +48,18 @@ class NodeHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Generate a label for a node with a chaining mechanism. To be used in nodetype definitions.
+     *
+     * @param string|null $label
+     * @param NodeInterface|null $node
+     * @return string
+     */
+    public function labelForNode(string $label = null, NodeInterface $node = null): NodeLabelToken
+    {
+        return new NodeLabelToken($node, $label);
+    }
+
+    /**
      * If this node type or any of the direct or indirect super types
      * has the given name.
      *

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -50,13 +50,12 @@ class NodeHelper implements ProtectedContextAwareInterface
     /**
      * Generate a label for a node with a chaining mechanism. To be used in nodetype definitions.
      *
-     * @param string|null $label
      * @param NodeInterface|null $node
-     * @return string
+     * @return NodeLabelToken
      */
-    public function labelForNode(string $label = null, NodeInterface $node = null): NodeLabelToken
+    public function labelForNode(NodeInterface $node = null): NodeLabelToken
     {
-        return new NodeLabelToken($node, $label);
+        return new NodeLabelToken($node);
     }
 
     /**

--- a/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
@@ -1,0 +1,137 @@
+<?php
+namespace Neos\Neos\Fusion\Helper;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\Helper\StringHelper;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\EelHelper\TranslationHelper;
+
+/**
+ * Provides a chainable interface to build a label for a nodetype
+ * with a fallback mechanism.
+ */
+class NodeLabelToken implements ProtectedContextAwareInterface
+{
+
+    /**
+     * @Flow\Inject
+     * @var TranslationHelper
+     */
+    protected $translationHelper;
+
+    /**
+     * @Flow\Inject
+     * @var StringHelper
+     */
+    protected $stringHelper;
+
+    /**
+     * @var string
+     */
+    protected $label = '';
+
+    /**
+     * @var int
+     */
+    protected $limit = 100;
+
+    /**
+     * @var string
+     */
+    protected $suffix = '...';
+
+    /**
+     * @var NodeInterface
+     */
+    protected $node = null;
+
+    public function __construct(NodeInterface $node = null, string $value = null)
+    {
+        $this->node = $node;
+        $this->label = $value;
+    }
+
+    public function or(string $fallback = null): NodeLabelToken
+    {
+        if (!$this->label && $fallback) {
+            $this->label = $fallback;
+        }
+        return $this;
+    }
+
+    public function limit(int $limit): NodeLabelToken
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function suffix(string $suffix): NodeLabelToken
+    {
+        $this->suffix = $suffix;
+        return $this;
+    }
+
+    /**
+     * Runs evaluate to avoid the need of calling evaluate as a finishing method
+     */
+    public function __toString(): string
+    {
+        return $this->evaluate();
+    }
+
+    /**
+     * Crops, removes special chars & tags and trim the label.
+     * If the label is empty a fallback based on the nodetype is provided.
+     */
+    public function evaluate(): string
+    {
+        $label = $this->label;
+
+        if (!$label && $this->node) {
+            $label = $this->getNodeTypeFallbackLabel();
+        }
+        $label = preg_replace('/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' ', $label);
+        $label = strip_tags($label);
+        $label = trim($label);
+        $label = $this->stringHelper->cropAtWord($label, $this->limit, $this->suffix);
+
+        return $label;
+    }
+
+    /**
+     * Returns a label based on the nodetype
+     */
+    protected function getNodeTypeFallbackLabel(): string
+    {
+        if (!$this->node) {
+            return '';
+        }
+        $nodeTypeLabel = $this->translationHelper->translate($this->node->getNodeType()->getLabel());
+        if (!$nodeTypeLabel) {
+            $nodeTypeLabel = $this->node->getNodeType()->getName();
+        }
+        return $nodeTypeLabel . ($this->node->isAutoCreated() ? ' (' . $this->node->getName() . ')' : '');
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
@@ -49,7 +49,7 @@ class NodeLabelToken implements ProtectedContextAwareInterface
     /**
      * @var string
      */
-    protected $suffix = '...';
+    protected $suffix = '…';
 
     /**
      * @var string

--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -1,6 +1,6 @@
 # Base node, which just configures the "removed" property of the node.
 'Neos.Neos:Node':
-  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('text') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' '))), 100, '...')}"
+  label: "${Neos.Node.labelForNode(q(node).property('title'), node).or(q(node).property('text'))}"
   abstract: true
   options:
     fusion:

--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -1,6 +1,6 @@
 # Base node, which just configures the "removed" property of the node.
 'Neos.Neos:Node':
-  label: "${Neos.Node.labelForNode(q(node).property('title'), node).or(q(node).property('text'))}"
+  label: "${Neos.Node.labelForNode(node).properties('title', 'text')}"
   abstract: true
   options:
     fusion:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -545,6 +545,11 @@ Neos:
     #        values: ['de_DE', 'de_ZZ', 'mul_ZZ']
     #        uriSegment: 'de'
 
+    labelGenerator:
+      eel:
+        defaultContext:
+          Neos.Node: Neos\Neos\Fusion\Helper\NodeHelper
+
   Fusion:
     rendering:
       exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\ThrowingHandler

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Fusion/NodeHelper.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Fusion/NodeHelper.fusion
@@ -1,0 +1,9 @@
+nodeHelper.defaultLabel = ${Neos.Node.labelForNode(node).properties('title', 'text')}
+
+nodeHelper.propertyFallback = ${Neos.Node.labelForNode(node).properties('foo', 'text')}
+
+nodeHelper.withPrefixOverrideAndPostfix = ${Neos.Node.labelForNode(node).prefix('Hello').override(' world ').postfix(' how are you')}
+
+nodeHelper.nodeTypeFallback = ${Neos.Node.labelForNode(node).properties('foo')}
+
+nodeHelper.crop = ${Neos.Node.labelForNode(node).override('Some long text').crop(6, '-')}

--- a/Neos.Neos/Tests/Functional/Fusion/Fixtures/Fusion/Root.fusion
+++ b/Neos.Neos/Tests/Functional/Fusion/Fixtures/Fusion/Root.fusion
@@ -1,0 +1,1 @@
+include: ./**/*.fusion

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -1,0 +1,151 @@
+<?php
+namespace Neos\Neos\Tests\Functional\Fusion;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Fusion\Tests\Functional\FusionObjects\AbstractFusionObjectTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Testcase for the Fusion NodeLabel helper
+ */
+class NodeHelperTest extends AbstractFusionObjectTest
+{
+    /**
+     * @var Node|MockObject
+     */
+    protected $textNode;
+
+    /**
+     * @test
+     */
+    public function defaultNodeLabel()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('nodeHelper/defaultLabel');
+
+        $view->assign('node', $this->textNode);
+
+        self::assertEquals('Some title', (string)$view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function withPropertyFallback()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('nodeHelper/propertyFallback');
+
+        $view->assign('node', $this->textNode);
+
+        self::assertEquals('Some text', (string)$view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function withPrefixOverrideAndPostfix()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('nodeHelper/withPrefixOverrideAndPostfix');
+
+        $view->assign('node', $this->textNode);
+
+        self::assertEquals('Hello world how are you', (string)$view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function nodeTypeFallback()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('nodeHelper/nodeTypeFallback');
+
+        $view->assign('node', $this->textNode);
+
+        self::assertEquals($this->textNode->getNodeType()->getLabel(), (string)$view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function crop()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('nodeHelper/crop');
+
+        $view->assign('node', $this->textNode);
+
+        self::assertEquals('Some -', (string)$view->render());
+    }
+
+    protected function buildView()
+    {
+        $view = parent::buildView();
+
+        $view->setPackageKey('Neos.Neos');
+        $view->setFusionPathPattern(__DIR__ . '/Fixtures/Fusion');
+        $view->assign('fixtureDirectory', __DIR__ . '/Fixtures/');
+
+        return $view;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $nodeType = $this
+            ->getMockBuilder(NodeType::class)
+            ->setMethods(['getName', 'getLabel'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $nodeType
+            ->method('getName')
+            ->willReturn('Neos.Neos:Content.Text');
+        $nodeType
+            ->method('getLabel')
+            ->willReturn('Content.Text');
+
+        $textNode = $this
+            ->getMockBuilder(Node::class)
+            ->setMethods(['hasProperty', 'getProperty', 'getNodeType', 'isAutoCreated'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $textNode
+            ->method('hasProperty')
+            ->willReturnCallback(function ($arg) {
+                return $arg === 'title' || $arg === 'text';
+            });
+        $textNode
+            ->method('isAutoCreated')
+            ->willReturn(false);
+        $textNode
+            ->method('getProperty')
+            ->willReturnCallback(function ($arg) {
+                if ($arg === 'title') {
+                    return 'Some title';
+                }
+                if ($arg === 'text') {
+                    return 'Some text';
+                }
+                return null;
+            });
+        $textNode
+            ->method('getNodeType')
+            ->willReturn($nodeType);
+
+        $this->textNode = $textNode;
+    }
+}


### PR DESCRIPTION
With this helper it’s easier to define custom node label schemas in nodetypes.

**What I did**

Moved the previously used Eel expression from the main `Neos.Neos:Node` nodetype into the NodeHelper.
Similar to the TranslationParameterToken it provides a chainable interface to simplify custom nodetype naming.

**How to verify it**

All labels in the Neos document and content tree should still be the same.
Override the nodetype label by copying the expression from `Neos.Neos:Node` and modifying it.

Examples: 

Use properties as label with fallback chain (replaces the previous default)
```
'Neos.Neos:Node':
  label: "${Neos.Node.labelForNode(node).properties('title', 'text')}"
```

Show number of elements in a multicolumn next to its label
```
'Neos.Demo:Content.Columns.Two':
  label: "${Neos.Node.labelForNode(node).postfix(' (' + q(node).children().children().count() + ' elements)')}"
```

Use override, prefix and postfix:
```
'Neos.Demo:Content.Special':
  label: "${Neos.Node.labelForNode(node).prefix('The ').override('child of').postfix(' ' + q(node).parent().get(0).label)}"
```

Adjust cropping:
```
'Neos.Demo:Content.Cropped':
  label: "${Neos.Node.labelForNode(node).crop(20, ' - - -')}"
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
