### PR TITLE
BUGFIX: Render labels of authentication providers

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -68,6 +68,12 @@ class UsersController extends AbstractModuleController
     protected $tokenAndProviderFactory;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Flow", path="security.authentication.providers")
+     * @var array
+     */
+    protected $authenticationProviderSettings;
+
+    /**
      * @return void
      * @throws NoSuchArgumentException
      */
@@ -381,9 +387,18 @@ class UsersController extends AbstractModuleController
      */
     protected function getAuthenticationProviders(): array
     {
-        $providerNames = array_keys($this->tokenAndProviderFactory->getProviders());
+        $providers = array_keys($this->tokenAndProviderFactory->getProviders());
+
+        $providerNames =[];
+        foreach ($providers as $authenticationProviderName) {
+            $providerNames[$authenticationProviderName] = [
+                'label' => ($this->authenticationProviderSettings[$authenticationProviderName]['label'] ?? $authenticationProviderName),
+                'identifier' => $authenticationProviderName
+            ];
+        }
+
         sort($providerNames);
-        return array_combine($providerNames, $providerNames);
+        return $providerNames;
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
@@ -38,7 +38,7 @@
               <div class="neos-control-group{f:validation.ifHasErrors(for: 'authenticationProviderName', then: ' neos-error')}">
                 <label class="neos-control-label" for="authenticationProviderName">{neos:backend.translate(id: 'users.new.userData.authenticationProviderName', value: 'Authentication Provider', source: 'Modules', package: 'Neos.Neos')}</label>
                 <div class="neos-controls">
-                  <f:form.select name="authenticationProviderName" id="authenticationProviderName" options="{providers}" prependOptionLabel="{neos:backend.translate(id: 'users.new.userData.authenticationProviderName.useDefault', source: 'Modules', value: 'Use system default')}" prependOptionValue="" class="neos-span12" />
+                  <f:form.select name="authenticationProviderName" id="authenticationProviderName" options="{providers}" optionLabelField="label" optionValueField="identifier" prependOptionLabel="{neos:backend.translate(id: 'users.new.userData.authenticationProviderName.useDefault', source: 'Modules', value: 'Use system default')}" prependOptionValue="" class="neos-span12" />
                   <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'authenticationProviderName'}"/>
                 </div>
               </div>


### PR DESCRIPTION
**What I did**
Extended the array that is used in the view. So that we have the provider identifier and the label.
So we use a structure like

`
[
    {
        identifier: 'Neos.Neos:Backend'
        label: 'Neos Backend label'
    },
    {
        identifier: 'Neos.Neos:FooName'
        label: 'Neos Backend Foo'
    }
]
`

**How to verify it**

    1. Configure a second authentication provider
    2. go to the user management in the backend
    3. create a new user
    4. check the drop down


![Screenshot 2021-11-03 at 10 27 50](https://user-images.githubusercontent.com/1014126/140036446-fedcdc33-d80d-4ea4-95b0-41fa385d9d53.png)


Fixes: #3488 