### PR TITLE
BUGFIX: Adjust contributing section to composer changes

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -49,11 +49,11 @@ Contributing
 
 If you want to contribute to Neos and want to set up a development environment, then follow these steps:
 
-``composer create-project neos/neos-development-distribution neos-development dev-master --keep-vcs``
+``composer create-project neos/neos-development-distribution neos-development dev-master --keep-vcs --prefer-install=auto``
 
 Note the **-distribution** package you create a project from, instead of just checking out this repository.
 
-The code of the CMS can then be found inside ``Packages/Neos``, which itself is the neos-development-collection Git repository (due to the ``--keep-vcs`` option above). You commit changes and create pull requests from this repository.
+The code of the CMS can then be found inside ``Packages/Neos``, which itself is the neos-development-collection Git repository (due to the ``--prefer-install`` option above). You commit changes and create pull requests from this repository.
 To commit changes to Neos switch into the ``Neos`` directory (``cd Packages/Neos``) and do all Git-related work (``git add .``, ``git commit``, etc) there.
 If you want to contribute to the Neos UI, please take a look at the explanations at https://github.com/neos/neos-ui#contributing on how to work with that.
 If you want to contribute to the Flow Framework, you find that inside the ``Packages/Framework`` folder. See https://github.com/neos/flow-development-collection


### PR DESCRIPTION
When installing for development purposes, `--prefer-install=auto` needs
to be used since Composer 2.1, see https://getcomposer.org/doc/06-config.md#preferred-install
