### PR TITLE
BUGFIX: Make NodeSearchService use new variable to search for identifier patterns

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/NodeSearchService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchService.php
@@ -66,9 +66,9 @@ class NodeSearchService implements NodeSearchServiceInterface
 
         $searchTerm = is_string($term) ? [$term] : $term;
 
-        foreach ($searchTerm as $term) {
-            if (preg_match(NodeIdentifierValidator::PATTERN_MATCH_NODE_IDENTIFIER, $term) !== 0) {
-                $nodeByIdentifier = $context->getNodeByIdentifier($term);
+        foreach ($searchTerm as $termvalue) {
+            if (preg_match(NodeIdentifierValidator::PATTERN_MATCH_NODE_IDENTIFIER, $termvalue) !== 0) {
+                $nodeByIdentifier = $context->getNodeByIdentifier($termvalue);
                 if ($nodeByIdentifier !== null && $this->nodeSatisfiesSearchNodeTypes($nodeByIdentifier, $searchNodeTypes)) {
                     $searchResult[$nodeByIdentifier->getPath()] = $nodeByIdentifier;
                 }


### PR DESCRIPTION
I just stumbled upon an issue, which was partly solved by [this PR](https://github.com/neos/neos-development-collection/pull/3165).

In short, the parameter `$term` is modified by the `foreach` loop and thus another value than the original parameter is forwarded to `$this->nodeDataRepository->findByProperties($term`. Thus the `findByProperties` from `NodeSearchService` doesn't work anymore as it was long time ago.

I've also considered the notes from @kdambekalns, except from

>     * pass `$searchTerm` (not `$term`) to the `NodeDataRepository` to fix the actual bug

Instead of using `$searchTerm` I introduced a separate variable.The idea was to revert the overwritten `$term` and keep the original intention of the method as it was before and the search for an identifier is just an additional feature without changing the old code in any way including variable names and argument types for `NodeDataRepository::findByProperties`.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
