### PR TITLE
TASK: Correct class loading for Neos Cli setup in master and restore alphabetical order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
     },
     "autoload": {
         "psr-4": {
+            "Neos\\CliSetup\\": [
+                "Neos.CliSetup/Classes"
+            ],
             "Neos\\ContentRepository\\": [
                 "Neos.ContentRepository/Classes"
             ],
@@ -113,9 +116,6 @@
             ],
             "Neos\\SiteKickstarter\\": [
                 "Neos.SiteKickstarter/Classes"
-            ],
-            "Neos\\CliSetup\\\\": [
-                "Neos.CliSetup/Classes"
             ]
         }
     },


### PR DESCRIPTION
as is in the 7.3 branch already

