### PR TITLE
!!! TASK: Fusion cleanup inheritance of `ArrayFusionObject`s

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -95,7 +95,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Security\Exception
      */
-    protected function evaluateNestedProperties(?string $defaultFusionPrototypeName = null):array
+    protected function evaluateNestedProperties(?string $defaultFusionPrototypeName = null): array
     {
         $sortedChildFusionKeys = $this->sortNestedProperties();
 

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -157,10 +157,10 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
      * Returns TRUE if the given fusion key has no type, meaning neither
      * having a fusion objectType, eelExpression or value
      *
-     * @param string $key fusion child key path to check
+     * @param string|int $key fusion child key path to check
      * @return bool
      */
-    protected function isUntyped(string $key): bool
+    protected function isUntyped(string|int $key): bool
     {
         $property = $this->properties[$key];
         if (!is_array($property)) {

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -154,7 +154,8 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     }
 
     /**
-     * Returns TRUE if the given property has no object type assigned
+     * Returns TRUE if the given fusion key has no type, meaning neither
+     * having a fusion objectType, eelExpression or value
      *
      * @param string $key fusion child key path to check
      * @return bool

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -106,7 +106,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
             $propertyPath = $key;
-            if ($this->isUntyped($key) && $defaultFusionPrototypeName) {
+            if ($defaultFusionPrototypeName !== null && $this->isUntyped($key)) {
                 $propertyPath .= '<' . $defaultFusionPrototypeName . '>';
             }
             try {

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -11,6 +11,10 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Utility\Exception\InvalidPositionException;
+use Neos\Utility\PositionalArraySorter;
+use Neos\Fusion\Exception as FusionException;
+use Neos\Fusion\Core\Runtime;
 
 /**
  * Base class for Fusion objects that need access to arbitrary properties, like DataStructureImplementation.
@@ -81,5 +85,86 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     public function offsetUnset($offset)
     {
         unset($this->properties[$offset]);
+    }
+
+    /**
+     * @param string|null $defaultFusionPrototypeName
+     * @return array
+     * @throws FusionException
+     * @throws \Neos\Flow\Configuration\Exception\InvalidConfigurationException
+     * @throws \Neos\Flow\Mvc\Exception\StopActionException
+     * @throws \Neos\Flow\Security\Exception
+     */
+    protected function evaluateNestedProperties(?string $defaultFusionPrototypeName = null):array
+    {
+        $sortedChildFusionKeys = $this->sortNestedProperties();
+
+        if (count($sortedChildFusionKeys) === 0) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($sortedChildFusionKeys as $key) {
+            $propertyPath = $key;
+            if ($this->isUntyped($key) && $defaultFusionPrototypeName) {
+                $propertyPath .= '<' . $defaultFusionPrototypeName . '>';
+            }
+            try {
+                $value = $this->fusionValue($propertyPath);
+            } catch (\Exception $e) {
+                $value = $this->runtime->handleRenderingException($this->path . '/' . $key, $e);
+            }
+            if ($value === null && $this->runtime->getLastEvaluationStatus() === Runtime::EVALUATION_SKIPPED) {
+                continue;
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sort the Fusion objects inside $this->properties depending on:
+     * - numerical ordering
+     * - position meta-property
+     *
+     * This will ignore all properties defined in "@ignoreProperties" in Fusion
+     *
+     * @see PositionalArraySorter
+     *
+     * @return array an ordered list of key value pairs
+     * @throws FusionException if the positional string has an unsupported format
+     */
+    protected function sortNestedProperties(): array
+    {
+        $arraySorter = new PositionalArraySorter($this->properties, '__meta.position');
+        try {
+            $sortedFusionKeys = $arraySorter->getSortedKeys();
+        } catch (InvalidPositionException $exception) {
+            throw new FusionException('Invalid position string', 1345126502, $exception);
+        }
+
+        foreach ($this->ignoreProperties as $ignoredPropertyName) {
+            $key = array_search($ignoredPropertyName, $sortedFusionKeys);
+            if ($key !== false) {
+                unset($sortedFusionKeys[$key]);
+            }
+        }
+        return $sortedFusionKeys;
+    }
+
+    /**
+     * Returns TRUE if the given property has no object type assigned
+     *
+     * @param string $key fusion child key path to check
+     * @return bool
+     */
+    protected function isUntyped(string $key): bool
+    {
+        $property = $this->properties[$key];
+        if (!is_array($property)) {
+            return false;
+        }
+        return !isset($property['__objectType']) && !isset($property['__eelExpression']) && !isset($property['__value']);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
@@ -21,7 +21,7 @@ use Neos\Fusion\Service\HtmlAugmenter;
  *
  * @api
  */
-class AugmenterImplementation extends JoinImplementation
+class AugmenterImplementation extends AbstractArrayFusionObject
 {
 
     /**
@@ -45,14 +45,7 @@ class AugmenterImplementation extends JoinImplementation
         $content = $this->fusionValue('content');
         $fallbackTagName = $this->fusionValue('fallbackTagName');
 
-        $sortedChildFusionKeys = $this->sortNestedFusionKeys();
-
-        $attributes = [];
-        foreach ($sortedChildFusionKeys as $key) {
-            if ($fusionValue = $this->fusionValue($key)) {
-                $attributes[$key] = $fusionValue;
-            }
-        }
+        $attributes = $this->evaluateNestedProperties();
 
         if ($attributes && is_array($attributes) && count($attributes) > 0) {
             return $this->htmlAugmenter->addAttributes($content, $attributes, $fallbackTagName);

--- a/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
@@ -23,7 +23,7 @@ use Neos\Fusion\Exception\UnsupportedObjectTypeAtPathException;
  * object; and all its children are by-default interpreted as "Matcher" Fusion
  * objects if no others are specified.
  */
-class CaseImplementation extends JoinImplementation
+class CaseImplementation extends AbstractArrayFusionObject
 {
     /**
      * This constant should be returned by individual matchers if the matcher
@@ -40,7 +40,7 @@ class CaseImplementation extends JoinImplementation
      */
     public function evaluate()
     {
-        $matcherKeys = $this->sortNestedFusionKeys();
+        $matcherKeys = $this->sortNestedProperties();
 
         foreach ($matcherKeys as $matcherName) {
             $renderedMatcher = $this->renderMatcher($matcherName);

--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -23,7 +23,7 @@ use Neos\Fusion\FusionObjects\Helpers\LazyProps;
  * //fusionPath * generic Fusion values that will be added to the ``props`` object in the context
  * @api
  */
-class ComponentImplementation extends JoinImplementation
+class ComponentImplementation extends AbstractArrayFusionObject
 {
     /**
      * Properties that are ignored and not included into the ``props`` context
@@ -66,7 +66,7 @@ class ComponentImplementation extends JoinImplementation
      */
     protected function getProps(array $context): \ArrayAccess
     {
-        $sortedChildFusionKeys = $this->sortNestedFusionKeys();
+        $sortedChildFusionKeys = $this->sortNestedProperties();
         $props = new LazyProps($this, $this->path, $this->runtime, $sortedChildFusionKeys, $context);
         return $props;
     }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -35,6 +35,6 @@ class DataStructureImplementation extends AbstractArrayFusionObject
      */
     protected function sortNestedFusionKeys()
     {
-        return parent::sortNestedProperties();
+        return $this->sortNestedProperties();
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -11,8 +11,6 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Fusion\Core\Parser;
-
 /**
  * Fusion object to render and array of key value pairs by evaluating all properties
  */
@@ -33,25 +31,10 @@ class DataStructureImplementation extends AbstractArrayFusionObject
      *
      * @param mixed $property
      * @return bool
-     * @deprecated since 8.0 can be renoved with 9.0 use \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::sortNestedProperties
+     * @deprecated since 8.0 can be removed with 9.0 use \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::sortNestedProperties
      */
     protected function sortNestedFusionKeys()
     {
         return parent::sortNestedProperties();
-    }
-
-    /**
-     * Returns TRUE if the given property has no object type assigned
-     *
-     * @param mixed $property
-     * @return bool
-     * @deprecated since 8.0 can be renoved with 9.0 use \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::isUntyped
-     */
-    private function isUntypedProperty($property): bool
-    {
-        if (!is_array($property)) {
-            return false;
-        }
-        return array_intersect_key(array_flip(Parser::$reservedParseTreeKeys), $property) === [];
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -11,15 +11,21 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Exception as FusionException;
+
 /**
  * Fusion object to render and array of key value pairs by evaluating all properties
  */
 class DataStructureImplementation extends AbstractArrayFusionObject
 {
     /**
-     * {@inheritdoc}
+     * Evaluate this Fusion object and return the result
      *
      * @return array
+     * @throws FusionException
+     * @throws \Neos\Flow\Configuration\Exception\InvalidConfigurationException
+     * @throws \Neos\Flow\Mvc\Exception\StopActionException
+     * @throws \Neos\Flow\Security\Exception
      */
     public function evaluate()
     {
@@ -27,11 +33,17 @@ class DataStructureImplementation extends AbstractArrayFusionObject
     }
 
     /**
-     * Returns TRUE if the given property has no object type assigned
+     * Sort the Fusion objects inside $this->properties depending on:
+     * - numerical ordering
+     * - position meta-property
      *
-     * @param mixed $property
-     * @return bool
-     * @deprecated since 8.0 can be removed with 9.0 use \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::sortNestedProperties
+     * This will ignore all properties defined in "@ignoreProperties" in Fusion
+     *
+     * @see PositionalArraySorter
+     *
+     * @return array an ordered list of key value pairs
+     * @throws FusionException if the positional string has an unsupported format
+     * @deprecated since 8.0 can be removed with 9.0 use {@see \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::sortNestedProperties}
      */
     protected function sortNestedFusionKeys()
     {

--- a/Neos.Fusion/Classes/FusionObjects/DebugConsoleImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugConsoleImplementation.php
@@ -20,7 +20,7 @@ namespace Neos\Fusion\FusionObjects;
  * //fusionPath content When used as process the console script will be appended to it.
  * @api
  */
-class DebugConsoleImplementation extends DataStructureImplementation
+class DebugConsoleImplementation extends AbstractArrayFusionObject
 {
     protected $ignoreProperties = ['__meta', 'title', 'method', 'value', 'content'];
 
@@ -56,7 +56,7 @@ class DebugConsoleImplementation extends DataStructureImplementation
         $method = $this->getMethod();
         $content = $this->getContent();
 
-        $arguments = parent::evaluate();
+        $arguments = $this->evaluateNestedProperties();
         array_unshift($arguments, $this->getValue());
 
         if ($title) {

--- a/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
@@ -25,7 +25,7 @@ use Neos\Fusion\Service\DebugStack;
  * //fusionPath plaintext If true, the dump is in plain text, if false the debug output is in HTML format. If not specified, the mode is guessed from FLOW_SAPITYPE
  * @api
  */
-class DebugImplementation extends JoinImplementation
+class DebugImplementation extends AbstractArrayFusionObject
 {
     /**
      * If you iterate over "properties" these in here should usually be ignored.
@@ -61,13 +61,7 @@ class DebugImplementation extends JoinImplementation
         $title = trim($this->getTitle());
         $plaintext = $this->getPlaintext();
 
-        $debugData = [];
-        foreach (array_keys($this->properties) as $key) {
-            if (in_array($key, $this->ignoreProperties)) {
-                continue;
-            }
-            $debugData[$key] = $this->fusionValue($key);
-        }
+        $debugData = $this->evaluateNestedProperties();
 
         $title .= ' @ ' . $this->path;
 

--- a/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DebugImplementation.php
@@ -61,7 +61,13 @@ class DebugImplementation extends AbstractArrayFusionObject
         $title = trim($this->getTitle());
         $plaintext = $this->getPlaintext();
 
-        $debugData = $this->evaluateNestedProperties();
+        $debugData = [];
+        foreach (array_keys($this->properties) as $key) {
+            if (in_array($key, $this->ignoreProperties)) {
+                continue;
+            }
+            $debugData[$key] = $this->fusionValue($key);
+        }
 
         $title .= ' @ ' . $this->path;
 

--- a/Neos.Fusion/Classes/FusionObjects/HttpResponseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/HttpResponseImplementation.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 /**
  *
  */
-class HttpResponseImplementation extends DataStructureImplementation
+class HttpResponseImplementation extends AbstractArrayFusionObject
 {
     /**
      * @Flow\Inject
@@ -51,9 +51,9 @@ class HttpResponseImplementation extends DataStructureImplementation
             throw new \InvalidArgumentException('Could not render HTTP response because the response head was not a valid HTTP response object.', 1557932997);
         }
 
-        $parentResult = parent::evaluate();
-        if ($parentResult !== []) {
-            $contentStream = $this->contentStreamFactory->createStream(implode('', $parentResult));
+        $resultParts = $this->evaluateNestedProperties();
+        if ($resultParts !== []) {
+            $contentStream = $this->contentStreamFactory->createStream(implode('', $resultParts));
             $response = $response->withBody($contentStream);
         }
 

--- a/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
@@ -11,9 +11,6 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Fusion\Core\Runtime;
-use Neos\Fusion\FusionObjects\Traits\EvaluatePropertyListTrait;
-
 /**
  * Fusion object to render a list of items as single concatenated string
  */
@@ -33,9 +30,9 @@ class JoinImplementation extends AbstractArrayFusionObject
     /**
      * {@inheritdoc}
      *
-     * @return string
+     * @return string|null
      */
-    public function evaluate(): string
+    public function evaluate()
     {
         $glue = $this->getGlue();
 
@@ -44,6 +41,6 @@ class JoinImplementation extends AbstractArrayFusionObject
             return implode($glue, $resultParts);
         }
 
-        return '';
+        return null;
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/JoinImplementation.php
@@ -11,11 +11,13 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Core\Runtime;
+use Neos\Fusion\FusionObjects\Traits\EvaluatePropertyListTrait;
 
 /**
  * Fusion object to render a list of items as single concatenated string
  */
-class JoinImplementation extends DataStructureImplementation
+class JoinImplementation extends AbstractArrayFusionObject
 {
 
     /**
@@ -33,13 +35,15 @@ class JoinImplementation extends DataStructureImplementation
      *
      * @return string
      */
-    public function evaluate()
+    public function evaluate(): string
     {
         $glue = $this->getGlue();
-        $parentResult = parent::evaluate();
-        if ($parentResult !== []) {
-            return implode($glue, $parentResult);
+
+        $resultParts = $this->evaluateNestedProperties();
+        if ($resultParts !== []) {
+            return implode($glue, $resultParts);
         }
-        return null;
+
+        return '';
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -95,4 +95,54 @@ class DataStructureTest extends AbstractFusionObjectTest
 
         $view->render();
     }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionIf(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithIf');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionProcess(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithProcess');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123, 0 => 'baz']], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionEelThisContext(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithThisContext');
+        self::assertEquals(['keyWithoutType' => ['foo' => 123, 'thisFoo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function untypedChildKeysWorkWithFusionPositionSorting(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/untypedChildKeysWithPositionOrdering');
+        self::assertEquals(['keyWithoutTypeLast' => ['baz' => 456], 'keyWithoutTypeFirst' => ['foo' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function unsetUntypedChildKeysWontRenderAsDataStructure(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/unsetUntypedChildKeysWontRenderAsDataStructure');
+        self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -139,10 +139,10 @@ class DataStructureTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function unsetUntypedChildKeysWontRenderAsDataStructure(): void
+    public function unsetUntypedChildKeysWillRenderAsDataStructure(): void
     {
         $view = $this->buildView();
-        $view->setFusionPath('dataStructure/unsetUntypedChildKeysWontRenderAsDataStructure');
+        $view->setFusionPath('dataStructure/unsetUntypedChildKeyWillRenderAsDataStructure');
         self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -107,3 +107,49 @@ dataStructure.nestingWithNonExistingChildObject = Neos.Fusion:DataStructure {
   }
   errorProperty = Some.NonExisting:Prototype
 }
+
+dataStructure.untypedChildKeysWithIf = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    @if.display = true
+    foo = 123
+  }
+  keyWithoutType2 {
+    @if.display = false
+    baz = 456
+  }
+}
+
+dataStructure.untypedChildKeysWithProcess = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    foo = 123
+    @process.addKey = ${Array.push(value, 'baz')}
+  }
+}
+
+dataStructure.untypedChildKeysWithThisContext = Neos.Fusion:DataStructure {
+  keyWithoutType {
+    foo = 123
+    thisFoo = ${this.foo}
+  }
+}
+
+dataStructure.untypedChildKeysWithPositionOrdering = Neos.Fusion:DataStructure {
+  keyWithoutTypeFirst {
+    foo = 123
+  }
+  keyWithoutTypeLast {
+    @postion = 'before keyWithoutTypeFirst'
+    baz = 456
+  }
+}
+
+dataStructure.unsetUntypedChildKeysWontRenderAsDataStructure = Neos.Fusion:DataStructure {
+  keyWithUnsetType = Neos.Fusion:Value {
+    value = 123
+  }
+  keyWithUnsetType >
+  keyWithUnsetType {
+    bat = 123
+  }
+  buz = 456
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -143,7 +143,7 @@ dataStructure.untypedChildKeysWithPositionOrdering = Neos.Fusion:DataStructure {
   }
 }
 
-dataStructure.unsetUntypedChildKeysWontRenderAsDataStructure = Neos.Fusion:DataStructure {
+dataStructure.unsetUntypedChildKeyWillRenderAsDataStructure = Neos.Fusion:DataStructure {
   keyWithUnsetType = Neos.Fusion:Value {
     value = 123
   }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Debug.fusion
@@ -12,7 +12,7 @@ debug.null = Debug {
 
 debug.nullWithTitle = Debug {
   title = 'Title'
-  value = NULL
+  value = null
 }
 
 debug.eelExpression = Debug {

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -52,57 +52,57 @@ class DataStructureImplementationTest extends UnitTestCase
         return [
             [
                 'Position end should put element to end',
-                ['second' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
+                ['second' => ['__meta' => ['position' => 'end'], '__value' => 1], 'first' => ['__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Position start should put element to start',
-                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'start']]],
+                ['second' => ['__value' => 1], 'first' => ['__meta' => ['position' => 'start'], '__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Position start should respect priority',
-                ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
+                ['second' => ['__meta' => ['position' => 'start 50'], '__value' => 1], 'first' => ['__meta' => ['position' => 'start 52'], '__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Position end should respect priority',
-                ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
+                ['second' => ['__meta' => ['position' => 'end 17'], '__value' => 1], 'first' => ['__meta' => ['position' => 'end'], '__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Positional numbers are in the middle',
-                ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
+                ['last' => ['__meta' => ['position' => 'end'], '__value' => 1], 'second' => ['__meta' => ['position' => '17'], '__value' => 2], 'first' => ['__meta' => ['position' => '5'], '__value' => 3], 'third' => ['__meta' => ['position' => '18'], '__value' => 4]],
                 ['/first', '/second', '/third', '/last']
             ],
             [
                 'Position before adds before named element if present',
-                ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['second' => ['__value' => 1], 'first' => ['__meta' => ['position' => 'before second'], '__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
+                ['third' => ['__value' => 1], 'second' => ['__meta' => ['position' => 'before third 12'], '__value' => 2], 'first' => ['__meta' => ['position' => 'before third'], '__value' => 3]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position before works recursively',
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+                ['third' => ['__value' => 1], 'second' => ['__meta' => ['position' => 'before third'], '__value' => 2], 'first' => ['__meta' => ['position' => 'before second'], '__value' => 3]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after adds after named element if present',
-                ['second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
+                ['second' => ['__meta' => ['position' => 'after first'], '__value' => 1], 'first' => ['__value' => 2]],
                 ['/first', '/second']
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
-                ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => ['__meta' => []]],
+                ['third' => ['__meta' => ['position' => 'after first'], '__value' => 1], 'second' => ['__meta' => ['position' => 'after first 12'], '__value' => 2], 'first' => ['__value' => 3]],
                 ['/first', '/second', '/third']
             ],
             [
                 'Position after works recursively',
-                ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
+                ['third' => ['__meta' => ['position' => 'after second'], '__value' => 1], 'second' => ['__meta' => ['position' => 'after first'], '__value' => 2], 'first' => ['__value' => 3]],
                 ['/first', '/second', '/third']
             ]
         ];
@@ -135,10 +135,10 @@ class DataStructureImplementationTest extends UnitTestCase
     {
         return [
             [
-                ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
+                ['second' => ['__meta' => ['position' => 'after unknown'], '__value' => 1], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__value' => 2]],
             ],
             [
-                ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
+                ['third' => ['__value' => 1], 'second' => ['__meta' => ['position' => 'before third'], '__value' => 2], 'first' => ['__meta' => ['position' => 'before unknown'], '__value' => 3]],
             ],
         ];
     }


### PR DESCRIPTION
Many FusionObjects inherited from DateStructure or Join because they used methods like sortNestedFusionKeys.
This change moves the methods that made this necessary to the AbstractArrayFusionObject and adjusts the inheritence chain.

New methods of the AbstractArrayFusionObject
- `evaluateNestedProperties(?string $defaultFusionPrototypeName = null)` - evaluate all children after sorting and applying an optional default fusion prototype name
- `isUntyped($key)` - dermine wether a fusion path configuration is untyped or not
- `sortNestedProperties()` - return the property configuration with sorted keys

The methods sortNestedFusionKeys and isUntypedProperty are still in the DateStructureImplementation but deprecated.

!!! This is breaky for everyone that inherited from the join implementation if methods previously inherited from DataStructure are used !!!

Resolves: #3577
Resolves: #3646 

This also removes unwanted effects of the inheritance when unnamed keys of `HttpMessges` or `Join` were interpreted as `DataStructure` which caused trouble. Also the problem that keys with only meta attributes where treated as typed was addressed.

Fixes: https://github.com/neos/neos-development-collection/issues/3513
Fixes: https://github.com/neos/neos-development-collection/issues/3441
Fixes: https://github.com/neos/neos-development-collection/issues/3576

Related: https://github.com/neos/neos-development-collection/pull/2729

Related: https://github.com/neos/neos-development-collection/pull/3568

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
