### PR TITLE
BUGFIX: Check for the native PHP extension instead of the ImagineService, since ImageService is not used further in this generator.

### DIFF
--- a/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
+++ b/Neos.Media/Classes/Domain/Model/ThumbnailGenerator/DocumentThumbnailGenerator.php
@@ -37,7 +37,7 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
         return (
             $thumbnail->getOriginalAsset() instanceof Document &&
             $this->isExtensionSupported($thumbnail) &&
-            $this->imagineService instanceof \Imagine\Imagick\Imagine
+            extension_loaded('imagick')
         );
     }
 
@@ -64,7 +64,7 @@ class DocumentThumbnailGenerator extends AbstractThumbnailGenerator
             $im->setImageFormat('png');
             $im->setImageBackgroundColor('white');
             $im->setImageCompose(\Imagick::COMPOSITE_OVER);
-            
+
             if (method_exists($im, 'mergeImageLayers')) {
                 // Replace flattenImages in imagick 3.3.0
                 // @see https://pecl.php.net/package/imagick/3.3.0RC2


### PR DESCRIPTION
Since there is no use of the ImagineService within the DocumentThumbnailGenerator, the availability of the native PHP extension for Imagick should be checked instead. This allows the use of the DocumentThumbnailGenerator with Imagick and the use of other Imagine based thumbnail generators using GDlib, for example.
