### PR TITLE
TASK: Fusion clean up the usages how `@process` adds css classes.

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
@@ -18,18 +18,9 @@ prototype(Neos.Neos:Content) < prototype(Neos.Fusion:Template) {
   #   attributes.class.@process.nodeType >
   # }
   # in your site's Fusion if you don't need that behavior.
-  attributes.class.@process.nodeType = Neos.Fusion:Case {
-    @context.nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
-
-    classIsString {
-      condition = ${Type.isString(value)}
-      renderer = ${String.trim(String.trim(value) + ' ' + nodeTypeClassName)}
-    }
-
-    classIsArray {
-      condition = ${Type.isArray(value)}
-      renderer = ${Array.push(value, nodeTypeClassName)}
-    }
+  attributes.class.@process.nodeType = Neos.Fusion:Value {
+    nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
+    value = ${Array.push(value, this.nodeTypeClassName)}
   }
 
   # The following line must not be removed as it adds required meta data to all content elements in backend

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
@@ -18,10 +18,7 @@ prototype(Neos.Neos:Content) < prototype(Neos.Fusion:Template) {
   #   attributes.class.@process.nodeType >
   # }
   # in your site's Fusion if you don't need that behavior.
-  attributes.class.@process.nodeType = Neos.Fusion:Value {
-    nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
-    value = ${Array.push(value, this.nodeTypeClassName)}
-  }
+  attributes.class.@process.nodeType = ${Array.push(value, String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-')))}
 
   # The following line must not be removed as it adds required meta data to all content elements in backend
   @process.contentElementWrapping {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -25,10 +25,7 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
   #   attributes.class.@process.collectionClass >
   # }
   attributes {
-    class.@process.collectionClass = Neos.Fusion:Value {
-      castedArray = ${Type.isArray(value) ? value : [value]}
-      value = ${Array.push(this.castedArray, 'neos-contentcollection')}
-    }
+    class.@process.collectionClass = ${Array.push(value, 'neos-contentcollection')}
     data-__neos-insertion-anchor = true
     data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${node.context.inBackend && node.context.currentRenderingMode.edit}
   }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -63,19 +63,8 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
     @position = '20'
     tagName = 'body'
     omitClosingTag = true
-    attributes.class.@process.addNeosBackendClass = Neos.Fusion:Case {
-      @if.onlyRenderWhenNotInLiveWorkspace = ${documentNode.context.inBackend}
-
-      classIsString {
-        condition = ${Type.isString(value)}
-        renderer = ${String.trim(value + ' neos-backend')}
-      }
-
-      classIsArray {
-        condition = ${Type.isArray(value)}
-        renderer = ${Array.push(value, 'neos-backend')}
-      }
-    }
+    attributes.class.@process.addNeosBackendClass = ${Array.push(value, 'neos-backend')}
+    attributes.class.@process.addNeosBackendClass.@if.onlyRenderWhenNotInLiveWorkspace = ${documentNode.context.inBackend}
   }
 
   # Content of the body tag. To be defined by the integrator.

--- a/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
@@ -12,7 +12,10 @@ prototype(Neos.NodeTypes.Navigation:Navigation) < prototype(Neos.Neos:Menu) {
   maximumLevels = ${q(node).property('maximumLevels')}
   maximumLevels.@process.1 = ${String.toInteger(value)}
 
-  attributes.class.@process < prototype(Neos.Neos:Content).attributes.class.@process
+  attributes.class.@process.nodeType = Neos.Fusion:Value {
+    nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
+    value = ${Array.push(value, this.nodeTypeClassName)}
+  }
 
   active.attributes = Neos.Fusion:Attributes {
     class = 'active'

--- a/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Fusion/Root.fusion
@@ -12,10 +12,7 @@ prototype(Neos.NodeTypes.Navigation:Navigation) < prototype(Neos.Neos:Menu) {
   maximumLevels = ${q(node).property('maximumLevels')}
   maximumLevels.@process.1 = ${String.toInteger(value)}
 
-  attributes.class.@process.nodeType = Neos.Fusion:Value {
-    nodeTypeClassName = ${String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-'))}
-    value = ${Array.push(value, this.nodeTypeClassName)}
-  }
+  attributes.class.@process.nodeType = ${Array.push(value, String.toLowerCase(String.pregReplace(node.nodeType.name, '/[[:^alnum:]]/', '-')))}
 
   active.attributes = Neos.Fusion:Attributes {
     class = 'active'


### PR DESCRIPTION
## Upgrade instructions to Neos 8.0

this change was not marked as breaking but it is a little breaky in the edge case, where you would override the bodyTag attributes class of a `Neos.Neos:Page` as `value` might now be an `array`:

```
prototype(Neos.Neos:Page).bodyTag.attributes.class.@process.addClass = ${value + " new-class"}
```

migrate it like this:
```
prototype(Neos.Neos:Page).bodyTag.attributes.class.@process.addClass = ${Array.push(value, "new-class")}
```

----

## Original pr body


with: https://github.com/neos/flow-development-collection/issues/2710

we can add any scalar types to Array.push as base, which will be auto casted to an array:
`Array.push("foo", "bar")`
which results in -> `["foo", "bar"]`
which is rendered as `foo bar`

previously we had to cast it to an array beforehand. I integrated this for the 'neos-contentcollection' once: https://github.com/neos/neos-development-collection/pull/3438 - but this cleans the manual cast up.

(this also fixes any real low level css class adding via `Type.isString()` etc by just casting to an array and then pushing the new value.)

Also the last use of copy will be removed, by manually copying the (now little) code over.
fixes: https://github.com/neos/neos-development-collection/issues/3588
