### PR TITLE
BUGFIX: Check if the rokka/imagine-vips package installed to prevent crashing the installer

### DIFF
--- a/Neos.CliSetup/Classes/Command/SetupCommandController.php
+++ b/Neos.CliSetup/Classes/Command/SetupCommandController.php
@@ -151,7 +151,12 @@ class SetupCommandController extends CommandController
      */
     public function imageHandlerCommand(string $driver = null): void
     {
+        $vipsAvailableMessage = $this->imageHandlerService->checkIfVipsIsAvailable();
         $availableImageHandlers = $this->imageHandlerService->getAvailableImageHandlers();
+
+        if ($vipsAvailableMessage !== '') {
+            $this->outputLine($vipsAvailableMessage);
+        }
 
         if (count($availableImageHandlers) == 0) {
             $this->outputLine('No supported image handler found.');

--- a/Neos.CliSetup/Classes/Command/SetupCommandController.php
+++ b/Neos.CliSetup/Classes/Command/SetupCommandController.php
@@ -151,11 +151,11 @@ class SetupCommandController extends CommandController
      */
     public function imageHandlerCommand(string $driver = null): void
     {
-        $vipsAvailableMessage = $this->imageHandlerService->checkIfVipsIsAvailable();
+        $unavailableDrivers= $this->imageHandlerService->checkDriverAvailability();
         $availableImageHandlers = $this->imageHandlerService->getAvailableImageHandlers();
 
-        if ($vipsAvailableMessage !== '') {
-            $this->outputLine($vipsAvailableMessage);
+        if (count($unavailableDrivers) > 0) {
+            $this->outputLine(sprintf('List of loaded but unavailable Drivers: <info>%s</info>', implode(', ', $unavailableDrivers )));
         }
 
         if (count($availableImageHandlers) == 0) {

--- a/Neos.CliSetup/Classes/Infrastructure/ImageHandler/ImageHandlerService.php
+++ b/Neos.CliSetup/Classes/Infrastructure/ImageHandler/ImageHandlerService.php
@@ -47,6 +47,9 @@ class ImageHandlerService
         $availableImageHandlers = [];
         foreach ($this->supportedImageHandlers as $driverName => $description) {
             if (\extension_loaded(strtolower($driverName))) {
+                if ($driverName == "Vips" && !class_exists("Imagine\\Vips\\Imagine")) {
+                    continue;
+                }
                 $unsupportedFormats = $this->findUnsupportedImageFormats($driverName);
                 if (\count($unsupportedFormats) === 0) {
                     $availableImageHandlers[$driverName] = $description;
@@ -54,6 +57,21 @@ class ImageHandlerService
             }
         }
         return $availableImageHandlers;
+    }
+
+    /**
+     * @return string
+     */
+    public function checkIfVipsIsAvailable(): string
+    {
+        if (
+            array_key_exists('Vips', $this->supportedImageHandlers) &&
+            \extension_loaded('vips') &&
+            !class_exists("Imagine\\Vips\\Imagine")) {
+            return 'It is also possible to use the vips php module. But right now its not available because you havent the rokka/imagine-vips package installed';
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
Resolves #3811

### Description:

If you haven't the rokka/imagine-vips package installed, the installer crashes because the `Imagine\Vips\Imagine` class can't be found. Now it checks, if the package is installed and outputs a message if it's not. If the package is installed, you can choose normally between `GD` and `Vips` if you run the `./flow setup:imagehandler` command.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
