### PR TITLE
TASK: Add missing exclamation-triangle icon to error message

### DIFF
--- a/Neos.Neos/Resources/Private/Styles/Error.scss
+++ b/Neos.Neos/Resources/Private/Styles/Error.scss
@@ -5,6 +5,8 @@
 @import "Mixins";
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic');
 @import "FontAwesome/fontawesome.scss";
+@import "FontAwesome/solid.scss";
+@import "Icons";
 
 $errorBoxWidth: $unit * 18;
 $errorBoxHeight: $unit * 3;

--- a/Neos.Neos/Resources/Private/Templates/Error/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Error/Index.html
@@ -11,7 +11,7 @@
 		<div class="neos-error-screen">
 			<div class="neos-message-header">
 				<div class="neos-message-icon">
-					<i class="fas fa-warning-sign"></i>
+					<i class="fas fa-exclamation-triangle"></i>
 				</div>
 				<h1>{neos:backend.translate(id: 'error.exception.{renderingOptions.renderingGroup}.title', package: 'Neos.Neos')}</h1>
 			</div>

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/FallbackNode.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/FallbackNode.html
@@ -1,7 +1,7 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <div{attributes -> f:format.raw()}>
 	<div class="neos-message-header">
-		<div class="neos-message-icon"><i class="fas fa-warning-sign"></i></div>
+		<div class="neos-message-icon"><i class="fas fa-exclamation-triangle"></i></div>
 		<h1>{neos:backend.translate(id: 'error.invalidNodeType.title', package: 'Neos.Neos')}</h1>
 	</div>
 	<div class="neos-message-wrapper">

--- a/Neos.Neos/Resources/Public/Styles/Error.css
+++ b/Neos.Neos/Resources/Public/Styles/Error.css
@@ -4413,6 +4413,45 @@ readers do not read off random characters that represent icons */
   position: static;
   width: auto; }
 
+/*!
+ * Font Awesome Free 5.12.1 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+  font-display: auto;
+  src: url(../Fonts/fa-solid-900.eot);
+  src: url(../Fonts/fa-solid-900.eot?#iefix) format("embedded-opentype"), url(../Fonts/fa-solid-900.woff2) format("woff2"), url(../Fonts/fa-solid-900.woff) format("woff"), url(../Fonts/fa-solid-900.ttf) format("truetype"), url(../Fonts/fa-solid-900.svg#fontawesome) format("svg"); }
+
+.fa,
+.fas {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900; }
+
+.neos [class^="fa-"],
+.neos [class*=" fa-"] {
+  vertical-align: baseline; }
+  .neos [class^="fa-"].fa-review,
+  .neos [class*=" fa-"].fa-review {
+    position: relative;
+    padding-right: 4px; }
+    .neos [class^="fa-"].fa-review:before,
+    .neos [class*=" fa-"].fa-review:before {
+      content: "\f15c";
+      font-weight: 400; }
+    .neos [class^="fa-"].fa-review:after,
+    .neos [class*=" fa-"].fa-review:after {
+      content: "\f058";
+      text-decoration: inherit;
+      display: inline-block;
+      speak: none;
+      position: absolute;
+      font-size: 12px;
+      top: 8px;
+      left: 7px; }
+
 body {
   background: #141414;
   margin: 0; }


### PR DESCRIPTION
When you see this error message style (`resource://Neos.Neos/Private/Templates/Error/Index.html`), an icon is missing.  
 
 Before:  
![screenshot-logopak localhost-2022 03 26-19_01_22](https://user-images.githubusercontent.com/1208133/160251760-a96f989b-0491-4f24-8c7b-a50cb4c07351.png)

After:  
![screenshot-logopak localhost-2022 03 26-19_03_15](https://user-images.githubusercontent.com/1208133/160251805-7bc2c476-af00-44b7-a202-b2fa07081708.png)


**Checklist**

- [x] ~~Code follows the PSR-2 coding style~~
- [x] ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
