### PR TITLE
BUGFIX: Fusion Array.keys() on null if documentNode doesnt exist in GlobalCacheIdentifiers

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/DefaultFusion.fusion
@@ -120,5 +120,6 @@ error = Neos.Fusion:Case {
 #
 prototype(Neos.Fusion:GlobalCacheIdentifiers) {
 	workspaceChain = ${documentNode.context.workspace.name + ',' + Array.join(Array.keys(documentNode.context.workspace.baseWorkspaces), ',')}
+	workspaceChain.@if.has = ${!!documentNode}
 	editPreviewMode = ${documentNode.context.currentRenderingMode.name}
 }


### PR DESCRIPTION
https://neos-project.slack.com/archives/C050C8FEK/p1657807863902929

For example when using Fusion in an ajax request, with cache enabled - but no documentNode provided as context, then the calculation of the GlobalCacheIdentifiers fails due to the Eel helper beeing incorrectly used.