### PR TITLE
!!! BUGFIX: Always show current node in breadcrumb

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
@@ -2,7 +2,16 @@
 #
 prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Neos:Menu) {
   templatePath = 'resource://Neos.Neos/Private/Templates/FusionObjects/BreadcrumbMenu.html'
-  itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
+
+  itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
+  // Show always the current node, event when it is hidden in index
+  items.@process.addCurrent = Neos.Fusion:Value {
+      currentItem = Neos.Neos:MenuItems {
+        renderHiddenInIndex = true
+        itemCollection = ${[documentNode]}
+      }
+      value = ${Array.concat(this.currentItem, value)}
+  }
 
   attributes.class = 'breadcrumb'
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,3 +1,6 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-  itemCollection = ${q(documentNode).add(q(documentNode).parents('[instanceof Neos.Neos:Document]')).get()}
+  itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
+  itemCollection.@process.reverseOrder = ${Array.reverse(value)}
+  // Show always the current node, event when it is hidden in index
+  @process.addCurrent = ${Array.push(value, {node:props.node})}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -2,5 +2,5 @@ prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
   itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
   itemCollection.@process.reverseOrder = ${Array.reverse(value)}
   // Show always the current node, event when it is hidden in index
-  @process.addCurrent = ${Array.push(value, {node:props.node})}
+  @process.addCurrent = ${Array.push(value, {node: documentNode})}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,6 +1,15 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-  itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
-  itemCollection.@process.reverseOrder = ${Array.reverse(value)}
-  // Show always the current node, event when it is hidden in index
-  @process.addCurrent = ${Array.push(value, {node: documentNode})}
+    itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
+    @process {
+        // Show always the current node, event when it is hidden in index
+        addCurrent = Neos.Fusion:Value {
+            currentItem = Neos.Neos:MenuItems {
+                renderHiddenInIndex = true
+                itemCollection = ${[documentNode]}
+            }
+            value = ${Array.concat(this.currentItem, value)}
+        }
+
+        reverseOder = ${Array.reverse(value)}
+    }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -10,6 +10,6 @@ prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
             value = ${Array.concat(this.currentItem, value)}
         }
 
-        reverseOder = ${Array.reverse(value)}
+        reverseOrder = ${Array.reverse(value)}
     }
 }


### PR DESCRIPTION
Fix #3407

* `Neos.Neos:BreadcrumbMenu` was using `node`, this is fixed and use `documentNode` now
* `Neos.Neos:BreadcrumbMenuItems ` returned the nodes in the wrong order
* On both prototypes the current node is now always rendered, even when it is hidden in index

