### PR TITLE
FEATURE: Add Fusion prototype for flash messages

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
@@ -1,0 +1,81 @@
+<?php
+namespace Neos\Fusion\FusionObjects;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Error\Messages\Message;
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\FusionObjects\MapImplementation;
+
+/**
+ * A Fusion object to return the flashmessages from the current controller context
+ * //fusionPath itemRenderer the Fusion object which is triggered for each flashMessage
+ * //fusionPath severity to filter the messages to return by severity (One of the Neos\Error\Messages\Message::SEVERITY_* constants)
+ * //fusionPath flushMessages whether the messages should be flushed after reading them, default is true
+ */
+class FlashMessagesImplementation extends MapImplementation
+{
+    /**
+     * @return Message[]
+     */
+    public function getItems()
+    {
+        if($this->getFlushMessages()){
+            $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessagesAndFlush($this->getSeverity());
+        }else{
+            $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessages($this->getSeverity());
+        }
+        return $messages;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSeverity()
+    {
+        return $this->fusionValue('severity') ?? null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFlushMessages()
+    {
+        return $this->fusionValue('flushMessages');
+    }
+
+    /**
+     * Get the glue to insert between items
+     *
+     * @return string
+     */
+    public function getGlue()
+    {
+        return $this->fusionValue('__meta/glue') ?? '';
+    }
+
+    /**
+     * Evaluate the collection nodes
+     *
+     * @return string|Message[]
+     * @throws \Neos\Fusion\Exception
+     */
+    public function evaluate()
+    {
+        if($this->runtime->canRender($this->path . '/content')) {
+            $glue = $this->getGlue();
+            return implode($glue, parent::evaluate());
+        }else{
+            return $this->getItems();
+        }
+    }
+
+}

--- a/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
@@ -28,13 +28,13 @@ class FlashMessagesImplementation extends AbstractFusionObject
      */
     protected function getFlashMessages()
     {
-        if ($this->getFlushMessages()){
+        if ($this->getFlushMessages()) {
             $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessagesAndFlush($this->getSeverity());
         } else {
             $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessages($this->getSeverity());
         }
 
-        foreach ($this->getAdditionalMessages() as $additionalMessage){
+        foreach ($this->getAdditionalMessages() as $additionalMessage) {
             switch ($additionalMessage['severity']) {
                 case Message::SEVERITY_ERROR:
                     $messages[] = new Error($additionalMessage['message'], $additionalMessage['code'], $additionalMessage['arguments'], $additionalMessage['title']);
@@ -105,8 +105,8 @@ class FlashMessagesImplementation extends AbstractFusionObject
         $rendererPath = $this->path . '/renderer';
         $contentPath = $this->path . '/content';
 
-        if ($this->runtime->canRender($rendererPath) === false){
-            if ($this->runtime->canRender($contentPath) === false){
+        if ($this->runtime->canRender($rendererPath) === false) {
+            if ($this->runtime->canRender($contentPath) === false) {
                 return $this->getFlashMessages();
             } else {
                 $rendererPath = $contentPath;

--- a/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/FlashMessagesImplementation.php
@@ -11,29 +11,26 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Neos\Error\Messages\Message;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Notice;
 use Neos\Error\Messages\Warning;
-
 
 /**
  * A Fusion object to return the flashmessages from the current controller context
  *
  * //fusionPath renderer a Fusion object to render the flashMessage collection
  */
-class FlashMessagesImplementation  extends AbstractFusionObject
+class FlashMessagesImplementation extends AbstractFusionObject
 {
     /**
      * @return Message[]
      */
     protected function getFlashMessages()
     {
-        if($this->getFlushMessages()){
+        if ($this->getFlushMessages()){
             $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessagesAndFlush($this->getSeverity());
-        }else{
+        } else {
             $messages = $this->getRuntime()->getControllerContext()->getFlashMessageContainer()->getMessages($this->getSeverity());
         }
 
@@ -111,7 +108,7 @@ class FlashMessagesImplementation  extends AbstractFusionObject
         if ($this->runtime->canRender($rendererPath) === false){
             if ($this->runtime->canRender($contentPath) === false){
                 return $this->getFlashMessages();
-            }else{
+            } else {
                 $rendererPath = $contentPath;
             }
         }
@@ -127,5 +124,4 @@ class FlashMessagesImplementation  extends AbstractFusionObject
 
         return $renderedMessages;
     }
-
 }

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -61,21 +61,7 @@ prototype(Neos.Fusion:Map) {
   itemKey = 'itemKey'
   iterationName = 'iterator'
 }
-prototype(Neos.Fusion:FlashMessages) < prototype(Neos.Fusion:Map) {
-  @propTypes {
-    # to filter the messages to return by severity (One of the Neos\Error\Messages\Message::SEVERITY_* constants)
-    severity = ${PropTypes.oneOf(["Notice", "Warning", "Error", "OK"])}
 
-    # whether the messages should be flushed after reading them, default is true
-    flushMessages = ${PropTypes.boolean}
-  }
-  @class = 'Neos\\Fusion\\FusionObjects\\FlashMessagesImplementation'
-  @sortProperties = false
-  flushMessages = true
-  itemName = 'message'
-  itemKey = 'messageIndex'
-  iterationName = 'iterator'
-}
 prototype(Neos.Fusion:Reduce) {
   @class = 'Neos\\Fusion\\FusionObjects\\ReduceImplementation'
   itemName = 'item'
@@ -304,3 +290,76 @@ prototype(Neos.Fusion:GlobalCacheIdentifiers) < prototype(Neos.Fusion:DataStruct
   format = ${request.format}
   baseUri = ${String.toString(BaseUri.getConfiguredBaseUriOrFallbackToCurrentRequest(request.httpRequest))}
 }
+
+# returns the current flashMessages as array, passes then to the renderer or to the content
+#
+# Usage:
+# flashMessages = Neos.Fusion:FlashMessages
+# renderer = afx`
+#   <Neos.Fusion:Loop items={props.flashMessages}>
+#     {item.message}
+#   </Neos.Fusion:Loop>
+# `
+#
+# Usage:
+# renderedFlashMessages = Neos.Fusion:FlashMessages {
+#   renderer = My.Package:FlashMessageRenderer
+# }
+# renderer = afx`
+#   {props.flashMessages}
+# `
+#
+# AFX only:
+# renderer = afx`
+#   <Neos.Fusion:FlashMessages>
+#     <Neos.Fusion:Loop items={props.flashMessages}>
+#       {item.message}
+#     </Neos.Fusion:Loop>
+#   </Neos.Fusion:FlashMessages>
+# `
+prototype(Neos.Fusion:FlashMessages) {
+  @class = 'Neos\\Fusion\\FusionObjects\\FlashMessagesImplementation'
+  @sortProperties = false
+
+  # severity of the messages to return (One of the Neos\Error\Messages\Message::SEVERITY_* constants)
+  severity = null
+
+  # whether the messages should be flushed after reading them, default is true
+  flushMessages = true
+
+  # name of the property that contains the flashMessages inside the prototype
+  collectionName = 'flashMessages'
+
+  # add flashMessages in the fusion code, expects an array of Neos.Fusion:FlashMessages.Message elements
+  additionalMessages = Neos.Fusion:DataStructure
+}
+
+# to pass additional flashMessages to Neos.Fusion:FlashMessages within the fusion code
+#
+# Usage:
+# flashMessages = Neos.Fusion:FlashMessages {
+#   additionalMessages {
+#     testCase1 = Neos.Fusion:FlashMessages.Message {
+#       message = 'Test'
+#     }
+#   }
+# }
+prototype(Neos.Fusion:FlashMessages.Message) < prototype(Neos.Fusion:DataStructure) {
+  @sortProperties = false
+
+  # severity of the messages to return (One of the Neos\Error\Messages\Message::SEVERITY_* constants)
+  severity = 'OK'
+
+  # An english error message which is used if no other error message can be resolved
+  message = ''
+
+  # A unique error code
+  code = 0
+
+  # Array of arguments to be replaced in message
+  arguments = Neos.Fusion:DataStructure
+
+  # optional title for the message
+  title = ''
+}
+

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -301,18 +301,18 @@ prototype(Neos.Fusion:GlobalCacheIdentifiers) < prototype(Neos.Fusion:DataStruct
 #   </Neos.Fusion:Loop>
 # `
 #
-# Usage:
+# Usage with renderer:
 # renderedFlashMessages = Neos.Fusion:FlashMessages {
 #   renderer = My.Package:FlashMessageRenderer
 # }
 # renderer = afx`
-#   {props.flashMessages}
+#   {props.renderedFlashMessages}
 # `
 #
 # AFX only:
 # renderer = afx`
 #   <Neos.Fusion:FlashMessages>
-#     <Neos.Fusion:Loop items={props.flashMessages}>
+#     <Neos.Fusion:Loop items={flashMessages}>
 #       {item.message}
 #     </Neos.Fusion:Loop>
 #   </Neos.Fusion:FlashMessages>

--- a/Neos.Fusion/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Root.fusion
@@ -61,6 +61,21 @@ prototype(Neos.Fusion:Map) {
   itemKey = 'itemKey'
   iterationName = 'iterator'
 }
+prototype(Neos.Fusion:FlashMessages) < prototype(Neos.Fusion:Map) {
+  @propTypes {
+    # to filter the messages to return by severity (One of the Neos\Error\Messages\Message::SEVERITY_* constants)
+    severity = ${PropTypes.oneOf(["Notice", "Warning", "Error", "OK"])}
+
+    # whether the messages should be flushed after reading them, default is true
+    flushMessages = ${PropTypes.boolean}
+  }
+  @class = 'Neos\\Fusion\\FusionObjects\\FlashMessagesImplementation'
+  @sortProperties = false
+  flushMessages = true
+  itemName = 'message'
+  itemKey = 'messageIndex'
+  iterationName = 'iterator'
+}
 prototype(Neos.Fusion:Reduce) {
   @class = 'Neos\\Fusion\\FusionObjects\\ReduceImplementation'
   itemName = 'item'


### PR DESCRIPTION
related: #3785 

**Review instructions**

The prototype can be used to render the flash messages in AFX like
```
<ul>
    <Neos.Fusion:FlashMessages severity="Error">
        <li>{message.message}</li>
    </Neos.Fusion:FlashMessages>
</ul>
```
but if there is no path /content to render the prototype returns the Messages as array and they can be processed further
```
flashMessages = Neos.Fusion:FlashMessages
renderer = Neos.Fusion:Loop {
    items={props.flashMessages}
    itemRenderer = My.Package:MyFlashMessageRenderer
} 
```
as Neos.Fusion:FlashMessages extends Neos.Fusion:Map, it inherits the iteration data feature
and as for Neos.Fusion:Loop the content between messages can be defined with the meta property `@glue`

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
