### PR TITLE
BUGFIX: Fusion Runtime @process with simple string

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -825,7 +825,7 @@ class Runtime
             }
 
             # If there is only the internal "__stopInheritanceChain" path set, skip evaluation
-            if (count($processorConfiguration[$key]) === 1 && isset($processorConfiguration[$key]['__stopInheritanceChain'])) {
+            if (isset($processorConfiguration[$key]['__stopInheritanceChain']) && count($processorConfiguration[$key]) === 1) {
                 continue;
             }
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
@@ -24,6 +24,8 @@ processors.newSyntax.basicProcessor {
 
   plainValueOverriddenByPlainValue = "bar"
   plainValueOverriddenByPlainValue.@process.replace = "foo"
+  // https://github.com/neos/neos-development-collection/pull/3847#issuecomment-1192941620
+  plainValueOverriddenByPlainValue.@process.replace.@if.1 = true
 }
 
 processors.newSyntax.processorBeforeValue {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/Processor.fusion
@@ -21,6 +21,9 @@ processors.newSyntax.basicProcessor {
     value.@process.2 = ${value + ' foo'}
     value.@process.1 = ${value + ' World'}
   }
+
+  plainValueOverriddenByPlainValue = "bar"
+  plainValueOverriddenByPlainValue.@process.replace = "foo"
 }
 
 processors.newSyntax.processorBeforeValue {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -42,11 +42,12 @@ class ProcessorTest extends AbstractFusionObjectTest
     }
 
     /**
+     * https://github.com/neos/neos-development-collection/pull/3847
      * @test
      */
     public function plainValueOverriddenByPlainValueWorks()
     {
-        $this->assertMultipleFusionPaths('foo', 'processors/newSyntax/basicProcessor/plainValueOverriddenByPlainValue');
+        $this->assertFusionPath('foo', 'processors/newSyntax/basicProcessor/plainValueOverriddenByPlainValue');
     }
 
     /**

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -42,6 +42,14 @@ class ProcessorTest extends AbstractFusionObjectTest
     }
 
     /**
+     * @test
+     */
+    public function plainValueOverriddenByPlainValueWorks()
+    {
+        $this->assertMultipleFusionPaths('foo', 'processors/newSyntax/basicProcessor/plainValueOverriddenByPlainValue');
+    }
+
+    /**
      * Data Provider for processorsCanBeUnset
      *
      * @return array


### PR DESCRIPTION
This makes it possible to use `@process` with a regular string.

Closes #3846

**Review instructions**
try the fusion code from the issue.

it now works as we switched a condition (the count will only happen if it is an array and not possibly a simple value)


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
