### PR TITLE
TASK: Replace deprecated guzzle functions with static methods

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/HttpResponseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/HttpResponseImplementation.php
@@ -1,7 +1,7 @@
 <?php
 namespace Neos\Fusion\FusionObjects;
 
-use function GuzzleHttp\Psr7\str;
+use GuzzleHttp\Psr7\Message;
 use Neos\Flow\Annotations as Flow;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -59,6 +59,6 @@ class HttpResponseImplementation extends DataStructureImplementation
 
         // FIXME: It would be neat to transfer the actual response object directly,
         // but the content cache currently cannot handle it, so we put it all into a string for now.
-        return str($response);
+        return Message::toString($response);
     }
 }

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\Http\ResponseHeadImplementation;
 use Psr\Http\Message\ResponseFactoryInterface;
-use function GuzzleHttp\Psr7\str;
+use GuzzleHttp\Psr7\Message;
 
 /**
  * Testcase for the Fusion ResponseHead object
@@ -74,6 +74,6 @@ class ResponseHeadImplementationTest extends UnitTestCase
 
         $result = $renderer->evaluate();
 
-        self::assertEquals($expectedOutput, str($result));
+        self::assertEquals($expectedOutput, Message::toString($result));
     }
 }

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Fusion\ExceptionHandlers;
  * source code.
  */
 
-use function GuzzleHttp\Psr7\str;
+use GuzzleHttp\Psr7\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
@@ -107,7 +107,7 @@ class PageHandler extends AbstractRenderingExceptionHandler
             $bodyContent
         );
 
-        return str($response);
+        return Message::toString($response);
     }
 
     /**

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\View;
  * source code.
  */
 
-use function GuzzleHttp\Psr7\parse_response;
+use GuzzleHttp\Psr7\Message;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\View\AbstractView;
@@ -102,7 +102,7 @@ class FusionView extends AbstractView
     protected function parsePotentialRawHttpResponse($output)
     {
         if ($this->isRawHttpResponse($output)) {
-            return parse_response($output);
+            return Message::parseResponse($output);
         }
 
         return $output;


### PR DESCRIPTION
See https://github.com/guzzle/psr7/pull/345

Related to https://github.com/neos/flow-development-collection/pull/2455 - hence why this targets 7.1 instead of master