### PR TITLE
BUGFIX: Raise gedmo/doctrine-extensions dependency to ^3.5

### DIFF
--- a/Neos.ContentRepository/composer.json
+++ b/Neos.ContentRepository/composer.json
@@ -15,7 +15,7 @@
         "neos/utility-files": "*",
         "neos/utility-arrays": "*",
         "doctrine/orm": "^2.6",
-        "gedmo/doctrine-extensions": "^3.0",
+        "gedmo/doctrine-extensions": "^3.5",
         "behat/transliterator": "^1.0"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "neos/utility-files": "*",
         "neos/utility-arrays": "*",
         "doctrine/orm": "^2.6",
-        "gedmo/doctrine-extensions": "^3.0",
+        "gedmo/doctrine-extensions": "^3.5",
         "behat/transliterator": "~1.0",
         "neos/utility-unicode": "*",
         "neos/utility-mediatypes": "*",


### PR DESCRIPTION
This avoids errors caused by calls to the deprecated
`AbstractClassMetadataFactory::getCacheDriver()` method.
