### PR TITLE
TASK: Replace deprecated fusion protoypes from transpiled AFX code

### DIFF
--- a/Neos.Fusion.Afx/Classes/Service/AfxService.php
+++ b/Neos.Fusion.Afx/Classes/Service/AfxService.php
@@ -288,7 +288,7 @@ class AfxService
                         );
                     }
                 } elseif ($attribute['type'] === 'propList') {
-                    $fusion .= $indentation . self::INDENTATION . $attributePrefix . '@apply.spread_' . $spreadIndex . ' = Neos.Fusion:RawArray {' . PHP_EOL;
+                    $fusion .= $indentation . self::INDENTATION . $attributePrefix . '@apply.spread_' . $spreadIndex . ' = Neos.Fusion:DataStructure {' . PHP_EOL;
                     $fusion .=  self::propListToFusion($attribute['payload'], '', $indentation . self::INDENTATION);
                     $fusion .= $indentation . self::INDENTATION . '}' . PHP_EOL;
                 }
@@ -357,7 +357,7 @@ class AfxService
         } elseif (count($payload) === 1) {
             return self::astToFusion(array_shift($payload), $indentation);
         } else {
-            $fusion = 'Neos.Fusion:Array {' . PHP_EOL;
+            $fusion = 'Neos.Fusion:Join {' . PHP_EOL;
             foreach ($payload as $astNode) {
                 // detect key
                 $fusionName = 'item_' . $index;

--- a/Neos.Fusion.Afx/README.md
+++ b/Neos.Fusion.Afx/README.md
@@ -51,7 +51,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
 
     renderer = Neos.Fusion:Tag {
         tagName = 'div'
-        content = Neos.Fusion:Array {
+        content = Neos.Fusion:Join {
             headline = Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = ${props.title}
@@ -155,7 +155,7 @@ Is transpiled as:
 Vendor.Site:Component {
     title = 'example'
     @apply.spread_1 = ${data}
-    @apply.spread_2 = Neos.Fusion:RawArray {
+    @apply.spread_2 = Neos.Fusion:DataStructure {
         description = 'description'
     }
     @apply.spread_3 = ${moreData}
@@ -189,7 +189,7 @@ Neos.Fusion:Tag {
 
 #### Multiple tag-children
 
-If an AFX-tag contains more than one child the content is are rendered as `Neos.Fusion:Array` into the
+If an AFX-tag contains more than one child the content is are rendered as `Neos.Fusion:Join` into the
 `content`-attribute. The children are interpreted as string, eel-expression, html- or fusion-object-tag.
 
 The following AFX-Code:
@@ -201,7 +201,7 @@ Is transpiled as:
 ```
 Neos.Fusion:Tag {
     tagName = 'h1'
-    content = Neos.Fusion:Array {
+    content = Neos.Fusion:Join {
         item_1 = {props.title}
         item_2 = ': '
         item_3 = ${props.subtitle}
@@ -221,7 +221,7 @@ If no `@key`-property is given `index_x` is used starting by `x=1`.
 Is transpiled as:
 ```
 Vendor.Site:Prototype {
-    text = Neos.Fusion:Array {
+    text = Neos.Fusion:Join {
         title = Neos.Fusion:Tag {
             tagName = 'h2'
             content  = ${props.title}
@@ -312,7 +312,7 @@ Is transpiled as:
 ```
 Neos.Fusion:Tag {
 	tagName = 'h1'
-	contents = Neos.Fusion:Array {
+	contents = Neos.Fusion:Join {
 		item_1 = ${'eelExpression 1'}
 		item_2 = ${'eelExpression 2'}
 	}
@@ -330,7 +330,7 @@ Is transpiled as:
 ```
 Neos.Fusion:Tag {
 	tagName = 'h1'
-	contents = Neos.Fusion:Array {
+	contents = Neos.Fusion:Join {
 		item_1 = ${'eelExpression 1'}
 		item_2 = ' '
 		item_3 = ${'eelExpression 2'}
@@ -346,7 +346,7 @@ foo<!-- comment -->bar
 ```
 Is transpiled as:
 ```
-Neos.Fusion:Array {
+Neos.Fusion:Join {
     item_1 = 'foo'
     item_2 = 'bar'
 }

--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -89,7 +89,7 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
-            Neos.Fusion:Array {
+            Neos.Fusion:Join {
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -111,7 +111,7 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = 'Foo<h1></h1>Bar<p></p>Baz';
         $expectedFusion = <<<'EOF'
-            Neos.Fusion:Array {
+            Neos.Fusion:Join {
                 item_1 = 'Foo'
                 item_2 = Neos.Fusion:Tag {
                     tagName = 'h1'
@@ -133,7 +133,7 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = '  <h1></h1><p></p>  ';
         $expectedFusion = <<<'EOF'
-            Neos.Fusion:Array {
+            Neos.Fusion:Join {
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -152,7 +152,7 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
-            Neos.Fusion:Array {
+            Neos.Fusion:Join {
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -478,7 +478,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -511,7 +511,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -535,7 +535,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     key_one = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -559,7 +559,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = 'a string'
                     item_2 = Neos.Fusion:Tag {
                         tagName = 'strong'
@@ -624,7 +624,7 @@ EOF;
                 propTwo = Vendor.Site:Prototype {
                     content = 'bar'
                 }
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'div'
                         content = 'a tag'
@@ -673,7 +673,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = ${eelExpression1}
                     item_2 = ${eelExpression2}
                     item_3 = ${eelExpression3}
@@ -695,7 +695,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = ${eelExpression1}
                     item_2 = ' '
                     item_3 = ${eelExpression2}
@@ -717,7 +717,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = 'String '
                     item_2 = ${eelExpression}
                     item_3 = ' String'
@@ -754,7 +754,7 @@ EOF;
                 stringBefore = 'string'
                 expressionBefore = ${expression}
                 @apply.spread_1 = ${spreadExpression}
-                @apply.spread_2 = Neos.Fusion:RawArray {
+                @apply.spread_2 = Neos.Fusion:DataStructure {
                     stringAfter = 'string'
                     expressionAfter = ${expression}
                 }
@@ -795,7 +795,7 @@ EOF;
                 attributes.stringBefore = 'string'
                 attributes.expressionBefore = ${expression}
                 attributes.@apply.spread_1 = ${spreadExpression}
-                attributes.@apply.spread_2 = Neos.Fusion:RawArray {
+                attributes.@apply.spread_2 = Neos.Fusion:DataStructure {
                     stringAfter = 'string'
                     expressionAfter = ${expression}
                 }
@@ -852,7 +852,7 @@ EOF;
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Tag {
                 tagName = 'h1'
-                content = Neos.Fusion:Array {
+                content = Neos.Fusion:Join {
                     item_1 = 'Example'
                     item_2 = 'Content'
                 }


### PR DESCRIPTION
Neos.Fusion:Array and Neos.Fusion:RawArray are deprected for a while now but are still used in AFX. This change makes afx use:

- Neos.Fusion:Join instead of Neos.Fusion:Array
- Neos.Fusion:DataStructure instead of Neos.Fusion:RawArray

Resolves: #3558