### PR TITLE
BUGFIX: Enable event log only when needed for Behat

### DIFF
--- a/Neos.Neos/Configuration/Testing/Behat/Settings.yaml
+++ b/Neos.Neos/Configuration/Testing/Behat/Settings.yaml
@@ -1,5 +1,0 @@
-
-Neos:
-  Neos:
-    eventLog:
-      enabled: true

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
@@ -6,9 +6,11 @@ use Neos\Neos\Domain\Service\UserService;
 use Neos\Neos\EventLog\Domain\Model\Event;
 use Neos\Neos\EventLog\Domain\Model\NodeEvent;
 use Neos\Neos\EventLog\Domain\Repository\EventRepository;
+use Neos\Neos\EventLog\Domain\Service\EventEmittingService;
 use Neos\Neos\EventLog\Integrations\ContentRepositoryIntegrationService;
 use Neos\Neos\EventLog\Integrations\EntityIntegrationService;
 use Neos\Utility\Arrays;
+use Neos\Utility\ObjectAccess;
 use PHPUnit\Framework\Assert as Assert;
 use Symfony\Component\Yaml\Yaml;
 
@@ -28,7 +30,9 @@ trait HistoryDefinitionsTrait
         try {
             $eventRepository = $this->getEventRepository();
             $eventRepository->removeAll();
-            $this->getTYPO3CRIntegrationService()->reset();
+            $this->getContentRepositoryIntegrationService()->reset();
+            $eventEmittingService = $this->getEventEmittingService();
+            ObjectAccess::setProperty($eventEmittingService, 'enabled', true, true);
         } catch (\Doctrine\DBAL\DBALException $e) {
             // Ignore DB exceptions, because the trait runs before applying migrations in FlowContext
         }
@@ -149,9 +153,17 @@ trait HistoryDefinitionsTrait
     /**
      * @return ContentRepositoryIntegrationService
      */
-    protected function getTYPO3CRIntegrationService()
+    protected function getContentRepositoryIntegrationService()
     {
         return $this->getObjectManager()->get(ContentRepositoryIntegrationService::class);
+    }
+
+    /**
+     * @return EventEmittingService
+     */
+    protected function getEventEmittingService()
+    {
+        return $this->getObjectManager()->get(EventEmittingService::class);
     }
 
     /**


### PR DESCRIPTION
This fixes an error caused by objects being created during "safe requests" as in this message:

```
 001 Scenario: Update existing live node variant in user workspace, publish to live # Features/Localization/LocalizationInWorkspaces.feature:250
      And I set the node name to "unterseite"                                      # Features/Localization/LocalizationInWorkspaces.feature:273
        Detected modified or new objects (Neos\ContentRepository\Domain\Model\NodeData, uuid:9126f22f-cad5-41b6-b838-86794f78182e) to be persisted which is not allowed for "safe requests"
        According to the HTTP 1.1 specification, so called "safe request" (usually GET or HEAD requests)
        should not change your data on the server side and should be considered read-only. If you need to add,
        modify or remove data, you should use the respective request methods (POST, PUT, DELETE and PATCH).
        
        If you need to store some data during a safe request (for example, logging some data for your analytics),
        you are still free to call PersistenceManager->persistAll() manually. (Neos\Flow\Persistence\Exception)
```

- The message is a bit misleading, as it is the result of a `persistAll(true)` call, and that can be found in `ContentRepositoryIntegrationService->updateEventsAfterPublish()`.
- The event log is enabled globally for the `Testing/Behat` context in the `Neos.Neos` configuration to be able to test it.
- This removes the configuration and instead switches the event logging on in `HistoryDefinitionsTrait->resetHistory()`
