### PR TITLE
FEATURE: Add ParsePartials cache to the fusion parser

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
@@ -50,8 +50,8 @@ class FusionParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
-        $identifier = 'file_' . $this->getCacheIdentifierForFile($contextPathAndFilename);
-        return $this->cacheByIdentifier($identifier, $generateValueToCache);
+        $identifier = $this->getCacheIdentifierForFile($contextPathAndFilename);
+        return $this->cacheForIdentifier($identifier, $generateValueToCache);
     }
 
     public function cacheForDsl(string $identifier, string $code, \Closure $generateValueToCache): mixed
@@ -59,8 +59,8 @@ class FusionParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
-        $identifier = 'dsl_' . md5($identifier . $code);
-        return $this->cacheByIdentifier($identifier, $generateValueToCache);
+        $identifier = $this->getCacheIdentifierForDslCode($identifier, $code);
+        return $this->cacheForIdentifier($identifier, $generateValueToCache);
     }
 
     /**
@@ -87,6 +87,14 @@ class FusionParserCache
     }
 
     /**
+     * creates a comparable hash of the dsl type and content to be used as cache identifier
+     */
+    private function getCacheIdentifierForDslCode(string $identifier, string $code): string
+    {
+        return 'dsl_' . $identifier . '_' . md5($code);
+    }
+
+    /**
      * creates a comparable hash of the absolute, resolved $fusionFileName
      *
      * @throws \InvalidArgumentException
@@ -104,7 +112,7 @@ class FusionParserCache
 
         $flowRoot = defined('FLOW_PATH_ROOT') ? FLOW_PATH_ROOT : '';
         $realFusionFilePathWithoutRoot = str_replace($flowRoot, '', $realPath);
-        return md5($realFusionFilePathWithoutRoot);
+        return 'file_' . md5($realFusionFilePathWithoutRoot);
     }
 
     /**

--- a/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
@@ -1,0 +1,126 @@
+<?php
+namespace Neos\Fusion\Core\Cache;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Package\PackageManager;
+use Neos\Fusion\Core\ObjectTreeParser\Ast\FusionFile;
+use Neos\Utility\Unicode\Functions as UnicodeFunctions;
+use Neos\Utility\Files;
+
+/**
+ * Helper around the ParsePartials Cache.
+ * Connected in the boot to flush caches on file-change.
+ * Caches partials when requested by the Fusion Parser.
+ *
+ */
+class FusionParserCache
+{
+    /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $parsePartialsCache;
+
+    /**
+     * @Flow\Inject
+     * @var PackageManager
+     */
+    protected $packageManager;
+
+    /**
+     * @Flow\InjectConfiguration(path="enableParsePartialsCache")
+     */
+    protected $enableCache;
+
+    public function cacheByIdentifier(string $identifier, \Closure $generateValueToCache): mixed
+    {
+        if ($this->enableCache === false) {
+            return $generateValueToCache();
+        }
+        if ($this->parsePartialsCache->has($identifier)) {
+            return $this->parsePartialsCache->get($identifier);
+        }
+        $value = $generateValueToCache();
+        $this->parsePartialsCache->set($identifier, $value);
+        return $value;
+    }
+
+    public function cacheByFusionFile(?string $contextPathAndFilename, \Closure $generateValueToCache): FusionFile
+    {
+        if ($this->enableCache === false) {
+            return $generateValueToCache();
+        }
+        $identifier = $this->getCacheIdentifierForFile($contextPathAndFilename);
+        return $this->cacheByIdentifier($identifier, $generateValueToCache);
+    }
+
+    /**
+     * @param array<string, int> $changedFiles
+     */
+    public function flushFileAstCacheOnFileChanges(array $changedFiles): void
+    {
+        foreach ($changedFiles as $changedFile => $status) {
+            $identifier = $this->getCacheIdentifierForFile($changedFile);
+            if ($this->parsePartialsCache->has($identifier)) {
+                $this->parsePartialsCache->remove($identifier);
+            }
+        }
+    }
+
+    /**
+     * creates a comparable hash of the absolute, resolved $fusionFileName
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function getCacheIdentifierForFile(string $fusionFileName): string
+    {
+        if (str_contains($fusionFileName, '://')) {
+            $fusionFileName = $this->getAbsolutePathForPackageRessourceUri($fusionFileName);
+        }
+
+        $realPath = realpath($fusionFileName);
+        if ($realPath === false) {
+            throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
+        }
+
+        $flowRoot = defined('FLOW_PATH_ROOT') ? FLOW_PATH_ROOT : '';
+        $realFusionFilePathWithoutRoot = str_replace($flowRoot, '', $realPath);
+        return md5($realFusionFilePathWithoutRoot);
+    }
+
+    /**
+     * Uses the same technic to resolve a package resource uri like flow.
+     *
+     * resource://My.Site/Private/Fusion/Foo/Bar.fusion
+     * ->
+     * FLOW_PATH_ROOT/Packages/Sites/My.Package/Resources/Private/Fusion/Foo/Bar.fusion
+     *
+     * {@see \Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper::evaluateResourcePath()}
+     * {@link https://github.com/neos/flow-development-collection/issues/2687}
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function getAbsolutePathForPackageRessourceUri(string $requestedPath): string
+    {
+        $resourceUriParts = UnicodeFunctions::parse_url($requestedPath);
+
+        if ((isset($resourceUriParts['scheme']) === false
+            || $resourceUriParts['scheme'] !== 'resource')) {
+            throw new \InvalidArgumentException("Unsupported stream wrapper: '$requestedPath'");
+        }
+
+        $package = $this->packageManager->getPackage($resourceUriParts['host']);
+        return Files::concatenatePaths([$package->getResourcesPath(), $resourceUriParts['path']]);
+    }
+}

--- a/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/FusionParserCache.php
@@ -50,7 +50,7 @@ class FusionParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
-        $identifier = $this->getCacheIdentifierForFile($contextPathAndFilename);
+        $identifier = 'file_' . $this->getCacheIdentifierForFile($contextPathAndFilename);
         return $this->cacheByIdentifier($identifier, $generateValueToCache);
     }
 
@@ -59,7 +59,7 @@ class FusionParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
-        $identifier = md5($identifier . $code);
+        $identifier = 'dsl_' . md5($identifier . $code);
         return $this->cacheByIdentifier($identifier, $generateValueToCache);
     }
 

--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -26,7 +26,7 @@ use Neos\Utility\Files;
  * Caches partials when requested by the Fusion Parser.
  *
  */
-class FusionParserCache
+class ParserCache
 {
     /**
      * @Flow\Inject

--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -50,6 +50,9 @@ class ParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
+        if ($contextPathAndFilename === null) {
+            return $generateValueToCache();
+        }
         $identifier = $this->getCacheIdentifierForFile($contextPathAndFilename);
         return $this->cacheForIdentifier($identifier, $generateValueToCache);
     }

--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -118,7 +118,7 @@ class ParserCache
     }
 
     /**
-     * Uses the same technic to resolve a package resource uri like flow.
+     * Uses the same technique to resolve a package resource URI like Flow.
      *
      * resource://My.Site/Private/Fusion/Foo/Bar.fusion
      * ->

--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -113,8 +113,7 @@ class ParserCache
             throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
         }
 
-        $flowRoot = defined('FLOW_PATH_ROOT') ? FLOW_PATH_ROOT : '';
-        $realFusionFilePathWithoutRoot = str_replace($flowRoot, '', $realPath);
+        $realFusionFilePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $realPath);
         return 'file_' . md5($realFusionFilePathWithoutRoot);
     }
 

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -14,7 +14,7 @@ namespace Neos\Fusion\Core;
  */
 
 use Neos\Fusion;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion\Core\ObjectTreeParser\Ast\FusionFile;
 use Neos\Fusion\Core\ObjectTreeParser\FilePatternResolver;
 use Neos\Fusion\Core\ObjectTreeParser\MergedArrayTree;
@@ -42,7 +42,7 @@ class Parser implements ParserInterface
 
     /**
      * @Flow\Inject
-     * @var FusionParserCache
+     * @var ParserCache
      */
     protected $parserCache;
 
@@ -87,20 +87,25 @@ class Parser implements ParserInterface
 
     protected function handleDslTranspile(string $identifier, string $code)
     {
-        return $this->parserCache->cacheForDsl($identifier, $code, function () use ($identifier, $code) {
-            $dslObject = $this->dslFactory->create($identifier);
+        return $this->parserCache->cacheForDsl(
+            $identifier,
+            $code,
+            function () use ($identifier, $code) {
+                $dslObject = $this->dslFactory->create($identifier);
 
-            $transpiledFusion = $dslObject->transpile($code);
+                $transpiledFusion = $dslObject->transpile($code);
 
-            $fusionFile = ObjectTreeParser::parse('value = ' . $transpiledFusion);
+                $fusionFile = ObjectTreeParser::parse('value = ' . $transpiledFusion);
 
-            $mergedArrayTree = $this->getMergedArrayTreeVisitor(new MergedArrayTree())->visitFusionFile($fusionFile);
+                $mergedArrayTree = $this->getMergedArrayTreeVisitor(new MergedArrayTree())->visitFusionFile($fusionFile);
 
-            $temporaryAst = $mergedArrayTree->getTree();
+                $temporaryAst = $mergedArrayTree->getTree();
 
-            $dslValue = $temporaryAst['value'];
-            return $dslValue;
-        });
+                $dslValue = $temporaryAst['value'];
+
+                return $dslValue;
+            }
+        );
     }
 
     protected function getMergedArrayTreeVisitor(MergedArrayTree $mergedArrayTree): MergedArrayTreeVisitor

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -87,7 +87,7 @@ class Parser implements ParserInterface
 
     protected function handleDslTranspile(string $identifier, string $code)
     {
-        return $this->parserCache->cacheByIdentifier(md5($identifier . $code), function () use ($identifier, $code) {
+        return $this->parserCache->cacheForDsl($identifier, $code, function () use ($identifier, $code) {
             $dslObject = $this->dslFactory->create($identifier);
 
             $transpiledFusion = $dslObject->transpile($code);
@@ -114,7 +114,7 @@ class Parser implements ParserInterface
 
     protected function getFusionFile(string $sourceCode, ?string $contextPathAndFilename): FusionFile
     {
-        return $this->parserCache->cacheByFusionFile(
+        return $this->parserCache->cacheForFusionFile(
             $contextPathAndFilename,
             fn () => ObjectTreeParser::parse($sourceCode, $contextPathAndFilename)
         );

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -18,7 +18,7 @@ use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Fusion\Core\Cache\FileMonitorListener;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 
 /**
  * The Neos Fusion Package
@@ -72,7 +72,7 @@ class Package extends BasePackage
                             return;
                         }
                         $objectManager = $bootstrap->getObjectManager();
-                        if ($objectManager->isRegistered(FusionParserCache::class) === false) {
+                        if ($objectManager->isRegistered(ParserCache::class) === false) {
                             // if we make a total `rm -rf Data/Temporary` all monitored `*.fusion` files will be seen as newly created.
                             // this triggers pretty early this `filesHaveChanged` and we still have the CompileTimeObjectManager
                             // we would get an exception like:
@@ -83,7 +83,7 @@ class Package extends BasePackage
                             $fusionParsePartialsCache->flush();
                             return;
                         }
-                        $fusionParserCache = $objectManager->get(FusionParserCache::class);
+                        $fusionParserCache = $objectManager->get(ParserCache::class);
                         $fusionParserCache->flushFileAstCacheOnFileChanges($changedFilesAndStatus);
                     };
                     $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushParsePartialsCache);

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -18,6 +18,7 @@ use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Fusion\Core\Cache\FileMonitorListener;
+use Neos\Fusion\Core\Cache\FusionParserCache;
 
 /**
  * The Neos Fusion Package
@@ -65,6 +66,27 @@ class Package extends BasePackage
                     $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
                     $listener = new FileMonitorListener($cacheManager);
                     $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $listener, 'flushContentCacheOnFileChanges');
+                    // Use a closure to invoke the FusionParserCache, so the object is not instantiated during compiletime and has working DI
+                    $flushParsePartialsCache = function ($identifier, $changedFilesAndStatus) use ($bootstrap) {
+                        if ($identifier !== 'Fusion_Files') {
+                            return;
+                        }
+                        $objectManager = $bootstrap->getObjectManager();
+                        if ($objectManager->isRegistered(FusionParserCache::class) === false) {
+                            // if we make a total `rm -rf Data/Temporary` all monitored `*.fusion` files will be seen as newly created.
+                            // this triggers pretty early this `filesHaveChanged` and we still have the CompileTimeObjectManager
+                            // we would get an exception like:
+                            // Cannot build object "FusionParserCache" because it is unknown to the compile time Object Manager.
+                            // so instead we will just make sure the cache is totally flushed.
+                            $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
+                            $fusionParsePartialsCache = $cacheManager->getCache('Neos_Fusion_ParsePartials');
+                            $fusionParsePartialsCache->flush();
+                            return;
+                        }
+                        $fusionParserCache = $objectManager->get(FusionParserCache::class);
+                        $fusionParserCache->flushFileAstCacheOnFileChanges($changedFilesAndStatus);
+                    };
+                    $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushParsePartialsCache);
                 }
             });
         }

--- a/Neos.Fusion/Configuration/Caches.yaml
+++ b/Neos.Fusion/Configuration/Caches.yaml
@@ -5,3 +5,7 @@ Neos_Fusion_Content:
 Neos_Fusion_ObjectTree:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
+
+Neos_Fusion_ParsePartials:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend

--- a/Neos.Fusion/Configuration/Development/Settings.yaml
+++ b/Neos.Fusion/Configuration/Development/Settings.yaml
@@ -1,0 +1,4 @@
+Neos:
+  Fusion:
+    rendering:
+      exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler

--- a/Neos.Fusion/Configuration/Development/Settings.yaml
+++ b/Neos.Fusion/Configuration/Development/Settings.yaml
@@ -1,5 +1,6 @@
 
 Neos:
   Fusion:
+    enableParsePartialsCache: true
     rendering:
       exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler

--- a/Neos.Fusion/Configuration/Development/Settings.yaml
+++ b/Neos.Fusion/Configuration/Development/Settings.yaml
@@ -1,6 +1,0 @@
-
-Neos:
-  Fusion:
-    enableParsePartialsCache: true
-    rendering:
-      exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -18,7 +18,7 @@ Neos\Fusion\Aspects\FusionCachingAspect:
           1:
             value: Neos_Fusion_ObjectTree
 
-Neos\Fusion\Core\Cache\FusionParserCache:
+Neos\Fusion\Core\Cache\ParserCache:
   properties:
     parsePartialsCache:
       object:

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -17,3 +17,13 @@ Neos\Fusion\Aspects\FusionCachingAspect:
         arguments:
           1:
             value: Neos_Fusion_ObjectTree
+
+Neos\Fusion\Core\Cache\FusionParserCache:
+  properties:
+    parsePartialsCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Neos_Fusion_ParsePartials

--- a/Neos.Fusion/Configuration/Production/Settings.yaml
+++ b/Neos.Fusion/Configuration/Production/Settings.yaml
@@ -5,3 +5,4 @@
 Neos:
   Fusion:
     enableObjectTreeCache: true
+    enableParsePartialsCache: false

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -31,7 +31,7 @@ Neos:
     # And the used DSL expressions will also be cached.
     # This is flushed partially on file change, but you can do so manually: `./flow cache:flushone --identifier Neos_Fusion_ParsePartials`
     # This option is suited only for development and enabled there by default.
-    enableParsePartialsCache: false
+    enableParsePartialsCache: true
 
     # Default context objects that are available in Eel expressions
     #

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -27,6 +27,12 @@ Neos:
     # This is case if you use automatic deployment and is also assumed in Production context
     enableObjectTreeCache: false
 
+    # The Fusion Parser will, if set to true cache for each fusion file the AST Object Tree,
+    # And the used DSL expressions will also be cached.
+    # This is flushed partially on file change, but you can do so manually: `./flow cache:flushone --identifier Neos_Fusion_ParsePartials`
+    # This option is suited only for development and enabled there by default.
+    enableParsePartialsCache: false
+
     # Default context objects that are available in Eel expressions
     #
     # New variables should be added with a package key prefix. Example:

--- a/Neos.Fusion/Configuration/Testing/Settings.yaml
+++ b/Neos.Fusion/Configuration/Testing/Settings.yaml
@@ -4,6 +4,7 @@ Neos:
     rendering:
       exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\ThrowingHandler
     enableContentCache: false
+    enableParsePartialsCache: false
     defaultContext:
       Testing.String: Neos\Eel\Helper\StringHelper
       Testing.Utility: Neos\Fusion\Tests\Functional\FusionObjects\Fixtures\Helper\UtilityHelper

--- a/Neos.Fusion/Resources/Private/Schema/Settings.Neos.Fusion.schema.yaml
+++ b/Neos.Fusion/Resources/Private/Schema/Settings.Neos.Fusion.schema.yaml
@@ -17,6 +17,8 @@ properties:
     type: boolean
   enableContentCache:
     type: boolean
+  enableParsePartialsCache:
+    type: boolean
   defaultContext:
     type: dictionary
     additionalProperties:

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -12,7 +12,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  */
 
 use Neos\Fusion\Core\Parser;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion\Core\ObjectTreeParser\Exception\ParserException;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -28,7 +28,7 @@ class ParserExceptionTest extends UnitTestCase
 
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
-        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
         $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
         $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -12,6 +12,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  */
 
 use Neos\Fusion\Core\Parser;
+use Neos\Fusion\Core\Cache\FusionParserCache;
 use Neos\Fusion\Core\ObjectTreeParser\Exception\ParserException;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -22,6 +23,15 @@ class ParserExceptionTest extends UnitTestCase
     public function setUp(): void
     {
         $this->parser = new Parser();
+        $this->injectParserCacheMockIntoParser($this->parser);
+    }
+
+    private function injectParserCacheMockIntoParser(Parser $parser): void
+    {
+        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $this->inject($parser, 'parserCache', $parserCache);
     }
 
     public function fullParserExceptionMessage(): \Generator

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -29,8 +29,8 @@ class ParserExceptionTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
-        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -35,8 +35,8 @@ class ParserIncludeTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
-        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -13,7 +13,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 use org\bovigo\vfs\vfsStream;
 use Neos\Fusion\Core\Parser;
 use org\bovigo\vfs\vfsStreamContent;
@@ -34,7 +34,7 @@ class ParserIncludeTest extends UnitTestCase
 
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
-        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
         $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
         $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -13,6 +13,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion;
+use Neos\Fusion\Core\Cache\FusionParserCache;
 use org\bovigo\vfs\vfsStream;
 use Neos\Fusion\Core\Parser;
 use org\bovigo\vfs\vfsStreamContent;
@@ -28,6 +29,15 @@ class ParserIncludeTest extends UnitTestCase
     public function setUp(): void
     {
         $this->parser = new Parser();
+        $this->injectParserCacheMockIntoParser($this->parser);
+    }
+
+    private function injectParserCacheMockIntoParser(Parser $parser): void
+    {
+        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $this->inject($parser, 'parserCache', $parserCache);
     }
 
     public static function setUpBeforeClass(): void
@@ -232,6 +242,7 @@ class ParserIncludeTest extends UnitTestCase
     public function testFusionIncludesArePassedCorrectlyToIncludeAndParseFilesByPattern($fusion, $includePattern): void
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleFileInclude'])->getMock();
+        $this->injectParserCacheMockIntoParser($parser);
         $parser
             ->expects(self::once())
             ->method('handleFileInclude')
@@ -269,6 +280,7 @@ class ParserIncludeTest extends UnitTestCase
         self::expectExceptionCode(1635878683);
 
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleFileInclude'])->getMock();
+        $this->injectParserCacheMockIntoParser($parser);
         $parser
             ->expects(self::never())
             ->method('handleFileInclude');

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -12,7 +12,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  */
 
 use Neos\Fusion\Core\Parser;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -28,7 +28,7 @@ class ParserTest extends UnitTestCase
 
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
-        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
         $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
         $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -29,8 +29,8 @@ class ParserTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
-        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -12,6 +12,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  */
 
 use Neos\Fusion\Core\Parser;
+use Neos\Fusion\Core\Cache\FusionParserCache;
 use Neos\Fusion;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -22,6 +23,15 @@ class ParserTest extends UnitTestCase
     public function setUp(): void
     {
         $this->parser = new Parser();
+        $this->injectParserCacheMockIntoParser($this->parser);
+    }
+
+    private function injectParserCacheMockIntoParser(Parser $parser): void
+    {
+        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $this->inject($parser, 'parserCache', $parserCache);
     }
 
     public function pathBlockTest(): array
@@ -1053,6 +1063,7 @@ class ParserTest extends UnitTestCase
     public function dslIsRecognizedAndPassed($sourceCode, $expectedDslName, $expectedDslContent)
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleDslTranspile'])->getMock();
+        $this->injectParserCacheMockIntoParser($parser);
 
         $parser
             ->expects($this->exactly(1))

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -32,8 +32,8 @@ class ParserTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
-        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -13,6 +13,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Parser;
+use Neos\Fusion\Core\Cache\FusionParserCache;
 use Neos\Fusion\Exception;
 
 /**
@@ -25,6 +26,15 @@ class ParserTest extends UnitTestCase
     public function setUp(): void
     {
         $this->parser = new Parser();
+        $this->injectParserCacheMockIntoParser($this->parser);
+    }
+
+    private function injectParserCacheMockIntoParser(Parser $parser): void
+    {
+        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache->method('cacheByIdentifier')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $parserCache->method('cacheByFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
+        $this->inject($parser, 'parserCache', $parserCache);
     }
 
     /**
@@ -861,6 +871,7 @@ class ParserTest extends UnitTestCase
     public function parserInvokesFusionDslParsingIfADslPatternIsDetected()
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleDslTranspile'])->getMock();
+        $this->injectParserCacheMockIntoParser($parser);
 
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture24');
 

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -13,7 +13,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Parser;
-use Neos\Fusion\Core\Cache\FusionParserCache;
+use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion\Exception;
 
 /**
@@ -31,7 +31,7 @@ class ParserTest extends UnitTestCase
 
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
-        $parserCache = $this->getMockBuilder(FusionParserCache::class)->getMock();
+        $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
         $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
         $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
         $this->inject($parser, 'parserCache', $parserCache);


### PR DESCRIPTION
Resolves: #3661

The New Fusion Parser now uses a `Neos_Fusion_ParsePartials` cache to store the generated FileAst _*_ for each Fusion File. Those File partials are flushed via file monitor when the source Fusion file was changed.
The generated merged array Fusion tree for a Fusion DSL is also cached seperately in this cache.

With this cache layer in place, only changed files are reparsed which **speeds up Fusion parsing** in Development mode by **factor of 2 to 8** depending on context. _**_

The ParsePartials cache is disabled in Production mode as this one already uses the ObjectTreeCache.

since we cache mostly AstNode objects its recommended to have the php extension `igbinary` installed.

the cache can be turned of by disabling: `Neos.Fusion.enableParsePartialsCache`

_*_ there are now more representations of the Fusion code - we created a step in between where we create AstNode Objects
see for more infos the PR of the New Fusion Parser: https://github.com/neos/neos-development-collection/pull/3497

_**_ in my tests, when the cached is warmed _***_, performance boost might not be notable on small projects.

_***_ of course is the cache warmed - as always for the statistics ;)