### PR TITLE
BUGFIX: Add raw content fallback renderer to prevent rendering exceptions

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
@@ -31,13 +31,24 @@ prototype(Neos.Neos:RawContent) < prototype(Neos.Fusion:Template) {
 }
 
 prototype(Neos.Neos:RawContentFallbackRenderer) < prototype(Neos.Neos:ContentComponent) {
+  node = ${node}
   label = ${node.label}
   nodeType = ${q(node).property('_nodeType.name')}
 
   renderer = afx`
     <div>
-      <strong>{props.label}</strong>
-      <p>Please create a Fusion prototype for <em>{props.nodeType}</em>.</p>
+      <h4>{props.label}</h4>
+
+      <Neos.Fusion:Loop items={props.node.nodeType.properties} itemKey="propertyName" itemName="propertyConfiguration">
+        <Neos.Fusion:Fragment @if.isInlineEditable={propertyConfiguration.ui.inlineEditable == true} class="property">
+          <strong>{propertyConfiguration.ui.label || propertyName}:</strong>
+          <Neos.Neos:Editable property={propertyName} />
+        </Neos.Fusion:Fragment>
+        <Neos.Fusion:Fragment @if.isImage={propertyConfiguration.type == 'Neos\Media\Domain\Model\ImageInterface' && q(props.node).property(propertyName)}>
+          <strong>{propertyConfiguration.ui.label || propertyName}:</strong>
+          <div><Neos.Neos:ImageTag asset={q(props.node).property(propertyName)} maximumWidth={200} maximumHeight={200} /></div>
+        </Neos.Fusion:Fragment>
+      </Neos.Fusion:Loop>
     </div>
   `
 }

--- a/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
@@ -13,9 +13,33 @@ prototype(Neos.Neos:RawContent) < prototype(Neos.Fusion:Template) {
 			columnContent = Neos.Neos:ContentCollection {
 				nodePath = '.'
 			}
-
 		}
 	}
+
+  prototype(Neos.Neos:ContentCase) {
+    default {
+      condition = Neos.Fusion:CanRender {
+        type = ${q(node).property('_nodeType.name')}
+      }
+    }
+    fallback {
+      @position = 'after default'
+      condition = true
+      type = 'Neos.Neos:RawContentFallbackRenderer'
+    }
+  }
+}
+
+prototype(Neos.Neos:RawContentFallbackRenderer) < prototype(Neos.Neos:ContentComponent) {
+  label = ${node.label}
+  nodeType = ${q(node).property('_nodeType.name')}
+
+  renderer = afx`
+    <div>
+      <strong>{props.label}</strong>
+      <p>Please create a Fusion prototype for <em>{props.nodeType}</em>.</p>
+    </div>
+  `
 }
 
 rawContent = Neos.Neos:Page {

--- a/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
@@ -33,7 +33,7 @@ prototype(Neos.Neos:RawContent) < prototype(Neos.Fusion:Template) {
 prototype(Neos.Neos:RawContentFallbackRenderer) < prototype(Neos.Neos:ContentComponent) {
   node = ${node}
   label = ${node.label}
-  nodeType = ${q(node).property('_nodeType.name')}
+  nodeType = ${node.nodeType.name}
 
   renderer = afx`
     <div>


### PR DESCRIPTION
Before Neos 5 it was only necessary to have a Fluid template and no Fusion prototype to work with nodes in Neos incl. the raw content mode.

As the default Fusion prototype generator was disabled in Neos 5 and later removed in Neos 7, even a Fluid template was not enough anymore and this broke the old behaviour.

Therefore a fallback renderer was added that will render a simple Fusion prototype which shows the elements label and editable properties and images. This way exceptions in the raw content mode due to missing prototypes should not happen anymore.

The whole raw content mode will then be later refactored as new feature in #376

<img width="852" alt="raw-content-fix-example" src="https://user-images.githubusercontent.com/596967/168566285-56f42c40-4cf5-4108-b907-05bd472550b9.png">