### PR TITLE
BUGFIX: #3513 #3441 meta keys "sparse" DataStructure

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -38,7 +38,8 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
             $propertyPath = $key;
-            if ($this->isUntypedProperty($this->properties[$key])) {
+            if ($this->fusionObjectName === 'Neos.Fusion:DataStructure'
+                && $this->isUntypedProperty($this->properties[$key])) {
                 $propertyPath .= '<Neos.Fusion:DataStructure>';
             }
             try {

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -86,7 +86,7 @@ class DataStructureImplementation extends AbstractArrayFusionObject
     }
 
     /**
-     * Returns TRUE if the given property has no object type assigned
+     * Returns TRUE if the given property has no object type value or eel assigned, and was not unset.
      *
      * @param mixed $property
      * @return bool
@@ -96,6 +96,10 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         if (!is_array($property)) {
             return false;
         }
-        return array_intersect_key(array_flip(Parser::$reservedParseTreeKeys), $property) === [];
+
+        $keysToIdentifyTypedProperty = array_flip(Parser::$reservedParseTreeKeys);
+        unset($keysToIdentifyTypedProperty['__meta']);
+
+        return array_intersect_key($keysToIdentifyTypedProperty, $property) === [];
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Flow\ObjectManagement\Proxy\Compiler;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Runtime;
 use Neos\Utility\Exception\InvalidPositionException;
@@ -38,7 +39,7 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
             $propertyPath = $key;
-            if ($this->fusionObjectName === 'Neos.Fusion:DataStructure'
+            if ($this->isImplementationDataStructureImplementation()
                 && $this->isUntypedProperty($this->properties[$key])) {
                 $propertyPath .= '<Neos.Fusion:DataStructure>';
             }
@@ -102,5 +103,16 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         unset($keysToIdentifyTypedProperty['__meta']);
 
         return array_intersect_key($keysToIdentifyTypedProperty, $property) === [];
+    }
+
+    /**
+     * Checks if the current instance (static) is really this very class (ignore proxy building)
+     * (fx. returns false, when this class was further inherited.)
+     *
+     */
+    private function isImplementationDataStructureImplementation(): bool
+    {
+        $classNameOfUnproxiedDataStructureImplementation = preg_replace('/' . Compiler::ORIGINAL_CLASSNAME_SUFFIX .  '$/', '', self::class);
+        return $classNameOfUnproxiedDataStructureImplementation === static::class;
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -95,4 +95,54 @@ class DataStructureTest extends AbstractFusionObjectTest
 
         $view->render();
     }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionIf(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithIf');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionProcess(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithProcess');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123, 0 => 'baz']], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionEelThisContext(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithThisContext');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123, 'thisFoo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionPositionSorting(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithPositionOrdering');
+        self::assertEquals(['keyWithoutTypeLast' => ['baz' => 456], 'keyWithoutTypeFirst' => ['foo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function unsetUntypedChildKeysWontRenderAsDataStructure(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/unsetUntypedChildKeysWontRenderAsDataStructure');
+        self::assertEquals(['buz' => 456], $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -107,3 +107,49 @@ dataStructure.nestingWithNonExistingChildObject = Neos.Fusion:DataStructure {
   }
   errorProperty = Some.NonExisting:Prototype
 }
+
+dataStructure.untypedChildKeysWithIf = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    @if.display = true
+    foo = 123
+  }
+  keyWithoutType2 {
+    @if.display = false
+    baz = 456
+  }
+}
+
+dataStructure.untypedChildKeysWithProcess = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    foo = 123
+    @process.addKey = ${Array.push(value, 'baz')}
+  }
+}
+
+dataStructure.untypedChildKeysWithThisContext = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    foo = 123
+    thisFoo = ${this.foo}
+  }
+}
+
+dataStructure.untypedChildKeysWithPositionOrdering = Neos.Fusion:DataStructure {
+  keyWithoutTypeFirst {
+    foo = 123
+  }
+  keyWithoutTypeLast {
+    @postion = 'before keyWithoutTypeFirst'
+    baz = 456
+  }
+}
+
+dataStructure.unsetUntypedChildKeysWontRenderAsDataStructure = Neos.Fusion:DataStructure {
+  keyWithUnsetType = Neos.Fusion:Value {
+    value = 123
+  }
+  keyWithUnsetType >
+  keyWithUnsetType {
+    bat = 123
+  }
+  buz = 456
+}

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -14,6 +14,7 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\DataStructureImplementation;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for the Fusion Concat object
@@ -21,14 +22,24 @@ use Neos\Fusion\FusionObjects\DataStructureImplementation;
 class DataStructureImplementationTest extends UnitTestCase
 {
     /**
+     * @var Runtime|MockObject
+     */
+    private $mockRuntime;
+
+
+    public function setUp(): void
+    {
+        $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
      * @test
      */
-    public function evaluateWithEmptyArrayRendersEmptyArray()
+    public function evaluateWithEmptyArrayRendersEmptyArray(): void
     {
-        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $path = 'array/test';
+        $path = 'datastructure/test';
         $fusionObjectName = 'Neos.Fusion:DataStructure';
-        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        $renderer = new DataStructureImplementation($this->mockRuntime, $path, $fusionObjectName);
         $result = $renderer->evaluate();
         self::assertSame($result, []);
     }
@@ -36,73 +47,64 @@ class DataStructureImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElements()
+    public function positionalSubElements(): array
     {
+        $ds = '<Neos.Fusion:DataStructure>';
         return [
             [
                 'Position end should put element to end',
-                ['second' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
-                ['/first', '/second']
+                ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Position start should put element to start',
-                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'start']]],
-                ['/first', '/second']
+                ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Position start should respect priority',
                 ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
-                ['/first', '/second']
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Position end should respect priority',
                 ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
-                ['/first', '/second']
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Positional numbers are in the middle',
                 ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
-                ['/first', '/second', '/third', '/last']
+                ["/first$ds", "/second$ds", "/third$ds", "/last$ds"]
             ],
             [
                 'Position before adds before named element if present',
-                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'before second']]],
-                ['/first', '/second']
-            ],
-            [
-                'Position before adds after start if named element not present',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
-                ['/first', '/second', '/third']
+                ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
-                ['/first', '/second', '/third']
+                ['third' => [], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
+                ["/first$ds", "/second$ds", "/third$ds"]
             ],
             [
                 'Position before works recursively',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
-                ['/first', '/second', '/third']
+                ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+                ["/first$ds", "/second$ds", "/third$ds"]
             ],
             [
                 'Position after adds after named element if present',
-                ['second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
-                ['/first', '/second']
-            ],
-            [
-                'Position after adds before end if named element not present',
-                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
-                ['/first', '/second', '/third']
+                ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ["/first$ds", "/second$ds"]
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
-                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => ['__meta' => []]],
-                ['/first', '/second', '/third']
+                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
+                ["/first$ds", "/second$ds", "/third$ds"]
             ],
             [
                 'Position after works recursively',
-                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
-                ['/first', '/second', '/third']
+                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+                ["/first$ds", "/second$ds", "/third$ds"]
             ]
         ];
     }
