### PR TITLE
BUGFIX: Add possibility to trigger build manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master, '[0-9]+.[0-9]' ]
   pull_request:


### PR DESCRIPTION
Sometimes the build process doesn't start on a new pull request. With this change, we could trigger it manually and don't have to close and reopen the pull request