### PR TITLE
FEATURE: Introduce ThumbnailRefreshed signal to the Neos.Media package

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -231,6 +231,7 @@ class ThumbnailService
     public function refreshThumbnail(Thumbnail $thumbnail): void
     {
         $thumbnail->refresh();
+        $this->emitThumbnailRefreshed($thumbnail);
         $this->persistenceManager->allowObject($thumbnail);
         if (!$this->persistenceManager->isNewObject($thumbnail)) {
             $this->thumbnailRepository->update($thumbnail);
@@ -258,6 +259,17 @@ class ThumbnailService
         }
 
         return $this->resourceManager->getPublicPackageResourceUriByPath($staticResource);
+    }
+
+    /**
+     * Signals that a thumbnail was refreshed.
+     *
+     * @Flow\Signal
+     * @param Thumbnail $thumbnail
+     * @return void
+     */
+    public function emitThumbnailRefreshed(Thumbnail $thumbnail): void
+    {
     }
 
     /**


### PR DESCRIPTION
Packages like MOC.ImageOptimizer that are necessary for achieving optimal performance currently have to use unstable apis (aspects) to get access to freshly created image-crops. The existing signals ThumbnailPersisted and ThumbnailCreated do not cover this usecase yet.

This change introduces the ThumbnailRefreshed signal to the Neos.Media package that can be used by package authors to optimize the rendered thumbnails further before they are presented to the user.

