### PR TITLE
BUGFIX: Change from DoctrineFilterInterface to FilterInterface

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
+++ b/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
@@ -69,6 +69,9 @@ class PropertyValue implements DoctrineFilterInterface
             JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE
         ), "{}\n\t ");
 
-        return [$baseQuery->like('properties', $likeParameter, false)];
+        $queryBuilder = $baseQuery->getQueryBuilder();
+        $queryBuilder->andWhere("LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :term")->setParameter('term', $likeParameter);
+
+        return [];
     }
 }


### PR DESCRIPTION
**Review instructions**

You can use a test migration in the Neos.Demo package.

```yaml
up:
  comments: 'Migrate boolean value test'
  migration:
    -
      filters:
        - type: 'NodeType'
          settings:
            nodeType: 'Neos.Demo:Document.NotFoundPage'
            withSubTypes: TRUE
        - type: 'PropertyValue'
          settings:
            propertyName: 'metaRobotsNoindex'
            propertyValue: false
      transformations:
        - type: 'ChangePropertyValue'
          settings:
            property: 'metaRobotsNoindex'
            newValue: true

down:
  warnings: 'No down migration available'
```

Before the patch this will fail with the error:
```bash
Too few parameters: the query defines 1 parameters but you only bound 0

  Type: Doctrine\ORM\Query\QueryException
  File: Packages/Libraries/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php
  Line: 94
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
