### PR TITLE
TASK: Fix Fusion Test And Make Them Test What They Say

### DIFF
--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
@@ -2,7 +2,7 @@ prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\V
 prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
 prototype(Neos.Fusion:Attributes).@class = 'Neos\\Fusion\\FusionObjects\\AttributesImplementation'
-prototype(Neos.Fusion:Tag) {
+prototype(Neos.Fusion:LegacyTag) {
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
 	attributes = Attributes
 	omitClosingTag = false
@@ -10,7 +10,7 @@ prototype(Neos.Fusion:Tag) {
 }
 
 
-prototype(Neos.Fusion:SpecialTag) < prototype(Neos.Fusion:Tag) {
+prototype(Neos.Fusion:SpecialTag) < prototype(Neos.Fusion:LegacyTag) {
 	attributes.class = Neos.Fusion:TestRenderer {
 		test = 'class'
 	}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
@@ -9,7 +9,7 @@ prototype(Neos.Fusion:LegacyTag) {
 }
 
 
-prototype(Neos.Fusion:SpecialTag) < prototype(Neos.Fusion:LegacyTag) {
+prototype(Neos.Fusion:SpecialTag) < prototype(Neos.Fusion:Tag) {
 	attributes.class = Neos.Fusion:TestRenderer {
 		test = 'class'
 	}
@@ -24,6 +24,6 @@ nestedOverwritesAndProcessors.deepProcessorAppliesToEel = Neos.Fusion:SpecialTag
 	attributes.tea.@process.addProcessed = ${value + ' infused'}
 }
 
-nnestedOverwritesAndProcessors.deepProcessorAppliesWithNoBaseValue = Neos.Fusion:Value {
+nestedOverwritesAndProcessors.deepProcessorAppliesWithNoBaseValue = Neos.Fusion:Value {
   value.@process.expectEmptyStringIfBaseIsNotDefined = ${value == '' ? 'EmptyString' : value}
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
@@ -4,7 +4,6 @@ prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayI
 prototype(Neos.Fusion:Attributes).@class = 'Neos\\Fusion\\FusionObjects\\AttributesImplementation'
 prototype(Neos.Fusion:LegacyTag) {
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
-	attributes = Attributes
 	omitClosingTag = false
 	selfClosingTag = false
 }
@@ -25,6 +24,6 @@ nestedOverwritesAndProcessors.deepProcessorAppliesToEel = Neos.Fusion:SpecialTag
 	attributes.tea.@process.addProcessed = ${value + ' infused'}
 }
 
-nestedOverwritesAndProcessors.deepProcessorAppliesWithNoBaseValue = Neos.Fusion:SpecialTag {
-	attributes.coffee.@process.addProcessed = ${String.trim(value + ' harvey')}
+nnestedOverwritesAndProcessors.deepProcessorAppliesWithNoBaseValue = Neos.Fusion:Value {
+  value.@process.expectEmptyStringIfBaseIsNotDefined = ${value == '' ? 'EmptyString' : value}
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/NestedOverwritesAndProcessors.fusion
@@ -2,8 +2,10 @@ prototype(Neos.Fusion:TestRenderer).@class = 'Neos\\Fusion\\Tests\\Functional\\V
 prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
 prototype(Neos.Fusion:Attributes).@class = 'Neos\\Fusion\\FusionObjects\\AttributesImplementation'
-prototype(Neos.Fusion:LegacyTag) {
+prototype(Neos.Fusion:Tag) {
+	# dummy declaration, will be overriden someplace - due to merged import of fixtures.
 	@class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
+	attributes = Neos.Fusion:DataStructure
 	omitClosingTag = false
 	selfClosingTag = false
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
@@ -44,6 +44,6 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTest
     {
         $view = $this->buildView();
         $view->setFusionPath('nestedOverwritesAndProcessors/deepProcessorAppliesWithNoBaseValue');
-        self::assertEquals('<div class="Xclass" tea="green" coffee="harvey"></div>', $view->render());
+        self::assertEquals('EmptyString', $view->render());
     }
 }


### PR DESCRIPTION
currently, when testing this locally:
```
NestedOverwritesAndProcessorsTest::applyingProcessorToNonExistingValueWorks
```

one gets a:

```
Array to string conversion
```

this is because the test is lying in our faces.

the fixture `NestedOverwritesAndProcessors.fusion` is telling us, that `Neos.Fusion:Tag` uses as attributes `Neos.Fusion:Attributes`.

but it's not!

`Neos.Fusion:Tag` uses `Neos.Fusion:DataStructure` because the fixtures are all merged together and not namespaced. So someplace this was changed to a DataStructure, and now we have a `Tag` with a `DataStructure`.

This *was* fine until we changed the behaviour of the `DataStructure` with: https://github.com/neos/neos-development-collection/pull/3645

so when a `DataStructure`

previously didn't make nested DataStructures here:
```
nestedOverwritesAndProcessors.deepProcessorAppliesWithNoBaseValue = Neos.Fusion:SpecialTag {
  attributes = Neos.Fusion:DataStructure {
    coffee { // since #3645 becomes a Neos.Fusion:DataStructure
      @process.addProcessed = ${String.trim(value + ' harvey')}
    }
  }
}
```

it now does.
That leads to `coffee` being an empty array, what leads to the process trying to append a string to it - what surprisingly always fails.

I agree, that based on the code above It's not really clear at first glance, that value is an empty array. But then again I would expect it to be null - which surprisingly isn't it either! Since we magically give `@process` an empty string, in case there is no value:
https://github.com/neos/neos-development-collection/blob/694649dab4f4b8bf9c71c605bb5cf00180396198/Neos.Fusion/Classes/Core/RuntimeConfiguration.php#L161

so either way there stucks the worm in this issue, and I choose know to make the tests do what they say - no more.

we can still think about if a DataStructure should not create nested DataStructures when the only key is a `@process`.

--------

note this targets master on purpose.