### PR TITLE
BUGFIX: Include Memo fusion

### DIFF
--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -1,5 +1,6 @@
 include: DebugConsole.fusion
 include: Match.fusion
+include: Memo.fusion
 
 prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'


### PR DESCRIPTION
The Neos.Fusion:Memo object was introduced with Neos 7.2 but the include somehow slipped through.
This change adds the missing include to the Root.fusion

Resolves: #3510