### PR TITLE
TASK: Remove deprecated removed content wraps

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -17,21 +17,6 @@ prototype(Neos.Neos:ContentCollectionRenderer) < prototype(Neos.Fusion:Loop) {
   itemName = 'node'
   iterationName = 'iterator'
 
-  # Using a processor here and not an Array as ContentCollectionRenderer to not push important userland properties further down.
-  @process.appendRemovedContentForBackend = Neos.Fusion:Join {
-    visibleContent = ${value}
-
-    removedContent = Neos.Fusion:Loop {
-      items = ${nodeAvailable ? q(node).context({'removedContentShown': true}).children('[_removed = true]') : []}
-      # Render every item by its own Fusion object
-      itemRenderer = Neos.Neos:ContentElementWrapping
-      itemName = 'node'
-      iterationName = 'iterator'
-    }
-
-    @if.onlyInBackend = ${nodeAvailable && node.context.inBackend}
-  }
-
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\BubblingHandler'
 }
 


### PR DESCRIPTION
**What I did**

Every content collections renders nodedata for its removed content.
This creates a lot of queries in the backend context of Neos as the query uses a modified context and therefore skips the first level nodecache.
But the nodedata was only used by the old Neos UI and
has no effect anymore on the new UI.
Therefore removing this from rendering reduces rendering
time a lot in the backend.

**How I did it**

Removed the Fusion part responsible for rendering the removed node wraps.

**How to verify it**

Load a page with 1 or more contentcollections in the Neos backend and compare query count.

In a large project this change reduced the number of SQL queries in the Neos backend or preview by ~21%.
