### PR TITLE
BUGFIX: Enable translations for overridden selectbox options

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -17,6 +17,7 @@ use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Neos\Service\IconNameMappingService;
 use Neos\Utility\Arrays;
 use Neos\Neos\Exception;
+use Neos\ContentRepository\Domain\Model\NodeType;
 
 /**
  * @Flow\Scope("singleton")
@@ -80,10 +81,11 @@ class NodeTypeConfigurationEnrichmentAspect
      */
     public function enrichNodeTypeLabelsConfiguration(JoinPointInterface $joinPoint): void
     {
+        $declaredSuperTypes = $joinPoint->getMethodArgument('declaredSuperTypes');
         $configuration = $joinPoint->getMethodArgument('configuration');
         $nodeTypeName = $joinPoint->getMethodArgument('name');
 
-        $this->addLabelsToNodeTypeConfiguration($nodeTypeName, $configuration);
+        $this->addLabelsToNodeTypeConfiguration($nodeTypeName, $configuration, $declaredSuperTypes);
 
         $joinPoint->setMethodArgument('configuration', $configuration);
         $joinPoint->getAdviceChain()->proceed($joinPoint);
@@ -92,16 +94,17 @@ class NodeTypeConfigurationEnrichmentAspect
     /**
      * @param string $nodeTypeName
      * @param array $configuration
+     * @param array $declaredSuperTypes
      * @return void
      */
-    protected function addLabelsToNodeTypeConfiguration($nodeTypeName, array &$configuration)
+    protected function addLabelsToNodeTypeConfiguration($nodeTypeName, array &$configuration, array $declaredSuperTypes)
     {
         if (isset($configuration['ui'])) {
             $this->setGlobalUiElementLabels($nodeTypeName, $configuration);
         }
 
         if (isset($configuration['properties'])) {
-            $this->setPropertyLabels($nodeTypeName, $configuration);
+            $this->setPropertyLabels($nodeTypeName, $configuration, $declaredSuperTypes);
         }
     }
 
@@ -186,9 +189,10 @@ class NodeTypeConfigurationEnrichmentAspect
     /**
      * @param string $nodeTypeLabelIdPrefix
      * @param array $configuration
+     * @param array $declaredSuperTypes
      * @return void
      */
-    protected function setPropertyLabels($nodeTypeName, array &$configuration)
+    protected function setPropertyLabels($nodeTypeName, array &$configuration, array $declaredSuperTypes)
     {
         $nodeTypeLabelIdPrefix = $this->generateNodeTypeLabelIdPrefix($nodeTypeName);
         foreach ($configuration['properties'] as $propertyName => &$propertyConfiguration) {
@@ -200,11 +204,19 @@ class NodeTypeConfigurationEnrichmentAspect
                 $propertyConfiguration['ui']['label'] = $this->getPropertyLabelTranslationId($nodeTypeLabelIdPrefix, $propertyName);
             }
 
-            if (isset($propertyConfiguration['ui']['inspector']['editor']) && isset($propertyConfiguration['ui']['inspector']['editorOptions'])) {
+            $editorName = $propertyConfiguration['ui']['inspector']['editor']
+                ?? array_reduce($declaredSuperTypes, function ($editorName, NodeType $superType) use ($propertyName) {
+                    $superTypeConfiguration = $superType->getLocalConfiguration();
+                    return $editorName ?? $superTypeConfiguration['properties'][$propertyName]['ui']['inspector']['editor'] ?? null;
+                }, null);
+            $hasEditor = !is_null($editorName);
+            $hasEditorOptions = isset($propertyConfiguration['ui']['inspector']['editorOptions']);
+
+            if ($hasEditor && $hasEditorOptions) {
                 $translationIdGenerator = function ($path) use ($nodeTypeLabelIdPrefix, $propertyName) {
                     return $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, $path);
                 };
-                $this->applyEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $propertyConfiguration['ui']['inspector']['editor'], $propertyConfiguration['ui']['inspector']['editorOptions'], $translationIdGenerator);
+                $this->applyEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $editorName, $propertyConfiguration['ui']['inspector']['editorOptions'], $translationIdGenerator);
             }
 
             if (isset($propertyConfiguration['ui']['aloha']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['aloha'], 'placeholder')) {


### PR DESCRIPTION
**What I did / How I did it**

I altered the `NodeTypeConfigurationEnrichmentAspect` so that it takes the node type inheritance chain into account when translating select box option labels in the respective inspector editor configuration.

This addresses an issue originally reported in the UI repo: https://github.com/neos/neos-ui/issues/2005

**How to verify it**

You'll need a mixin NodeType that provides a select box property with internationalized option labels like this:

```yaml
    brandColor:
      type: string
      defaultValue: 'primary'
      ui:
        label: i18n
        reloadIfChanged: true
        inspector:
          group: style
          position: 10
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            values:
              'primary':
                label: i18n
              'turquoise':
                label: i18n
              'gray-dark':
                label: i18n
              'gray-light':
                label: i18n
              'toyota-red':
                label: i18n
              'yellow':
                label: i18n
```
(let's call this one `Vendor.Site:Mixin.BrandColor`)

Then you'll need a second node type that inherits from `Vendor.Site:Mixin.BrandColor` and adds an new internationalized option to the property `brandColor`:

```yaml
    brandColor:
      defaultValue: 'none'
      ui:
        inspector:
          editorOptions:
            values:
              'none':
                label: 'i18n'
```

**Before the fix** the new option will show up as a plain string `"i18n"`.
**After the fix** the new option will show up as an XLIFF-translation address (bound to the node type that added the option).

**Additional remarks**

Imho, the entire `NodeTypeConfigurationEnrichmentAspect` should actually be moved out of the `Neos.Neos` package and into the UI package (All of these translations are an exclusive UI concern). Doing that would be out-of-scope for a bugfix though.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
  - To be precise: There are no tests for this aspect to begin with and would be extremely difficult to add them. I'd suggest to move this concern over to the UI and handle it in a more testable manner.
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
