### PR TITLE
!!! TASK: Remove remaining aloha configuration compatibility code

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -118,10 +118,6 @@ class NodeTypeConfigurationEnrichmentAspect
                 $this->applyEditorLabels($nodeTypeLabelIdPrefix, $propertyName, $editorName, $propertyConfiguration['ui']['inspector']['editorOptions'], $translationIdGenerator);
             }
 
-            if (isset($propertyConfiguration['ui']['aloha']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['aloha'], 'placeholder')) {
-                $propertyConfiguration['ui']['aloha']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'aloha.placeholder');
-            }
-
             if (isset($propertyConfiguration['ui']['inline']['editorOptions']) && $this->shouldFetchTranslation($propertyConfiguration['ui']['inline']['editorOptions'], 'placeholder')) {
                 $propertyConfiguration['ui']['inline']['editorOptions']['placeholder'] = $this->getPropertyConfigurationTranslationId($nodeTypeLabelIdPrefix, $propertyName, 'ui.inline.editorOptions.placeholder');
             }

--- a/Neos.Neos/Classes/Service/Controller/NodeController.php
+++ b/Neos.Neos/Classes/Service/Controller/NodeController.php
@@ -408,7 +408,7 @@ class NodeController extends AbstractServiceController
     }
 
     /**
-     * Returns an array with the data needed by for example the Hallo and Aloha
+     * Returns an array with the data needed by for example the frontend editing
      * link plugins to represent the passed Node instance.
      *
      * @param NodeInterface $node

--- a/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
+++ b/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
@@ -59,7 +59,6 @@ class NodeTypeSchemaBuilder
         foreach ($nodeTypes as $nodeTypeName => $nodeType) {
             if ($nodeType->isAbstract() === false) {
                 $configuration = $nodeType->getFullConfiguration();
-                $this->flattenAlohaFormatOptions($configuration);
                 $schema['nodeTypes'][$nodeTypeName] = $configuration;
                 $schema['nodeTypes'][$nodeTypeName]['label'] = $nodeType->getLabel();
             }
@@ -72,39 +71,6 @@ class NodeTypeSchemaBuilder
         }
 
         return $schema;
-    }
-
-    /**
-     * In order to allow unsetting options via the YAML settings merging, the
-     * formatting options can be set via 'option': true, however, the frontend
-     * schema expects a flattened plain numeric array. This methods adjust the setting
-     * accordingly.
-     *
-     * @param array $options The options array, passed by reference
-     * @return void
-     */
-    protected function flattenAlohaFormatOptions(array &$options)
-    {
-        if (isset($options['properties'])) {
-            foreach (array_keys($options['properties']) as $propertyName) {
-                if (isset($options['properties'][$propertyName]['ui']['aloha'])) {
-                    foreach ($options['properties'][$propertyName]['ui']['aloha'] as $formatGroup => $settings) {
-                        if (!is_array($settings) || in_array($formatGroup, ['formatlesspaste'])) {
-                            continue;
-                        }
-                        $flattenedSettings = [];
-                        foreach ($settings as $key => $option) {
-                            if (is_numeric($key) && is_string($option)) {
-                                $flattenedSettings[] = $option;
-                            } elseif ($option === true) {
-                                $flattenedSettings[] = $key;
-                            }
-                        }
-                        $options['properties'][$propertyName]['ui']['aloha'][$formatGroup] = $flattenedSettings;
-                    }
-                }
-            }
-        }
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Styles/_Global.scss
+++ b/Neos.Neos/Resources/Private/Styles/_Global.scss
@@ -111,15 +111,11 @@ body {
       background: none !important;
     }
 
-    // Handles around Aloha Blocks
     .neos-handle,
     .neos-status-indicator {
       display: none !important;
     }
 
-    // Aloha Floating Menu
-    #aloha-floatingmenu-shadow,
-    .aloha-floatingmenu,
     .x-shadow,
     .neos-contentelement-overlay,
     button.neos-create-new-content,
@@ -192,7 +188,3 @@ body {
     }
   }
 }
-
-// Include other global style files
-// @import "ContextBar/AlohaInlineTable";
-// @import "Shared/Select2";


### PR DESCRIPTION
**What I did**

Removed the last remaining PHP and SCSS code related to the old aloha editor which was deprecated since Neos 4.x.

This can be breaking if nodetypes still contain old style aloha specific configurations.
But the Neos.Ui package contains a migration `20180907103800` to adjust it.