### PR TITLE
Fix: Only document Nodes should appear in Breadcrumb

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,3 +1,3 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-  itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
+  itemCollection = ${q(documentNode).add(q(documentNode).parents('[instanceof Neos.Neos:Document]')).get()}
 }


### PR DESCRIPTION
When rendering the Breadcrumb-Menu in a Content Node, the Content-Node itself is added to the Menu.

**What I did**
Updated BreadcrumbMenuItems to only use DocumentNodes. 

**How I did it**
Replacted `q(node).add(...)` with `q(documentNode).add(...)`

**How to verify it**
Use BreadcrumbMenuItems inside a Content Node. 

**Checklist**

- [x] Code follows the PSR-2 coding style
~~- [ ] Tests have been created, run and adjusted as needed~~
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
