### PR TITLE
BUGFIX: Reset accidentally upmerged branch version constraints

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -4,7 +4,7 @@
   "license": ["GPL-3.0-or-later"],
   "type": "neos-package-collection",
   "require": {
-    "neos/flow-development-collection": "7.1.x-dev",
+    "neos/flow-development-collection": "dev-master",
     "neos/neos-setup": "^1.0"
   },
   "replace": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "type": "neos-package-collection",
     "require": {
-        "neos/flow-development-collection": "7.1.x-dev",
+        "neos/flow-development-collection": "dev-master",
         "neos/neos-setup": "^1.0",
         "php": "^7.3 || ^8.0",
         "neos/flow": "*",
@@ -30,7 +30,7 @@
         "neos/twitter-bootstrap": "*",
         "neos/fusion-form": "^1.0 || ^2.0",
         "neos/form": "*",
-        "neos/kickstarter": "~7.1.0"
+        "neos/kickstarter": "dev-master"
     },
     "replace": {
         "typo3/typo3cr": "self.version",


### PR DESCRIPTION
Some constraints of the 7.1 branch seem to have been accidentally upmerged to master. 
This change reset those to dev-master again.