### PR TITLE
TASK: Use indented heredoc syntax for AFX tests

### DIFF
--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -16,8 +16,8 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = '';
         $expectedFusion = <<<'EOF'
-''
-EOF;
+            ''
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -28,8 +28,8 @@ EOF;
     {
         $afxCode = '   ';
         $expectedFusion = <<<'EOF'
-''
-EOF;
+            ''
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -40,10 +40,10 @@ EOF;
     {
         $afxCode = '<h1></h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -54,11 +54,11 @@ EOF;
     {
         $afxCode = '<h1>   </h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = '   '
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = '   '
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -68,14 +68,14 @@ EOF;
     public function htmlTagsWithIgnoredContentAreConvertedToFusionTags(): void
     {
         $afxCode = '<h1>
-   
+
 </h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = ''
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = ''
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -86,18 +86,18 @@ EOF;
     {
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Array {
-    item_1 = Neos.Fusion:Tag {
-        tagName = 'h1'
-    }
-    item_2 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-    item_3 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-}
-EOF;
+            Neos.Fusion:Array {
+                item_1 = Neos.Fusion:Tag {
+                    tagName = 'h1'
+                }
+                item_2 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+                item_3 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -108,18 +108,18 @@ EOF;
     {
         $afxCode = 'Foo<h1></h1>Bar<p></p>Baz';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Array {
-    item_1 = 'Foo'
-    item_2 = Neos.Fusion:Tag {
-        tagName = 'h1'
-    }
-    item_3 = 'Bar'
-    item_4 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-    item_5 = 'Baz'
-}
-EOF;
+            Neos.Fusion:Array {
+                item_1 = 'Foo'
+                item_2 = Neos.Fusion:Tag {
+                    tagName = 'h1'
+                }
+                item_3 = 'Bar'
+                item_4 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+                item_5 = 'Baz'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -130,15 +130,15 @@ EOF;
     {
         $afxCode = '  <h1></h1><p></p>  ';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Array {
-    item_1 = Neos.Fusion:Tag {
-        tagName = 'h1'
-    }
-    item_2 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-}
-EOF;
+            Neos.Fusion:Array {
+                item_1 = Neos.Fusion:Tag {
+                    tagName = 'h1'
+                }
+                item_2 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -149,18 +149,18 @@ EOF;
     {
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Array {
-    item_1 = Neos.Fusion:Tag {
-        tagName = 'h1'
-    }
-    item_2 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-    item_3 = Neos.Fusion:Tag {
-        tagName = 'p'
-    }
-}
-EOF;
+            Neos.Fusion:Array {
+                item_1 = Neos.Fusion:Tag {
+                    tagName = 'h1'
+                }
+                item_2 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+                item_3 = Neos.Fusion:Tag {
+                    tagName = 'p'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -169,14 +169,14 @@ EOF;
      */
     public function whitespacesAndNewlinesAroundAfxCodeAreIgnored(): void
     {
-        $afxCode = '   
+        $afxCode = '
               <h1></h1>
         ';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -187,11 +187,11 @@ EOF;
     {
         $afxCode = '<h1/>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    selfClosingTag = true
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                selfClosingTag = true
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -202,13 +202,13 @@ EOF;
     {
         $afxCode = '<h1 content="bar" class="fooo" />';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    selfClosingTag = true
-    attributes.content = 'bar'
-    attributes.class = 'fooo'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                selfClosingTag = true
+                attributes.content = 'bar'
+                attributes.class = 'fooo'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -219,13 +219,13 @@ EOF;
     {
         $afxCode = '<h1 content="0" class=" " />';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    selfClosingTag = true
-    attributes.content = '0'
-    attributes.class = ' '
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                selfClosingTag = true
+                attributes.content = '0'
+                attributes.class = ' '
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -237,12 +237,12 @@ EOF;
     {
         $afxCode = '<h1 class="foo\'bar" >foo\'bar</h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    attributes.class = 'foo\'bar'
-    content = 'foo\'bar'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                attributes.class = 'foo\'bar'
+                content = 'foo\'bar'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -253,9 +253,9 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype/>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-}
-EOF;
+            Vendor.Site:Prototype {
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -266,11 +266,11 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype foo="bar" baz="bam" />';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    foo = 'bar'
-    baz = 'bam'
-}
-EOF;
+            Vendor.Site:Prototype {
+                foo = 'bar'
+                baz = 'bam'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -281,11 +281,11 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype @position="start" @if.hasTitle={title} />';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    @position = 'start'
-    @if.hasTitle = ${title}
-}
-EOF;
+            Vendor.Site:Prototype {
+                @position = 'start'
+                @if.hasTitle = ${title}
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -296,12 +296,12 @@ EOF;
     {
         $afxCode = '<div @position="start" @if.hasTitle={title} ></div>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'div'
-    @position = 'start'
-    @if.hasTitle = ${title}
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'div'
+                @position = 'start'
+                @if.hasTitle = ${title}
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -312,11 +312,11 @@ EOF;
     {
         $afxCode = '<h1>Fooo</h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = 'Fooo'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = 'Fooo'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -327,11 +327,11 @@ EOF;
     {
         $afxCode = '<h1>0</h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = '0'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = '0'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -342,11 +342,11 @@ EOF;
     {
         $afxCode = '<h1> </h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = ' '
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = ' '
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -357,10 +357,10 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype>Fooo</Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    content = 'Fooo'
-}
-EOF;
+            Vendor.Site:Prototype {
+                content = 'Fooo'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -371,10 +371,10 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype @children="children">Fooo</Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    children = 'Fooo'
-}
-EOF;
+            Vendor.Site:Prototype {
+                children = 'Fooo'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -385,10 +385,10 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype @children="children">{eelExpression()}</Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    children = ${eelExpression()}
-}
-EOF;
+            Vendor.Site:Prototype {
+                children = ${eelExpression()}
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -399,20 +399,20 @@ EOF;
     {
         $afxCode = '<h1><strong>foo</strong><i>bar</i></h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = Neos.Fusion:Tag {
-            tagName = 'strong'
-            content = 'foo'
-        }
-        item_2 = Neos.Fusion:Tag {
-            tagName = 'i'
-            content = 'bar'
-        }
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = Neos.Fusion:Tag {
+                        tagName = 'strong'
+                        content = 'foo'
+                    }
+                    item_2 = Neos.Fusion:Tag {
+                        tagName = 'i'
+                        content = 'bar'
+                    }
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -422,30 +422,30 @@ EOF;
     public function complexChildrenAreRenderedAsArrayIgnoringWhitespaceInBetween(): void
     {
         $afxCode = <<<'EOF'
-<h1>
-    
-    <strong>foo</strong>
-    
-    <i>bar</i>
-        
-</h1>
-EOF;
+            <h1>
+
+                <strong>foo</strong>
+
+                <i>bar</i>
+
+            </h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = Neos.Fusion:Tag {
-            tagName = 'strong'
-            content = 'foo'
-        }
-        item_2 = Neos.Fusion:Tag {
-            tagName = 'i'
-            content = 'bar'
-        }
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = Neos.Fusion:Tag {
+                        tagName = 'strong'
+                        content = 'foo'
+                    }
+                    item_2 = Neos.Fusion:Tag {
+                        tagName = 'i'
+                        content = 'bar'
+                    }
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -456,20 +456,20 @@ EOF;
     {
         $afxCode = '<h1><strong @key="key_one">foo</strong><i @key="key_two">bar</i></h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        key_one = Neos.Fusion:Tag {
-            tagName = 'strong'
-            content = 'foo'
-        }
-        key_two = Neos.Fusion:Tag {
-            tagName = 'i'
-            content = 'bar'
-        }
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    key_one = Neos.Fusion:Tag {
+                        tagName = 'strong'
+                        content = 'foo'
+                    }
+                    key_two = Neos.Fusion:Tag {
+                        tagName = 'i'
+                        content = 'bar'
+                    }
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -480,18 +480,18 @@ EOF;
     {
         $afxCode = '<h1>a string<strong>a tag</strong>{eelExpression()}</h1>';
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = 'a string'
-        item_2 = Neos.Fusion:Tag {
-            tagName = 'strong'
-            content = 'a tag'
-        }
-        item_3 = ${eelExpression()}
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = 'a string'
+                    item_2 = Neos.Fusion:Tag {
+                        tagName = 'strong'
+                        content = 'a tag'
+                    }
+                    item_3 = ${eelExpression()}
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -502,13 +502,13 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="namedProp">foo</strong></Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    namedProp = Neos.Fusion:Tag {
-        tagName = 'strong'
-        content = 'foo'
-    }
-}
-EOF;
+            Vendor.Site:Prototype {
+                namedProp = Neos.Fusion:Tag {
+                    tagName = 'strong'
+                    content = 'foo'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -519,16 +519,16 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    propOne = Neos.Fusion:Tag {
-        tagName = 'strong'
-        content = 'foo'
-    }
-    propTwo = Vendor.Site:Prototype {
-        content = 'bar'
-    }
-}
-EOF;
+            Vendor.Site:Prototype {
+                propOne = Neos.Fusion:Tag {
+                    tagName = 'strong'
+                    content = 'foo'
+                }
+                propTwo = Vendor.Site:Prototype {
+                    content = 'bar'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -539,26 +539,26 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype><div>a tag</div><div>another tag</div></Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    propOne = Neos.Fusion:Tag {
-        tagName = 'strong'
-        content = 'foo'
-    }
-    propTwo = Vendor.Site:Prototype {
-        content = 'bar'
-    }
-    content = Neos.Fusion:Array {
-        item_1 = Neos.Fusion:Tag {
-            tagName = 'div'
-            content = 'a tag'
-        }
-        item_2 = Neos.Fusion:Tag {
-            tagName = 'div'
-            content = 'another tag'
-        }
-    }
-}
-EOF;
+            Vendor.Site:Prototype {
+                propOne = Neos.Fusion:Tag {
+                    tagName = 'strong'
+                    content = 'foo'
+                }
+                propTwo = Vendor.Site:Prototype {
+                    content = 'bar'
+                }
+                content = Neos.Fusion:Array {
+                    item_1 = Neos.Fusion:Tag {
+                        tagName = 'div'
+                        content = 'a tag'
+                    }
+                    item_2 = Neos.Fusion:Tag {
+                        tagName = 'div'
+                        content = 'another tag'
+                    }
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -569,16 +569,16 @@ EOF;
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="a.fusion.path">foo</strong><Vendor.Site:Prototype @path="another.fusion.path">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    a.fusion.path = Neos.Fusion:Tag {
-        tagName = 'strong'
-        content = 'foo'
-    }
-    another.fusion.path = Vendor.Site:Prototype {
-        content = 'bar'
-    }
-}
-EOF;
+            Vendor.Site:Prototype {
+                a.fusion.path = Neos.Fusion:Tag {
+                    tagName = 'strong'
+                    content = 'foo'
+                }
+                another.fusion.path = Vendor.Site:Prototype {
+                    content = 'bar'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -594,15 +594,15 @@ EOF;
         </h1>';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = ${eelExpression1}
-        item_2 = ${eelExpression2}
-        item_3 = ${eelExpression3}
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = ${eelExpression1}
+                    item_2 = ${eelExpression2}
+                    item_3 = ${eelExpression3}
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -616,15 +616,15 @@ EOF;
         </h1>';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = ${eelExpression1}
-        item_2 = ' '
-        item_3 = ${eelExpression2}
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = ${eelExpression1}
+                    item_2 = ' '
+                    item_3 = ${eelExpression2}
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -638,15 +638,15 @@ EOF;
         </h1>';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = 'String '
-        item_2 = ${eelExpression}
-        item_3 = ' String'
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = 'String '
+                    item_2 = ${eelExpression}
+                    item_3 = ' String'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -658,10 +658,10 @@ EOF;
         $afxCode = '<Vendor.Site:Prototype {...spreadExpression} />';
 
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    @apply.spread_1 = ${spreadExpression}
-}
-EOF;
+            Vendor.Site:Prototype {
+                @apply.spread_1 = ${spreadExpression}
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -673,16 +673,16 @@ EOF;
         $afxCode = '<Vendor.Site:Prototype stringBefore="string" expressionBefore={expression} {...spreadExpression} stringAfter="string" expressionAfter={expression} />';
 
         $expectedFusion = <<<'EOF'
-Vendor.Site:Prototype {
-    stringBefore = 'string'
-    expressionBefore = ${expression}
-    @apply.spread_1 = ${spreadExpression}
-    @apply.spread_2 = Neos.Fusion:RawArray {
-        stringAfter = 'string'
-        expressionAfter = ${expression}
-    }
-}
-EOF;
+            Vendor.Site:Prototype {
+                stringBefore = 'string'
+                expressionBefore = ${expression}
+                @apply.spread_1 = ${spreadExpression}
+                @apply.spread_2 = Neos.Fusion:RawArray {
+                    stringAfter = 'string'
+                    expressionAfter = ${expression}
+                }
+            }
+            EOF;
 
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
@@ -695,12 +695,12 @@ EOF;
         $afxCode = '<h1 {...spreadExpression} />';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    selfClosingTag = true
-    attributes.@apply.spread_1 = ${spreadExpression}
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                selfClosingTag = true
+                attributes.@apply.spread_1 = ${spreadExpression}
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -712,18 +712,18 @@ EOF;
         $afxCode = '<h1 stringBefore="string" expressionBefore={expression} {...spreadExpression} stringAfter="string" expressionAfter={expression} />';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    selfClosingTag = true
-    attributes.stringBefore = 'string'
-    attributes.expressionBefore = ${expression}
-    attributes.@apply.spread_1 = ${spreadExpression}
-    attributes.@apply.spread_2 = Neos.Fusion:RawArray {
-        stringAfter = 'string'
-        expressionAfter = ${expression}
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                selfClosingTag = true
+                attributes.stringBefore = 'string'
+                attributes.expressionBefore = ${expression}
+                attributes.@apply.spread_1 = ${spreadExpression}
+                attributes.@apply.spread_2 = Neos.Fusion:RawArray {
+                    stringAfter = 'string'
+                    expressionAfter = ${expression}
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -735,11 +735,11 @@ EOF;
         $afxCode = '<h1>\o/</h1>';
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = '\\o/'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = '\\o/'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -749,15 +749,15 @@ EOF;
     public function textsAreEscaped(): void
     {
         $afxCode = <<<'EOF'
-<h1>foo'bar\baz"bam</h1>
-EOF;
+            <h1>foo'bar\baz"bam</h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = 'foo\'bar\\baz\"bam'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = 'foo\'bar\\baz\"bam'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -767,20 +767,20 @@ EOF;
     public function commentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
-<!-- comment before -->
-<h1>Example<!-- comment inside -->Content</h1>
-<!-- comment after -->
-EOF;
+            <!-- comment before -->
+            <h1>Example<!-- comment inside -->Content</h1>
+            <!-- comment after -->
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = Neos.Fusion:Array {
-        item_1 = 'Example'
-        item_2 = 'Content'
-    }
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = Neos.Fusion:Array {
+                    item_1 = 'Example'
+                    item_2 = 'Content'
+                }
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -790,12 +790,12 @@ EOF;
     public function standaloneCommentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
-<!-- comment -->
-EOF;
+            <!-- comment -->
+            EOF;
 
         $expectedFusion = <<<'EOF'
-''
-EOF;
+            ''
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -805,15 +805,15 @@ EOF;
     public function standaloneCommentsChildrenAreIgnored(): void
     {
         $afxCode = <<<'EOF'
-<h1><!-- comment --></h1>
-EOF;
+            <h1><!-- comment --></h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = ''
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = ''
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -823,22 +823,22 @@ EOF;
     public function multilineCommentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
-<h1>
-<!-- 
-    comment 
-    with
-    multiple 
-    lines 
--->
-</h1>
-EOF;
+            <h1>
+            <!--
+                comment
+                with
+                multiple
+                lines
+            -->
+            </h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    content = ''
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                content = ''
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -848,16 +848,16 @@ EOF;
     public function slashesInStringNodesArePreserved()
     {
         $afxCode = <<<'EOF'
-<h1 class="\\o/">foobar</h1>
-EOF;
+            <h1 class="\\o/">foobar</h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    attributes.class = '\\o/'
-    content = 'foobar'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                attributes.class = '\\o/'
+                content = 'foobar'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
@@ -867,16 +867,16 @@ EOF;
     public function stringsAreEscaped()
     {
         $afxCode = <<<'EOF'
-<h1 class="foo\'foo'bar\\baz\"bam\bam">foobar</h1>
-EOF;
+            <h1 class="foo\'foo'bar\\baz\"bam\bam">foobar</h1>
+            EOF;
 
         $expectedFusion = <<<'EOF'
-Neos.Fusion:Tag {
-    tagName = 'h1'
-    attributes.class = 'foo\'foo\'bar\\baz\"bambam'
-    content = 'foobar'
-}
-EOF;
+            Neos.Fusion:Tag {
+                tagName = 'h1'
+                attributes.class = 'foo\'foo\'bar\\baz\"bambam'
+                content = 'foobar'
+            }
+            EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 

--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -67,9 +67,12 @@ class AfxServiceTest extends TestCase
      */
     public function htmlTagsWithIgnoredContentAreConvertedToFusionTags(): void
     {
-        $afxCode = '<h1>
+        $afxCode = <<<'EOF'
+            <h1>
+                
+            </h1>
+            EOF;
 
-</h1>';
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
@@ -423,11 +426,11 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = <<<'EOF'
             <h1>
-
+                
                 <strong>foo</strong>
-
+                    
                 <i>bar</i>
-
+                
             </h1>
             EOF;
 


### PR DESCRIPTION
The indentation of heredoc and nowdoc was added in PHP 7.3 which is the minimal supported version of php.
This change adjusts the tests of the afx service to use the indented syntax to improve readability a lot.

https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes