### PR TITLE
FEATURE: Optimise cache tag generation before flushing content cache after publishing

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -173,6 +173,10 @@ class ContentCacheFlusher
                     break;
                 }
                 $tagName = 'DescendantOf_' . $workspaceHash . '_' . $nodeInWorkspace->getIdentifier();
+                // Prevent traversing the same parent multiple times for multiple children of the same node
+                if (array_key_exists($tagName, $this->tagsToFlush)) {
+                    break;
+                }
                 $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $node->getPath());
 
                 $legacyTagName = 'DescendantOf_' . $nodeInWorkspace->getIdentifier();


### PR DESCRIPTION
**What I did**

The generation of cache tags is quite slow for a large number of published changes as many operations
are done for each involved node and workspace.
I improved the performance by skipping repeated operations on the same node with the same context
and by caching the result of nodetype related calculations.

**How I did it**

* Reuse calculated list of implemented nodetypes for each node changed by introducing a variable to store each calculation
* Stop traversal through a nodes parents if one of the parents was already traversed before to generate `DescendantOf` cache tags.

**How to verify it**

* Tests still run fine