### PR TITLE
FEATURE: Introduce `Neos.Fusion:ActionUri` as replacement for `Neos.Fusion:UriBuilder`

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/ActionUriImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ActionUriImplementation.php
@@ -13,6 +13,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 
 /**
@@ -30,12 +31,20 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
  *  * addQueryString
  *  * argumentsToBeExcludedFromQueryString
  *  * absolute
- *  * useMainRequest
+ *  * request
  *
  * See respective getters for descriptions
  */
 class ActionUriImplementation extends AbstractFusionObject
 {
+    /**
+     * @return ActionRequest
+     */
+    public function getRequest(): ActionRequest
+    {
+        return $this->fusionValue('request');
+    }
+
     /**
      * Key of the target package
      *
@@ -148,27 +157,12 @@ class ActionUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * If true, an absolute the url is generated for the main request and ignores possible subrequests
-     *
-     * @return boolean
-     */
-    public function isUseMainRequest(): bool
-    {
-        return (boolean)$this->fusionValue('useMainRequest');
-    }
-
-    /**
      * @return string
      */
     public function evaluate()
     {
-        $controllerContext = $this->runtime->getControllerContext();
         $uriBuilder = new UriBuilder();
-        if ($this->isUseMainRequest()) {
-            $uriBuilder->setRequest($controllerContext->getRequest()->getMainRequest());
-        } else {
-            $uriBuilder->setRequest($controllerContext->getRequest());
-        }
+        $uriBuilder->setRequest($this->getRequest());
 
         $format = $this->getFormat();
         if ($format !== null) {

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -147,6 +147,52 @@ prototype(Neos.Fusion:ActionUri) {
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
 
+# Renders an link tag with a uri pointing to a controller/action
+#
+# Usage:
+# uri = Neos.Fusion:Link {
+#   content = 'to special controller'
+#   package = 'Some.Package'
+#   controller = 'Standard'
+#   action = 'index'
+# }
+prototype(Neos.Fusion:ActionLink) < prototype(Neos.Fusion:Tag) {
+  tagName = 'a'
+  additionalParams = Neos.Fusion:DataStructure
+  arguments = Neos.Fusion:DataStructure
+  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
+
+  attributes.href = Neos.Fusion:ActionUri {
+    package = ${__package}
+    subpackage = ${__subpackage}
+    controller = ${__controller}
+    action = ${__action}
+    arguments = ${__arguments}
+    format = ${__format}
+    section = ${__section}
+    additionalParams = ${__additionalParams}
+    argumentsToBeExcludedFromQueryString = ${__argumentsToBeExcludedFromQueryString}
+    addQueryString = ${__addQueryString}
+    absolute = ${__absolute}
+    useMainRequest = ${__useMainRequest}
+  }
+
+  @context {
+    __package = ${this.package}
+    __subpackage = ${this.subpackage}
+    __controller = ${this.controller}
+    __action = ${this.action}
+    __arguments = ${this.arguments}
+    __format = ${this.format}
+    __section = ${this.section}
+    __additionalParams = ${this.additionalParams}
+    __argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
+    __addQueryString = ${this.addQueryString}
+    __absolute = ${this.absolute}
+    __useMainRequest = ${this.useMainRequest}
+  }
+}
+
 # Modify given html content and add attributes
 #
 # Usage:

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -140,6 +140,7 @@ prototype(Neos.Fusion:UriBuilder) {
 #
 prototype(Neos.Fusion:ActionUri) {
   @class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+  request = ${request}
   additionalParams = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure
   argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
@@ -158,6 +159,7 @@ prototype(Neos.Fusion:ActionUri) {
 # }
 prototype(Neos.Fusion:ActionLink) < prototype(Neos.Fusion:Tag) {
   tagName = 'a'
+  request = ${request}
   additionalParams = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure
   argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
@@ -174,7 +176,7 @@ prototype(Neos.Fusion:ActionLink) < prototype(Neos.Fusion:Tag) {
     argumentsToBeExcludedFromQueryString = ${__argumentsToBeExcludedFromQueryString}
     addQueryString = ${__addQueryString}
     absolute = ${__absolute}
-    useMainRequest = ${__useMainRequest}
+    request = ${__request}
   }
 
   @context {
@@ -189,7 +191,7 @@ prototype(Neos.Fusion:ActionLink) < prototype(Neos.Fusion:Tag) {
     __argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
     __addQueryString = ${this.addQueryString}
     __absolute = ${this.absolute}
-    __useMainRequest = ${this.useMainRequest}
+    __request = ${this.request}
   }
 }
 

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -129,6 +129,24 @@ prototype(Neos.Fusion:UriBuilder) {
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
 
+# Renders an URI pointing to a controller/action
+#
+# Usage:
+# uri = Neos.Fusion:ActionUri {
+#   package = 'Some.Package'
+#   controller = 'Standard'
+#   action = 'index'
+# }
+#
+prototype(Neos.Fusion:ActionUri) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+  additionalParams = Neos.Fusion:DataStructure
+  arguments = Neos.Fusion:DataStructure
+  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
+
+  @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
+}
+
 # Modify given html content and add attributes
 #
 # Usage:

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -129,72 +129,6 @@ prototype(Neos.Fusion:UriBuilder) {
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
 
-# Renders an URI pointing to a controller/action
-#
-# Usage:
-# uri = Neos.Fusion:ActionUri {
-#   package = 'Some.Package'
-#   controller = 'Standard'
-#   action = 'index'
-# }
-#
-prototype(Neos.Fusion:ActionUri) {
-  @class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
-  request = ${request}
-  additionalParams = Neos.Fusion:DataStructure
-  arguments = Neos.Fusion:DataStructure
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
-
-  @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
-}
-
-# Renders an link tag with a uri pointing to a controller/action
-#
-# Usage:
-# uri = Neos.Fusion:Link {
-#   content = 'to special controller'
-#   package = 'Some.Package'
-#   controller = 'Standard'
-#   action = 'index'
-# }
-prototype(Neos.Fusion:ActionLink) < prototype(Neos.Fusion:Tag) {
-  tagName = 'a'
-  request = ${request}
-  additionalParams = Neos.Fusion:DataStructure
-  arguments = Neos.Fusion:DataStructure
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
-
-  attributes.href = Neos.Fusion:ActionUri {
-    package = ${__package}
-    subpackage = ${__subpackage}
-    controller = ${__controller}
-    action = ${__action}
-    arguments = ${__arguments}
-    format = ${__format}
-    section = ${__section}
-    additionalParams = ${__additionalParams}
-    argumentsToBeExcludedFromQueryString = ${__argumentsToBeExcludedFromQueryString}
-    addQueryString = ${__addQueryString}
-    absolute = ${__absolute}
-    request = ${__request}
-  }
-
-  @context {
-    __package = ${this.package}
-    __subpackage = ${this.subpackage}
-    __controller = ${this.controller}
-    __action = ${this.action}
-    __arguments = ${this.arguments}
-    __format = ${this.format}
-    __section = ${this.section}
-    __additionalParams = ${this.additionalParams}
-    __argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
-    __addQueryString = ${this.addQueryString}
-    __absolute = ${this.absolute}
-    __request = ${this.request}
-  }
-}
-
 # Modify given html content and add attributes
 #
 # Usage:
@@ -235,6 +169,25 @@ prototype(Neos.Fusion:ResourceUri) {
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }
 
+# Renders an URI pointing to a controller/action
+#
+# Usage:
+# uri = Neos.Fusion:ActionUri {
+#   package = 'Some.Package'
+#   controller = 'Standard'
+#   action = 'index'
+# }
+#
+prototype(Neos.Fusion:ActionUri) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+  request = ${request}
+  additionalParams = Neos.Fusion:DataStructure
+  arguments = Neos.Fusion:DataStructure
+  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
+
+  @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
+}
+
 # Renders a link pointing to a controller/action
 #
 # Usage:
@@ -245,7 +198,7 @@ prototype(Neos.Fusion:ResourceUri) {
 # `
 #
 prototype(Neos.Fusion:Link.Action) < prototype(Neos.Fusion:Component) {
-    href = Neos.Fusion:UriBuilder
+    href = Neos.Fusion:ActionUri
     content = ''
 
     renderer = Neos.Fusion:Tag {
@@ -262,7 +215,7 @@ prototype(Neos.Fusion:Link.Action) < prototype(Neos.Fusion:Component) {
 #
 # Usage:
 # link = afx`
-#    <Neos.Fusion:Link.Resource class="action-link" href.path="resource://Some.Package/Public/Images/SomeImage.png">
+#    <Neos.Fusion:Link.Resource class="resource-link" href.path="resource://Some.Package/Public/Images/SomeImage.png">
 #        Some Link
 #    </Neos.Fusion:Link.Resource>
 # `

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Neos\Fusion\Tests\Functional\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Testcase for the UriBuilder object
+ */
+class ActionUriTest extends AbstractFusionObjectTest
+{
+    /**
+     * @test
+     */
+    public function buildRelativeUriToAction()
+    {
+        $this->registerRoute(
+            'Fusion functional test',
+            'neos/flow/test/http/foo',
+            [
+                '@package' => 'Neos.Flow',
+                '@subpackage' => 'Tests\Functional\Http\Fixtures',
+                '@controller' => 'Foo',
+                '@action' => 'index',
+                '@format' => 'html'
+            ]
+        );
+
+        $view = $this->buildView();
+        $view->setFusionPath('actionUri/foo');
+        self::assertStringContainsString('/neos/flow/test/http/foo', $view->render());
+    }
+}

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ActionUri.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ActionUri.fusion
@@ -1,4 +1,7 @@
-prototype(Neos.Fusion:ActionUri).@class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+prototype(Neos.Fusion:ActionUri) {
+  @class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+  request = ${request}
+}
 
 actionUri.foo = Neos.Fusion:ActionUri {
   package = 'Neos.Flow'

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ActionUri.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ActionUri.fusion
@@ -1,0 +1,8 @@
+prototype(Neos.Fusion:ActionUri).@class = 'Neos\\Fusion\\FusionObjects\\ActionUriImplementation'
+
+actionUri.foo = Neos.Fusion:ActionUri {
+  package = 'Neos.Flow'
+  subpackage = 'Tests\\Functional\\Http\\Fixtures'
+  controller = 'Foo'
+  action = 'index'
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -655,6 +655,63 @@ A helper object to render the head of an HTTP response
 :statusCode: (integer) The HTTP status code for the response, defaults to ``200``
 :headers.*: (string) An HTTP header that should be set on the response, the property name (e.g. ``headers.Content-Type``) will be used for the header name
 
+.. _Neos_Fusion__ActionUri:
+
+Neos.Fusion:ActionUri
+---------------------
+
+Built a URI to a controller action
+
+:package: (string) The package key (e.g. ``'My.Package'``)
+:subpackage: (string) The subpackage, empty by default
+:controller: (string) The controller name (e.g. ``'Registration'``)
+:action: (string) The action name (e.g. ``'new'``)
+:arguments: (array) Arguments to the action by named key
+:format: (string) An optional request format (e.g. ``'html'``)
+:section: (string) An optional fragment (hash) for the URI
+:additionalParams: (array) Additional URI query parameters by named key
+:addQueryString: (boolean) Whether to keep the query parameters of the current URI
+:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
+:absolute: (boolean) Whether to create an absolute URI
+:useMainRequest: (boolean) If set, the main Request will be used instead of the current one.
+
+Example::
+
+	uri = Neos.Fusion:ActionUri {
+		package = 'My.Package'
+		controller = 'Registration'
+		action = 'new'
+	}
+
+A special case is generating URIs for links to Neos modules. In this case often the option `useMainRequest` is needed
+when linking to a controller outside of the context of the current subrequest.
+
+Link to content module::
+
+	uri = Neos.Fusion:ActionUri {
+		useMainRequest = true
+		package = 'Neos.Neos'
+		controller = 'Frontend\\Node'
+		action = 'show'
+		arguments.node = ${documentNode}
+	}
+
+Link to backend modules other than `content`::
+
+	uri = Neos.Fusion:ActionUri {
+		useMainRequest = true
+    action = "index"
+		package = "Neos.Neos"
+		controller = "Backend\\Module"
+		arguments {
+			module = 'administration/sites'
+			moduleArguments {
+				@action = 'edit'
+				site = ${site}
+			}
+		}
+	}
+
 .. _Neos_Fusion__UriBuilder:
 
 Neos.Fusion:UriBuilder
@@ -673,6 +730,8 @@ Built a URI to a controller action
 :addQueryString: (boolean) Whether to keep the query parameters of the current URI
 :argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
 :absolute: (boolean) Whether to create an absolute URI
+
+.. note:: The use of ``Neos.Fusion:UriBuilder`` is deprecated. Use :ref:`_Neos_Fusion__ActionUri` instead.
 
 Example::
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -691,8 +691,8 @@ Link to the content module::
 
 	uri = Neos.Fusion:ActionUri {
 		request = ${request.mainRequest}
-    package="Neos.Neos.Ui"
-    controller="Backend"
+        package="Neos.Neos.Ui"
+        controller="Backend"
 		action = 'index'
 		arguments.node = ${documentNode}
 	}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -674,7 +674,6 @@ Built a URI to a controller action
 :addQueryString: (boolean) Whether to keep the query parameters of the current URI
 :argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
 :absolute: (boolean) Whether to create an absolute URI
-:useMainRequest: (boolean) If set, the main Request will be used instead of the current one.
 
 Example::
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -700,7 +700,7 @@ Link to backend modules other than `content`::
 
 	uri = Neos.Fusion:ActionUri {
 		useMainRequest = true
-    action = "index"
+		action = "index"
 		package = "Neos.Neos"
 		controller = "Backend\\Module"
 		arguments {
@@ -713,6 +713,39 @@ Link to backend modules other than `content`::
 	}
 
 .. _Neos_Fusion__UriBuilder:
+
+Neos.Fusion:ActionLink
+---------------------
+
+The action link combines all properties form ``Neos.Fusion:Tag`` and ``Neos.Fusion:ActionUri`` with the deviation
+that the default ``tagName`` is an ``a`` other than ``div``.
+
+... from ``Neos.Fusion:Tag``:
+:tagName: (string) Tag name of the HTML element, defaults to ``a``
+:content: (string) The inner content of the element, will only be rendered if the tag is not self-closing and the closing tag is not omitted
+:attributes: (iterable) Tag attributes as key-value pairs. Default is ``Neos.Fusion:DataStructure``. If a non iterable is returned the value is casted to string.
+... from ``Neos.Fusion:ActionUri``:
+:package: (string) The package key (e.g. ``'My.Package'``)
+:subpackage: (string) The subpackage, empty by default
+:controller: (string) The controller name (e.g. ``'Registration'``)
+:action: (string) The action name (e.g. ``'new'``)
+:arguments: (array) Arguments to the action by named key
+:format: (string) An optional request format (e.g. ``'html'``)
+:section: (string) An optional fragment (hash) for the URI
+:additionalParams: (array) Additional URI query parameters by named key
+:addQueryString: (boolean) Whether to keep the query parameters of the current URI
+:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
+:absolute: (boolean) Whether to create an absolute URI
+:useMainRequest: (boolean) If set, the main Request will be used instead of the current one.
+
+Example::
+
+	link = Neos.Fusion:ActionLink {
+		content = "register"
+		package = 'My.Package'
+		controller = 'Registration'
+		action = 'new'
+	}
 
 Neos.Fusion:UriBuilder
 ----------------------

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -691,8 +691,8 @@ Link to the content module::
 
 	uri = Neos.Fusion:ActionUri {
 		request = ${request.mainRequest}
-        package="Neos.Neos.Ui"
-        controller="Backend"
+		package="Neos.Neos.Ui"
+		controller="Backend"
 		action = 'index'
 		arguments.node = ${documentNode}
 	}
@@ -714,64 +714,6 @@ Link to backend modules (other than `content`)::
 	}
 
 .. _Neos_Fusion__UriBuilder:
-
-Neos.Fusion:ActionLink
----------------------
-
-The action link combines all properties form ``Neos.Fusion:Tag`` and ``Neos.Fusion:ActionUri`` with the deviation
-that the default ``tagName`` is an ``a`` other than ``div``.
-
-... from ``Neos.Fusion:Tag``:
-:tagName: (string) Tag name of the HTML element, defaults to ``a``
-:content: (string) The inner content of the element, will only be rendered if the tag is not self-closing and the closing tag is not omitted
-:attributes: (iterable) Tag attributes as key-value pairs. Default is ``Neos.Fusion:DataStructure``. If a non iterable is returned the value is casted to string.
-... from ``Neos.Fusion:ActionUri``:
-:request: (ActionRequest, defaults to the the current ``request``) The action request the uri is build from.
-:package: (string) The package key (e.g. ``'My.Package'``)
-:subpackage: (string) The subpackage, empty by default
-:controller: (string) The controller name (e.g. ``'Registration'``)
-:action: (string) The action name (e.g. ``'new'``)
-:arguments: (array) Arguments to the action by named key
-:format: (string) An optional request format (e.g. ``'html'``)
-:section: (string) An optional fragment (hash) for the URI
-:additionalParams: (array) Additional URI query parameters by named key
-:addQueryString: (boolean) Whether to keep the query parameters of the current URI
-:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
-:absolute: (boolean) Whether to create an absolute URI
-
-Example::
-
-	link = Neos.Fusion:ActionLink {
-		content = "register"
-		package = 'My.Package'
-		controller = 'Registration'
-		action = 'new'
-	}
-
-Link to content module in afx::
-
-    <Neos.Fusion:ActionLink
-      request={request.mainRequest}
-      action="index"
-      package="Neos.Neos.Ui"
-      controller="Backend"
-      arguments.node={node}
-    >
-      to Content module
-    </Neos.Fusion:ActionLink>
-
-Link to backend modules (other than `content`)::
-
-    <Neos.Fusion:ActionLink
-      request={request.mainRequest}
-      action="index"
-      package="Neos.Neos"
-      controller="Backend\\Module"
-      arguments.module='administration/sites'
-      arguments.moduleArguments.@action='index'
-    >
-      to Site module
-    </Neos.Fusion:ActionLink>
 
 Neos.Fusion:UriBuilder
 ----------------------
@@ -822,6 +764,77 @@ Example::
 			}
 		}
 	}
+
+.. _Neos_Fusion__Link_Action:
+
+Neos.Fusion:Link.Action
+-----------------------
+
+Renders a link pointing to a controller/action
+
+:content: (string) content of the link tag
+:href: (string, default :ref:`Neos_Fusion__ActionUri`) The href for the link tag
+:[key]: (string) Other attributes for the link tag
+
+Example::
+
+	link = Neos.Fusion:Link.Action {
+		content = "register"
+		class="action-link"
+		href.package = 'My.Package'
+		href.controller = 'Registration'
+		href.action = 'new'
+	}
+
+	link = afx`
+		<Neos.Fusion:Link.Action class="action-link" href.package="My.Package" href.controller="Registration" href.action="new">
+			register
+		</Neos.Fusion:Link.Action>
+	`
+
+Link to the content-module in afx::
+
+ <Neos.Fusion:Link.Action
+		href.request={request.mainRequest}
+		href.action="index"
+		href.package="Neos.Neos.Ui"
+		href.controller="Backend"
+		href.arguments.node={node}
+	>
+		to content module
+	</Neos.Fusion:Link.Action>
+
+Link to backend-modules other than the content-module::
+
+	<Neos.Fusion:Link.Action
+		href.request={request.mainRequest}
+		href.action="index"
+		href.package="Neos.Neos"
+		href.controller="Backend\\Module"
+		href.arguments.module='administration/sites'
+		href.arguments.moduleArguments.@action='index'
+	>
+		to site module
+	</Neos.Fusion:Link.Action>
+
+.. _Neos_Fusion__Link_Resource:
+
+Neos.Fusion:Link.Resource
+-------------------------
+
+Renders a link pointing to a resource
+
+:content: (string) content of the link tag
+:href: (string,  default :ref:`Neos_Fusion__ResouceUri`) The href for the link tag
+:[key]: (string) Other attributes for the link tag
+
+Example::
+
+	link = afx`
+		<Neos.Fusion:Link.Resource class="resource-link" href.path="resource://Some.Package/Public/Images/SomeImage.png">
+			Some Link
+		</Neos.Fusion:Link.Resource>
+	`
 
 Neos.Fusion:CanRender
 ---------------------

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -662,6 +662,7 @@ Neos.Fusion:ActionUri
 
 Built a URI to a controller action
 
+:request: (ActionRequest, defaults to the the current ``request``) The action request the uri is build from.
 :package: (string) The package key (e.g. ``'My.Package'``)
 :subpackage: (string) The subpackage, empty by default
 :controller: (string) The controller name (e.g. ``'Registration'``)
@@ -686,20 +687,20 @@ Example::
 A special case is generating URIs for links to Neos modules. In this case often the option `useMainRequest` is needed
 when linking to a controller outside of the context of the current subrequest.
 
-Link to content module::
+Link to the content module::
 
 	uri = Neos.Fusion:ActionUri {
-		useMainRequest = true
-		package = 'Neos.Neos'
-		controller = 'Frontend\\Node'
-		action = 'show'
+		request = ${request.mainRequest}
+    package="Neos.Neos.Ui"
+    controller="Backend"
+		action = 'index'
 		arguments.node = ${documentNode}
 	}
 
-Link to backend modules other than `content`::
+Link to backend modules (other than `content`)::
 
 	uri = Neos.Fusion:ActionUri {
-		useMainRequest = true
+		request = ${request.mainRequest}
 		action = "index"
 		package = "Neos.Neos"
 		controller = "Backend\\Module"
@@ -725,6 +726,7 @@ that the default ``tagName`` is an ``a`` other than ``div``.
 :content: (string) The inner content of the element, will only be rendered if the tag is not self-closing and the closing tag is not omitted
 :attributes: (iterable) Tag attributes as key-value pairs. Default is ``Neos.Fusion:DataStructure``. If a non iterable is returned the value is casted to string.
 ... from ``Neos.Fusion:ActionUri``:
+:request: (ActionRequest, defaults to the the current ``request``) The action request the uri is build from.
 :package: (string) The package key (e.g. ``'My.Package'``)
 :subpackage: (string) The subpackage, empty by default
 :controller: (string) The controller name (e.g. ``'Registration'``)
@@ -736,7 +738,6 @@ that the default ``tagName`` is an ``a`` other than ``div``.
 :addQueryString: (boolean) Whether to keep the query parameters of the current URI
 :argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
 :absolute: (boolean) Whether to create an absolute URI
-:useMainRequest: (boolean) If set, the main Request will be used instead of the current one.
 
 Example::
 
@@ -746,6 +747,31 @@ Example::
 		controller = 'Registration'
 		action = 'new'
 	}
+
+Link to content module in afx::
+
+    <Neos.Fusion:ActionLink
+      request={request.mainRequest}
+      action="index"
+      package="Neos.Neos.Ui"
+      controller="Backend"
+      arguments.node={node}
+    >
+      to Content module
+    </Neos.Fusion:ActionLink>
+
+Link to backend modules (other than `content`)::
+
+    <Neos.Fusion:ActionLink
+      request={request.mainRequest}
+      action="index"
+      package="Neos.Neos"
+      controller="Backend\\Module"
+      arguments.module='administration/sites'
+      arguments.moduleArguments.@action='index'
+    >
+      to Site module
+    </Neos.Fusion:ActionLink>
 
 Neos.Fusion:UriBuilder
 ----------------------

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -683,7 +683,7 @@ Example::
 		action = 'new'
 	}
 
-A special case is generating URIs for links to Neos modules. In this case often the option `useMainRequest` is needed
+A special case is generating URIs for links to Neos modules. In this case often the option `request = ${request.mainRequest}` is needed
 when linking to a controller outside of the context of the current subrequest.
 
 Link to the content module::


### PR DESCRIPTION
The name  `Neos.Fusion:UriBuilder` stands out from other fusion prototypes because it describes what the prototype does
instead of what will be the result. This contradicts the declarative nature of fusion. In addition it is not possible render links from a subrequests to other main-requests without manipulating the controllerContext. A common case for that is fusion-backend modules that want to render links to the content or other modules.

This change adds the prototype `Neos.Fusion:ActionUri` as a 1:1 replacement that implements the same api but allows to configure the `request` the uri is to be built from. This allows to create links from subrequests into other contexts.

`Neos.Fusion:ActionUri`:
- `request`: (ActionRequest, defaults to the the current ``request``) The action request the uri is built from.
- ... all other attributes equal ``Neos.Fusion:UriBuilder``

Examples: 

```
uri = Neos.Fusion:ActionUri {
    package = 'My.Package'
    controller = 'Registration'
    action = 'new'
}
```

This prototype allows to link between different backend modules like the content-module

```
cotentModuleUri = Neos.Fusion:ActionUri {
    request = ${request.mainRequest}
    package="Neos.Neos.Ui"
    controller="Backend"
    action = 'index'
    arguments.node = ${documentNode}
}
```
or the sites-module which uses a subrequest of the `Backend\\Module` controller.
```
siteModuleUri = Neos.Fusion:ActionUri {
    request = ${request.mainRequest}
    action = "index"
    package = "Neos.Neos"
    controller = "Backend\\Module"
    arguments {
        module = 'administration/sites'
        moduleArguments {
            @action = 'edit'
            site = ${site}
        }
    }
}
```

In addition:

1. The prototype `Neos.Fusion:Link.Action` is adjusted to use `Neos.Fusion:ActionUri` instead of `Neos.Fusion:UriBuilder` for the `href` property.
2. Documentation is added for `Neos.Fusion:Link.Action` and `Neos.Fusion:Link.Resource`

**Review instructions**

The change adds a new implementation instead of modifying or extending the UriBuilderImplementation to avoid breakiness as the `UriBuilder` uses the UriBuilder from the controllerContext while `ActionUri` creates a new UriBuilder.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
