### PR TITLE
FEATURE: Fusion/AFX preserve dots in escaped paths

### DIFF
--- a/Neos.Fusion.Afx/Classes/Parser/Expression/Identifier.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/Identifier.php
@@ -39,6 +39,10 @@ class Identifier
                 case $lexer->isMinus():
                 case $lexer->isUnderscore():
                 case $lexer->isAt():
+                case $lexer->isDoubleQuote():
+                case $lexer->isSingleQuote():
+                case $lexer->isBackSlash() && $lexer->peek(2) === '\"':
+                case $lexer->isBackSlash() && $lexer->peek(2) === '\\\'':
                     $identifier .= $lexer->consume();
                     break;
                 case $lexer->isEqualSign():

--- a/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
@@ -222,6 +222,38 @@ class ParserTest extends TestCase
     /**
      * @test
      */
+    public function shouldParseSingleSelfClosingTagWithEmptyAttribute(): void
+    {
+        $parser = new Parser('<div prop/>');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'boolean',
+                                    'payload' => true,
+                                    'identifier' => 'prop'
+                                ]
+                            ]
+                        ],
+                        'children' => [],
+                        'selfClosing' => true
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function shouldParseSingleSelfClosingTagWithMultipleAttributes(): void
     {
         $parser = new Parser('<div prop="value" anotherProp="Another Value"/>');
@@ -287,6 +319,86 @@ class ParserTest extends TestCase
                                     'type' => 'string',
                                     'payload' => 'Another Value',
                                     'identifier' => 'anotherProp'
+                                ]
+                            ]
+                        ],
+                        'children' => [],
+                        'selfClosing' => true
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParseTagWithSingleOrDoubleQuoteEscapedAttributeIdentifier(): void
+    {
+        $parser = new Parser('<div "@click.blah.blih.blub"="value" \'@click.blah.blih.blub\'="value"/>');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => '"@click.blah.blih.blub"'
+                                ]
+                            ],
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => '\'@click.blah.blih.blub\''
+                                ]
+                            ]
+                        ],
+                        'children' => [],
+                        'selfClosing' => true
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParseTagWithEscapedAttributeIdentifierWithQuoteEscapesInside(): void
+    {
+        $parser = new Parser('<div "@click.escaped\"escaped"="value" \'escaped\\\'escaped\' />');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => '"@click.escaped\"escaped"'
+                                ]
+                            ],
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'boolean',
+                                    'payload' => true,
+                                    'identifier' => '\'escaped\\\'escaped\''
                                 ]
                             ]
                         ],

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -96,15 +96,17 @@ class Parser implements ParserInterface
 	/x';
 
     /**
-     * Split an object path like "foo.bar.baz.quux" or "foo.prototype(Neos.Fusion:Something).bar.baz"
-     * at the dots (but not the dots inside the prototype definition prototype(...))
+     * Split an object path like "foo.bar.baz.quux", "foo.'bar.baz.quux'" or "foo.prototype(Neos.Fusion:Something).bar.baz"
+     * at the dots (but not the dots inside the prototype definition prototype(...) or dots inside quotes)
      */
     const SPLIT_PATTERN_OBJECTPATH = '/
-		\.                         # we split at dot characters...
-		(?!                        # which are not inside prototype(...). Thus, the dot does NOT match IF it is followed by:
-			[^(]*                  # - any character except (
-			\)                     # - the character )
-		)
+        (                       # Matches area if:
+            prototype\(.*?\)        # inside prototype(...),
+            |"(?:\\\"|[^"])+"       # inside double quotes - respect escape,
+            |\'(?:\\\\\'|[^\'])+\'  # inside single quotes - respect escape
+        )
+        (*SKIP)(*FAIL)          # skip, when the preceding matches and fail (dont include them in the match)
+        |\.                     # for what was not matched, we split at dot characters...
 	/x';
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionFixture25.fusion
+++ b/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionFixture25.fusion
@@ -1,0 +1,9 @@
+
+//
+// Fusion Fixture 25
+//
+// Checks if quoted paths will escape the @ char
+// and if dots inside the quotes will not be interpreted as nested.
+
+attributes."@notAMeta" = "value"
+attributes."@notAMeta.notNested.reallyNotNested.string" = "value"

