### PR TITLE
BUGFIX: Correctly handle empty property elements in node import

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
@@ -431,6 +431,7 @@ class NodeImportService
                     $currentClassName = $reader->getAttribute('__classname');
                     $currentEncoding = $reader->getAttribute('__encoding');
 
+                    // handle self-closing tags
                     if ($reader->isEmptyElement) {
                         switch ($currentType) {
                             case 'array':
@@ -452,6 +453,21 @@ class NodeImportService
                     }
                     break;
                 case \XMLReader::END_ELEMENT:
+                    // handle empty tags
+                    if ($reader->name === $currentProperty && !isset($properties[$currentProperty])) {
+                        switch ($currentType) {
+                            case 'array':
+                                $properties[$currentProperty] = [];
+                                break;
+                            case 'string':
+                                $properties[$currentProperty] = '';
+                                break;
+                            default:
+                                $properties[$currentProperty] = null;
+                        }
+                        $currentType = null;
+                    }
+
                     if ($reader->name === 'properties') {
                         return $properties;
                     }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -71,6 +71,7 @@ class NodeImportServiceTest extends UnitTestCase
                 'layout' => 'landingPage',
                 'uriPathSegment' => 'home',
                 'imageTitleText' => 'Photo by www.daniel-bischoff.photo',
+                'subpageLayout' => '',
             ],
             'accessRoles' => [],
             'hiddenBeforeDateTime' => new \DateTime('2015-10-01T03:45:04+02:00'),
@@ -191,6 +192,7 @@ class NodeImportServiceTest extends UnitTestCase
                     'title' => 'Home',
                     'layout' => 'landingPage',
                     'uriPathSegment' => 'home',
+                    'relatedDocuments' => [],
                     'image' =>
                         [
                             'targetType' => \Neos\Media\Domain\Model\ImageVariant::class,
@@ -242,7 +244,7 @@ class NodeImportServiceTest extends UnitTestCase
                                 ],
                         ],
                     'imageTitleText' => 'Photo by www.daniel-bischoff.photo',
-                    'relatedDocuments' => []
+                    'subpageLayout' => '',
                 ],
                 'accessRoles' => [],
                 'dimensionValues' => [


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->

**What I did**

Made sure that properties with an empty value are actually set during the import.

**How I did it**

`$reader->isEmptyElement` seems to only work for self-closing tags (for example, see `relatedDocuments` in the tests), but not for tags with empty content (for example, see `subpageLayout` in the tests). To work around this, also test for `isset($properties[$currentProperty])` when matching a suitable `END_ELEMENT`.

**How to verify it**

Import a `Sites.xml` with empty properties and run `node:repair`. There should be no missing default values.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
