### PR TITLE
!!! TASK: Fusion ContentCollectionRenderer remove legacy 'collection' prop

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -6,10 +6,6 @@ prototype(Neos.Neos:ContentCollectionRenderer) < prototype(Neos.Fusion:Loop) {
   # Needed for publish function to be able to publish removed nodes.
   items = ${nodeAvailable ? q(node).children() : []}
 
-  # To ensure backwards compatibility override items if collection is set
-  items.@process.collectionLegacy = ${this.collection}
-  items.@process.collectionLegacy.@if.hasCollectionProp = ${this.collection != null && Array.length(this.collection) > 0}
-
   # Render every item by its own Fusion object
   itemRenderer = Neos.Neos:ContentCase
   itemName = 'node'


### PR DESCRIPTION
resolves: #3642

## !!! Breaking, migrate the following in your Fusion:

```diff
Neos.Neos:ContentCollectionRenderer {
-    collection = ${[]}
+    items = ${[]}
}
```

With 5.3 https://github.com/neos/neos-development-collection/pull/2772
`Neos.Neos:ContentCollectionRenderer` was changed from `Neos.Fusion:Collection` to `Neos.Fusion:Loop`

for backwards compatibility, the prop `collection` was also allowed to be set as alias for `items`

but the `collection` prop alias doenst fully work as 1:1 replacement fx. it doesnt work if it was set to an empty array:
https://github.com/neos/neos-development-collection/issues/3114

this pr removes this this legacy fallback with 8.0

