### PR TITLE
FEATURE: Capture exceptions when creating new user or updating password

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
+++ b/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Controller\Module\User;
 
 /*
@@ -131,8 +132,13 @@ class UserSettingsController extends AbstractModuleController
         $user = $this->currentUser;
         $password = array_shift($password);
         if (strlen(trim(strval($password))) > 0) {
-            $this->userService->setUserPassword($user, $password);
-            $this->addFlashMessage('The password has been updated.', 'Password updated', Message::SEVERITY_OK);
+            try {
+                $this->userService->setUserPassword($user, $password);
+                $this->addFlashMessage('The password has been updated.', 'Password updated', Message::SEVERITY_OK);
+            } catch (\Exception $e) {
+                $this->addFlashMessage($e->getMessage(), 'Password could not be saved', Message::SEVERITY_ERROR, [], 1647335912);
+                $this->forward('edit', null, null, ['user' => $user]);
+            }
         }
         $this->redirect('index');
     }


### PR DESCRIPTION
**Upgrade instructions**

Creating a user or changing the password will no longer throw an exception with a 500 error page but instead show the error in a flash message. This is done by wrapping `UserService::addUser()` and `UserService::setUserPassword()` with a try-catch block. 


**Review instructions**

This PR changes the exception handling when creating new users or updating passwords by wrapping the used methods (`UserService::addUser()` and `UserService::setUserPassword()`) inside a try catch block and showing an error message (FlashMessage) if there was an exception. 
That way it will be easier to extend Neos and add some password checks without showing a 500 error page in the Neos backend, which is currently the case with [JvMTECH.NeosHardening](https://github.com/jvm-tech/JvMTECH.NeosHardening) (see jvm-tech/JvMTECH.NeosHardening#2) and maybe others.

With the adjusted code you can add checks to the password through an Aspect and simply throw an exception, if the requirements do not pass. 


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
