### PR TITLE
BUGFIX: Apply autorotate before image adjustments

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -456,9 +456,6 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
             throw new \InvalidArgumentException('Invalid mode specified', 1574686891);
         }
 
-        $autorotateFilter = new \Imagine\Filter\Basic\Autorotate();
-        $autorotateFilter->apply($image);
-
         $imageSize = $image->getSize();
         $requestedDimensions = $this->calculateDimensions($imageSize);
 

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -133,6 +133,9 @@ class ImageService
 
         $imagineImage = $this->imagineService->open($resourceUri);
 
+        $autorotateFilter = new \Imagine\Filter\Basic\Autorotate();
+        $autorotateFilter->apply($imagineImage);
+
         $convertCMYKToRGB = $this->getOptionsMergedWithDefaults()['convertCMYKToRGB'];
         if ($convertCMYKToRGB && $imagineImage->palette() instanceof CMYK) {
             $imagineImage->usePalette(new RGB());


### PR DESCRIPTION
Applies the Imagine autorotate filter before doing image adjustments,
so images are consistently rotated from metadata also for crop
operations.

Fixes #3300

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
