### PR TITLE
TASK: Destroy user sessions on certain actions

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -841,7 +841,7 @@ class UserService
      * @param bool $keepCurrentSession
      * @throws SessionNotStartedException
      */
-    public function destroyActiveSessionsForUser(User $user, bool $keepCurrentSession = false): void
+    private function destroyActiveSessionsForUser(User $user, bool $keepCurrentSession = false): void
     {
         $sessionToKeep = $keepCurrentSession ? $this->sessionManager->getCurrentSession() : null;
 


### PR DESCRIPTION
This adds a new method

    UserService::destroyActiveSessionsForUser(User $user, bool $keepCurrentSession = false): void

and calls the method when a user is deactivated, removed or when the password is changed.