### PR TITLE
BUGFIX: Flush content cache of pages with internal links when target changes

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -217,6 +217,7 @@ class ContentCacheFlusher
     {
         $this->tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
         $this->tagsToFlush['Node_' . $cacheIdentifier] = sprintf('which were tagged with "Node_%s" because that identifier has changed.', $cacheIdentifier);
+        $this->tagsToFlush['NodeDynamicTag_' . $cacheIdentifier] = sprintf('which were tagged with "NodeDynamicTag_%s" because that identifier has changed.', $cacheIdentifier);
 
         // Note, as we don't have a node here we cannot go up the structure.
         $tagName = 'DescendantOf_' . $cacheIdentifier;


### PR DESCRIPTION
This extends `\Neos\Neos\Fusion\Cache\ContentCacheFlusher::registerChangeOnNodeIdentifier()`
such that it flushes *dynamic* node tags, too.

Background:

The `Neos.Neos:ConvertUris` processor invokes `\Neos\Fusion\Core\Runtime::addCacheTag()` for
every converted node and asset link leading to a cache tag of `<type>DynamicTag_<id>` (e.g.
`NodeDynamicTag_12345`) to be added to the current `RuntimeContentCache`.

This fix makes sure that those dynamic node tags are also flushed whenever a node is changed.

Fixes: #3482