### PR TITLE
TASK: Use local fonts instead of from Google

### DIFF
--- a/Neos.Neos/Resources/Private/Styles/Error.scss
+++ b/Neos.Neos/Resources/Private/Styles/Error.scss
@@ -3,7 +3,7 @@
 @import "Foundation/mixins";
 @import "Constants";
 @import "Mixins";
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic');
+@import "Fonts";
 @import "FontAwesome/fontawesome.scss";
 
 $errorBoxWidth: $unit * 18;


### PR DESCRIPTION
Removes the use of remote fonts from Google in favor of local
font files.

**Review instructions**

Noto should still be the font used on error pages.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
