### PR TITLE
BUGFIX: NodeTypesLoader respect package overrides

### DIFF
--- a/Neos.ContentRepository/Classes/Configuration/NodeTypesLoader.php
+++ b/Neos.ContentRepository/Classes/Configuration/NodeTypesLoader.php
@@ -48,8 +48,10 @@ class NodeTypesLoader implements LoaderInterface
                         $fileInfo->getPath(),
                         $fileInfo->getBasename('.' . $fileInfo->getExtension())
                     ]);
-                    $configuration = Arrays::arrayMergeRecursiveOverrule($configuration,
-                        $this->yamlSource->load($path, false));
+                    $configuration = Arrays::arrayMergeRecursiveOverrule(
+                        $configuration,
+                        $this->yamlSource->load($path, false)
+                    );
                 }
             }
 

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/NodeTypes.SomeSuffix.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/NodeTypes.SomeSuffix.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/NodeTypes.SomeSuffix.yaml
+    pathConfiguration.NodeTypes_SomeSuffix_yaml: true
+'NodeType:PathConfiguration.NodeTypes_SomeSuffix_yaml':
+  options:
+    path: Configuration/NodeTypes.SomeSuffix.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/NodeTypes.yaml
+    pathConfiguration.NodeTypes_yaml: true
+'NodeType:PathConfiguration.NodeTypes_yaml':
+  options:
+    path: Configuration/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/NodeTypes.SomeSuffix.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/NodeTypes.SomeSuffix.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/Testing/NodeTypes.SomeSuffix.yaml
+    pathConfiguration.Testing.NodeTypes_SomeSuffix_yaml: true
+'NodeType:PathConfiguration.Testing.NodeTypes_SomeSuffix_yaml':
+  options:
+    path: Configuration/Testing/NodeTypes.SomeSuffix.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/Testing/NodeTypes.yaml
+    pathConfiguration.Testing.NodeTypes_yaml: true
+'NodeType:PathConfiguration.Testing.NodeTypes_yaml':
+  options:
+    path: Configuration/Testing/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/Testing/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
+    pathConfiguration.Testing.SomeOtherSubContext.NodeTypes_SomeSuffix_yaml: true
+'NodeType:PathConfiguration.Testing.SomeOtherSubContext.NodeTypes_SomeSuffix_yaml':
+  options:
+    path: Configuration/Testing/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeOtherSubContext/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeOtherSubContext/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/Testing/SomeOtherSubContext/NodeTypes.yaml
+    pathConfiguration.Testing.SomeOtherSubContext.NodeTypes_yaml: true
+'NodeType:PathConfiguration.Testing.SomeOtherSubContext.NodeTypes_yaml':
+  options:
+    path: Configuration/Testing/SomeOtherSubContext/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeSubContext/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Configuration/Testing/SomeSubContext/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Configuration/Testing/SomeSubContext/NodeTypes.yaml
+    pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml: true
+'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml':
+  options:
+    path: Configuration/Testing/SomeSubContext/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/NodeTypes/Bar.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/NodeTypes/Bar.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: NodeTypes/Bar.yaml
+    pathNodeTypes.Bar_yaml: true
+'NodeType:PathNodeTypes.Bar_yaml':
+  options:
+    path: NodeTypes/Bar.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/NodeTypes/Foo.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/NodeTypes/Foo.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: NodeTypes/Foo.yaml
+    pathNodeTypes.Foo_yaml: true
+'NodeType:PathNodeTypes.Foo_yaml':
+  options:
+    path: NodeTypes/Foo.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Neos.Seo/Configuration/NodeTypes.Mixin.TitleTag.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Neos.Seo/Configuration/NodeTypes.Mixin.TitleTag.yaml
@@ -1,0 +1,17 @@
+'Neos.Seo:TitleTagMixin':
+  abstract: true
+  properties:
+    titleOverride:
+      type: string
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        inspector:
+          group: 'document'
+          position: 10000
+          editor: 'Neos.Neos/Inspector/Editors/TextAreaEditor'
+          editorOptions:
+            placeholder: i18n
+      validation:
+        'Neos.Neos/Validation/StringLengthValidator':
+          maximum: 60

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/NodeTypes.SomeSuffix.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/NodeTypes.SomeSuffix.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/Configuration/NodeTypes.SomeSuffix.yaml
+    pathPackages.Package1.Configuration.NodeTypes_SomeSuffix_yaml: true
+'NodeType:PathPackages.Package1.Configuration.NodeTypes_SomeSuffix_yaml':
+  options:
+    path: Packages/Package1/Configuration/NodeTypes.SomeSuffix.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/Configuration/NodeTypes.yaml
+    pathPackages.Package1.Configuration.NodeTypes_yaml: true
+'NodeType:PathPackages.Package1.Configuration.NodeTypes_yaml':
+  options:
+    path: Packages/Package1/Configuration/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml
+    pathPackages.Package1.Configuration.SomeOtherSubContext.NodeTypes_SomeSuffix_yaml: true
+'NodeType:PathPackages.Package1.Configuration.SomeOtherSubContext.NodeTypes_SomeSuffix_yaml':
+  options:
+    path: Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.yaml
+    pathPackages.Package1.Configuration.SomeOtherSubContext.NodeTypes_yaml: true
+'NodeType:PathPackages.Package1.Configuration.SomeOtherSubContext.NodeTypes_yaml':
+  options:
+    path: Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeSubContext/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/Configuration/SomeSubContext/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/Configuration/SomeSubContext/NodeTypes.yaml
+    pathPackages.Package1.Configuration.SomeSubContext.NodeTypes_yaml: true
+'NodeType:PathPackages.Package1.Configuration.SomeSubContext.NodeTypes_yaml':
+  options:
+    path: Packages/Package1/Configuration/SomeSubContext/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/NodeTypes/Bar.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/NodeTypes/Bar.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/NodeTypes/Bar.yaml
+    pathPackages.Package1.NodeTypes.Bar_yaml: true
+'NodeType:PathPackages.Package1.NodeTypes.Bar_yaml':
+  options:
+    path: Packages/Package1/NodeTypes/Bar.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/NodeTypes/Foo.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package1/NodeTypes/Foo.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package1/NodeTypes/Foo.yaml
+    pathPackages.Package1.NodeTypes.Foo_yaml: true
+'NodeType:PathPackages.Package1.NodeTypes.Foo_yaml':
+  options:
+    path: Packages/Package1/NodeTypes/Foo.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/Configuration/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/Configuration/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package2/Configuration/NodeTypes.yaml
+    pathPackages.Package2.Configuration.NodeTypes_yaml: true
+'NodeType:PathPackages.Package2.Configuration.NodeTypes_yaml':
+  options:
+    path: Packages/Package2/Configuration/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/Configuration/SomeOtherSubContext/NodeTypes.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/Configuration/SomeOtherSubContext/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package2/Configuration/SomeOtherSubContext/NodeTypes.yaml
+    pathPackages.Package2.Configuration.SomeOtherSubContext.NodeTypes_yaml: true
+'NodeType:PathPackages.Package2.Configuration.SomeOtherSubContext.NodeTypes_yaml':
+  options:
+    path: Packages/Package2/Configuration/SomeOtherSubContext/NodeTypes.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/NodeTypes/Foo.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Package2/NodeTypes/Foo.yaml
@@ -1,0 +1,7 @@
+'Some.Node:Type':
+  options:
+    finalPath: Packages/Package2/NodeTypes/Foo.yaml
+    pathPackages.Package2.NodeTypes.Foo_yaml: true
+'NodeType:PathPackages.Package2.NodeTypes.Foo_yaml':
+  options:
+    path: Packages/Package2/NodeTypes/Foo.yaml

