### PR TITLE
BUGFIX: Apply array_filter to augmenter values to prevent rendering attributes for null values

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
@@ -45,7 +45,7 @@ class AugmenterImplementation extends AbstractArrayFusionObject
         $content = $this->fusionValue('content');
         $fallbackTagName = $this->fusionValue('fallbackTagName');
 
-        $attributes = $this->evaluateNestedProperties();
+        $attributes = array_filter($this->evaluateNestedProperties());
 
         if ($attributes && is_array($attributes) && count($attributes) > 0) {
             return $this->htmlAugmenter->addAttributes($content, $attributes, $fallbackTagName);


### PR DESCRIPTION
Originally the fusion augmenter only passed non falsy values to the HtmlAugmenter.
This was changed by using the evaluateNestedProperties method (inherited from AbstractArrayFusionObject) instead ob the previously used sortNestedFusionKeys (inherited from JoinImplementation) plus custom loop.

See: https://github.com/neos/neos-development-collection/pull/3645/files#diff-40c9edd185fdb14a7c3b4b89b78f32b4fa58eba26d5e750b236ce730f45342b6

This is fixed by applying array_filter that will filter all falsy values (null | false).
