### PR TITLE
!!! FEATURE: Remove legacy cache tag support

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -162,10 +162,6 @@ class ContentCacheFlusher
             $this->registerChangeOnNodeIdentifier($workspaceHash .'_'. $nodeIdentifier);
             $this->registerChangeOnNodeType($node->getNodeType()->getName(), $nodeIdentifier, $workspaceHash);
 
-            // Still register legacy cache configuration tags
-            $this->registerChangeOnNodeIdentifier($nodeIdentifier);
-            $this->registerChangeOnNodeType($node->getNodeType()->getName(), $nodeIdentifier, '');
-
             $nodeInWorkspace = $node;
             while ($nodeInWorkspace->getDepth() > 1) {
                 $nodeInWorkspace = $nodeInWorkspace->getParent();
@@ -175,9 +171,6 @@ class ContentCacheFlusher
                 }
                 $tagName = 'DescendantOf_' . $workspaceHash . '_' . $nodeInWorkspace->getIdentifier();
                 $this->addTagToFlush($tagName, sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $node->getPath()));
-
-                $legacyTagName = 'DescendantOf_' . $nodeInWorkspace->getIdentifier();
-                $this->addTagToFlush($legacyTagName, sprintf('which were tagged with legacy "%s" because node "%s" has changed.', $legacyTagName, $node->getPath()));
             }
         }
     }

--- a/Neos.Neos/Migrations/Code/Version20220318111600.php
+++ b/Neos.Neos/Migrations/Code/Version20220318111600.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Replace legacy content cache tag definitions in Fusion
+ *
+ * - Replace legacy NodeType tags with the corresponding eel helper call and the current node as context
+ * - Replace legacy DescendantOf tags with the corresponding eel helper call
+ * - Replace legacy Node tags with the corresponding eel helper call
+ */
+class Version20220318111600 extends AbstractMigration
+{
+
+    public function getIdentifier(): string
+    {
+        return 'Neos.Neos-20220318111600';
+    }
+
+    public function up(): void
+    {
+        $this->searchAndReplaceRegex('/(.*) = \$?\{?\'NodeType_(.*)\'\}?/', "$1 = \${Neos.Caching.nodeTypeTag('$2', node)}", ['fusion']);
+        $this->searchAndReplaceRegex('/(.*) = \$\{\'Node_\' \+ (.*)\.identifier\}/', "$1 = \${Neos.Caching.nodeTag($2)}", ['fusion']);
+        $this->searchAndReplaceRegex('/(.*) = \$\{\'DescendantOf_\' \+ (.*)\.identifier\}/', "$1 = \${Neos.Caching.descendantOfTag($2)}", ['fusion']);
+    }
+}

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -193,10 +193,6 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
         $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
 
-        // Check for legacy tags wich are still supported
-        self::assertArrayHasKey('Node_'.$nodeIdentifier, $tagsToFlush);
-        self::assertArrayHasKey('DescendantOf_'.$nodeIdentifier, $tagsToFlush);
-
         foreach ($workspacesToTest as $name => $workspaceHash) {
             self::assertArrayHasKey('Node_'.$workspaceHash.'_'.$nodeIdentifier, $tagsToFlush, 'on workspace ' . $name);
             self::assertArrayHasKey('DescendantOf_'.$workspaceHash.'_'.$nodeIdentifier, $tagsToFlush, 'on workspace ' . $name);
@@ -229,11 +225,6 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $workspacesToTest = [];
         $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
         $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
-
-        // Check for legacy tags wich are still supported
-        self::assertArrayHasKey('NodeType_Neos.Neos:Content', $tagsToFlush);
-        self::assertArrayHasKey('NodeType_Neos.Neos:Node', $tagsToFlush);
-        self::assertArrayHasKey('NodeType_Acme.Demo:Text', $tagsToFlush);
 
         // Check for tags that respect the workspace hash
         foreach ($workspacesToTest as $name => $workspaceHash) {
@@ -269,11 +260,6 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $workspacesToTest = [];
         $workspacesToTest[$liveWorkspace->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($liveWorkspace->getName());
         $workspacesToTest[$workspaceFirstLevel->getName()] = $cachingHelper->renderWorkspaceTagForContextNode($workspaceFirstLevel->getName());
-
-        // Check for legacy tags wich are still supported
-        self::assertArrayHasKey('DescendantOf_c381f64d-4269-429a-9c21-6d846115addd', $tagsToFlush);
-        self::assertArrayHasKey('DescendantOf_c381f64d-4269-429a-9c21-6d846115adde', $tagsToFlush);
-        self::assertArrayHasKey('DescendantOf_c381f64d-4269-429a-9c21-6d846115addf', $tagsToFlush);
 
         foreach ($workspacesToTest as $name => $workspaceHash) {
             self::assertArrayHasKey('DescendantOf_'.$workspaceHash.'_c381f64d-4269-429a-9c21-6d846115addd', $tagsToFlush, 'on workspace ' . $name);

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -31,8 +31,8 @@ class ContentCacheFlusherTest extends UnitTestCase
         $contentCacheFlusher->expects(self::never())->method('resolveWorkspaceChain');
 
         // Assume 2 calls as we still register all legacy tags as well
-        $contentCacheFlusher->expects($this->exactly(2))->method('registerChangeOnNodeIdentifier');
-        $contentCacheFlusher->expects($this->exactly(2))->method('registerChangeOnNodeType');
+        $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeIdentifier');
+        $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeType');
 
         $this->inject($contentCacheFlusher, 'workspacesToFlush', ['live' => ['some-hash']]);
 

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -30,7 +30,6 @@ class ContentCacheFlusherTest extends UnitTestCase
         $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
         $contentCacheFlusher->expects(self::never())->method('resolveWorkspaceChain');
 
-        // Assume 2 calls as we still register all legacy tags as well
         $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeIdentifier');
         $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeType');
 


### PR DESCRIPTION
**What I did**

In Neos 4.1 new Eel helpers were introduced to generate content cache tags in Fusion. Those make sure that the cache tags provided by the integrator are valid. 
Until Neos 4.0 they needed to be written manually as string which was error prone. 

But to support old cache tags that were lacking the workspace context the `ContentCacheFlusher` still cleared them.
This change removes that support. So this is breaking and projects need to be adjusted when upgrading and still using those old cache tags.

The advantage of removing them is that the number of cache tags to be flushed during publishing is lower. TODO: Add number.

This change requires #3631 to be merged first.

**How I did it**

Removed the legacy cache tag generation.

The change also include a new code migration version `20220318111600` to replace the most commonly used legacy cache tags with matching eel helper calls:

```
node = ${'Node_' + node.identifier}
descendants = ${'DescendantOf_' + node.identifier}
nodeType = 'NodeType_My.Vendor:Content.Foo'
```