### PR TITLE
BUGFIX: Fusion DataStructure don't auto create nested DataStructures if only `@process` is present

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Core\Parser;
 use Neos\Utility\Exception\InvalidPositionException;
 use Neos\Utility\PositionalArraySorter;
 use Neos\Fusion\Exception as FusionException;
@@ -164,6 +165,10 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     {
         $property = $this->properties[$key];
         if (!is_array($property)) {
+            return false;
+        }
+        if (array_diff(array_keys($property), Parser::$reservedParseTreeKeys) === []) {
+            // $property has no own properties (it might have @if or @process but this doesn't count.)
             return false;
         }
         return !isset($property['__objectType']) && !isset($property['__eelExpression']) && !isset($property['__value']);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -145,4 +145,14 @@ class DataStructureTest extends AbstractFusionObjectTest
         $view->setFusionPath('dataStructure/unsetUntypedChildKeyWillRenderAsDataStructure');
         self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function childKeysWithoutValueOrObjectOrEelIsNotUntyped(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/childKeysWithoutValueOrObjectOrEelIsNotUntyped');
+        self::assertEquals(['keyOnlyWithProcess' => 'EmptyString'], $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -153,3 +153,19 @@ dataStructure.unsetUntypedChildKeyWillRenderAsDataStructure = Neos.Fusion:DataSt
   }
   buz = 456
 }
+
+dataStructure.childKeysWithoutValueOrObjectOrEelIsNotUntyped = Neos.Fusion:DataStructure {
+  keyOnlyWithProcess {
+    // should be an EmptyString because of:
+    // https://github.com/neos/neos-development-collection/blob/694649dab4f4b8bf9c71c605bb5cf00180396198/Neos.Fusion/Classes/Core/RuntimeConfiguration.php#L161
+    @process.onNothing = ${value == '' ? 'EmptyString' : value}
+  }
+  keyOnlyWithIf {
+    @if.has = true
+  }
+  keyOnlyWithPrototype {
+    prototype(Neos.Foo:Bar) {
+      buz = "bat"
+    }
+  }
+}


### PR DESCRIPTION
see
additional fix for:
https://github.com/neos/neos-development-collection/pull/3663

```
foo = Neos.Fusion:Tag {
  attributes = Neos.Fusion:DataStructure {
    coffee { // since #3645 becomes a Neos.Fusion:DataStructure
      @process.addProcessed = ${String.trim(value + ' harvey')}
    }
  }
}
```

since #3645 `coffee` will be a nested auto created DataStructure -> since there is an `@process` in this. The coffee key dont really has `own properties` but this is now enought to count as `isUntyped()`.

with this fix, `value` will be an empty string (again like in 7.3) - to be discussed if this makes sense.
