### PR TITLE
BUGFIX: Fix media commands output

### DIFF
--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -272,6 +272,7 @@ class MediaCommandController extends CommandController
             $this->assetRepository->remove($asset);
         }
         !$quiet && $this->output->progressFinish();
+        !$quiet && $this->output->outputLine();
     }
 
     /**
@@ -307,6 +308,7 @@ class MediaCommandController extends CommandController
             }
         }
         !$quiet && $this->output->progressFinish();
+        !$quiet && $this->output->outputLine();
     }
 
     /**
@@ -339,6 +341,7 @@ class MediaCommandController extends CommandController
             !$quiet && $this->output->progressAdvance(1);
         }
         !$quiet && $this->output->progressFinish();
+        !$quiet && $this->output->outputLine();
     }
 
     /**


### PR DESCRIPTION
Fix Neos.Media commands `media:clearthumbnails`, `media:createthumbnails` and `media:removeunused` to properly print a final newline.

Output before:
```
user $ ./flow media:clearthumbnails
0 [->--------------------------]user $
                                ^-- next prompt
```
Output after:
```
user $ ./flow media:clearthumbnails
0 [->--------------------------]
user $
```
Resolved: #3894

**Upgrade instructions**

None.

**Review instructions**

in `bash`, execute
`./flow media:clearthumbnails`
(by default, `zsh` is less affected, it recovers but shows a percent sign)

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
