### PR TITLE
TASK: Tweak note about target branches for PRs

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -62,4 +62,6 @@ To switch the branch you intend to work on:
 .. note:: We use an upmerging strategy: create all bugfixes to the lowest maintained branch that contains the issue. Typically, this is the second last LTS release - see the diagram at https://www.neos.io/features/release-process.html.
 For new features, pull requests should be made against the branch for the next minor version (named like ``x.y``). Breaking changes must only go into the branch for the next major version.
 
-For more detailed information, see https://discuss.neos.io/t/development-setup/504 and https://discuss.neos.io/t/creating-a-pull-request/506
+For more detailed information, see https://discuss.neos.io/t/development-setup/504,
+https://discuss.neos.io/t/creating-a-pull-request/506 and
+https://discuss.neos.io/t/git-branch-handling-in-the-neos-project/6013

--- a/Readme.rst
+++ b/Readme.rst
@@ -57,7 +57,7 @@ In the root directory of the development distribution, you can do the following 
 To run tests, run ``./bin/phpunit -c ./Build/BuildEssentials/PhpUnit/UnitTests.xml`` for unit or ``./bin/phpunit -c ./Build/BuildEssentials/PhpUnit/FunctionalTests.xml`` for functional/integration tests.
 
 To switch the branch you intend to work on:
-``git checkout 8.0 && composer update``
+``git checkout 8.2 && composer update``
 
 .. note:: We use an upmerging strategy: create all bugfixes to the lowest maintained branch that contains the issue. Typically, this is the second last LTS release - see the diagram at https://www.neos.io/features/release-process.html.
 For new features, pull requests should be made against the branch for the next minor version (named like ``x.y``). Breaking changes must only go into the branch for the next major version.

--- a/Readme.rst
+++ b/Readme.rst
@@ -59,6 +59,7 @@ To run tests, run ``./bin/phpunit -c ./Build/BuildEssentials/PhpUnit/UnitTests.x
 To switch the branch you intend to work on:
 ``git checkout 8.0 && composer update``
 
-.. note:: We use an upmerging strategy, so create all bugfixes to lowest maintained branch that contains the issue (typically the second last LTS release, which is 5.3 currently), or master for new features.
+.. note:: We use an upmerging strategy: create all bugfixes to the lowest maintained branch that contains the issue. Typically, this is the second last LTS release - see the diagram at https://www.neos.io/features/release-process.html.
+For new features, pull requests should be made against the branch for the next minor version (named like ``x.y``). Breaking changes must only go into the branch for the next major version.
 
 For more detailed information, see https://discuss.neos.io/t/development-setup/504 and https://discuss.neos.io/t/creating-a-pull-request/506


### PR DESCRIPTION
This removes an explicit mention of the oldest supported branch,
so we don't have to keep updating it.