### PR TITLE
 BUGFIX: Add better is untyped property check

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -96,6 +96,7 @@ class DataStructureImplementation extends AbstractArrayFusionObject
         if (!is_array($property)) {
             return false;
         }
-        return array_intersect_key(array_flip(Parser::$reservedParseTreeKeys), $property) === [];
+        
+        return !isset($property['__objectType']) && !isset($property['__eelExpression']) && !isset($property['__value']);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -11,7 +11,6 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Runtime;
 use Neos\Utility\Exception\InvalidPositionException;
 use Neos\Utility\PositionalArraySorter;


### PR DESCRIPTION
The previous condition leads to an error if you have an @if or another meta key in the data structure. 

Related: #3645
