### PR TITLE
PHP 8 Changes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -558,7 +558,7 @@ class NodeData extends AbstractNodeData
      * @param array $dimensions
      * @return integer The number of child nodes
      */
-    public function getNumberOfChildNodes($nodeTypeFilter = null, Workspace $workspace, array $dimensions)
+    public function getNumberOfChildNodes($nodeTypeFilter, Workspace $workspace, array $dimensions)
     {
         return $this->nodeDataRepository->countByParentAndNodeType($this->path, $nodeTypeFilter, $workspace, $dimensions);
     }

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -1098,9 +1098,9 @@ class NodesTest extends FunctionalTestCase
         $childNodes = $rootNode->getChildNodes();
         $names = new \stdClass();
         $names->names = [];
-        array_walk($childNodes, function ($value, $key, &$names) {
+        array_walk($childNodes, function ($value, $key) use (&$names) {
             $names->names[] = $value->getName();
-        }, $names);
+        });
         self::assertSame(['fluss', 'baz', 'flux'], $names->names);
     }
 
@@ -1119,9 +1119,9 @@ class NodesTest extends FunctionalTestCase
         $childNodes = $rootNode->getChildNodes();
         $names = new \stdClass();
         $names->names = [];
-        array_walk($childNodes, function ($value, $key, &$names) {
+        array_walk($childNodes, function ($value, $key) use (&$names) {
             $names->names[] = $value->getName();
-        }, $names);
+        });
         self::assertSame(['baz', 'fluss', 'flux'], $names->names);
     }
 
@@ -1174,9 +1174,9 @@ class NodesTest extends FunctionalTestCase
 
         $names = new \stdClass();
         $names->names = [];
-        array_walk($copiedChildNodes, function ($value, $key, &$names) {
+        array_walk($copiedChildNodes, function ($value, $key) use (&$names) {
             $names->names[] = $value->getName();
-        }, $names);
+        });
         self::assertSame(['capacitor', 'second', 'third'], $names->names);
     }
 
@@ -1197,9 +1197,9 @@ class NodesTest extends FunctionalTestCase
 
         $names = new \stdClass();
         $names->names = [];
-        array_walk($copiedChildNodes, function ($value, $key, &$names) {
+        array_walk($copiedChildNodes, function ($value, $key) use (&$names) {
             $names->names[] = $value->getName();
-        }, $names);
+        });
         self::assertSame(['capacitor', 'second', 'third'], $names->names);
     }
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeService;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Testcase for the NodeService
@@ -196,7 +197,7 @@ class NodeServiceTest extends UnitTestCase
     {
         $nodeService = $this->createNodeService();
 
-        $mockNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
+        $mockNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->onlyMethods(['getNodeType', 'createNode', 'getIdentifier'])->getMock();
 
         $mockNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:Content');
         $firstChildNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:Content');
@@ -208,6 +209,8 @@ class NodeServiceTest extends UnitTestCase
                 'first-child-node-name' => $firstChildNodeType,
                 'second-child-node-name' => $secondChildNodeType
             ]));
+
+        $mockNode->method('getIdentifier')->willReturn(Uuid::uuid4());
 
         $mockNode->expects(self::once())
             ->method('getNodeType')

--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -157,7 +157,7 @@ class ContentCache
      * @param string $cacheDiscriminator The evaluated cache discriminator value
      * @return string The original content, but with additional markers added
      */
-    public function createDynamicCachedSegment($content, $fusionPath, array $contextVariables, array $cacheIdentifierValues, array $tags = [], $lifetime = null, $cacheDiscriminator)
+    public function createDynamicCachedSegment($content, $fusionPath, array $contextVariables, array $cacheIdentifierValues, array $tags, $lifetime, $cacheDiscriminator)
     {
         $metadata = implode(',', $tags);
         if ($lifetime !== null) {

--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetAssetCollectionConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetAssetCollectionConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Media\Security\Authorization\Privilege\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetTagConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetTagConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Media\Security\Authorization\Privilege\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetWithoutAssetCollectionConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetWithoutAssetCollectionConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Media\Security\Authorization\Privilege\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
+++ b/Neos.Neos/Tests/Functional/Domain/Service/Fixtures/Sites.xml
@@ -8,8 +8,8 @@
       <language>en_US</language>
      </dimensions>
      <accessRoles __type="array"/>
-     <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</creationDateTime>
-     <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</lastModificationDateTime>
+     <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+00:00</creationDateTime>
+     <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+00:00</lastModificationDateTime>
      <properties>
       <title __type="string">example.org</title>
      </properties>
@@ -20,8 +20,8 @@
        <language>en_US</language>
       </dimensions>
       <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+01:00</lastModificationDateTime>
+      <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+00:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:09:49+00:00</lastModificationDateTime>
       <properties>
        <title __type="string">&lt;h1&gt;Home&lt;/h1&gt;</title>
        <uriPathSegment __type="string">home</uriPathSegment>
@@ -36,8 +36,8 @@
         <entry0 __type="string">Neos.Neos:Editor</entry0>
         <entry1 __type="string">Neos.Neos:Administrator</entry1>
        </accessRoles>
-       <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+01:00</creationDateTime>
-       <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+01:00</lastModificationDateTime>
+       <creationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+00:00</creationDateTime>
+       <lastModificationDateTime __type="object" __classname="DateTime">2015-02-23T14:13:11+00:00</lastModificationDateTime>
        <properties>
         <title __type="string">&lt;h1&gt;This node is protected&lt;/h1&gt;</title>
         <uriPathSegment __type="string">protected</uriPathSegment>


### PR DESCRIPTION
Updates the ClassMetadata Namespace from
Doctrine\Common\Persistence\Mapping\ClassMetadata to
 Doctrine\Persistence\Mapping\ClassMetadata.

Fixes Unit-Tests.

Removes optional parameters after mandatory parameters.