--- a/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Some.Package/NodeTypes/NodeTypes.Override.Seo.yaml
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/Fixture/Packages/Some.Package/NodeTypes/NodeTypes.Override.Seo.yaml
@@ -1,0 +1,4 @@
+'Neos.Seo:TitleTagMixin':
+  properties:
+    titleOverride:
+      validation: ~

--- a/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
@@ -27,22 +27,22 @@ class NodeTypesLoaderTest extends UnitTestCase
     /**
      * @var NodeTypesLoader|MockObject
      */
-    private NodeTypesLoader $nodeTypesLoader;
+    private $nodeTypesLoader;
 
     /**
      * @var ApplicationContext|MockObject
      */
-    private ApplicationContext $mockApplicationContext;
+    private $mockApplicationContext;
 
     /**
      * @var FlowPackageInterface|MockObject
      */
-    private FlowPackageInterface $mockPackage1;
+    private $mockPackage1;
 
     /**
      * @var FlowPackageInterface|MockObject
      */
-    private FlowPackageInterface $mockPackage2;
+    private $mockPackage2;
 
     public function setUp(): void
     {

--- a/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
@@ -105,7 +105,7 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -175,7 +175,7 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -233,7 +233,7 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -315,7 +315,7 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -397,7 +397,7 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -435,6 +435,6 @@ class NodeTypesLoaderTest extends UnitTestCase
                 ],
             ],
         ];
