### PR TITLE
TASK: Replace deprecated window.Typo3Neos

### DIFF
--- a/Neos.Media.Browser/Resources/Public/JavaScript/collections-and-tagging.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/collections-and-tagging.js
@@ -57,9 +57,9 @@ window.addEventListener('DOMContentLoaded', (event) => {
 											}
 									}).fail(function () {
 											var message = 'Tagging the asset failed.';
-											if (window.Typo3Neos) {
-													message = window.Typo3Neos.I18n.translate('taggingAssetsFailed', message, 'Neos.Media.Browser');
-													window.Typo3Neos.Notification.error(message);
+											if (window.NeosCMS) {
+													message = window.NeosCMS.I18n.translate('taggingAssetsFailed', message, 'Neos.Media.Browser');
+													window.NeosCMS.Notification.error(message);
 											} else {
 													alert(message);
 											}
@@ -100,9 +100,9 @@ window.addEventListener('DOMContentLoaded', (event) => {
 											}
 									}).fail(function () {
 											var message = 'Adding the asset to the collection failed.';
-											if (window.Typo3Neos) {
-													message = window.Typo3Neos.I18n.translate('addingAssetsToCollectionFailed', message, 'Neos.Media.Browser');
-													window.Typo3Neos.Notification.error(message);
+											if (window.NeosCMS) {
+													message = window.NeosCMS.I18n.translate('addingAssetsToCollectionFailed', message, 'Neos.Media.Browser');
+													window.NeosCMS.Notification.error(message);
 											} else {
 													alert(message);
 											}
@@ -122,7 +122,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
 							value.focus();
 							e.preventDefault();
 					} else {
-							var label = window.Typo3Neos.I18n.translate('creating', 'Creating', 'Neos.Media.Browser');
+							var label = window.NeosCMS.I18n.translate('creating', 'Creating', 'Neos.Media.Browser');
 							$('button[type="submit"]', this).addClass('neos-disabled').html(label + '<span class="neos-ellipsis" />');
 					}
 			});

--- a/Neos.Media.Browser/Resources/Public/JavaScript/new.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/new.js
@@ -15,18 +15,18 @@
                 var readableFileSize = readablizeBytes(filesize);
                 var readableMaximumFileSize = readablizeBytes(maximumFileUploadSize);
                 var message = 'The file size of ' + readableFileSize + ' exceeds the allowed limit of ' + readableMaximumFileSize;
-                if (window.Typo3Neos) {
-                    message = window.Typo3Neos.I18n.translate('fileSizeExceedsAllowedLimit', message, 'Neos.Media.Browser', 'Main', [readableFileSize, readableMaximumFileSize]);
-                    window.Typo3Neos.Notification.error(message);
+                if (window.NeosCMS) {
+                    message = window.NeosCMS.I18n.translate('fileSizeExceedsAllowedLimit', message, 'Neos.Media.Browser', 'Main', [readableFileSize, readableMaximumFileSize]);
+                    window.NeosCMS.Notification.error(message);
                 } else {
                     alert(message);
                 }
                 $(this.form).on('submit.invalidfile', function (e) {
                     e.preventDefault();
                     var message = 'Cannot upload the file';
-                    if (window.Typo3Neos) {
-                        message = window.Typo3Neos.I18n.translate('cannotUploadFile', message, 'Neos.Media.Browser');
-                        window.Typo3Neos.Notification.warning(message);
+                    if (window.NeosCMS) {
+                        message = window.NeosCMS.I18n.translate('cannotUploadFile', message, 'Neos.Media.Browser');
+                        window.NeosCMS.Notification.warning(message);
                     } else {
                         alert(message);
                     }
@@ -42,9 +42,9 @@
                 if (!$resource.val()) {
                     e.preventDefault();
                     var message = 'No file selected';
-                    if (window.Typo3Neos) {
-                        message = window.Typo3Neos.I18n.translate('noFileSelected', message, 'Neos.Media.Browser');
-                        window.Typo3Neos.Notification.warning(message);
+                    if (window.NeosCMS) {
+                        message = window.NeosCMS.I18n.translate('noFileSelected', message, 'Neos.Media.Browser');
+                        window.NeosCMS.Notification.warning(message);
                     } else {
                         alert(message);
                     }

--- a/Neos.Media.Browser/Resources/Public/JavaScript/upload.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/upload.js
@@ -54,8 +54,8 @@ window.addEventListener('DOMContentLoaded', (event) => {
 											var readableFileSize = readablizeBytes(err.file.size);
 											var readableMaximumFileSize = readablizeBytes(maximumFileUploadSize);
 											message = 'The file size of ' + readableFileSize + ' exceeds the allowed limit of ' + readableMaximumFileSize;
-											if (window.Typo3Neos) {
-													message = window.Typo3Neos.I18n.translate('fileSizeExceedsAllowedLimit', message, 'Neos.Media.Browser', 'Main', [readableFileSize, readableMaximumFileSize]);
+											if (window.NeosCMS) {
+													message = window.NeosCMS.I18n.translate('fileSizeExceedsAllowedLimit', message, 'Neos.Media.Browser', 'Main', [readableFileSize, readableMaximumFileSize]);
 											}
 											break;
 									default:
@@ -63,15 +63,15 @@ window.addEventListener('DOMContentLoaded', (event) => {
 							}
 							if (err.file) {
 									message += ' ';
-									if (window.Typo3Neos) {
-											message += window.Typo3Neos.I18n.translate('forTheFile', 'for the file', 'Neos.Media.Browser');
+									if (window.NeosCMS) {
+											message += window.NeosCMS.I18n.translate('forTheFile', 'for the file', 'Neos.Media.Browser');
 									} else {
 											message += 'for the file';
 									}
 									message += ' "' + err.file.name + '"';
 							}
-							if (window.Typo3Neos) {
-									window.Typo3Neos.Notification.error(message);
+							if (window.NeosCMS) {
+									window.NeosCMS.Notification.error(message);
 							} else {
 									alert(message);
 							}
@@ -83,9 +83,9 @@ window.addEventListener('DOMContentLoaded', (event) => {
 							if (preventReload) {
 									$('#filelist').html('');
 									var message = 'Only some of the files were successfully uploaded. Refresh the page to see the those.';
-									if (window.Typo3Neos) {
-											message = window.Typo3Neos.I18n.translate('onlySomeFilesWereUploaded', message, 'Neos.Media.Browser');
-											window.Typo3Neos.Notification.warning(message);
+									if (window.NeosCMS) {
+											message = window.NeosCMS.I18n.translate('onlySomeFilesWereUploaded', message, 'Neos.Media.Browser');
+											window.NeosCMS.Notification.warning(message);
 									} else {
 											alert(message);
 									}


### PR DESCRIPTION
The usage of `window.Typo3Neos` has been replaces with `window.NeosCMS` and with version 8 the old Typo3Neos will not work anymore. So we as core should use the latest version of course.


**What I did**
Just replaced the old `window.Typo3Neos` with `window.NeosCMS`

**How to verify it**
Just edit tags, create tags or images.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
