### PR TITLE
TASK: Avoid deprecated Doctrine ORM proxy

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -13,7 +13,7 @@ namespace Neos\ContentRepository\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Doctrine\ORM\QueryBuilder;
 use Neos\ContentRepository\Exception\NodeConfigurationException;
 use Neos\ContentRepository\Exception\NodeException;

--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeExportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeExportService.php
@@ -12,6 +12,7 @@ namespace Neos\ContentRepository\Domain\Service\ImportExport;
  */
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -398,7 +399,7 @@ class NodeExportService
                     if ($objectIdentifier !== null) {
                         $this->xmlWriter->writeAttribute('__identifier', $objectIdentifier);
                     }
-                    if ($propertyValue instanceof \Doctrine\ORM\Proxy\Proxy) {
+                    if ($propertyValue instanceof DoctrineProxy) {
                         $className = get_parent_class($propertyValue);
                     } else {
                         $className = get_class($propertyValue);

--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -18,7 +18,7 @@ use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Utility\Algorithms;
 use Neos\Fusion\Exception;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Neos\Fusion\Exception\CacheException;
 
 /**


### PR DESCRIPTION
The `Doctrine\ORM\Proxy\Proxy` is deprecated and extends the
`Doctrine\Persistence\Proxy`.
