### PR TITLE
Allow asset variant editing in secondary inspector editor for external asset sources

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -413,7 +413,7 @@ class AssetController extends ActionController
             // The variantsAction fetches the variants the same way, so having an originalAsset that is an instance of VariantSupportInterface should be sufficient
             if ($assetProxy->getLocalAssetIdentifier() !== null) {
                 $asset = $this->persistenceManager->getObjectByIdentifier($assetProxy->getLocalAssetIdentifier(), Asset::class);
-                            /** @var VariantSupportInterface $originalAsset */
+                /** @var VariantSupportInterface $originalAsset */
                 $originalAsset = ($asset instanceof AssetVariantInterface ? $asset->getOriginalAsset() : $asset);
             }
 

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -410,6 +410,12 @@ class AssetController extends ActionController
                     }
                 }
             }
+            // The variantsAction fetches the variants the same way, so having an originalAsset that is an instance of VariantSupportInterface should be sufficient
+            if ($assetProxy->getLocalAssetIdentifier() !== null) {
+                $asset = $this->persistenceManager->getObjectByIdentifier($assetProxy->getLocalAssetIdentifier(), Asset::class);
+                            /** @var VariantSupportInterface $originalAsset */
+                $originalAsset = ($asset instanceof AssetVariantInterface ? $asset->getOriginalAsset() : $asset);
+            }
 
             $this->view->assignMultiple([
                 'tags' => $tags,
@@ -417,7 +423,7 @@ class AssetController extends ActionController
                 'assetCollections' => $this->assetCollectionRepository->findAll(),
                 'contentPreview' => $contentPreview,
                 'assetSource' => $assetSource,
-                'canShowVariants' => ($assetProxy instanceof NeosAssetProxy) && ($assetProxy->getAsset() instanceof VariantSupportInterface)
+                'canShowVariants' => isset($originalAsset) && ($originalAsset instanceof VariantSupportInterface)
             ]);
         } catch (AssetNotFoundExceptionInterface | AssetSourceConnectionExceptionInterface $e) {
             $this->view->assign('connectionError', $e);


### PR DESCRIPTION
With this fix it is possible to edit image variants from the secondary inspector editor. This was already implemented for the neos asset source only and is now extended to external asset sources.
The fix confirms the existence of image variants the same way the variant editor receives the data, so there should be no discrepancy between the availability of the image variant editor and the usage of it.

**How to verify it**
For manual testing you need an external asset source and image variants configured. Without the fix, you can't edit the image variants from the secondary editor, with it, you can.
