### PR TITLE
BUGFIX: Use old account user extraction behavior

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -896,10 +896,17 @@ class UserService
     /**
      * @param Account $account
      * @return User|null
+     * @throws Exception
      */
     private function getNeosUserForAccount(Account $account):? User
     {
         $user = $this->partyService->getAssignedPartyOfAccount($account);
+        if ($user === null) {
+            $user = $this->getUser(
+                $account->getAccountIdentifier(),
+                $account->getAuthenticationProviderName()
+            );
+        }
         return ($user instanceof User) ? $user : null;
     }
 }


### PR DESCRIPTION
Since Neos 7.2.1 it happens that the user could not be extracted from the current authenticated token when you authenticate with the Azure SSO for instance.

The account could be fetched from the authenticated token, but it is not possible to get the matching user. As fallback, this patch adds the old behavior. So, when the account is authenticated and the related user could not be found, we just use the old getUser method.

fixes: #3566