### PR TITLE
BUGFIX: Have FlowQuery operations reliably detect nodes during canEvaluate

### DIFF
--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
@@ -69,7 +69,7 @@ class CacheLifetimeOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
@@ -34,6 +34,8 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
  */
 class CacheLifetimeOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -60,17 +62,6 @@ class CacheLifetimeOperation extends AbstractOperation
      * @var Now
      */
     protected $now;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
@@ -11,7 +11,6 @@ namespace Neos\ContentRepository\Eel\FlowQueryOperations;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CacheLifetimeOperation.php
@@ -65,6 +65,17 @@ class CacheLifetimeOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery The FlowQuery object
      * @param array $arguments None
      * @return integer The cache lifetime in seconds or NULL if either no content collection was given or no child node had a "hiddenBeforeDateTime" or "hiddenAfterDateTime" property set

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Eel\FlowQueryOperations;
 
+use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 
 trait CanEvaluateNodeContextTrait
@@ -13,7 +14,26 @@ trait CanEvaluateNodeContextTrait
      * @param array|\Traversable (or array-like object) $context onto which this operation should be applied
      * @return boolean true if the operation can be applied onto the $context, false otherwise
      */
-    public function canEvaluate($context)
+    public function checkContextForNodeInterface($context)
+    {
+        if (is_array($context)) {
+            return count($context) > 0 ? reset($context) instanceof NodeInterface : true;
+        } elseif ($context instanceof \Traversable) {
+            foreach ($context as $item) {
+                return $item instanceof NodeInterface;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array|\Traversable (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function checkContextForTraversableNodeInterface($context)
     {
         if (is_array($context)) {
             return count($context) > 0 ? reset($context) instanceof TraversableNodeInterface : true;

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Eel\FlowQueryOperations;
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+
+trait CanEvaluateNodeContextTrait
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param array|\Traversable (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        if (is_array($context)) {
+            return count($context) > 0 ? reset($context) instanceof TraversableNodeInterface : true;
+        } elseif ($context instanceof \Traversable) {
+            foreach ($context as $item) {
+                return $item instanceof TraversableNodeInterface;
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/CanEvaluateNodeContextTrait.php
@@ -12,9 +12,8 @@ trait CanEvaluateNodeContextTrait
      * {@inheritdoc}
      *
      * @param array|\Traversable (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
      */
-    public function checkContextForNodeInterface($context)
+    public function checkContextForNodeInterface($context): bool
     {
         if (is_array($context)) {
             return count($context) > 0 ? reset($context) instanceof NodeInterface : true;
@@ -31,9 +30,8 @@ trait CanEvaluateNodeContextTrait
      * {@inheritdoc}
      *
      * @param array|\Traversable (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
      */
-    public function checkContextForTraversableNodeInterface($context)
+    public function checkContextForTraversableNodeInterface($context): bool
     {
         if (is_array($context)) {
             return count($context) > 0 ? reset($context) instanceof TraversableNodeInterface : true;

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
@@ -55,7 +55,7 @@ class ChildrenOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return isset($context[0]) && ($context[0] instanceof TraversableNodeInterface);
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
@@ -55,7 +55,7 @@ class ChildrenOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
+        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
@@ -52,6 +52,17 @@ class ChildrenOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ChildrenOperation.php
@@ -27,6 +27,8 @@ use Neos\Flow\Annotations as Flow;
  */
 class ChildrenOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -46,17 +48,6 @@ class ChildrenOperation extends AbstractOperation
      * @var NodeTypeConstraintFactory
      */
     protected $nodeTypeConstraintFactory;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
@@ -42,6 +42,17 @@ class ClosestOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
@@ -45,7 +45,7 @@ class ClosestOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ClosestOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class ClosestOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class ClosestOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
@@ -57,6 +57,17 @@ class ContextOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery The FlowQuery object
      * @param array $arguments The arguments for this operation
      * @todo reimplement using TraversableNodeInterface / new NodeInterface once subgraphs are available

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Eel\FlowQueryOperations;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\FlowQueryException;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
@@ -59,7 +60,7 @@ class ContextOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ContextOperation.php
@@ -32,6 +32,8 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
  */
 class ContextOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -51,17 +53,6 @@ class ContextOperation extends AbstractOperation
      * @var ContextFactoryInterface
      */
     protected $contextFactory;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -45,6 +45,17 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery
      * @param array $arguments
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -48,7 +48,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
      */
     public function canEvaluate($context)
     {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
+        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -48,7 +48,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
      */
     public function canEvaluate($context)
     {
-        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -33,23 +33,14 @@ use Neos\ContentRepository\Domain\Model\Node;
  */
 class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -48,7 +48,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
      */
     public function canEvaluate($context)
     {
-        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -55,7 +55,6 @@ use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
  */
 class FindOperation extends AbstractOperation
 {
-    use CanEvaluateNodeContextTrait;
 
     /**
      * {@inheritdoc}
@@ -76,6 +75,26 @@ class FindOperation extends AbstractOperation
      * @var NodeDataRepository
      */
     protected $nodeDataRepository;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        if (is_countable($context) && count($context) === 0) {
+            return true;
+        }
+
+        foreach ($context as $contextNode) {
+            if (!$contextNode instanceof NodeInterface) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /**
      * This operation operates rather on the given Context object than on the given node

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -55,6 +55,8 @@ use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
  */
 class FindOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -74,26 +76,6 @@ class FindOperation extends AbstractOperation
      * @var NodeDataRepository
      */
     protected $nodeDataRepository;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        if (count($context) === 0) {
-            return true;
-        }
-
-        foreach ($context as $contextNode) {
-            if (!$contextNode instanceof NodeInterface) {
-                return false;
-            }
-        }
-        return true;
-    }
 
     /**
      * This operation operates rather on the given Context object than on the given node

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -84,16 +84,18 @@ class FindOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        if (is_countable($context) && count($context) === 0) {
+        if (is_iterable($context)) {
+            if (is_countable($context) && count($context) === 0) {
+                return true;
+            }
+            foreach ($context as $contextNode) {
+                if (!$contextNode instanceof NodeInterface) {
+                    return false;
+                }
+            }
             return true;
         }
-
-        foreach ($context as $contextNode) {
-            if (!$contextNode instanceof NodeInterface) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
@@ -44,6 +44,17 @@ class HasOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery
      * @param array $arguments
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
@@ -47,7 +47,7 @@ class HasOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/HasOperation.php
@@ -25,6 +25,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class HasOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -38,17 +40,6 @@ class HasOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
@@ -42,6 +42,17 @@ class NextAllOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class NextAllOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class NextAllOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextAllOperation.php
@@ -45,7 +45,7 @@ class NextAllOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
@@ -43,6 +43,17 @@ class NextOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
@@ -24,6 +24,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class NextOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -37,17 +39,6 @@ class NextOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextOperation.php
@@ -46,7 +46,7 @@ class NextOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
@@ -43,6 +43,17 @@ class NextUntilOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
@@ -24,6 +24,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class NextUntilOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -37,17 +39,6 @@ class NextUntilOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/NextUntilOperation.php
@@ -46,7 +46,7 @@ class NextUntilOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
@@ -42,6 +42,17 @@ class ParentOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class ParentOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class ParentOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentOperation.php
@@ -45,7 +45,7 @@ class ParentOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
@@ -42,6 +42,17 @@ class ParentsOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
@@ -45,7 +45,7 @@ class ParentsOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class ParentsOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class ParentsOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -46,7 +46,7 @@ class ParentsUntilOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof  TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -43,6 +43,17 @@ class ParentsUntilOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/ParentsUntilOperation.php
@@ -24,6 +24,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class ParentsUntilOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -37,17 +39,6 @@ class ParentsUntilOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof  TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
@@ -45,7 +45,7 @@ class PrevAllOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
@@ -42,6 +42,17 @@ class PrevAllOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevAllOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class PrevAllOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class PrevAllOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
@@ -43,6 +43,17 @@ class PrevOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
@@ -24,6 +24,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class PrevOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -37,17 +39,6 @@ class PrevOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevOperation.php
@@ -46,7 +46,7 @@ class PrevOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
@@ -24,6 +24,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class PrevUntilOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -37,17 +39,6 @@ class PrevUntilOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 0;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
@@ -46,7 +46,7 @@ class PrevUntilOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PrevUntilOperation.php
@@ -43,6 +43,17 @@ class PrevUntilOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -56,7 +56,7 @@ class PropertyOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
+        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -50,6 +50,17 @@ class PropertyOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return mixed

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -56,7 +56,7 @@ class PropertyOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -25,6 +25,8 @@ use Neos\Utility\ObjectAccess;
  */
 class PropertyOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -45,19 +47,6 @@ class PropertyOperation extends AbstractOperation
      * @var boolean
      */
     protected static $final = true;
-
-    /**
-     * {@inheritdoc}
-     *
-     * We can only handle ContentRepository Nodes.
-     *
-     * @param mixed $context
-     * @return boolean
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && reset($context) instanceof TraversableNodeInterface;
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -12,7 +12,6 @@ namespace Neos\ContentRepository\Eel\FlowQueryOperations;
  */
 
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
-use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\FlowQueryException;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/PropertyOperation.php
@@ -12,6 +12,7 @@ namespace Neos\ContentRepository\Eel\FlowQueryOperations;
  */
 
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\FlowQueryException;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
@@ -55,7 +56,7 @@ class PropertyOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
@@ -42,6 +42,17 @@ class SiblingsOperation extends AbstractOperation
     /**
      * {@inheritdoc}
      *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return $this->checkContextForTraversableNodeInterface($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param FlowQuery $flowQuery the FlowQuery object
      * @param array $arguments the arguments for this operation
      * @return void

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
@@ -23,6 +23,8 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  */
 class SiblingsOperation extends AbstractOperation
 {
+    use CanEvaluateNodeContextTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -36,17 +38,6 @@ class SiblingsOperation extends AbstractOperation
      * @var integer
      */
     protected static $priority = 100;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array (or array-like object) $context onto which this operation should be applied
-     * @return boolean true if the operation can be applied onto the $context, false otherwise
-     */
-    public function canEvaluate($context)
-    {
-        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
-    }
 
     /**
      * {@inheritdoc}

--- a/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
+++ b/Neos.ContentRepository/Classes/Eel/FlowQueryOperations/SiblingsOperation.php
@@ -45,7 +45,7 @@ class SiblingsOperation extends AbstractOperation
      */
     public function canEvaluate($context)
     {
-        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof TraversableNodeInterface));
+        return is_array($context) && (count($context) === 0 || reset($context) instanceof TraversableNodeInterface);
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
@@ -12,6 +12,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  */
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ContextOperation;
@@ -44,7 +45,7 @@ class ContextOperationTest extends AbstractQueryOperationsTest
      */
     public function canEvaluateReturnsTrueIfNodeIsInContext()
     {
-        $mockNode = $this->createMock(NodeInterface::class);
+        $mockNode = $this->createMock(TraversableNodeInterface::class);
 
         $result = $this->operation->canEvaluate([$mockNode]);
         self::assertTrue($result);

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
@@ -7,6 +7,7 @@ use Neos\ContentRepository\Eel\FlowQueryOperations\ChildrenOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ClosestOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ContextOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\FilterOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\FindOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\HasOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\NextAllOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\NextOperation;
@@ -31,6 +32,7 @@ class GenericOperationTest extends AbstractQueryOperationsTest
             ClosestOperation::class,
             ContextOperation::class,
             FilterOperation::class,
+            FindOperation::class,
             HasOperation::class,
             NextAllOperation::class,
             NextOperation::class,
@@ -54,6 +56,14 @@ class GenericOperationTest extends AbstractQueryOperationsTest
             ],
             'arrayStartsWithIntegerOne' => [
                 'context' => [1 => $secondNodeInLevel],
+                'expected' => true,
+            ],
+            'traversableNoNode' => [
+                'context' => new \ArrayIterator(['noNode']),
+                'expected' => false,
+            ],
+            'traversableNode' => [
+                'context' =>  new \ArrayIterator([$firstNodeInLevel, $secondNodeInLevel]),
                 'expected' => true,
             ],
             'noArray' => [

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
@@ -32,7 +32,6 @@ class GenericOperationTest extends AbstractQueryOperationsTest
             ClosestOperation::class,
             ContextOperation::class,
             FilterOperation::class,
-            FindOperation::class,
             HasOperation::class,
             NextAllOperation::class,
             NextOperation::class,

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
@@ -20,7 +20,6 @@ use Neos\ContentRepository\Eel\FlowQueryOperations\SiblingsOperation;
 
 class GenericOperationTest extends AbstractQueryOperationsTest
 {
-
     public function contextDataProvider(): array
     {
         $firstNodeInLevel = $this->mockNode('node1');
@@ -87,5 +86,4 @@ class GenericOperationTest extends AbstractQueryOperationsTest
         $operation = new $operationClass();
         self::assertEquals($expected, $operation->canEvaluate($context), 'For Operation ' . $operationClass);
     }
-
 }

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
+
+use Neos\ContentRepository\Eel\FlowQueryOperations\CacheLifetimeOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ChildrenOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ClosestOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ContextOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\FilterOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\HasOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\NextAllOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\NextOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\NextUntilOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ParentOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ParentsOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\ParentsUntilOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\PrevUntilOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\PropertyOperation;
+use Neos\ContentRepository\Eel\FlowQueryOperations\SiblingsOperation;
+
+class GenericOperationTest extends AbstractQueryOperationsTest
+{
+
+    public function contextDataProvider(): array
+    {
+        $firstNodeInLevel = $this->mockNode('node1');
+        $secondNodeInLevel = $this->mockNode('node2');
+
+        $operationClasses = [
+            CacheLifetimeOperation::class,
+            ChildrenOperation::class,
+            ClosestOperation::class,
+            ContextOperation::class,
+            FilterOperation::class,
+            HasOperation::class,
+            NextAllOperation::class,
+            NextOperation::class,
+            NextUntilOperation::class,
+            ParentOperation::class,
+            ParentsOperation::class,
+            ParentsUntilOperation::class,
+            PrevUntilOperation::class,
+            PropertyOperation::class,
+            SiblingsOperation::class,
+        ];
+
+        $testCases = [
+            'noNodeInArray' => [
+                'context' => ['noNode'],
+                'expected' => false,
+            ],
+            'arrayWithIntegerKeysStartingOnZero' => [
+                'context' => [$firstNodeInLevel, $secondNodeInLevel],
+                'expected' => true,
+            ],
+            'arrayStartsWithIntegerOne' => [
+                'context' => [1 => $secondNodeInLevel],
+                'expected' => true,
+            ],
+            'noArray' => [
+                'context' => 'noArray',
+                'expected' => false,
+            ],
+        ];
+
+        $testData = [];
+
+        foreach ($operationClasses as $operationClass) {
+            foreach ($testCases as $testCaseName => $testCase) {
+                $testData[$testCaseName . 'For' . $operationClass] = [
+                    'operationClass' => $operationClass,
+                    'context' => $testCase['context'],
+                    'expected' => $testCase['expected'],
+                ];
+            }
+        }
+
+        return $testData;
+    }
+
+    /**
+     * @test
+     * @dataProvider contextDataProvider
+     */
+    public function checkIfFirstElementInCanEvaluateIsANode(string $operationClass, $context, bool $expected): void
+    {
+        $operation = new $operationClass();
+        self::assertEquals($expected, $operation->canEvaluate($context), 'For Operation ' . $operationClass);
+    }
+
+}

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/GenericOperationTest.php
@@ -7,7 +7,6 @@ use Neos\ContentRepository\Eel\FlowQueryOperations\ChildrenOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ClosestOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ContextOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\FilterOperation;
-use Neos\ContentRepository\Eel\FlowQueryOperations\FindOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\HasOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\NextAllOperation;
 use Neos\ContentRepository\Eel\FlowQueryOperations\NextOperation;


### PR DESCRIPTION
When a collection of nodes is referenced some items may become invisible over time or may be deleted. In this case the references may end up with an array that has no key 0. Since this key was used to check wether a flowQuery operation can be applied this could lead to errors. 

The change adjusts the detection by looking at using reset to get the first value if the context is an array and by using an foreach that returns in the first cycle for traversables.

**Review Instructions** 

To test this you can use the contentReferences Element in Neos.Demo. 

1. Create 3 contents
2. Create a reference element that references all three
3. Hide the content that is selected first
4. Apply `@process.filterContent( q(value).filter('[instanceof Neos.Neos:Content]').get())` to that.

Without the change in live context no content is shown because the first item is not available live. 
This change allows to still proceed with the remaining nodes.

Fixes: #3624