### PR TITLE
FEATURE: Provide Uris in MenuItemsImplementation

### DIFF
--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -191,12 +191,12 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
 
         $item = [
             'node' => $currentNode,
-            'state' => self::STATE_NORMAL,
+            'state' => $this->calculateItemState($currentNode),
             'label' => $currentNode->getLabel(),
-            'menuLevel' => $this->currentLevel
+            'menuLevel' => $this->currentLevel,
+            'uri' => $this->buildUri($currentNode),
         ];
 
-        $item['state'] = $this->calculateItemState($currentNode);
         if (!$this->isOnLastLevelOfMenu($currentNode)) {
             $this->currentLevel++;
             $item['subItems'] = $this->buildMenuLevelRecursive($currentNode->getChildNodes($this->getFilter()));
@@ -302,5 +302,16 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
         }
 
         return $depth;
+    }
+
+    protected function buildUri(NodeInterface $currentNode): string
+    {
+        $this->runtime->pushContextArray([
+            'itemNode' => $currentNode,
+            'documentNode' => $currentNode,
+        ]);
+        $uri = $this->runtime->render($this->path . '/itemUriRenderer');
+        $this->runtime->popContext();
+        return $uri;
     }
 }

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1270,6 +1270,7 @@ Create a list of menu-items items for nodes.
 :filter: (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``
 :renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered, defaults to ``false``
 :itemCollection: (array) Explicitly set the Node items for the menu (alternative to ``startingPoints`` and levels)
+:itemUriRenderer: (:ref:`Neos_Neos__NodeUri`) prototype to use for rendering the URI of each item
 
 MenuItems item properties:
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1278,7 +1279,8 @@ MenuItems item properties:
 :originalNode: (Node) Original node for the item
 :state: (string) Menu state of the item: ``'normal'``, ``'current'`` (the current node) or ``'active'`` (ancestor of current node)
 :label: (string) Full label of the node
-:menuLevel: (integer) Men^u level the item is rendered on
+:menuLevel: (integer) Menu level the item is rendered on
+:uri: (string) Frontend URI of the node
 
 Examples:
 ^^^^^^^^^
@@ -1308,6 +1310,17 @@ Menu with custom starting point:
 		entryLevel = 2
 		maximumLevels = 1
 		startingPoint = ${q(site).children('[uriPathSegment="metamenu"]').get(0)}
+	}
+
+Menu with absolute uris:
+""""""""""""""""""""""""
+
+::
+
+	menuItems = Neos.Neos:MenuItems {
+		itemUriRenderer {
+			absolute = true
+		}
 	}
 
 .. _Neos_Neos__BreadcrumbMenuItems:

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
@@ -9,4 +9,10 @@ prototype(Neos.Neos:MenuItems) {
   filter = 'Neos.Neos:Document'
   renderHiddenInIndex = false
   itemCollection = null
+
+  // This property is used internally by `MenuItemsImplementation` to render each items uri.
+  // It can be modified to change behaviour for all rendered uris.
+  itemUriRenderer = Neos.Neos:NodeUri {
+    node = ${itemNode}
+  }
 }

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/BreadcrumbMenu.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/BreadcrumbMenu.html
@@ -9,7 +9,7 @@
 					{item.label}
 				</f:then>
 				<f:else>
-					<neos:link.node node="{item.node}" />
+					<a href="{item.uri}" title="{item.label}">{item.label}</a>
 				</f:else>
 			</f:if>
 		</li>

--- a/Neos.Neos/Resources/Private/Templates/FusionObjects/Menu.html
+++ b/Neos.Neos/Resources/Private/Templates/FusionObjects/Menu.html
@@ -7,7 +7,7 @@
 <f:section name="itemsList">
 	<f:for each="{items}" as="item">
 		<li{ts:render(path: '{item.state}.attributes', context: {item: item}) -> f:format.raw()}>
-		<neos:link.node node="{item.node}" />
+		<a href="{item.uri}" title="{item.label}">{item.label}</a>
 		<f:if condition="{item.subItems}">
 			<ul>
 				<f:render section="itemsList" arguments="{items: item.subItems}" />

--- a/Neos.NodeTypes.Navigation/Resources/Private/Templates/NodeTypes/Navigation.html
+++ b/Neos.NodeTypes.Navigation/Resources/Private/Templates/NodeTypes/Navigation.html
@@ -18,7 +18,7 @@
 <f:section name="itemsList">
 	<f:for each="{items}" as="item">
 		<li{ts:render(path: '{item.state}.attributes', context: {item: item}) -> f:format.raw()}>
-		<neos:link.node node="{item.node}">{item.label}</neos:link.node>
+		<a href={item.uri} title={item.label}>{item.label}</a>
 		<f:if condition="{item.subItems}">
 			<ul>
 				<f:render section="itemsList" arguments="{items: item.subItems}" />


### PR DESCRIPTION
With this change the uris for nodes are included in menuitems. This makes it easier to use them in presentational components as no further processing is needed to turn nodes into uris.

Resolves: #3907

**Review instructions**

Debugdump the output of a `Neos.Neos:MenuItems` instance. It should include `uri` fields for all items.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
