### PR TITLE
BUGFIX: Skip unnecessary queries for nodedata

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -1272,6 +1272,10 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      */
     public function getNumberOfChildNodes($nodeTypeFilter = null): int
     {
+        $nodes = $this->context->getFirstLevelNodeCache()->getChildNodesByPathAndNodeTypeFilter($this->getPath(), $nodeTypeFilter);
+        if ($nodes !== false) {
+            return count($nodes);
+        }
         return $this->nodeData->getNumberOfChildNodes($nodeTypeFilter, $this->context->getWorkspace(), $this->context->getDimensions());
     }
 

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1618,6 +1618,10 @@ class NodeDataRepository extends Repository
      */
     protected function filterNodeDataByBestMatchInContext(array $nodeDataObjects, Workspace $workspace, array $dimensions, $includeRemovedNodes = false)
     {
+        if (!$nodeDataObjects) {
+            return [];
+        }
+
         $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
         $nonPersistedNodes = [];
         $nodeIdentifier = [];


### PR DESCRIPTION
**What I did and how I did it**

1.  Prevent node queries when is is clear that there would be an empty result
2. Prevent childnode count queries, when the children are already known due to previously cached query results for the same children

**How to verify it**

In the Neos page `/en/features.html` this reduces the number of queries from 138 to 133.
In larger projects with more complex components this has a larger effect.

In a large project this reduced the SQL query count on one page from 1379 to 1115 (~23%) and the resulting rendering time by ~20%.

**Checklist**

- [x ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
