### PR TITLE
BUGFIX: Fusion Runtime when no context is set, preparing it for Eel will fail

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -84,7 +84,7 @@ class Runtime
      *
      * @var array
      */
-    protected $currentContext = null;
+    protected $currentContext = [];
 
     /**
      * Reference to the current apply value
@@ -215,7 +215,7 @@ class Runtime
     public function popContext()
     {
         $lastItem = array_pop($this->contextStack);
-        $this->currentContext = end($this->contextStack);
+        $this->currentContext = empty($this->contextStack) ? [] : end($this->contextStack);
         return $lastItem;
     }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -11,6 +11,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * source code.
  */
 
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Fusion\Core\Parser;
+use Neos\Fusion\Core\Runtime;
+
 /**
  * Testcase for Eel expressions in Fusion
  */
@@ -38,5 +42,24 @@ class ExpressionsTest extends AbstractFusionObjectTest
         $view->setFusionPath($path);
         $view->assign('foo', 'Bar');
         self::assertSame($expected, $view->render());
+    }
+
+    /**
+     * The view and runtime of the AbstractFusionObjectTest
+     * is not used to make sure the runtime context is empty.
+     *
+     * @test
+     */
+    public function usingEelWorksWithoutSetCurrentContextInRuntime()
+    {
+        $fusion = 'root = ${"foo"}';
+        $fusionAst = (new Parser())->parse($fusion);
+
+        $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
+        $runtime = new Runtime($fusionAst, $controllerContext);
+
+        $renderedFusion = $runtime->render('root');
+
+        self::assertSame('foo', $renderedFusion);
     }
 }


### PR DESCRIPTION
fixes: #3548
fixes: #3556

added tests, that verify that the runtime context stack is working correctly.