### PR TITLE
Make adjustments to support PHP8.1's stricter type system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1']
         dependencies: ['highest']
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
         dependencies: ['highest']
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']

--- a/Neos.ContentRepository/Classes/Domain/ContentSubgraph/NodePath.php
+++ b/Neos.ContentRepository/Classes/Domain/ContentSubgraph/NodePath.php
@@ -103,7 +103,7 @@ final class NodePath implements \JsonSerializable
         return (string) $this === (string) $other;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->path;
     }

--- a/Neos.ContentRepository/Classes/Domain/NodeAggregate/NodeAggregateIdentifier.php
+++ b/Neos.ContentRepository/Classes/Domain/NodeAggregate/NodeAggregateIdentifier.php
@@ -76,7 +76,7 @@ final class NodeAggregateIdentifier implements \JsonSerializable, CacheAwareInte
     /**
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->value;
     }

--- a/Neos.ContentRepository/Classes/Domain/NodeType/NodeTypeName.php
+++ b/Neos.ContentRepository/Classes/Domain/NodeType/NodeTypeName.php
@@ -54,7 +54,7 @@ final class NodeTypeName implements \JsonSerializable
         return $this->value === $other->getValue();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->value;
     }

--- a/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
@@ -184,7 +184,7 @@ class NodeTypeManager
      */
     protected function loadNodeTypes()
     {
-        $this->fullNodeTypeConfigurations = $this->fullConfigurationCache->get('fullNodeTypeConfigurations');
+        $this->fullNodeTypeConfigurations = $this->fullConfigurationCache->get('fullNodeTypeConfigurations') ?: null;
         $fillFullConfigurationCache = !is_array($this->fullNodeTypeConfigurations);
 
         $completeNodeTypeConfiguration = $this->configurationManager->getConfiguration('NodeTypes');

--- a/Neos.Diff/Classes/SequenceMatcher.php
+++ b/Neos.Diff/Classes/SequenceMatcher.php
@@ -80,7 +80,7 @@ class SequenceMatcher
      * @param string|array $b A string or array containing the lines to compare.
      * @param string|array $junkCallback Either an array or string that references a callback function (if there is one) to determine 'junk' characters.
      */
-    public function __construct($a, $b, $junkCallback = null, $options)
+    public function __construct($a, $b, $junkCallback = null, $options = [])
     {
         $this->a = null;
         $this->b = null;

--- a/Neos.Neos/Classes/Domain/Service/SiteExportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteExportService.php
@@ -88,7 +88,7 @@ class SiteExportService
      * @return void
      * @throws NeosException
      */
-    public function exportToPackage(array $sites, $tidy = false, $packageKey, $nodeTypeFilter = null)
+    public function exportToPackage(array $sites, $tidy, $packageKey, $nodeTypeFilter = null)
     {
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
             throw new NeosException(sprintf('Error: Package "%s" is not active.', $packageKey), 1404375719);
@@ -116,7 +116,7 @@ class SiteExportService
      * @param string $nodeTypeFilter Filter the node type of the nodes, allows complex expressions (e.g. "Neos.Neos:Page", "!Neos.Neos:Page,Neos.Neos:Text")
      * @return void
      */
-    public function exportToFile(array $sites, $tidy = false, $pathAndFilename, $nodeTypeFilter = null)
+    public function exportToFile(array $sites, $tidy, $pathAndFilename, $nodeTypeFilter = null)
     {
         $this->resourcesPath = Files::concatenatePaths([dirname($pathAndFilename), 'Resources']);
         Files::createDirectoryRecursively($this->resourcesPath);

--- a/Neos.Neos/Classes/ViewHelpers/Backend/IfModuleAccessibleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/IfModuleAccessibleViewHelper.php
@@ -63,7 +63,7 @@ class IfModuleAccessibleViewHelper extends AbstractConditionViewHelper
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         if (!$renderingContext instanceof RenderingContext) {
             return false;


### PR DESCRIPTION
This adds additional type hints where required in PHP 8.1 ~while maintaining support for 7.4~.
These are only the adjustments required fir the ESCR test suite, more are to follow