### PR TITLE
!!!FEATURE: Support asset collection count

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -258,7 +258,8 @@ class AssetController extends ActionController
         try {
             foreach ($this->assetCollectionRepository->findAll()->toArray() as $retrievedAssetCollection) {
                 assert($retrievedAssetCollection instanceof AssetCollection);
-                $assetCollections[] = ['object' => $retrievedAssetCollection, 'count' => $this->assetRepository->countByAssetCollection($retrievedAssetCollection)];
+                $assetCollectionCount = ($assetProxyRepository instanceof SupportsCollectionsInterface ? $assetProxyRepository->countByAssetCollection($retrievedAssetCollection) : $this->assetRepository->countByAssetCollection($retrievedAssetCollection));
+                $assetCollections[] = ['object' => $retrievedAssetCollection, 'count' => $assetCollectionCount];
             }
 
             foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $retrievedTag) {

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
@@ -229,6 +229,14 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
         return $query->count();
     }
 
+    public function countByAssetCollection(AssetCollection $assetCollection): int
+    {
+        $queryResult = $this->assetRepository->findByAssetCollection($assetCollection);
+        $query = $this->filterOutImportedAssetsFromOtherAssetSources($queryResult->getQuery());
+        $query = $this->filterOutImageVariants($query);
+        return $query->count();
+    }
+
     /**
      * @param QueryInterface $query
      * @return QueryInterface

--- a/Neos.Media/Classes/Domain/Model/AssetSource/SupportsCollectionsInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/SupportsCollectionsInterface.php
@@ -25,4 +25,10 @@ interface SupportsCollectionsInterface
      * @param AssetCollection $assetCollection
      */
     public function filterByCollection(AssetCollection $assetCollection = null): void;
+
+    /**
+     * @param AssetCollection $assetCollection
+     * @return int
+     */
+    public function countByAssetCollection(AssetCollection  $assetCollection): int;
 }


### PR DESCRIPTION
**Upgrade instructions**

The `SupportsCollectionInterface` have a new method `countByAssetCollection`. If your AssetProxy implements that interface, you must include that method in your implementation

**Review instructions**

 * Checkout this PR
 * Add images to a certain collection
 * Add images from your AssetProxy to a collection
 * See the number adjust accordingly


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
