### PR TITLE
BUGFIX: Only document Nodes should appear in Breadcrumb

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,3 +1,3 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-	itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
+	itemCollection = ${q(documentNode).add(q(documentNode).parents('[instanceof Neos.Neos:Document]')).get()}
 }


### PR DESCRIPTION
When rendering the Breadcrumb menu in a Content node, the Content node itself is no longer added to the menu.

This is done by replacing `q(node).add(...)` with `q(documentNode).add(...)`
