### PR TITLE
BUGFIX: Separate fusion parserCache and parserCacheFlusher 

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -17,8 +17,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Package\PackageManager;
 use Neos\Fusion\Core\ObjectTreeParser\Ast\FusionFile;
-use Neos\Utility\Unicode\Functions as UnicodeFunctions;
-use Neos\Utility\Files;
 
 /**
  * Helper around the ParsePartials Cache.
@@ -28,6 +26,8 @@ use Neos\Utility\Files;
  */
 class ParserCache
 {
+    use ParserCacheIdentifierTrait;
+
     /**
      * @Flow\Inject
      * @var VariableFrontend
@@ -66,19 +66,6 @@ class ParserCache
         return $this->cacheForIdentifier($identifier, $generateValueToCache);
     }
 
-    /**
-     * @param array<string, int> $changedFiles
-     */
-    public function flushFileAstCacheOnFileChanges(array $changedFiles): void
-    {
-        foreach ($changedFiles as $changedFile => $status) {
-            $identifier = $this->getCacheIdentifierForFile($changedFile);
-            if ($this->parsePartialsCache->has($identifier)) {
-                $this->parsePartialsCache->remove($identifier);
-            }
-        }
-    }
-
     private function cacheForIdentifier(string $identifier, \Closure $generateValueToCache): mixed
     {
         if ($this->parsePartialsCache->has($identifier)) {
@@ -87,58 +74,5 @@ class ParserCache
         $value = $generateValueToCache();
         $this->parsePartialsCache->set($identifier, $value);
         return $value;
-    }
-
-    /**
-     * creates a comparable hash of the dsl type and content to be used as cache identifier
-     */
-    private function getCacheIdentifierForDslCode(string $identifier, string $code): string
-    {
-        return 'dsl_' . $identifier . '_' . md5($code);
-    }
-
-    /**
-     * creates a comparable hash of the absolute, resolved $fusionFileName
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function getCacheIdentifierForFile(string $fusionFileName): string
-    {
-        if (str_contains($fusionFileName, '://')) {
-            $fusionFileName = $this->getAbsolutePathForPackageRessourceUri($fusionFileName);
-        }
-
-        $realPath = realpath($fusionFileName);
-        if ($realPath === false) {
-            throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
-        }
-
-        $realFusionFilePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $realPath);
-        return 'file_' . md5($realFusionFilePathWithoutRoot);
-    }
-
-    /**
-     * Uses the same technique to resolve a package resource URI like Flow.
-     *
-     * resource://My.Site/Private/Fusion/Foo/Bar.fusion
-     * ->
-     * FLOW_PATH_ROOT/Packages/Sites/My.Package/Resources/Private/Fusion/Foo/Bar.fusion
-     *
-     * {@see \Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper::evaluateResourcePath()}
-     * {@link https://github.com/neos/flow-development-collection/issues/2687}
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function getAbsolutePathForPackageRessourceUri(string $requestedPath): string
-    {
-        $resourceUriParts = UnicodeFunctions::parse_url($requestedPath);
-
-        if ((isset($resourceUriParts['scheme']) === false
-            || $resourceUriParts['scheme'] !== 'resource')) {
-            throw new \InvalidArgumentException("Unsupported stream wrapper: '$requestedPath'");
-        }
-
-        $package = $this->packageManager->getPackage($resourceUriParts['host']);
-        return Files::concatenatePaths([$package->getResourcesPath(), $resourceUriParts['path']]);
     }
 }

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Fusion\Core\Cache;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Cache\Frontend\VariableFrontend;
+
+/**
+ * Helper around the ParsePartials Cache.
+ * Connected in the boot to flush caches on file-change.
+ * Caches partials when requested by the Fusion Parser.
+ *
+ */
+class ParserCacheFlusher
+{
+    use ParserCacheIdentifierTrait;
+
+    /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $parsePartialsCache;
+
+    /**
+     * @param array<string, int> $changedFiles
+     */
+    public function flushFileAstCacheOnFileChanges(array $changedFiles): void
+    {
+        foreach ($changedFiles as $changedFile => $status) {
+            $identifier = $this->getCacheIdentifierForFile($changedFile);
+            if ($this->parsePartialsCache->has($identifier)) {
+                $this->parsePartialsCache->remove($identifier);
+            }
+        }
+    }
+}

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
@@ -20,7 +20,6 @@ use Psr\Log\LoggerInterface;
 /**
  * Helper around the ParsePartials Cache.
  * Connected in the boot to flush caches on file-change.
- * Caches partials when requested by the Fusion Parser.
  *
  */
 class ParserCacheFlusher

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
@@ -13,9 +13,6 @@ namespace Neos\Fusion\Core\Cache;
  * source code.
  */
 
-use Neos\Utility\Unicode\Functions as UnicodeFunctions;
-use Neos\Utility\Files;
-
 /**
  * Identifier for the ParsePartials Cache.
  */
@@ -37,10 +34,6 @@ trait ParserCacheIdentifierTrait
      */
     private function getCacheIdentifierForFile(string $fusionFileName): string
     {
-        if (str_contains($fusionFileName, '://')) {
-            $fusionFileName = $this->getAbsolutePathForPackageRessourceUri($fusionFileName);
-        }
-
         $realPath = realpath($fusionFileName);
         if ($realPath === false) {
             throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
@@ -48,30 +41,5 @@ trait ParserCacheIdentifierTrait
 
         $realFusionFilePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $realPath);
         return 'file_' . md5($realFusionFilePathWithoutRoot);
-    }
-
-    /**
-     * Uses the same technique to resolve a package resource URI like Flow.
-     *
-     * resource://My.Site/Private/Fusion/Foo/Bar.fusion
-     * ->
-     * FLOW_PATH_ROOT/Packages/Sites/My.Package/Resources/Private/Fusion/Foo/Bar.fusion
-     *
-     * {@see \Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper::evaluateResourcePath()}
-     * {@link https://github.com/neos/flow-development-collection/issues/2687}
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function getAbsolutePathForPackageRessourceUri(string $requestedPath): string
-    {
-        $resourceUriParts = UnicodeFunctions::parse_url($requestedPath);
-
-        if ((isset($resourceUriParts['scheme']) === false
-            || $resourceUriParts['scheme'] !== 'resource')) {
-            throw new \InvalidArgumentException("Unsupported stream wrapper: '$requestedPath'");
-        }
-
-        $package = $this->packageManager->getPackage($resourceUriParts['host']);
-        return Files::concatenatePaths([$package->getResourcesPath(), $resourceUriParts['path']]);
     }
 }

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Fusion\Core\Cache;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Utility\Unicode\Functions as UnicodeFunctions;
+use Neos\Utility\Files;
+
+/**
+ * Identifier for the ParsePartials Cache.
+ */
+trait ParserCacheIdentifierTrait
+{
+
+    /**
+     * creates a comparable hash of the dsl type and content to be used as cache identifier
+     */
+    private function getCacheIdentifierForDslCode(string $identifier, string $code): string
+    {
+        return 'dsl_' . $identifier . '_' . md5($code);
+    }
+
+    /**
+     * creates a comparable hash of the absolute, resolved $fusionFileName
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function getCacheIdentifierForFile(string $fusionFileName): string
+    {
+        if (str_contains($fusionFileName, '://')) {
+            $fusionFileName = $this->getAbsolutePathForPackageRessourceUri($fusionFileName);
+        }
+
+        $realPath = realpath($fusionFileName);
+        if ($realPath === false) {
+            throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
+        }
+
+        $realFusionFilePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $realPath);
+        return 'file_' . md5($realFusionFilePathWithoutRoot);
+    }
+
+    /**
+     * Uses the same technique to resolve a package resource URI like Flow.
+     *
+     * resource://My.Site/Private/Fusion/Foo/Bar.fusion
+     * ->
+     * FLOW_PATH_ROOT/Packages/Sites/My.Package/Resources/Private/Fusion/Foo/Bar.fusion
+     *
+     * {@see \Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper::evaluateResourcePath()}
+     * {@link https://github.com/neos/flow-development-collection/issues/2687}
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function getAbsolutePathForPackageRessourceUri(string $requestedPath): string
+    {
+        $resourceUriParts = UnicodeFunctions::parse_url($requestedPath);
+
+        if ((isset($resourceUriParts['scheme']) === false
+            || $resourceUriParts['scheme'] !== 'resource')) {
+            throw new \InvalidArgumentException("Unsupported stream wrapper: '$requestedPath'");
+        }
+
+        $package = $this->packageManager->getPackage($resourceUriParts['host']);
+        return Files::concatenatePaths([$package->getResourcesPath(), $resourceUriParts['path']]);
+    }
+}

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -19,6 +19,7 @@ use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Fusion\Core\Cache\FileMonitorListener;
 use Neos\Fusion\Core\Cache\ParserCache;
+use Neos\Fusion\Core\Cache\ParserCacheFlusher;
 
 /**
  * The Neos Fusion Package
@@ -72,7 +73,7 @@ class Package extends BasePackage
                             return;
                         }
                         $objectManager = $bootstrap->getObjectManager();
-                        if ($objectManager->isRegistered(ParserCache::class) === false) {
+                        if ($objectManager->isRegistered(ParserCacheFlusher::class) === false) {
                             // if we make a total `rm -rf Data/Temporary` all monitored `*.fusion` files will be seen as newly created.
                             // this triggers pretty early this `filesHaveChanged` and we still have the CompileTimeObjectManager
                             // we would get an exception like:
@@ -83,8 +84,8 @@ class Package extends BasePackage
                             $fusionParsePartialsCache->flush();
                             return;
                         }
-                        $fusionParserCache = $objectManager->get(ParserCache::class);
-                        $fusionParserCache->flushFileAstCacheOnFileChanges($changedFilesAndStatus);
+                        $fusionParserCacheFlusher = $objectManager->get(ParserCacheFlusher::class);
+                        $fusionParserCacheFlusher->flushFileAstCacheOnFileChanges($changedFilesAndStatus);
                     };
                     $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushParsePartialsCache);
                 }

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -66,27 +66,8 @@ class Package extends BasePackage
                     $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
                     $listener = new FileMonitorListener($cacheManager);
                     $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $listener, 'flushContentCacheOnFileChanges');
-                    // Use a closure to invoke the FusionParserCache, so the object is not instantiated during compiletime and has working DI
-                    $flushParsePartialsCache = function ($identifier, $changedFilesAndStatus) use ($bootstrap) {
-                        if ($identifier !== 'Fusion_Files') {
-                            return;
-                        }
-                        $objectManager = $bootstrap->getObjectManager();
-                        if ($objectManager->isRegistered(ParserCacheFlusher::class) === false) {
-                            // if we make a total `rm -rf Data/Temporary` all monitored `*.fusion` files will be seen as newly created.
-                            // this triggers pretty early this `filesHaveChanged` and we still have the CompileTimeObjectManager
-                            // we would get an exception like:
-                            // Cannot build object "FusionParserCache" because it is unknown to the compile time Object Manager.
-                            // so instead we will just make sure the cache is totally flushed.
-                            $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
-                            $fusionParsePartialsCache = $cacheManager->getCache('Neos_Fusion_ParsePartials');
-                            $fusionParsePartialsCache->flush();
-                            return;
-                        }
-                        $fusionParserCacheFlusher = $objectManager->get(ParserCacheFlusher::class);
-                        $fusionParserCacheFlusher->registerFileChanges($changedFilesAndStatus);
-                    };
-                    $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushParsePartialsCache);
+                    $parsePartialCacheFlusher = new ParserCacheFlusher($cacheManager);
+                    $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $parsePartialCacheFlusher, 'flushPartialCacheOnFileChanges');
                 }
             });
         }

--- a/Neos.Fusion/Classes/Package.php
+++ b/Neos.Fusion/Classes/Package.php
@@ -18,7 +18,6 @@ use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Fusion\Core\Cache\FileMonitorListener;
-use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion\Core\Cache\ParserCacheFlusher;
 
 /**
@@ -85,7 +84,7 @@ class Package extends BasePackage
                             return;
                         }
                         $fusionParserCacheFlusher = $objectManager->get(ParserCacheFlusher::class);
-                        $fusionParserCacheFlusher->flushFileAstCacheOnFileChanges($changedFilesAndStatus);
+                        $fusionParserCacheFlusher->registerFileChanges($changedFilesAndStatus);
                     };
                     $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushParsePartialsCache);
                 }

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -27,13 +27,3 @@ Neos\Fusion\Core\Cache\ParserCache:
         arguments:
           1:
             value: Neos_Fusion_ParsePartials
-
-Neos\Fusion\Core\Cache\ParserCacheFlusher:
-  properties:
-    parsePartialsCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Neos_Fusion_ParsePartials

--- a/Neos.Fusion/Configuration/Objects.yaml
+++ b/Neos.Fusion/Configuration/Objects.yaml
@@ -27,3 +27,13 @@ Neos\Fusion\Core\Cache\ParserCache:
         arguments:
           1:
             value: Neos_Fusion_ParsePartials
+
+Neos\Fusion\Core\Cache\ParserCacheFlusher:
+  properties:
+    parsePartialsCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Neos_Fusion_ParsePartials


### PR DESCRIPTION
This fixes a race condition described in #3685. When PHP code was changed at the same time as Fusion code, the parse partial cache tried to flush before the cache was injected which lead to a PHP error.

The change extracts the logic for flushing the partial cache into a very simple object with the generating of identifiers kept as a shared trait between `ParserCacheFlusher` and `ParserCache`.

resolves: https://github.com/neos/neos-development-collection/issues/3685
related: https://github.com/neos/neos-development-collection/pull/3659
replaces: https://github.com/neos/neos-development-collection/pull/3688