### PR TITLE
Collect affected nodes for each dimension to remove undefined properties

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -744,7 +744,7 @@ HELPTEXT;
                     }
                 }
                 if ($undefinedProperties !== []) {
-                    $nodesWithUndefinedPropertiesNodes[$node->getIdentifier()] = ['node' => $node, 'undefinedProperties' => $undefinedProperties];
+                    $nodesWithUndefinedPropertiesNodes[] = ['node' => $node, 'undefinedProperties' => $undefinedProperties];
                     foreach ($undefinedProperties as $undefinedProperty) {
                         $undefinedPropertiesCount++;
                         $this->dispatch(self::EVENT_NOTICE, sprintf('Found undefined property named "<i>%s</i>" in "<i>%s</i>" (<i>%s</i>)', $undefinedProperty, $node->getPath(), $node->getNodeType()->getName()));


### PR DESCRIPTION
If you run `removeUndefinedProperties` of the `./flow node:repair` command not all undefined properties get removed.

Currently the affected nodes get indexed by the node identifier. But this identifier is the same for all dimensions. So the list of nodes reflects all dimensions, but the actual removal just run on ONE node of any dimension. So you have to run the command n-times (n = number of dimensions).

**Expected behavior**
Remove all undefined properties in all dimensions

**Actual behavior**
Removes just undefinded properties of a node in one dimension

**How to test**
* Set up with more than one dimension
* Create a node with properties in more than one dimension
* Remove a property definition of that node
* run `./flow node:repair`
* run again to see, if it had removed all properties in the run before