### PR TITLE
BUGFIX: move comment on @Flow\SkipCsrfProtection tag

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -97,7 +97,8 @@ class NodeController extends ActionController
      * @param NodeInterface $node
      * @return string View output for the specified node
      * @throws NodeNotFoundException | UnresolvableShortcutException | NeosException
-     * @Flow\SkipCsrfProtection We need to skip CSRF protection here because this action could be called with unsafe requests from widgets or plugins that are rendered on the node - For those the CSRF token is validated on the sub-request, so it is safe to be skipped here
+     * We need to skip CSRF protection here because this action could be called with unsafe requests from widgets or plugins that are rendered on the node - For those the CSRF token is validated on the sub-request, so it is safe to be skipped here
+     * @Flow\SkipCsrfProtection
      * @Flow\IgnoreValidation("node")
      */
     public function showAction(NodeInterface $node = null)


### PR DESCRIPTION
When using Neos 7.2+ with the Flowpack.Neos.FrontendLogin package trying to login with a frontend leads to a CSRF protection error:

`21-12-12 10:29:27 6580       DEBUG                          CSRF: token was empty but a valid token is required for Neos\Neos\Controller\Frontend\NodeController::showAction()`

See neos/flow-development-collection#2612 – that discusses a change from Neos 7.1 to 7.2 where the tag changes in combination with a comment.

This PR allows to use the FrontendLogin again.

