### PR TITLE
BUGFIX: Persist Thumbnail using DBAL to avoid unique constraint errors

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
@@ -11,14 +11,17 @@ namespace Neos\Media\Domain\Repository;
  * source code.
  */
 
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\QueryBuilder;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Persistence\Repository;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\Thumbnail;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Psr\Log\LoggerInterface;
 
 /**
  * A repository for Thumbnails
@@ -34,6 +37,12 @@ class ThumbnailRepository extends Repository
      * @var EntityManagerInterface
      */
     protected $entityManager;
+
+    /**
+     * @Flow\Inject
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * Iterate over an IterableResult and return a Generator
@@ -123,5 +132,69 @@ class ThumbnailRepository extends Repository
 
         $query->setMaxResults(1);
         return $query->getOneOrNullResult();
+    }
+
+    /**
+     * store via DBAL to avoid errors caused by concurrent creation of thumbnails - see
+     * https://github.com/neos/neos-development-collection/issues/3479#issuecomment-1016375400
+     *
+     * @param Thumbnail $thumbnail
+     * @param ThumbnailConfiguration $configuration
+     * @return Thumbnail|null
+     * @throws DBALException
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     */
+    public function persistThumbnailDirectly(Thumbnail $thumbnail, ThumbnailConfiguration $configuration)
+    {
+        $thumbnailIdentifier = $this->persistenceManager->getIdentifierByObject($thumbnail);
+        $assetIdentifier = $this->persistenceManager->getIdentifierByObject($thumbnail->getOriginalAsset());
+        $thumbnailResource = $thumbnail->getResource();
+
+        $sql = 'INSERT INTO neos_media_domain_model_thumbnail (persistence_object_identifier, originalasset, resource, width, height, configuration, configurationhash, staticresource, quality) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        $params = [
+            $thumbnailIdentifier,
+            $assetIdentifier,
+            null,
+            $thumbnail->getWidth(),
+            $thumbnail->getHeight(),
+            json_encode($configuration->toArray()),
+            $configuration->getHash(),
+            $thumbnail->getStaticResource(),
+            $thumbnail->getQuality(),
+        ];
+
+        $connection = $this->entityManager->getConnection();
+        try {
+            $affectedRows = $connection->prepare($sql)->executeStatement($params);
+            if ($affectedRows === 0) {
+                $this->logger->error('Could not persist thumbnail', LogEnvironment::fromMethodName(__METHOD__));
+            }
+        } catch (DBALException\UniqueConstraintViolationException $e) {
+            // ignore, the thumbnail has been generated already; re-fetch
+            $this->logger->debug('Persisting thumbnail caused a UniqueConstraintViolationException, ignoring: ' . $e->getMessage(), LogEnvironment::fromMethodName(__METHOD__));
+        } catch (DBALException\ForeignKeyConstraintViolationException $e) {
+            // TODO
+            // why do we end up here, this method is called only if !$this->persistenceManager->isNewObject($asset)
+            // but actually that check doesn't even seem to make a difference…
+            $this->logger->debug('Persisting thumbnail caused a ForeignKeyConstraintViolationException, ignoring: ' . $e->getMessage(), LogEnvironment::fromMethodName(__METHOD__));
+            // ignore, the asset has not been persisted yet, rely on "cascade" persistence later
+            return $thumbnail;
+        }
+
+        // fetch via ORM to make it known to UoW
+        $thumbnail = $this->findOneByAssetAndThumbnailConfiguration($thumbnail->getOriginalAsset(), $configuration);
+
+        // set resource if available and missing on the thumbnail
+        if ($thumbnailResource !== null && $thumbnail->getResource() === null) {
+            $this->logger->error('Set resource on re-fetched thumbnail', LogEnvironment::fromMethodName(__METHOD__));
+            $thumbnail->setResource($thumbnailResource);
+            $this->update($thumbnail);
+            // Allow thumbnails to be persisted even if this is a "safe" HTTP request:
+            $this->persistenceManager->allowObject($thumbnail);
+        }
+
+        return $thumbnail;
     }
 }

--- a/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
@@ -188,7 +188,7 @@ class ThumbnailRepository extends Repository
 
         // set resource if available and missing on the thumbnail
         if ($thumbnailResource !== null && $thumbnail->getResource() === null) {
-            $this->logger->error('Set resource on re-fetched thumbnail', LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger->debug('Set resource on re-fetched thumbnail', LogEnvironment::fromMethodName(__METHOD__));
             $thumbnail->setResource($thumbnailResource);
             $this->update($thumbnail);
             // Allow thumbnails to be persisted even if this is a "safe" HTTP request:

--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -142,17 +142,16 @@ class ThumbnailService
 
             // If the thumbnail strategy failed to generate a valid thumbnail
             if ($async === false && $thumbnail->getResource() === null && $thumbnail->getStaticResource() === null) {
+                // the thumbnail should not be persisted at this point, but remove is a no-op if the thumbnail
+                // does not exist - and if it does, this keeps it out of the way…
                 $this->thumbnailRepository->remove($thumbnail);
                 return null;
             }
 
             if (!$this->persistenceManager->isNewObject($asset)) {
-                $this->thumbnailRepository->add($thumbnail);
+                $thumbnail = $this->thumbnailRepository->persistThumbnailDirectly($thumbnail, $configuration);
             }
             $asset->addThumbnail($thumbnail);
-
-            // Allow thumbnails to be persisted even if this is a "safe" HTTP request:
-            $this->persistenceManager->allowObject($thumbnail);
             $this->thumbnailCache[$assetIdentifier][$configurationHash] = $thumbnail;
         } elseif ($async === false && $thumbnail->getResource() === null) {
             $this->refreshThumbnail($thumbnail);


### PR DESCRIPTION
This uses a direct SQL INSERT via DBAL to store Thumbnails. Doing this
avoid unique constraint exceptions that otherwise occur when multiple
concurrent requests trigger Thumbnail creation.

Fixes #3479