@@ -110,22 +112,15 @@ class DataStructureImplementationTest extends UnitTestCase
     /**
      * @test
      * @dataProvider positionalSubElements
-     *
-     * @param string $message
-     * @param array $subElements
-     * @param array $expectedKeyOrder
      */
-    public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
+    public function evaluateRendersKeysSortedByPositionMetaProperty(string $message, array $subElements, array $expectedKeyOrder): void
     {
-        $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-
-        $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
+        $this->mockRuntime->method('evaluate')->willReturnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;
-        }));
+        });
 
-        $path = '';
         $fusionObjectName = 'Neos.Fusion:DataStructure';
-        $renderer = new DataStructureImplementation($mockRuntime, $path, $fusionObjectName);
+        $renderer = new DataStructureImplementation($this->mockRuntime, '', $fusionObjectName);
         foreach ($subElements as $key => $value) {
             $renderer[$key] = $value;
         }


### PR DESCRIPTION
## This is the minefield PR for the range 5.3 - 7.3 (later stuff is fixed)

current state summed up here: https://github.com/neos/neos-development-collection/pull/3568#issuecomment-1140829355

--------


fixes: #3513
fixes: #3441
fixes: https://github.com/neos/neos-development-collection/pull/3568 #3576 

#### untypedChildKey with meta key is still now an untypedChildKey!

If a meta key was set on an 'untyped' child of a DataStructure, it was counted as typed and such rendered to null.

Btw, ANY meta key would let a key without object, value etc... count as typed. So this wouldnt work until now:

```
root = Neos.Fusion:DataStructure {
    untypedKey {
        renderMe = 'please'
        @somethingAnything = "foo"
    }
}
```

Added tests in relation to untyped child keys of DataStructures

#### Unsetting typedChildKey === untypedChildKey?
currently thats not working, whether this should work could be discussed, but i think it was meant this way?
https://github.com/mhsdesign/neos-development-collection/blob/777d11ff1402e9dd47501bb55c6717b6201dd63d/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion#L146
https://github.com/mhsdesign/neos-development-collection/blob/777d11ff1402e9dd47501bb55c6717b6201dd63d/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php#L142

**Checklist**
- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
