### PR TITLE
TASK: Address PHP 8 deprecation warnings

### DIFF
--- a/Neos.Diff/Classes/SequenceMatcher.php
+++ b/Neos.Diff/Classes/SequenceMatcher.php
@@ -79,8 +79,9 @@ class SequenceMatcher
      * @param string|array $a A string or array containing the lines to compare against.
      * @param string|array $b A string or array containing the lines to compare.
      * @param string|array $junkCallback Either an array or string that references a callback function (if there is one) to determine 'junk' characters.
+     * @param array $options An array of options for the matcher.
      */
-    public function __construct($a, $b, $junkCallback = null, $options)
+    public function __construct($a, $b, $junkCallback = null, array $options = [])
     {
         $this->a = null;
         $this->b = null;

--- a/Neos.Neos/Classes/Domain/Service/SiteExportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteExportService.php
@@ -88,7 +88,7 @@ class SiteExportService
      * @return void
      * @throws NeosException
      */
-    public function exportToPackage(array $sites, $tidy = false, $packageKey, $nodeTypeFilter = null)
+    public function exportToPackage(array $sites, $tidy, $packageKey, $nodeTypeFilter = null)
     {
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
             throw new NeosException(sprintf('Error: Package "%s" is not active.', $packageKey), 1404375719);
@@ -116,7 +116,7 @@ class SiteExportService
      * @param string $nodeTypeFilter Filter the node type of the nodes, allows complex expressions (e.g. "Neos.Neos:Page", "!Neos.Neos:Page,Neos.Neos:Text")
      * @return void
      */
-    public function exportToFile(array $sites, $tidy = false, $pathAndFilename, $nodeTypeFilter = null)
+    public function exportToFile(array $sites, $tidy, $pathAndFilename, $nodeTypeFilter = null)
     {
         $this->resourcesPath = Files::concatenatePaths([dirname($pathAndFilename), 'Resources']);
         Files::createDirectoryRecursively($this->resourcesPath);

--- a/Neos.Neos/Classes/ViewHelpers/Backend/IfModuleAccessibleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/IfModuleAccessibleViewHelper.php
@@ -59,11 +59,11 @@ class IfModuleAccessibleViewHelper extends AbstractConditionViewHelper
     }
 
     /**
-     * @param array|null $arguments
+     * @param array $arguments
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         if (!$renderingContext instanceof RenderingContext) {
             return false;


### PR DESCRIPTION
This fixes the following deprecation warnings by removing optional arguments that were placed before non optional ones.
While this changes the api it should not break any code as the optional arguments could not be used that way anyways.

```
PHP Deprecated:  Optional parameter $junkCallback declared before required parameter $options is implicitly treated as a required parameter in /var/www/html/Packages/Neos/Neos.Diff/Classes/SequenceMatcher.php on line 83
PHP Deprecated:  Optional parameter $arguments declared before required parameter $renderingContext is implicitly treated as a required parameter in /var/www/html/Packages/Neos/Neos.Neos/Classes/ViewHelpers/Backend/IfModuleAccessibleViewHelper.php on line 66
PHP Deprecated:  Optional parameter $tidy declared before required parameter $packageKey is implicitly treated as a required parameter in /var/www/html/Packages/Neos/Neos.Neos/Classes/Domain/Service/SiteExportService.php on line 91
PHP Deprecated:  Optional parameter $tidy declared before required parameter $pathAndFilename is implicitly treated as a required parameter in /var/www/html/Packages/Neos/Neos.Neos/Classes/Domain/Service/SiteExportService.php on line 119
```

This change targets Neos 7.0 as this is the lowest version that allows php 8. No class or method that is @api is changed. When used the changes are non breaking and the modified classes are unlikely to be extended.

Resolves: #3619 