### PR TITLE
BUGFIX: Collapse afx whitespace connected to newlines to spaces inside of text literals

### DIFF
--- a/Neos.Fusion.Afx/Classes/Service/AfxService.php
+++ b/Neos.Fusion.Afx/Classes/Service/AfxService.php
@@ -303,7 +303,10 @@ class AfxService
         // ignore blank text if it is connected to a newline
         $payload = array_map(function ($astNode) {
             if ($astNode['type'] === 'text') {
-                $astNode['payload'] = preg_replace('/[\\s]*\\n[\\s]*/u', '', $astNode['payload']);
+                // remove whitespace connected to newlines at the beginning or end of text payloads
+                $astNode['payload'] = preg_replace('/(^[\\s]*\\n[\\s]*|[\\s]*\\n[\\s]*$)/u', '', $astNode['payload']);
+                // collapse whitespace connected to newlines in the middle of text payloads to spaces
+                $astNode['payload'] = preg_replace('/([\\s]*\\n[\\s]*)+/u', ' ', $astNode['payload']);
             }
             return $astNode;
         }, $payload);

--- a/Neos.Fusion.Afx/README.md
+++ b/Neos.Fusion.Afx/README.md
@@ -5,7 +5,7 @@
 __This repository is a **read-only subsplit** of a package that is part of the Neos project (learn more on `www.neos.io <https://www.neos.io/>`_).__
 
 This package provides a fusion preprocessor that expands a compact xml-ish syntax to pure fusion code. This allows
-to write compact components that do'nt need a seperate template file and enables unplanned extensibility for the defined 
+to write compact components that do'nt need a seperate template file and enables unplanned extensibility for the defined
 prototypes because the generated fusion-code can be overwritten and controlled from the outside if needed.
 
 ## Installation
@@ -25,10 +25,10 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
     title = 'title text'
     subtitle = 'subtitle line'
     imageUri = 'https://dummyimage.com/600x400/000/fff'
-    
+
     #
-    # The code afx`...` is converted to the fusion code below at parse time. 
-    # Attention: Currently there is no way to escape closing-backticks inside the Expression. 
+    # The code afx`...` is converted to the fusion code below at parse time.
+    # Attention: Currently there is no way to escape closing-backticks inside the Expression.
     #
     renderer = afx`
        <div>
@@ -48,7 +48,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
     title = 'title text'
     subtitle = 'subtitle line'
     imageUri = 'https://dummyimage.com/600x400/000/fff'
-    
+
     renderer = Neos.Fusion:Tag {
         tagName = 'div'
         content = Neos.Fusion:Array {
@@ -78,8 +78,8 @@ All whitepaces around the outer elements are ignored. Whitepaces that are connec
 ### HTML-Tags (Tags without Namespace)
 
 HTML-Tags are converted to `Neos.Fusion:Tag` Objects. All attributes of the afx-tag are rendered as tag-attributes.
- 
-The following html: 
+
+The following html:
 ```
 <h1 class="headline" @if.hasHeadline={props.headline ? true : false}>{props.headline}</h1>
 ```
@@ -91,9 +91,9 @@ Neos.Fusion:Tag {
     content = ${props.headline}
     @if.hasHeadline = ${props.headline ? true : false}
 }
-``` 
+```
 
-If a tag is self-closing and has no content it will be rendered as self closing fusion-tag:.  
+If a tag is self-closing and has no content it will be rendered as self closing fusion-tag:.
 ```
 <br/>
 ```
@@ -103,13 +103,13 @@ Neos.Fusion:Tag {
     tagName = 'br'
     selfClosingTag = true
 }
-``` 
+```
 
 ### Fusion-Object-Tags (namespaced Tags)
 
 All namespaced-tags are interpreted as prototype-names and all attributes are passed as top-level fusion-properties.
 
-The following html: 
+The following html:
 ```
 <Vendor.Site:Prototype type="headline" @if.hasHeadline={props.headline ? true : false}>{props.headline}</Vendor.Site:Prototype>
 ```
@@ -171,14 +171,14 @@ The handling of child-nodes below an afx-node is differs based on the number of 
 
 #### Single tag-children
 
-If a AFX-tag contains exactly one child this child is rendered directly into the `content`-attribute.  
-The child is then interpreted as string, eel-expression, html- or fusion-object-tag. 
+If a AFX-tag contains exactly one child this child is rendered directly into the `content`-attribute.
+The child is then interpreted as string, eel-expression, html- or fusion-object-tag.
 
-The following AFX-Code: 
- 
+The following AFX-Code:
+
 ```
 <h1>{props.title}</h1>
