### PR TITLE
FEATURE: Implement choice to sort properties for array objects

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -39,7 +39,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
      *
      * @var array
      */
-    protected $ignoreProperties = ['__meta'];
+    protected $ignoreProperties = [];
 
     /**
      * @param array $ignoreProperties

--- a/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
@@ -40,7 +40,7 @@ class CaseImplementation extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        $matcherKeys = $this->sortNestedProperties();
+        $matcherKeys = $this->preparePropertyKeys($this->properties);
 
         foreach ($matcherKeys as $matcherName) {
             $renderedMatcher = $this->renderMatcher($matcherName);

--- a/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CaseImplementation.php
@@ -40,7 +40,7 @@ class CaseImplementation extends AbstractArrayFusionObject
      */
     public function evaluate()
     {
-        $matcherKeys = $this->preparePropertyKeys($this->properties);
+        $matcherKeys = $this->preparePropertyKeys($this->properties, $this->ignoreProperties);
 
         foreach ($matcherKeys as $matcherName) {
             $renderedMatcher = $this->renderMatcher($matcherName);

--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -66,7 +66,7 @@ class ComponentImplementation extends AbstractArrayFusionObject
      */
     protected function getProps(array $context): \ArrayAccess
     {
-        $sortedChildFusionKeys = $this->preparePropertyKeys($this->properties);
+        $sortedChildFusionKeys = $this->preparePropertyKeys($this->properties, $this->ignoreProperties);
         $props = new LazyProps($this, $this->path, $this->runtime, $sortedChildFusionKeys, $context);
         return $props;
     }

--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -66,7 +66,7 @@ class ComponentImplementation extends AbstractArrayFusionObject
      */
     protected function getProps(array $context): \ArrayAccess
     {
-        $sortedChildFusionKeys = $this->sortNestedProperties();
+        $sortedChildFusionKeys = $this->preparePropertyKeys($this->properties);
         $props = new LazyProps($this, $this->path, $this->runtime, $sortedChildFusionKeys, $context);
         return $props;
     }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -39,14 +39,14 @@ class DataStructureImplementation extends AbstractArrayFusionObject
      *
      * This will ignore all properties defined in "@ignoreProperties" in Fusion
      *
-     * @see PositionalArraySorter
-     *
      * @return array an ordered list of key value pairs
      * @throws FusionException if the positional string has an unsupported format
-     * @deprecated since 8.0 can be removed with 9.0 use {@see \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::sortNestedProperties}
+     * @see PositionalArraySorter
+     *
+     * @deprecated since 8.0 can be removed with 9.0 use {@see \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::preparePropertyKeys}
      */
     protected function sortNestedFusionKeys()
     {
-        return $this->sortNestedProperties();
+        return $this->preparePropertyKeys($this->properties);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -47,6 +47,6 @@ class DataStructureImplementation extends AbstractArrayFusionObject
      */
     protected function sortNestedFusionKeys()
     {
-        return $this->preparePropertyKeys($this->properties);
+        return $this->preparePropertyKeys($this->properties, $this->ignoreProperties);
     }
 }

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -1,15 +1,32 @@
 include: *.fusion
-
-prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
-prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
-prototype(Neos.Fusion:Join).@class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'
-prototype(Neos.Fusion:DataStructure).@class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
 prototype(Neos.Fusion:Template).@class = 'Neos\\Fusion\\FusionObjects\\TemplateImplementation'
-prototype(Neos.Fusion:Case).@class = 'Neos\\Fusion\\FusionObjects\\CaseImplementation'
-prototype(Neos.Fusion:Matcher).@class = 'Neos\\Fusion\\FusionObjects\\MatcherImplementation'
 prototype(Neos.Fusion:Renderer).@class = 'Neos\\Fusion\\FusionObjects\\RendererImplementation'
 prototype(Neos.Fusion:Value).@class = 'Neos\\Fusion\\FusionObjects\\ValueImplementation'
-prototype(Neos.Fusion:Component).@class = 'Neos\\Fusion\\FusionObjects\\ComponentImplementation'
+prototype(Neos.Fusion:Case) {
+  @class = 'Neos\\Fusion\\FusionObjects\\CaseImplementation'
+  @sortProperties = true
+}
+prototype(Neos.Fusion:Matcher).@class = 'Neos\\Fusion\\FusionObjects\\MatcherImplementation'
+prototype(Neos.Fusion:Array) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ArrayImplementation'
+  @sortProperties = true
+}
+prototype(Neos.Fusion:RawArray) {
+  @class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
+  @sortProperties = true
+}
+prototype(Neos.Fusion:Join) {
+  @class = 'Neos\\Fusion\\FusionObjects\\JoinImplementation'
+  @sortProperties = true
+}
+prototype(Neos.Fusion:DataStructure) {
+  @class = 'Neos\\Fusion\\FusionObjects\\DataStructureImplementation'
+  @sortProperties = true
+}
+prototype(Neos.Fusion:Component) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ComponentImplementation'
+  @sortProperties = false
+}
 prototype(Neos.Fusion:CanRender).@class = 'Neos\\Fusion\\FusionObjects\\CanRenderImplementation'
 prototype(Neos.Fusion:DebugDump) {
   @class = 'Neos\\Fusion\\FusionObjects\\DebugDumpImplementation'
@@ -57,7 +74,9 @@ prototype(Neos.Fusion:Reduce) {
 #
 prototype(Neos.Fusion:Http.ResponseHead) {
   @class = 'Neos\\Fusion\\FusionObjects\\Http\\ResponseHeadImplementation'
-  headers = Neos.Fusion:DataStructure
+  headers = Neos.Fusion:DataStructure {
+    @sortProperties = false
+  }
 }
 
 # Render an HTTP message (response)
@@ -75,6 +94,7 @@ prototype(Neos.Fusion:Http.ResponseHead) {
 #
 prototype(Neos.Fusion:Http.Message) < prototype(Neos.Fusion:Join) {
   @class = 'Neos\\Fusion\\FusionObjects\\HttpResponseImplementation'
+  @sortProperties = true
   httpResponseHead = Neos.Fusion:Http.ResponseHead
   httpResponseHead.@position = 'start 1000'
 }
@@ -106,7 +126,9 @@ prototype(Neos.Fusion:Attributes) {
 #
 prototype(Neos.Fusion:Tag) {
   @class = 'Neos\\Fusion\\FusionObjects\\TagImplementation'
-  attributes = Neos.Fusion:DataStructure
+  attributes = Neos.Fusion:DataStructure {
+    @sortProperties = false
+  }
   omitClosingTag = false
   selfClosingTag = false
 }
@@ -122,8 +144,12 @@ prototype(Neos.Fusion:Tag) {
 #
 prototype(Neos.Fusion:UriBuilder) {
   @class = 'Neos\\Fusion\\FusionObjects\\UriBuilderImplementation'
-  additionalParams = Neos.Fusion:DataStructure
-  arguments = Neos.Fusion:DataStructure
+  additionalParams = Neos.Fusion:DataStructure {
+    @sortProperties = false
+  }
+  arguments = Neos.Fusion:DataStructure {
+    @sortProperties = false
+  }
   argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
 
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
@@ -145,6 +171,7 @@ prototype(Neos.Fusion:UriBuilder) {
 #
 prototype(Neos.Fusion:Augmenter) {
   @class = 'Neos\\Fusion\\FusionObjects\\AugmenterImplementation'
+  @sortProperties = false
 
   # If more than one tag is found the content is wrapped in the fallback tag before augmentation
   fallbackTagName = 'div'

--- a/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
@@ -34,6 +34,8 @@ class CaseImplementationTest extends \Neos\Flow\Tests\UnitTestCase
             switch ($relativePath) {
                 case '__meta/ignoreProperties':
                     return $ignoredProperties;
+                case '__meta/sortProperties':
+                    return true;
             }
             return ObjectAccess::getProperty($that, $relativePath, true);
         }));

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -53,57 +53,57 @@ class DataStructureImplementationTest extends UnitTestCase
             [
                 'Position end should put element to end',
                 ['second' => ['__meta' => ['position' => 'end'], '__value' => 1], 'first' => ['__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position start should put element to start',
                 ['second' => ['__value' => 1], 'first' => ['__meta' => ['position' => 'start'], '__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position start should respect priority',
                 ['second' => ['__meta' => ['position' => 'start 50'], '__value' => 1], 'first' => ['__meta' => ['position' => 'start 52'], '__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position end should respect priority',
                 ['second' => ['__meta' => ['position' => 'end 17'], '__value' => 1], 'first' => ['__meta' => ['position' => 'end'], '__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Positional numbers are in the middle',
                 ['last' => ['__meta' => ['position' => 'end'], '__value' => 1], 'second' => ['__meta' => ['position' => '17'], '__value' => 2], 'first' => ['__meta' => ['position' => '5'], '__value' => 3], 'third' => ['__meta' => ['position' => '18'], '__value' => 4]],
-                ['/first', '/second', '/third', '/last']
+                ['/__meta/sortProperties', '/first', '/second', '/third', '/last']
             ],
             [
                 'Position before adds before named element if present',
                 ['second' => ['__value' => 1], 'first' => ['__meta' => ['position' => 'before second'], '__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
                 ['third' => ['__value' => 1], 'second' => ['__meta' => ['position' => 'before third 12'], '__value' => 2], 'first' => ['__meta' => ['position' => 'before third'], '__value' => 3]],
-                ['/first', '/second', '/third']
+                ['/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position before works recursively',
                 ['third' => ['__value' => 1], 'second' => ['__meta' => ['position' => 'before third'], '__value' => 2], 'first' => ['__meta' => ['position' => 'before second'], '__value' => 3]],
-                ['/first', '/second', '/third']
+                ['/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position after adds after named element if present',
                 ['second' => ['__meta' => ['position' => 'after first'], '__value' => 1], 'first' => ['__value' => 2]],
-                ['/first', '/second']
+                ['/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
                 ['third' => ['__meta' => ['position' => 'after first'], '__value' => 1], 'second' => ['__meta' => ['position' => 'after first 12'], '__value' => 2], 'first' => ['__value' => 3]],
-                ['/first', '/second', '/third']
+                ['/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position after works recursively',
                 ['third' => ['__meta' => ['position' => 'after second'], '__value' => 1], 'second' => ['__meta' => ['position' => 'after first'], '__value' => 2], 'first' => ['__value' => 3]],
-                ['/first', '/second', '/third']
+                ['/__meta/sortProperties', '/first', '/second', '/third']
             ]
         ];
     }

--- a/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
@@ -42,57 +42,57 @@ class JoinImplementationTest extends UnitTestCase
             [
                 'Position end should put element to end',
                 ['second' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position start should put element to start',
                 ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'start']]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position start should respect priority',
                 ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position end should respect priority',
                 ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Positional numbers are in the middle',
                 ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
-                ['/__meta/glue', '/first', '/second', '/third', '/last']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third', '/last']
             ],
             [
                 'Position before adds before named element if present',
                 ['second' => ['__meta' => []], 'first' => ['__meta' => ['position' => 'before second']]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
                 ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third 12']], 'first' => ['__meta' => ['position' => 'before third']]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position before works recursively',
                 ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position after adds after named element if present',
                 ['second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
-                ['/__meta/glue', '/first', '/second']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second']
             ],
             [
                 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
                 ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => ['__meta' => []]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position after works recursively',
                 ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => ['__meta' => []]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ]
         ];
     }
@@ -106,12 +106,12 @@ class JoinImplementationTest extends UnitTestCase
             [
                 'Position before adds after start if named element not present',
                 ['third' => ['__meta' => []], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before unknown']]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ],
             [
                 'Position after adds before end if named element not present',
                 ['second' => ['__meta' => ['position' => 'after unknown']], 'third' => ['__meta' => ['position' => 'end']], 'first' => ['__meta' => []]],
-                ['/__meta/glue', '/first', '/second', '/third']
+                ['/__meta/glue', '/__meta/sortProperties', '/first', '/second', '/third']
             ]
         ];
     }


### PR DESCRIPTION
The new meta property `@sortProperties` can now be used to define
if properties should adhere to the `@sorting` meta and general
order of definition or if that is irrelevant.

Sorting itself is time consuming, and while that does not matter
for a single sort, a bigger site might have so many fusion objects
to render that the sorting can have massive influence on the render
performance. Therefore it's advisable to disable it whenever possible.

Specifically `Neos.Fusion:Component` as well as attributes in
`Neos.Fusion:Tag` are now unsorted. Also http headers are unsorted.

Fixes: #3792