### PR TITLE
TASK: Add  `NodeTypes` folder to fusion file monitoring for cache invalidation

### DIFF
--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -47,7 +47,8 @@ class Package extends BasePackage
                         }
 
                         $fusionPaths = [
-                            $package->getResourcesPath() . 'Private/Fusion'
+                            $package->getResourcesPath() . 'Private/Fusion',
+                            $package->getPackagePath() . 'NodeTypes'
                         ];
                         foreach ($fusionPaths as $fusionPath) {
                             if (is_dir($fusionPath)) {


### PR DESCRIPTION
The NodeTypes folder was just added to have a hierarchical structure for the nodeTypes. Since nodetypes are often tightly coupled to the integration it makes sense to put the fusion prototypes that implement the rendering of for the prototype there aswell. Especially when presentation and integration are seperated.

This can already be done via `include: ../../../NodeTypes/**/*.fusion` in the Root.fusion. However changes to fusion files in the `NodeTypes` folder are not detected yet.

To support this pattern this change adds the folder `NodeTypes` to the folders that are monitored for fusion file changes.

See: https://github.com/neos/neos-development-collection/issues/3000