-        self::assertSame($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
@@ -1,0 +1,330 @@
+<?php
+declare(strict_types=1);
+namespace Neos\ContentRepository\Tests\Unit\Configuration;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Configuration\NodeTypesLoader;
+use Neos\Flow\Configuration\Source\YamlSource;
+use Neos\Flow\Core\ApplicationContext;
+use Neos\Flow\Package\FlowPackageInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Utility\Arrays;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Yaml\Yaml;
+
+class NodeTypesLoaderTest extends UnitTestCase
+{
+    /**
+     * @var NodeTypesLoader|MockObject
+     */
+    private NodeTypesLoader $nodeTypesLoader;
+
+    /**
+     * @var ApplicationContext|MockObject
+     */
+    private ApplicationContext $mockApplicationContext;
+
+    /**
+     * @var FlowPackageInterface|MockObject
+     */
+    private FlowPackageInterface $mockPackage1;
+
+    /**
+     * @var FlowPackageInterface|MockObject
+     */
+    private FlowPackageInterface $mockPackage2;
+
+    public function setUp(): void
+    {
+        $nodeTypeFiles = $this->mockNodeTypeDefinitions([
+            'Configuration/NodeTypes.yaml',
+            'Configuration/NodeTypes.SomeSuffix.yaml',
+            'Configuration/Testing/NodeTypes.yaml',
+            'Configuration/Testing/NodeTypes.SomeSuffix.yaml',
+            'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+            'Configuration/Testing/SomeOtherSubContext/NodeTypes.yaml',
+            'Configuration/Testing/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml',
+            'NodeTypes/Foo.yaml',
+            'NodeTypes/Bar.yaml',
+            'Packages/Package1/Configuration/NodeTypes.yaml',
+            'Packages/Package1/Configuration/NodeTypes.SomeSuffix.yaml',
+            'Packages/Package1/Configuration/SomeSubContext/NodeTypes.yaml',
+            'Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.yaml',
+            'Packages/Package1/Configuration/SomeOtherSubContext/NodeTypes.SomeSuffix.yaml',
+            'Packages/Package1/NodeTypes/Foo.yaml',
+            'Packages/Package1/NodeTypes/Bar.yaml',
+            'Packages/Package2/Configuration/NodeTypes.yaml',
+            'Packages/Package2/Configuration/SomeOtherSubContext/NodeTypes.yaml',
+            'Packages/Package2/NodeTypes/Foo.yaml',
+        ]);
+        vfsStream::setup('root', null, $nodeTypeFiles);
+        $this->nodeTypesLoader = new NodeTypesLoader(new YamlSource(), vfsStream::url('root/Configuration/'));
+
+        $this->mockApplicationContext = $this->getMockBuilder(ApplicationContext::class)->disableOriginalConstructor()->getMock();
+        $this->mockApplicationContext->method('getHierarchy')->willReturn(['Testing', 'Testing/SomeSubContext']);
+
+        $this->mockPackage1 = $this->getMockBuilder(FlowPackageInterface::class)->getMock();
+        $this->mockPackage1->method('getPackagePath')->willReturn(vfsStream::url('root/Packages/Package1'));
+
+        $this->mockPackage2 = $this->getMockBuilder(FlowPackageInterface::class)->getMock();
+        $this->mockPackage2->method('getPackagePath')->willReturn(vfsStream::url('root/Packages/Package2'));
+    }
+
+    private function mockNodeTypeDefinitions(array $paths): array
+    {
+        $result = [];
+        foreach ($paths as $path) {
+            $escapedPath = str_replace(['.', '/'], ['_', '.'], $path);
+            $nodeTypeDefinitions = Yaml::dump([
+                'Some.Node:Type' => [
+                    'options' => [
+                        'finalPath' => $path,
+                        'path' . $escapedPath => true,
+                    ]
+                ],
+                'NodeType:Path' . $escapedPath => [
+                    'options' => [
+                        'path' => $path,
+                    ]
+                ],
+            ]);
+            $pathSegments = explode('/', $path);
+            $result = Arrays::setValueByPath($result, $pathSegments, $nodeTypeDefinitions);
+        }
+        return $result;
+    }
+
+    /**
+     * @test
+     */
+    public function emptyPackageList(): void
+    {
+        $actualResult = $this->nodeTypesLoader->load([], $this->mockApplicationContext);
+        $expectedResult = [
+            'Some.Node:Type' => [
+                'options' => [
+                    'finalPath' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                    'pathConfiguration.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => true,
+                ]
+            ],
+            'NodeType:PathConfiguration.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/NodeTypes.yaml'
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/NodeTypes.yaml'
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml'
+                ]
+            ],
+        ];
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function firstPackage(): void
+    {
+        $actualResult = $this->nodeTypesLoader->load([$this->mockPackage1], $this->mockApplicationContext);
+        $expectedResult = [
+            'Some.Node:Type' => [
+                'options' => [
+                    'finalPath' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                    'pathPackages.Package1.NodeTypes.Foo_yaml' => true,
+                    'pathPackages.Package1.NodeTypes.Bar_yaml' => true,
+                    'pathConfiguration.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => true,
+                ]
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Foo.yaml'
+                ]
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Bar_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Bar.yaml'
+                ]
+            ],
+            'NodeType:PathConfiguration.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/NodeTypes.yaml'
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/NodeTypes.yaml'
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml'
+                ]
+            ],
+        ];
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function secondPackage(): void
+    {
+        $actualResult = $this->nodeTypesLoader->load([$this->mockPackage2], $this->mockApplicationContext);
+        $expectedResult = [
+            'Some.Node:Type' => [
+                'options' => [
+                    'finalPath' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                    'pathPackages.Package2.NodeTypes.Foo_yaml' => true,
+                    'pathConfiguration.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => true,
+                ],
+            ],
+            'NodeType:PathPackages.Package2.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package2/NodeTypes/Foo.yaml',
+                ]
+            ],
+            'NodeType:PathConfiguration.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/NodeTypes.yaml',
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/NodeTypes.yaml',
+                ]
+            ],
+            'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                ]
+            ]
+        ];
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function bothPackages(): void
+    {
+        $actualResult = $this->nodeTypesLoader->load([$this->mockPackage1, $this->mockPackage2], $this->mockApplicationContext);
+        $expectedResult = [
+            'Some.Node:Type' => [
+                'options' => [
+                    'finalPath' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                    'pathPackages.Package1.NodeTypes.Foo_yaml' => true,
+                    'pathPackages.Package1.NodeTypes.Bar_yaml' => true,
+                    'pathPackages.Package2.NodeTypes.Foo_yaml' => true,
+                    'pathConfiguration.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => true,
+                ],
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Foo.yaml',
+                ],
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Bar_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Bar.yaml',
+                ],
+            ],
+            'NodeType:PathPackages.Package2.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package2/NodeTypes/Foo.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/NodeTypes.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.Testing.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/NodeTypes.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                ],
+            ],
+        ];
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function bothPackagesReversedOrder(): void
+    {
+        $actualResult = $this->nodeTypesLoader->load([$this->mockPackage2, $this->mockPackage1], $this->mockApplicationContext);
+        $expectedResult = [
+            'Some.Node:Type' => [
+                'options' => [
+                    'finalPath' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                    'pathPackages.Package2.NodeTypes.Foo_yaml' => true,
+                    'pathPackages.Package1.NodeTypes.Foo_yaml' => true,
+                    'pathPackages.Package1.NodeTypes.Bar_yaml' => true,
+                    'pathConfiguration.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.NodeTypes_yaml' => true,
+                    'pathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => true,
+                ],
+            ],
+            'NodeType:PathPackages.Package2.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package2/NodeTypes/Foo.yaml',
+                ],
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Foo_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Foo.yaml',
+                ],
+            ],
+            'NodeType:PathPackages.Package1.NodeTypes.Bar_yaml' => [
+                'options' => [
+                    'path' => 'Packages/Package1/NodeTypes/Bar.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/NodeTypes.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.Testing.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/NodeTypes.yaml',
+                ],
+            ],
+            'NodeType:PathConfiguration.Testing.SomeSubContext.NodeTypes_yaml' => [
+                'options' => [
+                    'path' => 'Configuration/Testing/SomeSubContext/NodeTypes.yaml',
+                ],
+            ],
+        ];
+        self::assertSame($expectedResult, $actualResult);
+    }
+}


### PR DESCRIPTION
**What I did**

The NodeTypesLoader introduced in FLOW 7.2 does not allow to override NodeTypes in the newly introduced `NodeTypes` directory. This is because, the `Configuration` directory is loaded in a separate loop after the `NodeTypes` directory.  

For example, the NodeType `Neos.Neos:ContentCollection` cannot be overriden in the `NodeTypes` directory, because it is loaded in `Neos.Neos/Configuration`. This means, everything defined in the `NodeTypes` directory of a custom package is overriden by the `Neos.Neos/Configuration` NodeType.

**How I did it**

This PR uses a single `$packages` loop to first load from the `NodeTypes` directory, directly followed by the `Configuration` for a given `$package`.

**How to verify it**

Try to modify `Neos.Neos:ContentCollection` like this
```
'Neos.Neos:ContentCollection':
  constraints:
    nodeTypes:
      '*': false
```
in a `NodeTypes` directory.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
