### PR TITLE
BUGFIX: Don’t evaluate reference nodes collection twice

### DIFF
--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
@@ -7,6 +7,7 @@ prototype(Neos.NodeTypes.ContentReferences:ContentReferences) < prototype(Neos.N
     itemRenderer = Neos.Neos:ContentCase
     itemName = 'node'
   }
+  hasReferences = ${!!referenceNodesArray}
   @cache {
     mode = 'cached'
     entryIdentifier {

--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Templates/NodeTypes/ContentReferences.html
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Templates/NodeTypes/ContentReferences.html
@@ -1,5 +1,5 @@
 {namespace neos=Neos\Neos\ViewHelpers}
-<f:if condition="{referenceNodes}">
+<f:if condition="{hasReferences}">
   <f:then>
     <div{attributes -> f:format.raw()}>
       {referenceNodes -> f:format.raw()}


### PR DESCRIPTION
The condition in fluid evaluates the „referenceNodes“ and the result
is not cached. Therefore when the variable is used for the output
the whole code is evaluated again.

Resolves #3355
