### PR TITLE
BUGFIX: Prevent exception when deleting an electronic address

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -348,7 +348,10 @@ class UsersController extends AbstractModuleController
         $user->removeElectronicAddress($electronicAddress);
         $this->userService->updateUser($user);
 
-        $this->addFlashMessage('The electronic address "%s" (%s) has been deleted for "%s".', 'Electronic address removed', Message::SEVERITY_NOTICE, [htmlspecialchars($electronicAddress->getIdentifier()), htmlspecialchars($electronicAddress->getType()), htmlspecialchars($user->getName())], 1412374678);
+        /** @var PersonName $personName */
+        $personName = $user->getName();
+        $name = $personName ? $personName->getFullName() : '';
+        $this->addFlashMessage('The electronic address "%s" (%s) has been deleted for "%s".', 'Electronic address removed', Message::SEVERITY_NOTICE, [htmlspecialchars($electronicAddress->getIdentifier()), htmlspecialchars($electronicAddress->getType()), htmlspecialchars($name)], 1412374678);
         $this->redirect('edit', null, null, ['user' => $user]);
     }
 


### PR DESCRIPTION
When you delete an electronic address we throw a flash message that the address has been delete for the given user. We had the issue that the PersonName object could not be transformed to a string that is needed for the flash message.

**What I did**

Use the full name of the PersonName object instead of the direct PersonName object for the flash message.

**How to verify it**

1. Open the user module
2. Edit a user
3. Optionally create a electronic address
4. Delete a electronic address
5. check the flash message 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Fixes: #3435