### PR TITLE
BUGFIX: Skip constraints of abstract nodetypes in schema generation

### DIFF
--- a/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
+++ b/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
@@ -118,6 +118,9 @@ class NodeTypeSchemaBuilder
         $nodeTypes = $this->nodeTypeManager->getNodeTypes(true);
         /** @var NodeType $nodeType */
         foreach ($nodeTypes as $nodeTypeName => $nodeType) {
+            if ($nodeType->isAbstract()) {
+                continue;
+            }
             $constraints[$nodeTypeName] = [
                 'nodeTypes' => [],
                 'childNodes' => []


### PR DESCRIPTION
**What I did**

Don't generate constraints for mixin nodetypes as those are never queried by the ui.
Previously each abstract nodetype without defined constraints had every other nodetype set as constraint with a value of true.
Therefore it would have even allowed any other nodetype as child.

This change can reduce the size of the nodetype schema quite a lot. In a large project with ~900 types the size of the schema was reduced from 18mb to 12mb. The generation of the schema got twice as fast from 15s to 8s.

This change shouldn't cause any problem as the ui uses the non abstract nodetypes and their constraints are already the combination of their own constraints and inherited constraints from their supertypes.

Resolves: #1098 

**How I did it**

The `NodeTypeSchemaBuilder` already skips generating the configuration for abstract types. This patch also skips the generation of the constraint list for abstract nodetypes.

**How to verify it**

1. Open a page in the Neos backend and inspect the result of the `neos/schema/node-type?version=xyz` request.
2. Check that the constraints in the resulting JSON object don't contain any abstract nodetypes.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
