### PR TITLE
BUGFIX: Don’t skip childnodes when discarding nodes

### DIFF
--- a/Neos.Neos/Classes/Service/PublishingService.php
+++ b/Neos.Neos/Classes/Service/PublishingService.php
@@ -76,7 +76,21 @@ class PublishingService extends \Neos\ContentRepository\Domain\Service\Publishin
             );
         }
 
-        $this->discardNodes($nodes);
+        parent::discardNodes($nodes);
+    }
+
+    /**
+     * Discards the given nodes.
+     *
+     * @param array<\Neos\ContentRepository\Domain\Model\NodeInterface> $nodes The nodes to discard
+     * @return void
+     * @api
+     */
+    public function discardNodes(array $nodes)
+    {
+        foreach ($nodes as $node) {
+            $this->discardNode($node);
+        }
     }
 
     /**


### PR DESCRIPTION
Previously autocreated childnodes like ContentCollections were ignored
when discarding selected nodes via the workspace module.

When deleting a node and discarding the change the auto created children
would then stay deleted in the database and the backend would show no
content/errors.

The behaviour is now the same as for publishing nodes and the direct
child nodes are included in the discard if the node has auto-created
child nodes or is a document.

Fixes: #3274, #3387
See: #3275

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
