### PR TITLE
BUGFIX: Use "stable" identifier when auto-creating child nodes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
@@ -74,7 +74,14 @@ class NodeService implements NodeServiceInterface
         $nodeType = $node->getNodeType();
         foreach ($nodeType->getAutoCreatedChildNodes() as $childNodeName => $childNodeType) {
             try {
-                $node->createNode($childNodeName, $childNodeType);
+                $node->createNode(
+                    $childNodeName,
+                    $childNodeType,
+                    Utility::buildAutoCreatedChildNodeIdentifier(
+                        $childNodeName,
+                        $node->getNodeAggregateIdentifier()
+                    )
+                );
             } catch (NodeExistsException $exception) {
                 // If you have a node that has been marked as removed, but is needed again
                 // the old node is recovered


### PR DESCRIPTION
Since ``node:repair`` uses the ``buildAutoCreatedChildNodeIdentifier``, it would
best to ensure the ``identifier`` is already correct when auto-creating child nodes.

Otherwise the identifier will be changed to a so called "stable"
identifier during a ``node:repair`` run which can lead to unwanted
behaviour in certain applications.