### PR TITLE
TASK: inline 'docs' and cleaner code for Neos.Neos:ContentCollection

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -26,30 +26,20 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
   attributes = Neos.Fusion:DataStructure
 
   # The following is used to automatically append class and data attribute needed for editing.
-  # You can disable the following line with:
+  # You can disable the behavior in your site's Fusion with:
   # prototype(Neos.Neos:ContentCollection) {
   #   attributes.class.@process.collectionClass >
   # }
-  # in your site's Fusion if you don't need that behavior.
   attributes {
-    class.@process.collectionClass = Neos.Fusion:Case {
-      @context.collectionClass = 'neos-contentcollection'
-
-      classIsString {
-        condition = ${Type.isString(value)}
-        renderer = ${String.trim(value + ' ' + collectionClass)}
-      }
-
-      classIsArray {
-        condition = ${Type.isArray(value)}
-        renderer = ${Array.push(value, collectionClass)}
-      }
+    class.@process.collectionClass = Neos.Fusion:Value {
+      castedArray = ${Type.isArray(value) ? value : [value]}
+      value = ${Array.push(this.castedArray, 'neos-contentcollection')}
     }
-
     data-__neos-insertion-anchor = true
     data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${node.context.inBackend && node.context.currentRenderingMode.edit}
   }
 
+  # Doesnt need to be set, if node is a content collection.
   nodePath = 'to-be-set-by-user'
 
   # You may override this to get your content collection from a different place than the current node.
@@ -69,7 +59,12 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
     }
 
     entryTags {
+      # A cache entry with this tag will be flushed
+			# whenever a node (for any variant) that is a descendant (child on any level)
+			# of one of the given nodes is updated.
       1 = ${Neos.Caching.descendantOfTag(node)}
+      # A cache entry with this tag will be flushed
+			# whenever one of the given nodes (for any variant) is updated.
       2 = ${Neos.Caching.nodeTag(node)}
     }
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -39,7 +39,7 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
     data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${node.context.inBackend && node.context.currentRenderingMode.edit}
   }
 
-  # Doesnt need to be set, if node is a content collection.
+  # Doesn't need to be set, if the node is a content collection.
   nodePath = 'to-be-set-by-user'
 
   # You may override this to get your content collection from a different place than the current node.


### PR DESCRIPTION
## Upgrade instructions to Neos 7.3

this change was not supposed to be breaking but it is a little breaky in the edge case, where you would override the attributes class of a `Neos:ContentCollection` as `value` might now be an `array`:

```
prototype(Neos.Neos:ContentCollection).attributes.class.@process.addClass = ${value + " new-class"}
```

if youre at least on Neos 8.0 migrate it like this:
```
prototype(Neos.Neos:ContentCollection).attributes.class.@process.addClass = ${Array.push(value, "new-class")}
```

if youre on 7.3 where `Array.push` cannot handle [array autocasting](https://github.com/neos/flow-development-collection/issues/2710) migrate it like this:

```
prototype(Neos.Neos:ContentCollection).attributes.class.@process.addClass = Neos.Fusion:Value {
      castedArray = ${Type.isArray(value) ? value : [value]}
      value = ${Array.push(this.castedArray, "new-class")}
}
```

----

## Original pr body

Fusion Neos.Neos:ContentCollection:
* cleaner `class.@process.collectionClass`
* added some information about the caching as can be found in the root caching config.
* doc note for nodePath

Since the Neos.Neos:ContentCollection fusion prototype is at some point found by a neos beginner, i think it makes sense to explain certain things inline and make the code less verbose.
