### PR TITLE
!!! TASK: Fusion Parser deprecate namespace alias

### DIFF
--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -260,6 +260,7 @@ class Parser implements ParserInterface
      * with that namespace and name must be defined elsewhere.
      *
      * These namespaces are _not_ used for resolution of processor class names.
+     * @deprecated with version 7.3 will be removed with 8.0
      * @var array
      */
     protected $objectTypeNamespaces = [
@@ -317,6 +318,7 @@ class Parser implements ParserInterface
      * @return void
      * @throws Fusion\Exception
      * @api
+     * @deprecated with version 7.3 will be removed with 8.0
      */
     public function setObjectTypeNamespace($alias, $namespace)
     {

--- a/Neos.Fusion/Classes/Core/ParserInterface.php
+++ b/Neos.Fusion/Classes/Core/ParserInterface.php
@@ -50,6 +50,7 @@ interface ParserInterface
      * @param string $namespace The namespace, for example "Neos.Neos"
      * @return void
      * @api
+     * @deprecated with version 7.3 will be removed with 8.0
      */
     public function setObjectTypeNamespace($alias, $namespace);
 }


### PR DESCRIPTION
related #3498

Add deprecation notice for the namespace to the parser and corresponding interface.

## Starting with Neos version 8, this code will not work anymore: 

### alias a namespace
```
namespace: Foo = Acme.Demo
video = Foo:YouTube
```

### use the default Neos.Fusion namespace
you will need to fully declare the namespace (add `Neos.Fusion:` infront)
```
content = DataStructure
```
or
```
root = Page
```