### PR TITLE
FEATURE: Add additionalParams to ConvertUrisImplementation

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -78,6 +78,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         }
 
         $node = $this->fusionValue('node');
+        $additionalParams = $this->fusionValue('additionalParams');
 
         if (!$node instanceof NodeInterface) {
             throw new Exception(sprintf('The current node must be an instance of NodeInterface, given: "%s".', gettype($text)), 1382624087);
@@ -93,14 +94,20 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
         $absolute = $this->fusionValue('absolute');
 
-        $processedContent = preg_replace_callback(LinkingService::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $linkingService, $controllerContext, &$unresolvedUris, $absolute) {
+        $processedContent = preg_replace_callback(LinkingService::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $linkingService, $controllerContext, &$unresolvedUris, $absolute, $additionalParams) {
             switch ($matches[1]) {
                 case 'node':
                     $resolvedUri = $linkingService->resolveNodeUri($matches[0], $node, $controllerContext, $absolute);
+                    if (is_array($additionalParams) && count($additionalParams)) {
+                        $resolvedUri .= '?' . http_build_query($additionalParams);
+                    }
                     $this->runtime->addCacheTag('node', $matches[2]);
                     break;
                 case 'asset':
                     $resolvedUri = $linkingService->resolveAssetUri($matches[0]);
+                    if (is_array($additionalParams) && count($additionalParams)) {
+                        $resolvedUri .= '?' . http_build_query($additionalParams);
+                    }
                     $this->runtime->addCacheTag('asset', $matches[2]);
                     break;
                 default:

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1377,6 +1377,7 @@ overriding the target attribute for external links and resource links.
 :forceConversion: (boolean) Whether to convert URIs in a non-live workspace, defaults to ``FALSE``
 :absolute: (boolean) Can be used to convert node URIs to absolute links, defaults to ``FALSE``
 :setNoOpener: (boolean) Sets the rel="noopener" attribute to external links, which is good practice, defaults to ``TRUE``
+:additionalParams: (array) Additional URI query parameters.
 
 Example::
 


### PR DESCRIPTION
If you create newsletter with Neos, it is crucial to have some additional parameters like `utm_source`, `utm_medium` and `utm_campaign` to every link. This change enables the `ConvertUrisImplementation` to have `additionalParams`.

```
prototype(Neos.Neos:ConvertUris) {
    absolute = true
    forceConversion = true
    additionalParams {
         utm_source = 'newsletter'
         utm_medium = 'email'
         utm_campaign = ${node.label}
    }
}
```