--- a/Neos.Fusion/Tests/Unit/Core/Parser/PatternTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/PatternTest.php
@@ -135,6 +135,25 @@ class PatternTest extends UnitTestCase
         self::assertSame($expected, preg_split($pattern, 'foo.bar'));
 
         $expected = [
+            0 => 'attributes',
+            1 => '"dots.inside.double.quotes"'
+        ];
+        self::assertSame($expected, preg_split($pattern, 'attributes."dots.inside.double.quotes"'));
+
+        $expected = [
+            0 => 'attributes',
+            1 => '\'dots.inside.single.quotes\''
+        ];
+        self::assertSame($expected, preg_split($pattern, 'attributes.\'dots.inside.single.quotes\''));
+
+        $expected = [
+            0 => '"quo\"tes.mix\'ed"',
+            1 => 'bla',
+            2 => '\'he\\\'.llo\''
+        ];
+        self::assertSame($expected, preg_split($pattern, '"quo\"tes.mix\'ed".bla.\'he\\\'.llo\''));
+
+        $expected = [
             0 => 'prototype(Neos.Foo)',
             1 => 'bar'
         ];
@@ -148,7 +167,7 @@ class PatternTest extends UnitTestCase
         self::assertSame($expected, preg_split($pattern, 'asdf.prototype(Neos.Foo).bar'));
 
         $expected = [
-            0 =>  'blah',
+            0 => 'blah',
             1 => 'asdf',
             2 => 'prototype(Neos.Foo)',
             3 => 'bar'
@@ -156,7 +175,7 @@ class PatternTest extends UnitTestCase
         self::assertSame($expected, preg_split($pattern, 'blah.asdf.prototype(Neos.Foo).bar'));
 
         $expected = [
-            0 =>  'b-lah',
+            0 => 'b-lah',
             1 => 'asdf',
             2 => 'prototype(Neos.Foo)',
             3 => 'b-ar'
@@ -164,12 +183,19 @@ class PatternTest extends UnitTestCase
         self::assertSame($expected, preg_split($pattern, 'b-lah.asdf.prototype(Neos.Foo).b-ar'));
 
         $expected = [
-            0 =>  'b:lah',
+            0 => 'b:lah',
             1 => 'asdf',
             2 => 'prototype(Neos.Foo)',
             3 => 'b:ar'
         ];
         self::assertSame($expected, preg_split($pattern, 'b:lah.asdf.prototype(Neos.Foo).b:ar'));
+
+        $expected = [
+            0 => 'asdf',
+            1 => 'prototype(Neos.Foo)',
+            2 => '"@click.blah.blub"'
+        ];
+        self::assertSame($expected, preg_split($pattern, 'asdf.prototype(Neos.Foo)."@click.blah.blub"'));
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -921,6 +921,26 @@ class ParserTest extends UnitTestCase
     }
 
     /**
+     * Checks if identifiers starting with digits are parsed correctly
+     *
+     * @test
+     */
+    public function parserCorrectlyParsesFixture25()
+    {
+        $sourceCode = $this->readFusionFixture('ParserTestFusionFixture25');
+
+        $expectedParseTree = [
+            'attributes' => [
+                '@notAMeta' => 'value',
+                '@notAMeta.notNested.reallyNotNested.string' => 'value'
+            ]
+        ];
+
+        $actualParseTree = $this->parser->parse($sourceCode);
+        self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 23.');
+    }
+
+    /**
      * Checks if really long strings are parsed correctly
      *
      * @test


### PR DESCRIPTION
fixes #3112

This makes it possible to use f.x. Alpinejs in AFX and Fusion - If you escape the attribute, the Fusion parser will not disturb you and wont nest it as before.

- Fusion parser: dont split paths at dots, who are inside quotes.
- AFX: allow quoted attribute identifier.

Example:
AFX:
```html
<div '@foo.bar'='baz'></div>
```

Fusion:
```ts
Neos.Fusion:Tag {
    attributes.'@foo.bar' = 'baz'
}
```
Fusion ast (excerpt):
```php
'attributes' => [
    '@foo.bar' => 'baz'
]
```

Before this, AFX doesnt allow quoted attribute identifier,
and the Fusion parser split at dots in quotes too, making those paths nested.

**What I did**
adjusted SPLIT_PATTERN_OBJECTPATH in the parser and allowed quotes in AFX Expression/Identifier.php
i also added a Fusion Fixture 25 - okay?

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
