### PR TITLE
BUGFIX: Fix support for NodeType presets in the Creation Dialog

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.Content.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Content.yaml
@@ -9,6 +9,7 @@
       '*': false
   postprocessors:
     'CreationDialogPostprocessor':
+      position: 'after NodeTypePresetPostprocessor'
       postprocessor: 'Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor'
   options:
     nodeCreationHandlers:

--- a/Neos.Neos/Configuration/NodeTypes.Document.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Document.yaml
@@ -14,6 +14,7 @@
       'Neos.Neos:Document': true
   postprocessors:
     'CreationDialogPostprocessor':
+      position: 'after NodeTypePresetPostprocessor'
       postprocessor: 'Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor'
   options:
     nodeCreationHandlers:


### PR DESCRIPTION
This change makes sure that the `CreationDialogPostprocessor` is
executed _after_ the `NodeTypePresetPostprocessor` so that the
presets are replaced before the Creation Dialog fields are generated.

Fixes: #3329