### PR TITLE
BUGFIX: backend message partials not found

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Error/NeosBackendMessage.html
+++ b/Neos.Neos/Resources/Private/Templates/Error/NeosBackendMessage.html
@@ -3,19 +3,11 @@
 <f:section name="head">
 	<title>Neos Error</title>
 	<link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Error.css', package: 'Neos.Neos')}" />
-	<f:if condition="{isBackend}">
-		<f:render partial="NeosBackendHeaderData" arguments="{_all}" />
-		<f:render partial="NeosBackendEndpoints" arguments="{_all}" />
-	</f:if>
 </f:section>
 
 <f:section name="body">
 	<body class="neos">
 		<f:if condition="{isBackend}">{metaData -> f:format.raw()}</f:if>
 		<div class="neos-error-screen">{message -> f:format.raw()}</div>
-		<f:if condition="{isBackend}">
-			<f:render partial="NeosBackendContainer" arguments="{_all}" />
-			<f:render partial="NeosBackendFooterData" arguments="{_all}" />
-		</f:if>
 	</body>
 </f:section>


### PR DESCRIPTION
**What I did**

Fix error the circumstances leading to:

```
The partial files "resource://Neos.Neos/Private/Templates/FusionObjects/NeosBackendHeaderData.html", "resource://Neos.Neos/Private/Templates/FusionObjects/NeosBackendHeaderData" could not be loaded.
```

This error message is hiding the actual error message I need to see.

**How I did it**

Remove usage of partials that had been deleted already in 2019 in 86088dc 

**How to verify it**

Go to various page in backend with a certain content Node Type on it. Go to this Node Type's yaml and change its Name from, e.g. `Vendor.Site:Box` to `Vendor.Site:Boxers`. Reload the backend and find the partial error above occur. After applying this bugfix, you'll find the real error message, `An exception was thrown while Neos tried to render your page`

**Checklist**

- [x] Code follows the PSR-2 coding style (irrelevant)
- [x] Tests have been created, run and adjusted as needed (irrelevant)
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

fixes: #2757