### PR TITLE
TASK: Equalize indentation of Neos.Fusion:Match example in docs

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -498,8 +498,8 @@ Matches the given subject to a value
 Example::
 
 	myValue = Neos.Fusion:Match {
-	  @subject = 'hello'
-	  @default = 'World?'
+		@subject = 'hello'
+		@default = 'World?'
 		hello = 'Hello World'
 		bye = 'Goodbye world'
 	}


### PR DESCRIPTION
- spaces and tabs were mixed up
- came up while working on the neos fusion plugin for vscode

No code changes. 
