### PR TITLE
BUGFIX: prevent failure for disabled superTypes

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -205,9 +205,12 @@ class NodeTypeConfigurationEnrichmentAspect
             }
 
             $editorName = $propertyConfiguration['ui']['inspector']['editor']
-                ?? array_reduce($declaredSuperTypes, function ($editorName, NodeType $superType) use ($propertyName) {
+                ?? array_reduce($declaredSuperTypes, function ($editorName, ?NodeType $superType) use ($propertyName) {
+                    if ($editorName !== null || $superType === null) {
+                        return $editorName;
+                    }
                     $superTypeConfiguration = $superType->getLocalConfiguration();
-                    return $editorName ?? $superTypeConfiguration['properties'][$propertyName]['ui']['inspector']['editor'] ?? null;
+                    return $superTypeConfiguration['properties'][$propertyName]['ui']['inspector']['editor'] ?? null;
                 }, null);
             $hasEditor = !is_null($editorName);
             $hasEditorOptions = isset($propertyConfiguration['ui']['inspector']['editorOptions']);


### PR DESCRIPTION
When there are disabled `superTypes` in NodeTypes, an exception is thrown.
This happens when a superType is disabled in a NodeType and no specific editor is defined.

```yaml
'My.Package:FormElement':
  superTypes:
    'Neos.Form.Builder:FormElement': true
    'Neos.Form.Builder:LabelMixin': false
  properties:
    property:
      type: string
      ui:
        label: i18n
```

This issue was introduced in neos/neos-development-collection#3395

Closes neos/neos-development-collection#3520