### PR TITLE
TASK: Use nodeIdentifier instead of getNodeAggregateIdentifier

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeService.php
@@ -79,7 +79,7 @@ class NodeService implements NodeServiceInterface
                     $childNodeType,
                     Utility::buildAutoCreatedChildNodeIdentifier(
                         $childNodeName,
-                        $node->getNodeAggregateIdentifier()
+                        $node->getIdentifier()
                     )
                 );
             } catch (NodeExistsException $exception) {


### PR DESCRIPTION
As the NodeAggregateIdentifier class is final and not mockable in unit tests.