### PR TITLE
TASK: Fusion Page Rendering - access internal node properties directly: `node.nodeType.name`

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -58,9 +58,9 @@ root {
   documentType {
     @position = 'end 9998'
     condition = Neos.Fusion:CanRender {
-      type = ${q(documentNode).property('_nodeType.name')}
+      type = ${documentNode.nodeType.name}
     }
-    type = ${q(documentNode).property('_nodeType.name')}
+    type = ${documentNode.nodeType.name}
   }
 
   default {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
@@ -19,7 +19,7 @@ prototype(Neos.Neos:Content) < prototype(Neos.Fusion:Template) {
   # }
   # in your site's Fusion if you don't need that behavior.
   attributes.class.@process.nodeType = Neos.Fusion:Case {
-    @context.nodeTypeClassName = ${String.toLowerCase(String.pregReplace(q(node).property('_nodeType.name'), '/[[:^alnum:]]/', '-'))}
+    @context.nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
 
     classIsString {
       condition = ${Type.isString(value)}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -6,6 +6,6 @@ prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
   default {
     @position = 'end'
     condition = true
-    type = ${q(node).property('_nodeType.name')}
+    type = ${node.nodeType.name}
   }
 }


### PR DESCRIPTION
replace FlowQuery style syntax (underscore for internal props) with direct object access via `get*` in EEL.

see discussion:
https://neos-project.slack.com/archives/C04PYL8H3/p1647433062072679
