### PR TITLE
!!! FEATURE: Neos.Media: Extend SupportsTaggingInterface by countByTag

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -263,7 +263,8 @@ class AssetController extends ActionController
 
             foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $retrievedTag) {
                 assert($retrievedTag instanceof Tag);
-                $tags[] = ['object' => $retrievedTag, 'count' => $this->assetRepository->countByTag($retrievedTag, $activeAssetCollection)];
+                $tagCount = ($assetProxyRepository instanceof SupportsTaggingInterface ? $assetProxyRepository->countByTag($retrievedTag) : $this->assetRepository->countByTag($retrievedTag, $activeAssetCollection));
+                $tags[] = ['object' => $retrievedTag, 'count' => $tagCount];
             }
 
             if ($searchTerm !== null) {

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
@@ -218,6 +218,17 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
         return $query->count();
     }
 
+     /**
+     * @return int
+     */
+    public function countByTag(Tag $tag): int
+    {
+        $queryResult = $this->assetRepository->findByTag($tag, $this->activeAssetCollection);
+        $query = $this->filterOutImportedAssetsFromOtherAssetSources($queryResult->getQuery());
+        $query = $this->filterOutImageVariants($query);
+        return $query->count(); 
+    }
+
     /**
      * @param QueryInterface $query
      * @return QueryInterface

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
@@ -218,7 +218,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
         return $query->count();
     }
 
-     /**
+    /**
      * @return int
      */
     public function countByTag(Tag $tag): int
@@ -226,7 +226,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
         $queryResult = $this->assetRepository->findByTag($tag, $this->activeAssetCollection);
         $query = $this->filterOutImportedAssetsFromOtherAssetSources($queryResult->getQuery());
         $query = $this->filterOutImageVariants($query);
-        return $query->count(); 
+        return $query->count();
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Model/AssetSource/SupportsTaggingInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/SupportsTaggingInterface.php
@@ -33,4 +33,11 @@ interface SupportsTaggingInterface
      * @return int
      */
     public function countUntagged(): int;
+
+
+    /**
+     * @param Tag $tag
+     * @return int
+     */
+    public function countByTag(Tag $tag): int;
 }


### PR DESCRIPTION
**What I did**
Currently classes that implement the SupportsTaggingInterface can only count untagged Assets. 
When using the interface with external Assets, this leads to the MediaBrowser displaying the count of Neos Media Assets for the external Source, not the count of the Assets matching that Tag in the external source. 
I extended the SupportsTaggingInterface so that Classes using this interface can change the count of the Tags that are displayed in the Media Browser, just like they can change the count of untagged Assets. 

**How I did it**
I added the countByTag method to the SupportsTaggingInterface and implemented it in the Neos MediaBrowser where the count happens. 
Since I am new to Neos I was not sure if countByTags should also pass the active AssetCollection, but I decided against it since the findByTag function also does not pass the active AssetCollection and the count should match the result. This could both be changed. 
Also, this could throw errors with Packages implementing the Interface. 

**How to verify it**
When implementing the SupportsTaggingInterface the method countByTag must be implemented and will change the count of Assets for every tag  displayed in the left sidebar.

Related: #3452

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
