### PR TITLE
BUGFIX: Remove unused nodetype configuration cache

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
@@ -12,7 +12,6 @@ namespace Neos\ContentRepository\Domain\Service;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Exception;
@@ -53,12 +52,6 @@ class NodeTypeManager
      * @var string
      */
     protected $fallbackNodeTypeName;
-
-    /**
-     * @Flow\Inject
-     * @var StringFrontend
-     */
-    protected $fullConfigurationCache;
 
     /**
      * @var array
@@ -184,25 +177,14 @@ class NodeTypeManager
      */
     protected function loadNodeTypes()
     {
-        $this->fullNodeTypeConfigurations = $this->fullConfigurationCache->get('fullNodeTypeConfigurations');
-        $fillFullConfigurationCache = !is_array($this->fullNodeTypeConfigurations);
-
         $completeNodeTypeConfiguration = $this->configurationManager->getConfiguration('NodeTypes');
 
         foreach (array_keys($completeNodeTypeConfiguration) as $nodeTypeName) {
             if (!is_array($completeNodeTypeConfiguration[$nodeTypeName])) {
                 continue;
             }
-            $nodeType = $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration, (isset($this->fullNodeTypeConfigurations[$nodeTypeName]) ? $this->fullNodeTypeConfigurations[$nodeTypeName] : null));
-            if ($fillFullConfigurationCache) {
-                $this->fullNodeTypeConfigurations[$nodeTypeName] = $nodeType->getFullConfiguration();
-            }
+            $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration);
         }
-
-        if ($fillFullConfigurationCache) {
-            $this->fullConfigurationCache->set('fullNodeTypeConfigurations', $this->fullNodeTypeConfigurations);
-        }
-        $this->fullNodeTypeConfigurations = null;
     }
 
     /**
@@ -228,13 +210,12 @@ class NodeTypeManager
      *
      * @param string $nodeTypeName
      * @param array $completeNodeTypeConfiguration the full node type configuration for all node types
-     * @param array $fullNodeTypeConfigurationForType
      * @return NodeType
      * @throws NodeConfigurationException
      * @throws NodeTypeIsFinalException
      * @throws Exception
      */
-    protected function loadNodeType($nodeTypeName, array &$completeNodeTypeConfiguration, array $fullNodeTypeConfigurationForType = null)
+    protected function loadNodeType($nodeTypeName, array &$completeNodeTypeConfiguration)
     {
         if (isset($this->cachedNodeTypes[$nodeTypeName])) {
             return $this->cachedNodeTypes[$nodeTypeName];

--- a/Neos.ContentRepository/Configuration/Caches.yaml
+++ b/Neos.ContentRepository/Configuration/Caches.yaml
@@ -1,5 +1,0 @@
-# This cache is currently not cleared via FileMonitor,
-# therefore it is activated only in Production Context (see Production/Caches.yaml).
-Neos_ContentRepository_FullNodeTypeConfiguration:
-  frontend: Neos\Cache\Frontend\VariableFrontend
-  backend: Neos\Cache\Backend\NullBackend

--- a/Neos.ContentRepository/Configuration/Objects.yaml
+++ b/Neos.ContentRepository/Configuration/Objects.yaml
@@ -16,13 +16,3 @@
   className: Neos\ContentRepository\Domain\Model\ExpressionBasedNodeLabelGenerator
 'Neos\ContentRepository\Domain\Service\NodeServiceInterface':
   className: Neos\ContentRepository\Domain\Service\NodeService
-
-'Neos\ContentRepository\Domain\Service\NodeTypeManager':
-  properties:
-    fullConfigurationCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Neos_ContentRepository_FullNodeTypeConfiguration

--- a/Neos.ContentRepository/Configuration/Production/Caches.yaml
+++ b/Neos.ContentRepository/Configuration/Production/Caches.yaml
@@ -1,2 +1,0 @@
-Neos_ContentRepository_FullNodeTypeConfiguration:
-  backend: Neos\Cache\Backend\SimpleFileBackend

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
@@ -11,7 +11,6 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * source code.
  */
 
-use Neos\Cache\Frontend\StringFrontend;
 use Neos\ContentRepository\Exception;
 use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
 use Neos\Flow\Configuration\ConfigurationManager;
@@ -48,10 +47,6 @@ class NodeTypeManagerTest extends UnitTestCase
         $this->nodeTypeManager = new NodeTypeManager();
 
         $this->mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
-
-        $mockCache = $this->getMockBuilder(StringFrontend::class)->disableOriginalConstructor()->getMock();
-        $mockCache->expects(self::any())->method('get')->willReturn(null);
-        $this->inject($this->nodeTypeManager, 'fullConfigurationCache', $mockCache);
 
         $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('NodeTypes')->will(self::returnValue($nodeTypesFixtureData));
         $this->inject($this->nodeTypeManager, 'configurationManager', $this->mockConfigurationManager);


### PR DESCRIPTION
The cache with its current implementation actually
hurts performance as it forces loading of all
nodetypes instead of lazy loading the required ones.
Also the cached data is never used.
In development context all nodetypes are reloaded
on every request accessing the nodetypemanager.

Therefore its better to remove the cache until there
is a proper implementation.

Resolves: #3681
