### PR TITLE
TASK: Introduce migration to convert Fusion objects without namespace

### DIFF
--- a/Neos.Fusion/Migrations/Code/Version20220326120900.php
+++ b/Neos.Fusion/Migrations/Code/Version20220326120900.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Expand Neos.Fusion-FusionObjects without namespace to fully qualified names
+ */
+class Version20220326120900 extends AbstractMigration
+{
+    /**
+     * The name of all prototypes from Neos.Fusion that could be used without
+     * namespace previously because of the `default` namespace
+     */
+    protected array $namesToMigrate = [
+        'Array',
+        'RawArray',
+        'Join',
+        'DataStructure',
+        'Template',
+        'Case',
+        'Matcher',
+        'Renderer',
+        'Value',
+        'Component',
+        'CanRender',
+        'DebugDump',
+        'Debug',
+        'Collection',
+        'RawCollection',
+        'Loop',
+        'Map',
+        'Reduce',
+        'Http.ResponseHead',
+        'Http.Message',
+        'Attributes',
+        'Tag',
+        'UriBuilder',
+        'Augmenter',
+        'ResourceUri',
+        'Link.Action',
+        'Link.Resource',
+        'Fragment',
+        'GlobalCacheIdentifiers'
+    ];
+
+    public function getIdentifier():string
+    {
+        return 'Neos.Fusion-20220326120900';
+    }
+
+    public function up():void
+    {
+        foreach ($this->namesToMigrate as $name) {
+            // fusion object assignments
+            $this->searchAndReplaceRegex('/(?<=\\=)([\\s]*)(' . preg_quote($name) . ')(?=[$\\s\\{])/u', '$1Neos.Fusion:$2', ['fusion']);
+            // prototype declarations
+            $this->searchAndReplaceRegex('/(?<=prototype\\()(' . preg_quote($name) . ')(?=\\))/u', 'Neos.Fusion:$1', ['fusion']);
+        }
+    }
+}


### PR DESCRIPTION
Fusion Objects without namespace were located in Neos.Fusion namespace in the past.
The namespace support is dropped with Neos 8 and this migration migrates Object names that
made use of this to the fully qualified names.

Note: This converts the only the default namespace. If custom namespaces are used they 
are not touched but have to be removed manually. The new Fusion parser tell you that.

Relates: #3497

This is based on an older migration when we changed the default Namespace to Neos.Fusion with Neos 4.0
see: https://github.com/neos/neos-development-collection/blob/4.0/Neos.Fusion/Migrations/Code/Version20180211175500.php

**How to verify it**

Run the migration with some fusion code that  uses FusionObjects without the Neos.Fusion namespace

```
./flow core:migrate Neos.Demo --force --verbose --version Neos.Fusion-20220326120900
```

A possible example for fusion code to check is here.

```
test = Join {

    #####################################################################################
    # Fusion objects without namespace that should be converted to Neos.Fusion Namspace #
    #####################################################################################

    objectWithoutBraces1 = Tag
    objectWithoutBraces2 = Http.Message

    objectWithBraces1 = Tag {
        tagName = "div"
    }
    objectWithBraces2 = Http.Message  {
        foo = "bar"
    }

    ##########################################################################################
    # Things that should not be converted because they already use the Neos.Fusion namespace #
    ##########################################################################################

    namespacedObjectWithoutBraces1 = Neos.Fusion:Tag
    namespacedObjectWithoutBraces1 = Neos.Fusion:Http.Message

    namespacedObjectWithBraces1 = Neos.Fusion:Tag {
        tagName = "div"
    }
    namespacedObjectWithBraces1 = Neos.Fusion:Http.Message  {
        foo = "bar"
    }

    #################################################################
    # Examples for objects without namespace that did not exist and #
    # that should not be touched and are left as invalid as before  # 
    #################################################################

    unknownObjectNameWithoutBraces1 = TagFooBar
    unknownObjectNameWithoutBraces2 = FooBarTag
    unknownObjectNameWithoutBraces3 = FooTagBar
    unknownObjectNameWithoutBraces4 = Tag.FooBar
    unknownObjectNameWithoutBraces5 = Foo.Tag.Bar
    unknownObjectNameWithoutBraces6 = FooBar.Tag

    unknownObjectNameWithBraces1 = TagFooBar {
        foo = "bar"
    }
    unknownObjectNameWithBraces2 = FooTagBar {
        foo = "bar"
    }
    unknownObjectNameWithBraces3 = FooBarTag {
        foo = "bar"
    }
    unknownObjectNameWithBraces4 = Tag.FooBar {
        foo = "bar"
    }
    unknownObjectNameWithBraces5 = Foo.Tag.Bar {
        foo = "bar"
    }
    unknownObjectNameWithBraces6 = FooBar.Tag {
        foo = "bar"
    }
}
```

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
