### PR TITLE
[TASK] Remove asset count condition from creation dialog.

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -101,19 +101,19 @@
     </f:if>
     <div class="neos-media-aside-group">
         <f:if condition="!{activeAssetSource.readOnly}">
-        <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
-            <f:then>
-                <h2>
-                    {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
-                    <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
-                </h2>
-            </f:then>
-            <f:else>
-                <f:if condition="{assetCollections}">
-                    <h2>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</h2>
-                </f:if>
-            </f:else>
-        </f:security.ifAccess>
+            <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+                <f:then>
+                    <h2>
+                        {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
+                        <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
+                    </h2>
+                </f:then>
+                <f:else>
+                    <f:if condition="{assetCollections}">
+                        <h2>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</h2>
+                    </f:if>
+                </f:else>
+            </f:security.ifAccess>
         </f:if>
         <f:if condition="{assetCollections -> f:count()}">
             <ul class="neos-media-aside-list">
@@ -139,43 +139,45 @@
                 </f:for>
             </ul>
             <f:if condition="!{activeAssetSource.readOnly}">
-            <div class="neos-hide" id="delete-assetcollection-modal">
-                <div class="neos-modal-centered">
-                    <div class="neos-modal-content">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser')}</div>
-                            <div>
-                                <div class="neos-subheader">
-                                    <p>
-                                        {neos:backend.translate(id: 'message.willDeleteCollection', package: 'Neos.Media.Browser')}<br />
-                                        {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
-                                    </p>
+                <div class="neos-hide" id="delete-assetcollection-modal">
+                    <div class="neos-modal-centered">
+                        <div class="neos-modal-content">
+                            <div class="neos-modal-header">
+                                <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser')}</div>
+                                <div>
+                                    <div class="neos-subheader">
+                                        <p>
+                                            {neos:backend.translate(id: 'message.willDeleteCollection', package: 'Neos.Media.Browser')}<br />
+                                            {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
+                                        </p>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
-                                <f:form.hidden name="assetCollection" id="modal-form-object" />
-                                <button type="submit" class="neos-button neos-button-danger">
-                                    {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
-                                </button>
-                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-                            </f:form>
+                            <div class="neos-modal-footer">
+                                <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
+                                <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
+                                    <f:form.hidden name="assetCollection" id="modal-form-object" />
+                                    <button type="submit" class="neos-button neos-button-danger">
+                                        {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
+                                    </button>
+                                    <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+                                </f:form>
+                            </div>
                         </div>
                     </div>
+                    <div class="neos-modal-backdrop neos-in"></div>
                 </div>
-                <div class="neos-modal-backdrop neos-in"></div>
-            </div>
-            <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
-            <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
-                <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
-                <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
-                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-            </f:form>
-            </f:security.ifAccess>
             </f:if>
+        </f:if>
+        <f:if condition="!{activeAssetSource.readOnly}">
+            <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+                <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
+                    <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
+                    <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
+                    <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+                </f:form>
+            </f:security.ifAccess>
         </f:if>
     </div>
 


### PR DESCRIPTION
<!--
If you are reporting a new issue, make sure that we do not have any duplicates
already open. You can ensure this by searching the issue list for this
repository. If there is a duplicate, please close your issue and add a comment
to the existing issue instead.
-->

### Description

In a new NEOS Instance if i have no asset collection, i can't create a new one. Because in the Issue  [3480](https://github.com/neos/neos-development-collection/issues/3480) is the asset creation dialog wrapped in a count condition (`... <f:if condition="{assetCollections -> f:count()}"> ...`).

### Steps to Reproduce

1. Go to the Management /  Media Modul
2. Ensure that no asset collection already exists
3. Try to create a new asset collection

#### Expected behavior

The asset collection dialog will be shown.

#### Actual behavior

Nothing happens because the required dialogue box is never rendered.

### Affected Versions

<!--
If you want to be a super-hero, try to find out the oldest supported version
affected by the bug you describe. Thanks!
-->

Neos: 
7.3.0
