### PR TITLE
BUGFIX: setter for: enable parse partials cache

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -45,6 +45,11 @@ class ParserCache
      */
     protected $enableCache;
 
+    public function enableCache(bool $enable): void
+    {
+        $this->enableCache = $enable;
+    }
+
     public function cacheForFusionFile(?string $contextPathAndFilename, \Closure $generateValueToCache): FusionFile
     {
         if ($this->enableCache === false) {

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -69,6 +69,11 @@ class Parser implements ParserInterface
         return $mergedArrayTree->getTree();
     }
 
+    public function enableParsePartialsCache(bool $enable): void
+    {
+        $this->parserCache->enableCache($enable);
+    }
+
     protected function handleFileInclude(MergedArrayTree $mergedArrayTree, string $filePattern, ?string $contextPathAndFilename): void
     {
         $filesToInclude = FilePatternResolver::resolveFilesByPattern($filePattern, $contextPathAndFilename, '.fusion');


### PR DESCRIPTION
i added this, as i think it was missing:
```php
Parser::enableParsePartialsCache(bool $enable);
```
it might be helpful for people using this parser for custom stuff ...
but, by doing this we give the parser a state > meaning it can never become a singleton right?
