### PR TITLE
BUGFIX: Fusion Parser ignores non existing context file

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -52,7 +52,7 @@ class ParserCache
         if ($this->enableCache === false) {
             return $generateValueToCache();
         }
-        if ($contextPathAndFilename === null) {
+        if ($contextPathAndFilename === null || !\is_file($contextPathAndFilename)) {
             return $generateValueToCache();
         }
         if (str_contains($contextPathAndFilename, '://')) {

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -78,6 +78,7 @@ class Parser implements ParserInterface
             }
             // Check if not trying to recursively include the current file via globbing
             if ($contextPathAndFilename === null
+                || !\is_file($contextPathAndFilename)
                 || stat($contextPathAndFilename) !== stat($file)) {
                 $fusionFile = $this->getFusionFile(file_get_contents($file), $file);
                 $this->getMergedArrayTreeVisitor($mergedArrayTree)->visitFusionFile($fusionFile);


### PR DESCRIPTION
In case of missing the Root.fusion file of a site package, the Fusion parser, now, ignores those files.

**Upgrade instructions**

Nothing needs to be done.

**Review instructions**

In a multi site project, it might be, that the Root.fusion does not exist for a site. The filename for the site is created in FusionService::getMergedFusionObjectTree() like
```
$siteRootFusionPathAndFilename = sprintf($this->siteRootFusionPattern, $siteResourcesPackageKey);
```
Because this file is optional, the `stat($contextPathAndFilename)` in the Parser::handleFileInclude() causes an error and aborts parsing with

```
Warning: stat(): stat failed for resource://Some.Package/Private/Fusion/Root.fusion in /var/www/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Fusion_Core_Parser.php line 88
```

This PR fixes this case.

@mhsdesign This PR is not related to the issue we talked in slack today. I just noticed this additional issue during debugging.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
