### PR TITLE
BUGFIX: Allow adding first asset collection again

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -168,15 +168,15 @@
                 </div>
                 <div class="neos-modal-backdrop neos-in"></div>
             </div>
-            <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+          </f:if>
+        </f:if>
+        <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
             <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
                 <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
                 <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
                 <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
             </f:form>
-            </f:security.ifAccess>
-            </f:if>
-        </f:if>
+        </f:security.ifAccess>
     </div>
 
     <div class="neos-media-aside-group">


### PR DESCRIPTION
**What I did**

This fix resolves a regression in 0143d67d8bdfa4458fd9bfb02f3ce6d82d1b400f (https://github.com/neos/neos-development-collection/pull/3481)
which prevents adding an asset collection if there was none before
as the form was not rendered.

**How I did it**

Move collection creation form outside of condition which checks for the existence of any least one collection.

**How to verify it**

Try to add a new collection inside the media module in a fresh Neos without any collections

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
