### PR TITLE
TASK: Add documentation for previewIcon

### DIFF
--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -144,18 +144,38 @@ The following options are allowed for defining a NodeType:
 
   ``icon``
     This setting defines the icon that the Neos UI will use to display the node type.
+    The icon can contain a custom SVG icon as resource URI or a Fontawesome icon.
 
-    Legacy:
-    In Neos versions before 4.0 it was required to use icons from the Fontawesome 3 or 4 versions,
-    prefixed with "icon-"
+    Resource icon:
+    For custom SVG icons a resource URI to the file needs to be configured.
+    e.g. 'resource://Neos.Demo/Images/logo.svg'
 
-    Current:
-    In Neos 4.0, Fontawesome 5 was introduced, enabling the usage of all free Fontawesome icons:
+    Fontawesome icon:
+    All free Fontawesome 5 icons can be used:
     https://fontawesome.com/icons?d=gallery&m=free
-    Those can still be referenced via "icon-[name]", as the UI includes a fallback to the "fas"
+
+    Those can be referenced via "icon-[name]", as the UI includes a fallback to the "fas"
     prefix-classes. To be sure which icon will be used, they can also be referenced by their
     icon-classes, e.g. "fas fa-check".
 
+
+    ``previewIcon``
+    This setting defines the icon that will be used in the tile view of the NodeType selection dialog.
+    It is an additional icon that can be used to have more detailed icons for the node type. So that the users get a better idea what the node type is for.
+
+    Preview icons are by default bit bigger. We scale them to the doubled size.
+    It is also possible to adjust the scaling by the previewIconSize setting.
+    Like the icon it can be a Fontawesome icon name or an SVG Asset Resource URL.
+
+    ``previewIconSize``
+    The previewIconSize setting defines the size of the previewIcon. By default the previewIcon has the size "2x".
+
+    The following options are available:
+    - 'xs'
+    - 'sm'
+    - 'lg'
+    - '2x'
+    - '3x'
 
   ``help``
     Configuration of contextual help. Displays a message that is rendered as popover

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -165,7 +165,7 @@ The following options are allowed for defining a NodeType:
 
     Preview icons are by default bit bigger. We scale them to the doubled size.
     It is also possible to adjust the scaling by the previewIconSize setting.
-    Like the icon it can be a Fontawesome icon name or an SVG Asset Resource URL.
+    It can be a Fontawesome icon name or an SVG Asset Resource URL like the icon.
 
     ``previewIconSize``
     The previewIconSize setting defines the size of the previewIcon. By default the previewIcon has the size "2x".

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -144,7 +144,7 @@ The following options are allowed for defining a NodeType:
 
   ``icon``
     This setting defines the icon that the Neos UI will use to display the node type.
-    The icon can contain a custom SVG icon as resource URI or a Fontawesome icon.
+    The icon can contain a custom SVG icon as a resource URI or a Fontawesome icon.
 
     Resource icon:
     For custom SVG icons a resource URI to the file needs to be configured.

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -168,7 +168,7 @@ The following options are allowed for defining a NodeType:
     It can be a Fontawesome icon name or an SVG Asset Resource URL like the icon.
 
     ``previewIconSize``
-    The previewIconSize setting defines the size of the previewIcon. By default the previewIcon has the size "2x".
+    The previewIconSize setting defines the size of the previewIcon. By default, the previewIcon has the size "2x".
 
     The following options are available:
     - 'xs'

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -161,7 +161,7 @@ The following options are allowed for defining a NodeType:
 
     ``previewIcon``
     This setting defines the icon that will be used in the tile view of the NodeType selection dialog.
-    It is an additional icon that can be used to have more detailed icons for the node type. So that the users get a better idea what the node type is for.
+    It is an additional icon that can be used to have more detailed icons for the node type. So that the users get a better idea of what the node type is for.
 
     Preview icons are by default bit bigger. We scale them to the doubled size.
     It is also possible to adjust the scaling by the previewIconSize setting.


### PR DESCRIPTION
**What I did**

The neos-ui introduces a new NodeType setting called `previewIcon` and `previewIconSize`.
As the neos-ui does not contain documentation, the PR will add the new options here.

The change also adjust the icon description, as we are now able to use custom SVG icons.

Related PR: https://github.com/neos/neos-ui/pull/3042
