### PR TITLE
BUGFIX: Fusion Runtime lazy-props evaluation confuses `getLastEvaluat…

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -773,10 +773,8 @@ class Runtime
                     $singleApplyPath .= '/expression';
                 }
                 $singleApplyValues = $this->evaluate($singleApplyPath, null, self::BEHAVIOR_EXCEPTION);
-                if ($this->getLastEvaluationStatus() !== static::EVALUATION_SKIPPED) {
-                    if ($singleApplyValues === null) {
-                        continue;
-                    } elseif (is_array($singleApplyValues)) {
+                if ($singleApplyValues !== null || $this->getLastEvaluationStatus() !== static::EVALUATION_SKIPPED) {
+                    if (is_array($singleApplyValues)) {
                         foreach ($singleApplyValues as $key => $value) {
                             // skip keys which start with __, as they are purely internal.
                             if ($key[0] === '_' && $key[1] === '_' && in_array($key, Parser::$reservedParseTreeKeys, true)) {
@@ -837,7 +835,7 @@ class Runtime
 
             $this->pushContext('value', $valueToProcess);
             $result = $this->evaluate($processorPath, $contextObject, self::BEHAVIOR_EXCEPTION);
-            if ($this->getLastEvaluationStatus() !== static::EVALUATION_SKIPPED) {
+            if ($result !== null || $this->getLastEvaluationStatus() !== static::EVALUATION_SKIPPED) {
                 $valueToProcess = $result;
             }
             $this->popContext();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -286,4 +286,14 @@ class ApplyTest extends AbstractFusionObjectTest
         $view->setFusionPath('apply/renderWithNestedProps');
         self::assertEquals('::example::', $view->render());
     }
+
+    /**
+     * @test
+     */
+    public function evaluateLazyPropsWithLastOneSkipped()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('apply/evaluateLazyPropsWithLastOneSkipped');
+        self::assertSame(['lazyPropValue' => 'foo'], $view->render());
+    }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Apply.fusion
@@ -169,3 +169,15 @@ prototype(Neos.Fusion:TestNestedPropsB) < prototype(Neos.Fusion:Component) {
     item_2 = '::'
   }
 }
+
+// https://github.com/neos/neos-development-collection/issues/3469
+apply.evaluateLazyPropsWithLastOneSkipped = Neos.Fusion:Component {
+  lazyPropValue = "foo"
+
+  lazyPropSkipped = "skip"
+  lazyPropSkipped.@if.1 = false
+
+  renderer = Neos.Fusion:DataStructure {
+    @apply.forceEvaluatedProps = ${Array.filter(props, prop => prop != null)}
+  }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
@@ -114,3 +114,16 @@ processors.newSyntax.usingThisInProcessor = Value {
 	@process.1 = ${value + this.append}
 	append = " append"
 }
+
+// https://github.com/neos/neos-development-collection/issues/3469
+processors.newSyntax.skippedLazyPropsInProcessor = Neos.Fusion:Component {
+  lazyPropValue = "foo"
+
+  lazyPropSkipped = "skip"
+  lazyPropSkipped.@if.1 = false
+
+  renderer = Neos.Fusion:DataStructure {
+    buz = "bar"
+    @process.combine = ${Array.concat(value, Array.filter(props, prop => prop != null))}
+  }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -74,4 +74,14 @@ class ProcessorTest extends AbstractFusionObjectTest
     {
         $this->assertFusionPath('my value append', 'processors/newSyntax/usingThisInProcessor');
     }
+
+    /**
+     * @test
+     */
+    public function skippedLazyPropsInProcessor()
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('processors/newSyntax/skippedLazyPropsInProcessor');
+        self::assertSame(['buz' => 'bar', 'lazyPropValue' => 'foo'], $view->render());
+    }
 }


### PR DESCRIPTION
fixes: #3469

doing the check if a render was successful cannot only happen via `$this->getLastEvaluationStatus()`
-> as the render path might contain a lazy-prop (closure) which, when evaluated uses the same runtime.
-> if the last lazy-prop has an `@if` annotation its skipped, but the `$lastEvaluationStatus` is set on the same runtime.
-> there might still be partial successful output (the first values of a lazy-prop eg.) so we need to check additionally if the return value is null.