### PR TITLE
Remove @deprecated error renderingGroups options.

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -478,15 +478,18 @@ Neos:
               - 410
             options:
               viewClassName: \Neos\Neos\View\FusionExceptionView
+              viewOptions:
+                templatePathAndFilename: ~
           databaseConnectionExceptions:
             matchingExceptionClassNames:
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseException
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseConnectionException
               - Neos\Flow\Persistence\Doctrine\Exception\DatabaseStructureException
             options: &welcomeTemplate
-              templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Welcome.html'
-              layoutRootPath: 'resource://Neos.Neos/Private/Layouts/'
-              format: html
+              viewClassName: Neos\FluidAdaptor\View\StandaloneView
+              viewOptions:
+                templatePathAndFilename: 'resource://Neos.Neos/Private/Templates/Error/Welcome.html'
+                layoutRootPaths: ['resource://Neos.Neos/Private/Layouts/']
           noHomepageException:
             matchingExceptionClassNames:
               - Neos\Neos\Routing\Exception\NoHomepageException


### PR DESCRIPTION
resolves: #3644
bound to: https://github.com/neos/flow-development-collection/pull/2743

Concerning:
`Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options`

`templatePathAndFilename`, `layoutRootPath`, and `format` are legacy and should be removed: https://github.com/neos/flow-development-collection/issues/2742

migrate them to the `viewOptions`.

the difficulty is that 'Neos.Flow' will also define for the 'renderingGroups' `notFoundExceptions` and `databaseConnectionExceptions`  view specific 'viewOptions' that will be merged with the 'Neos.Neos' config and
thus an error will occur if another view is used and doesnt support a merged option - e.g. for the `notFoundExceptions` 'Neos.Neos' swaps the viewClassName to 'FusionExceptionView' which does not support the option 'tem
platePathAndFilename' which will be set by 'Neos.Flow' to make the Fluid view happy.

Those fluid viewOptions set by flow will be reset like: `templatePathAndFilename: ~`


### How to test:

wait for https://github.com/neos/flow-development-collection/pull/2743

throw some of these at your favorite places and marvel at the great exceptions:

```php
throw new DatabaseException();
throw new NoHomepageException();
throw new NodeNotFoundException();

```