### PR TITLE
TASK: Allow Neos.Fusion:Match to return a default value with a type other than string

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/MatchImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MatchImplementation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Fusion\FusionObjects;
 
 /*
@@ -23,7 +24,7 @@ class MatchImplementation extends AbstractFusionObject
         return (string)($this->fusionValue('__meta/subject') ?? '');
     }
 
-    public function getDefault(): ?string
+    public function getDefault()
     {
         return $this->fusionValue('__meta/default');
     }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Match.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Match.fusion
@@ -1,6 +1,5 @@
-prototype(Neos.Fusion:Match) {
-  @class = 'Neos\\Fusion\\FusionObjects\\MatchImplementation'
-}
+prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
+prototype(Neos.Fusion:Match).@class = 'Neos\\Fusion\\FusionObjects\\MatchImplementation'
 
 match.empty = Neos.Fusion:Match {
   @subject = ''
@@ -26,4 +25,11 @@ match.errorWithoutMatch = Neos.Fusion:Match {
   @subject = 'foo'
   left = 'module--left'
   right = 'module--right'
+}
+
+match.defaultDataStructure = Neos.Fusion:Match {
+  @subject = 'foo'
+  @default = Neos.Fusion:DataStructure {
+    key = 'value'
+  }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
 /*
@@ -59,5 +60,16 @@ class MatchTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->setFusionPath('match/errorWithoutMatch');
         $view->render();
+    }
+
+    /**
+     * @test
+     */
+    public function matchDefaultDataStructure()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('match/defaultDataStructure');
+        $result = $view->render();
+        self::assertEquals(['key' => 'value'], $result);
     }
 }


### PR DESCRIPTION
**What I did**

I removed the return type declaration of the `Neos\Fusion\FusionObjects\MatchImplementation::getDefault()` method. This allows developers to return other types then string when using `Neos.Fusion:Match`. 

**How to verify it**

Create a new fusion value and use a value that is not a string, for example:

```
prototype(Vendor.Prefix:Component) {
  value = Neos.Fusion:Match {
    @subject = ${q(node).property('someProp')}
    valueA = Neos.Fusion:DataStructure {
      key = 'valueA'
    }
    @default = Neos.Fusion:DataStructure {
      key = 'valueB'
    }
  }
}
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) (7.1 in this case, as `Neos.Fusion:Match` does not exist before)
