### PR TITLE
BUGFIX Fix NodeTypeConfigurationEnrichmentAspect

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -205,7 +205,10 @@ class NodeTypeConfigurationEnrichmentAspect
             }
 
             $editorName = $propertyConfiguration['ui']['inspector']['editor']
-                ?? array_reduce($declaredSuperTypes, function ($editorName, NodeType $superType) use ($propertyName) {
+                ?? array_reduce($declaredSuperTypes, function ($editorName, $superType) use ($propertyName) {
+                    if (!$superType instanceof NodeType) {
+                        return null;
+                    }
                     $superTypeConfiguration = $superType->getLocalConfiguration();
                     return $editorName ?? $superTypeConfiguration['properties'][$propertyName]['ui']['inspector']['editor'] ?? null;
                 }, null);


### PR DESCRIPTION
Handle variable type check inside function body. `$superType` can be null. Therefore the type check is done within function body.

closes #3520 