### PR TITLE
BUGFIX: Capture exceptions when creating new user or updating password

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
+++ b/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Controller\Module\User;
 
 /*
@@ -143,12 +144,24 @@ class UserSettingsController extends AbstractModuleController
         $user = $this->currentUser;
         $password = array_shift($password);
         if (strlen(trim(strval($password))) > 0) {
-            $this->userService->setUserPassword($user, $password);
-            $this->addFlashMessage(
-                $this->translator->translateById('userSettings.passwordUpdated.body', [], null, null, 'Modules', 'Neos.Neos'),
-                $this->translator->translateById('userSettings.passwordUpdated.title', [], null, null, 'Modules', 'Neos.Neos'),
-                Message::SEVERITY_OK
-            );
+            try {
+                $this->userService->setUserPassword($user, $password);
+                $this->addFlashMessage(
+                    $this->translator->translateById('userSettings.passwordUpdated.body', [], null, null, 'Modules', 'Neos.Neos'),
+                    $this->translator->translateById('userSettings.passwordUpdated.title', [], null, null, 'Modules', 'Neos.Neos'),
+                    Message::SEVERITY_OK
+                );
+            } catch (\Exception $e) {
+                $this->addFlashMessage(
+                    // The shown message must be translated when throwing the actual exception.
+                    $e->getMessage(),
+                    $this->translator->translateById('userSettings.passwordUpdateFailed.title', [], null, null, 'Modules', 'Neos.Neos'),
+                    Message::SEVERITY_ERROR,
+                    [],
+                    1647335912
+                );
+                $this->forward('edit', null, null, ['user' => $user]);
+            }
         }
         $this->redirect('index');
     }

--- a/Neos.Neos/Resources/Private/Translations/ar/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ar/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/cs/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/cs/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/da/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/da/Modules.xlf
@@ -1151,6 +1151,10 @@ Klik på en af noderne for kun at se dens tilbagefald og varianter. Klik igen fo
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Klik på en af noderne for kun at se dens tilbagefald og varianter. Klik igen fo
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -1151,6 +1151,10 @@ Klicken Sie auf einen der Knoten um nur die Fallbacks und Varianten für diesen 
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="final">Sie dürfen keinen Benutzer mit den Rollen "{0}" erstellen.</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="final">Bearbeitung des Benutzers verweigert</target>
@@ -1254,6 +1258,14 @@ Klicken Sie auf einen der Knoten um nur die Fallbacks und Varianten für diesen 
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="final">Ihr Benutzer wurde aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/el/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/el/Modules.xlf
@@ -880,6 +880,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="users.userCreationDenied.body" xml:space="preserve">
 				<source>You are not allowed to create a user with roles "{0}".</source>
 			<target state="needs-translation">You are not allowed to create a user with roles "{0}".</target></trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
 			<target state="needs-translation">User editing denied</target></trans-unit>
@@ -958,6 +962,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
 			<target state="needs-translation">Your user has been updated.</target></trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>
 			<target state="needs-translation">Password updated</target></trans-unit>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -880,6 +880,9 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 			<trans-unit id="users.userCreationDenied.body" xml:space="preserve">
 				<source>You are not allowed to create a user with roles "{0}".</source>
 			</trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+      </trans-unit>
 			<trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
 			</trans-unit>
@@ -959,6 +962,12 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 			<trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
 			</trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+      </trans-unit>
 			<trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>
 			</trans-unit>

--- a/Neos.Neos/Resources/Private/Translations/es/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/es/Modules.xlf
@@ -1150,6 +1150,10 @@ Las suplencias primarias son están marcadas en azul y son siempre visibles, mie
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1253,6 +1257,14 @@ Las suplencias primarias son están marcadas en azul y son siempre visibles, mie
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/fi/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/fi/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/fr/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/fr/Modules.xlf
@@ -1151,6 +1151,10 @@ Cliquez sur l'un des nœuds pour ne voir que ses substituts et ses variantes. Cl
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Cliquez sur l'un des nœuds pour ne voir que ses substituts et ses variantes. Cl
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/hu/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/hu/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/id_ID/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/id_ID/Modules.xlf
@@ -1147,6 +1147,10 @@ Klik salah satu node untuk hanya melihat fallback dan variannya. Klik lagi untuk
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1250,6 +1254,14 @@ Klik salah satu node untuk hanya melihat fallback dan variannya. Klik lagi untuk
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/it/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/it/Modules.xlf
@@ -1151,6 +1151,10 @@ Clicca su uno dei nodi per vedere solo i suoi fallback e varianti. Clicca di nuo
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Clicca su uno dei nodi per vedere solo i suoi fallback e varianti. Clicca di nuo
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/ja/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ja/Modules.xlf
@@ -1147,6 +1147,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1250,6 +1254,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/km/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/km/Modules.xlf
@@ -1150,6 +1150,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1253,6 +1257,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/lv/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/lv/Modules.xlf
@@ -1151,6 +1151,10 @@ Iezīmējiet vienu no mezgliem redzēsiet visus iespējamos elementu (mezglu) sa
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Iezīmējiet vienu no mezgliem redzēsiet visus iespējamos elementu (mezglu) sa
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/nl/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/nl/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/no/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/no/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/pl/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pl/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/pt/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pt/Modules.xlf
@@ -1152,6 +1152,10 @@ Clique em um dos nodes para ver apenas os seus fallbacks e variantes. Clique nov
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1255,6 +1259,14 @@ Clique em um dos nodes para ver apenas os seus fallbacks e variantes. Clique nov
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/pt_BR/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pt_BR/Modules.xlf
@@ -1151,6 +1151,10 @@ Clique em um dos nós para apenas ver seus fallbacks e variantes. Clique novamen
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Clique em um dos nós para apenas ver seus fallbacks e variantes. Clique novamen
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/ru/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ru/Modules.xlf
@@ -875,7 +875,7 @@
 Primary fallbacks are marked blue and always visible, while lower priority fallbacks are shown on mouseover. The higher the priority the higher the opacity.
 Click on one of the nodes to only see its fallbacks and variants. Click again to remove the filter.</source>
         <target state="final">Междименсиональная диаграмма резервного поведения отображает все возможные поведения(изображены как грани) между вложенными диаграммами(изображены как элементы).
-Основные резервные поведения помечены синим и отображаются всегда. Вторичные отображаются только при наведении курсора мыши. Чем выше приоритет, тем выше затененность. 
+Основные резервные поведения помечены синим и отображаются всегда. Вторичные отображаются только при наведении курсора мыши. Чем выше приоритет, тем выше затененность.
 Щёлкните на одно из измерений, чтобы увидеть только его резервные поведения и варианты. Щёлкните снова, чтобы удалить этот фильтр.</target>
       </trans-unit>
       <trans-unit id="dimensions.intraDimension.legend" xml:space="preserve" approved="yes">
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/sr/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/sr/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/sv/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/sv/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/tl_PH/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/tl_PH/Modules.xlf
@@ -880,6 +880,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="users.userCreationDenied.body" xml:space="preserve">
 				<source>You are not allowed to create a user with roles "{0}".</source>
 			<target state="needs-translation">You are not allowed to create a user with roles "{0}".</target></trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
 			<target state="needs-translation">User editing denied</target></trans-unit>
@@ -958,6 +962,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
 			<target state="needs-translation">Your user has been updated.</target></trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>
 			<target state="needs-translation">Password updated</target></trans-unit>

--- a/Neos.Neos/Resources/Private/Translations/tr/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/tr/Modules.xlf
@@ -1151,6 +1151,10 @@ Yalnızca geri dönüşünü ve değişkenlerini görmek için düğümlerden bi
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Yalnızca geri dönüşünü ve değişkenlerini görmek için düğümlerden bi
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/uk/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/uk/Modules.xlf
@@ -1151,6 +1151,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1254,6 +1258,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/vi/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/vi/Modules.xlf
@@ -1147,6 +1147,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1250,6 +1254,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/zh/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/zh/Modules.xlf
@@ -1147,6 +1147,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1250,6 +1254,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>

--- a/Neos.Neos/Resources/Private/Translations/zh_TW/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/zh_TW/Modules.xlf
@@ -1147,6 +1147,10 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 				<source>You are not allowed to create a user with roles "{0}".</source>
         <target state="needs-translation">You are not allowed to create a user with roles "{0}".</target>
       </trans-unit>
+      <trans-unit id="users.userCreationError.title" xml:space="preserve">
+				<source>Unable to create user.</source>
+        <target state="needs-translation">Unable to create user.</target>
+      </trans-unit>
       <trans-unit id="users.userEditingDenied.editing.title" xml:space="preserve">
 				<source>User editing denied</source>
         <target state="needs-translation">User editing denied</target>
@@ -1250,6 +1254,14 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
       <trans-unit id="userSettings.UserUpdated.body" xml:space="preserve">
 				<source>Your user has been updated.</source>
         <target state="needs-translation">Your user has been updated.</target>
+      </trans-unit>
+      <trans-unit id="userSettings.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
+      </trans-unit>
+      <trans-unit id="userAccount.passwordUpdateFailed.title" xml:space="preserve">
+				<source>Updating password failed</source>
+        <target state="needs-translation">Updating password failed</target>
       </trans-unit>
       <trans-unit id="userSettings.passwordUpdated.title" xml:space="preserve">
 				<source>Password updated</source>


### PR DESCRIPTION
This PR replaces #3901.

**Upgrade instructions**

Creating a user or changing the password will no longer throw an exception with a 500 error page but instead show the error in a flash message. This is done by wrapping `UserService::addUser()` and `UserService::setUserPassword()` with a try-catch block. 


**Review instructions**

This PR changes the exception handling when creating new users or updating passwords by wrapping the used methods (`UserService::addUser()` and `UserService::setUserPassword()`) inside a try catch block and showing an error message (FlashMessage) if there was an exception. 
That way it will be easier to extend Neos and add some password checks without showing a 500 error page in the Neos backend, which is currently the case with [JvMTECH.NeosHardening](https://github.com/jvm-tech/JvMTECH.NeosHardening) (see jvm-tech/JvMTECH.NeosHardening#2) and maybe others.

With the adjusted code you can add checks to the password through an Aspect and simply throw an exception, if the requirements do not pass. 


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