-``` 
+```
 Is transpiled as:
 ```
 Neos.Fusion:Tag {
@@ -189,14 +189,14 @@ Neos.Fusion:Tag {
 
 #### Multiple tag-children
 
-If an AFX-tag contains more than one child the content is are rendered as `Neos.Fusion:Array` into the 
-`content`-attribute. The children are interpreted as string, eel-expression, html- or fusion-object-tag. 
- 
+If an AFX-tag contains more than one child the content is are rendered as `Neos.Fusion:Array` into the
+`content`-attribute. The children are interpreted as string, eel-expression, html- or fusion-object-tag.
+
 The following AFX-Code:
- 
+
 ```
 <h1>{props.title}: {props.subtitle}</h1>
-``` 
+```
 Is transpiled as:
 ```
 Neos.Fusion:Tag {
@@ -209,19 +209,19 @@ Neos.Fusion:Tag {
 }
 ```
 
-The `@key`-property of tag-children inside alters the name of the fusion-attribute to recive render the array-child into. 
+The `@key`-property of tag-children inside alters the name of the fusion-attribute to recive render the array-child into.
 If no `@key`-property is given `index_x` is used starting by `x=1`.
 
 ```
 <Vendor.Site:Prototype @children="text">
-    <h2 @key="title">{props.title}</h1> 
+    <h2 @key="title">{props.title}</h1>
     <p @key="description">{props.description}</p>
 </Vendor.Site:Prototype>
-``` 
+```
 Is transpiled as:
 ```
 Vendor.Site:Prototype {
-    text = Neos.Fusion:Array { 
+    text = Neos.Fusion:Array {
         title = Neos.Fusion:Tag {
             tagName = 'h2'
             content  = ${props.title}
@@ -240,10 +240,10 @@ to assign Fusion-prototypes to props.
 
 ```
 <Vendor.Site:Prototype>
-    <h2 @path="title">{props.title}</h1> 
+    <h2 @path="title">{props.title}</h1>
     <p @path="description">{props.description}</p>
 </Vendor.Site:Prototype>
-``` 
+```
 Is transpiled as:
 ```
 Vendor.Site:Prototype {
@@ -260,29 +260,47 @@ Vendor.Site:Prototype {
 
 ### Meta-Attributes
 
-In general all meta-attributes start with an @-sign. 
+In general all meta-attributes start with an @-sign.
 
 The `@path`-attribute can be used to render a child node directly into the given path below the parent Fusion:Object
 instead of beeing included into the `content` property.
 
-The `@children`-attribute defined the property that is used to render the content/children of the current tag into. 
+The `@children`-attribute defined the property that is used to render the content/children of the current tag into.
 The default property name for the children is `content`.
 
-The `@key`-attribute can be used to define the property name of an item among its siblings if an array is rendered. 
-If no `@key` is defined `index_x` is used starting at `x=1. 
+The `@key`-attribute can be used to define the property name of an item among its siblings if an array is rendered.
+If no `@key` is defined `index_x` is used starting at `x=1.
 
 Attention: `@path`, `@children` and `@key` only support string-values and no expressions.
 
-All other meta attributes are directly added to the generated prototype and can be used for @if or @process statements. 
+All other meta attributes are directly added to the generated prototype and can be used for @if or @process statements.
 
 ### Whitespace and Newlines
- 
-AFX is not html and makes some simplifications to the code to optimize the generated fusion and allow a structured notation 
-of the component hierarchy. 
+
+AFX is not html and makes some simplifications to the code to optimize the generated fusion and allow a structured notation
+of the component hierarchy.
 
 The following rules are applied for that:
 
-1. **Newlines and Whitespace-Characters that are connected to a newline are considered irrelevant and are ignored**
+1. **Newlines and Whitespace-Characters inside a text literal collapse to a single space.**
+
+```
+<h1>
+    This is a string literal
+    with multiple lines
+    that shall collapse
+    to spaces.
+</h1>
+```
+Is transpiled as:
+```
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = 'This is a string literal with multiple lines that shall collapse to spaces.'
+}
+```
+
+2. **Newlines and Whitespace-Characters that are connected to a newline are considered irrelevant and are ignored**
 
 ```
 <h1>
@@ -290,7 +308,7 @@ The following rules are applied for that:
 	{'eelExpression 2'}
 </h1>
 ```
-Is transpiled as: 
+Is transpiled as:
 ```
 Neos.Fusion:Tag {
 	tagName = 'h1'
@@ -301,21 +319,21 @@ Neos.Fusion:Tag {
 }
 ```
 
-2. **Spaces between Elements on a single line are considered meaningful and are preserved**
- 
+3. **Spaces between Elements on a single line are considered meaningful and are preserved**
+
 ```
 <h1>
 	{'eelExpression 1'} {'eelExpression 2'}
 </h1>
 ```
-Is transpiled as: 
+Is transpiled as:
 ```
 Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Array {
 		item_1 = ${'eelExpression 1'}
 		item_2 = ' '
-		item_3 = ${'eelExpression 2'}   
+		item_3 = ${'eelExpression 2'}
 	}
 }
 ```
@@ -326,7 +344,7 @@ AFX accepts html comments but they are not transpiled to any fusion. However if 
 ```
 foo<!-- comment -->bar
 ```
-Is transpiled as: 
+Is transpiled as:
 ```
 Neos.Fusion:Array {
     item_1 = 'foo'
@@ -338,16 +356,16 @@ Neos.Fusion:Array {
 
 ### Rendering of Collections with `Neos.Fusion:Collection`
 
-For rendering of lists or menus a presentational-component usually will recieve arrays of 
-preprocessed data as prop. To iterate over such an array the `Neos.Fusion:Collection` 
+For rendering of lists or menus a presentational-component usually will recieve arrays of
+preprocessed data as prop. To iterate over such an array the `Neos.Fusion:Collection`
 can be used in afx.
 
 ```
 prototype(Vendor.Site:IterationExample) < prototype(Neos.Fusion:Component) {
-    
+
     # array {[href:'http://www.example_1.com', title:'Title 1'], [href:'http://example_2.com', title:'Title 2']}
     items = null
-    
+
     renderer = afx`
         <ul @if.has={props.items ? true : false}>
         <Neos.Fusion:Collection collection={props.items} itemName="item">
@@ -362,8 +380,8 @@ prototype(Vendor.Site:IterationExample) < prototype(Neos.Fusion:Component) {
 
 ### Augmentation of Child-Components with `Neos.Fusion:Augmenter`
 
-The `Neos.Fusion:Augmenter` can be used to add additional attributes to rendered content. 
-This allows some rendering flexibility without extending the api of the component. This is a 
+The `Neos.Fusion:Augmenter` can be used to add additional attributes to rendered content.
+This allows some rendering flexibility without extending the api of the component. This is a
 useful pattern to avoid unneeded tag-wrapping in cases where only additional classes are needed.
 
 ```
@@ -375,13 +393,13 @@ prototype(PackageFactory.AtomicFusion.AFX:SliderExample) < prototype(Packagefact
             <Neos.Fusion:Augmenter class="slider__slide" data-index={iteration.index}>
                 <Vendor.Site:ImageExample {...image} />
             </Neos.Fusion:Augmenter>
-        </Neos.Fusion:Collection>  
+        </Neos.Fusion:Collection>
      </div>
   `
 }
 ```
 
-The example iterates over a list of images and uses the `Vendor.Site:ImageExample` to render each one 
+The example iterates over a list of images and uses the `Vendor.Site:ImageExample` to render each one
 while the `Neos.Fusion:Augmenter` adds a class- and data-attribute from outside.
 
 ## License

--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -183,6 +183,28 @@ EOF;
     /**
      * @test
      */
+    public function newlinesInsideStringsAreCollapsedToSpaces(): void
+    {
+        $afxCode = '
+            <h1>
+                This is a string literal
+                with multiple lines
+                that shall collapse
+                to spaces.
+            </h1>';
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = 'This is a string literal with multiple lines that shall collapse to spaces.'
+}
+EOF;
+
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
     public function htmlTagsAreConvertedToSelfClosingFusionTags(): void
     {
         $afxCode = '<h1/>';


### PR DESCRIPTION
The removal of all whitespaces connected to newlines yields unexpected results in text literals. This change adjusts the behavior and converts newlines and connected whitespaces inside of text literals to a single space. Whitespaces and connected newlines at the beginning and end of text literals are still removed.

So the following afx code:
```
<h1>
    This is a string literal
    with multiple lines
    that shall collapse
    to spaces.
</h1>
```
will be transpiled as:
```
Neos.Fusion:Tag {
    tagName = 'h1'
    content = 'This is a string literal with multiple lines that shall collapse to spaces.'
}
```
instead of: 
```
Neos.Fusion:Tag {
    tagName = 'h1'
    content = 'This is a string literalwith multiple linesthat shall collapseto spaces.'
}
```
Relates: #3331