### PR TITLE
BUGFIX: Use Testing/Behat for DB setup in Behat steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,9 @@ jobs:
         if: matrix.static-analysis == 'no'
         #if: env.BEHAT == true
         run: |
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:create
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrationversion --add --version all
           bin/behat --stop-on-failure -f progress -c Packages/Neos/Neos.Neos/Tests/Behavior/behat.yml.dist --tags ~@browser
           bin/behat --stop-on-failure -f progress -c Packages/Neos/Neos.ContentRepository/Tests/Behavior/behat.yml.dist
 
@@ -208,7 +210,9 @@ jobs:
         if: matrix.static-analysis == 'no'
         #if: env.BEHAT == true
         run: |
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:create
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrationversion --add --version all
           bin/behat --stop-on-failure -f progress -c Packages/Neos/Neos.Neos/Tests/Behavior/behat.yml.dist --tags ~@browser
           bin/behat --stop-on-failure -f progress -c Packages/Neos/Neos.ContentRepository/Tests/Behavior/behat.yml.dist
 


### PR DESCRIPTION
The command `FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all` is broken, because the context is only active for the `behat:setup` call, not the `doctrine:…` calls later.