### PR TITLE
FEATURE: Fusion Memo object

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/MemoImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MemoImplementation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Fusion\FusionObjects;
 
 /*
@@ -16,7 +17,7 @@ namespace Neos\Fusion\FusionObjects;
  */
 class MemoImplementation extends AbstractFusionObject
 {
-    static protected $cache = [];
+    protected static $cache = [];
 
     /**
      * Return the processed value or its cached version based on the discriminator

--- a/Neos.Fusion/Classes/FusionObjects/MemoImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MemoImplementation.php
@@ -1,0 +1,51 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Memo object that returns the result of previous calls with the same "discriminator"
+ */
+class MemoImplementation extends AbstractFusionObject
+{
+    static protected $cache = [];
+
+    /**
+     * Return the processed value or its cached version based on the discriminator
+     *
+     * @return mixed
+     */
+    public function evaluate()
+    {
+        $discriminator = $this->getDiscriminator();
+        if (array_key_exists($discriminator, self::$cache)) {
+            return self::$cache[$discriminator];
+        }
+
+        $value = $this->getValue();
+        self::$cache[$discriminator] = $value;
+
+        return $value;
+    }
+
+    public function getDiscriminator(): string
+    {
+        return (string)$this->fusionValue('discriminator');
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->fusionValue('value');
+    }
+}

--- a/Neos.Fusion/Resources/Private/Fusion/Memo.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Memo.fusion
@@ -1,0 +1,13 @@
+##
+# Returns the result of previous calls with the same "discriminator"
+#
+# prototype(My.Vendor:Expensive.Calculation) < prototype(Neos.Fusion:Memo) {
+#     discriminator = 'expensive-calculation'
+#     value = ${1+2}
+# }
+#
+prototype(Neos.Fusion:Memo) {
+  @class = 'Neos\\Fusion\\FusionObjects\\MemoImplementation'
+  discriminator = ''
+  value = ''
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Memo.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Memo.fusion
@@ -1,0 +1,12 @@
+prototype(Neos.Fusion:Memo) {
+  @class = 'Neos\\Fusion\\FusionObjects\\MemoImplementation'
+}
+
+memo.returnsValue = Neos.Fusion:Memo {
+  discriminator = 'simple'
+  value = ${1 + 1}
+}
+memo.returnsPreviousValueForDiscriminator = Neos.Fusion:Memo {
+  discriminator = 'simple'
+  value = 3
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the Memo object
+ *
+ */
+class MemoTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function returnsSameResult()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('memo/returnsValue');
+        $result = $view->render();
+        self::assertEquals(2, $result);
+
+        $view->setFusionPath('memo/returnsPreviousValueForDiscriminator');
+        $secondResult = $view->render();
+
+        self::assertEquals($result, $secondResult);
+    }
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -506,6 +506,23 @@ Example::
 
 .. note:: This can be used to simplify many usages of :ref:`Neos_Fusion__Case` when the subject is a string.
 
+.. _Neos_Fusion__Memo:
+
+Neos.Fusion:Memo
+-----------------
+
+Returns the result of previous calls with the same "discriminator"
+
+:discriminator: (string, **required**) Cache identifier
+:value: (mixed) The value to evaluate and store for future calls during rendering
+
+Example::
+
+  prototype(My.Vendor:Expensive.Calculation) < prototype(Neos.Fusion:Memo) {
+    discriminator = 'expensive-calculation'
+    value = ${1+2}
+  }
+
 .. _Neos_Fusion__RawArray:
 
 Neos.Fusion:RawArray


### PR DESCRIPTION
This Fusion object stores its value based on
the given discriminator and returns the same
result in future calls during the same rendering.
The value will then not be evaluated again.

Example:
```
prototype(My.Vendor:Expensive.Calculation) < prototype(Neos.Fusion:Memo) {
    discriminator = 'expensive-calculation'
    value = ${1+2}
}
myValue = My.Vendor:Expensive.Calculation
myValue2 = My.Vendor:Expensive.Calculation
```