### PR TITLE
!!! TASK: Remove (long) deprecated ConvertNodeUris

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertNodeUris.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ConvertNodeUris.fusion
@@ -1,6 +1,0 @@
-# ConvertNodeUris implementation
-#
-# replaces all occurrences of "node://<UUID>" by proper URIs.
-#
-# Deprecated since 1.1, use Neos.Neos:ConvertUris instead
-prototype(Neos.Neos:ConvertNodeUris) < prototype(Neos.Neos:ConvertUris)


### PR DESCRIPTION
This has been replaced by `ConvertUris` since 1.1
