### PR TITLE
FEATURE: Display the rawContent-mode in the backend when neither documentType nor `/page` can be rendered

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/CanRenderImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/CanRenderImplementation.php
@@ -30,10 +30,26 @@ class CanRenderImplementation extends AbstractFusionObject
     }
 
     /**
+     * Fusion path which shall be rendered
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->fusionValue('path');
+    }
+
+    /**
      * @return boolean
      */
     public function evaluate()
     {
-        return $this->runtime->canRender('/type<' . $this->getType() . '>');
+        if ($type = $this->getType()) {
+            return $this->runtime->canRender('/type<' . $type . '>');
+        }
+        if ($path = $this->getPath()) {
+            return $this->runtime->canRender($path);
+        }
+        return false;
     }
 }

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -711,6 +711,7 @@ Neos.Fusion:CanRender
 Check whether a Fusion prototype can be rendered. For being renderable a prototype must exist and have an implementation class, or inherit from an existing renderable prototype. The implementation class can be defined indirectly via base prototypes.
 
 :type: (string) The prototype name that is checked
+:path: (string) The fusion path name that is checked
 
 Example::
 

--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -40,8 +40,23 @@ root {
 
   default {
     @position = 'end 9999'
-    condition = true
+    condition = Neos.Fusion:CanRender {
+      path = '/page'
+    }
     renderPath = '/page'
+  }
+
+  rawContent {
+    @position = 'end 10000'
+    condition = ${documentNode.context.inBackend && documentNode.context.currentRenderingMode.edit}
+    renderPath = '/rawContent'
+  }
+
+  # Fail but create a helpful error message
+  error {
+    @position = 'end 10001'
+    condition = true
+    type = ${documentNode.nodeType.name}
   }
 
   @cache {


### PR DESCRIPTION
The Neos backend will fallback to the RawContent mode as last resort if no other document rendering is possible. In the frontend a last try to render the via the `documentType` is done to create at least helpful error message that encourages good practices.

To implement this the `path` option is added to the `Neos.Fusion:CanRender` prototype to check wether the `/page` is available.

The whole feature is a building block to eventually allow content first workflows where no fusion rendering gas to be defined to edit content.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
