### PR TITLE
FEATURE: Make login logo configurable

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -286,6 +286,7 @@ Neos:
 
       backendLoginForm:
         backgroundImage: 'resource://Neos.Neos/Public/Images/Login/Wallpaper.webp'
+        logoImage: 'resource://Neos.Neos/Public/Images/Login/Logo.svg'
         stylesheets:
           'Neos.Neos:DefaultStyles': 'resource://Neos.Neos/Public/Styles/Login.css'
 

--- a/Neos.Neos/Documentation/References/Configuration/Configuration.rst
+++ b/Neos.Neos/Documentation/References/Configuration/Configuration.rst
@@ -69,3 +69,33 @@ In addition to the ``default`` preset, additional presets can be configured such
 
 If at least one custom preset is defined, instead of the list of all node types the filter will
 display the configured presets.
+
+
+Login Form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The login form can be customized by configuring a different background image or logo.
+You can even use custom CSS to change the look and feel of the login form.
+
+To achieve this, you are able to change several values in your ``Settings.yaml``:
+By default we use the following values:
+
+.. code-block:: yaml
+
+  Neos:
+    Neos:
+      userInterface:
+        backendLoginForm:
+            backgroundImage: 'resource://Neos.Neos/Public/Images/Login/Wallpaper.webp'
+            logoImage: 'resource://Neos.Neos/Public/Images/Login/Logo.svg'
+            stylesheets:
+                'Neos.Neos:DefaultStyles': 'resource://Neos.Neos/Public/Styles/Login.css'
+
+
+``backgroundImage`` defines the background image of the login form on the login page.
+The image can be a resource or a path to an image.
+
+``logoImage`` defines the logo image of the login form on the login page.
+The image can be a resource or a path to an image.
+
+``stylesheets`` defines the stylesheets which are loaded on the login page.

--- a/Neos.Neos/Resources/Private/Fusion/Backend/Component/ImageSource.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Component/ImageSource.fusion
@@ -1,0 +1,17 @@
+prototype(Neos.Neos:Component.ImageSource) < prototype(Neos.Fusion:Component) {
+    path = ''
+    @if.set = ${this.path}
+    renderer = Neos.Fusion:Case {
+        resourcePath {
+            condition = ${String.indexOf(props.path, 'resource://') == 0}
+            renderer = Neos.Fusion:ResourceUri {
+                path = ${props.path}
+            }
+        }
+
+        default {
+            condition = true
+            renderer = ${props.path}
+        }
+    }
+}

--- a/Neos.Neos/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Root.fusion
@@ -1,6 +1,7 @@
 include: resource://Neos.Fusion/Private/Fusion/Root.fusion
 include: resource://Neos.Fusion.Form/Private/Fusion/Root.fusion
 include: Views/*.fusion
+include: Component/*.fusion
 
 Neos.Neos.LoginController.index = Neos.Neos:View.Login {
   site = ${site}

--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -11,10 +11,10 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
     content = Neos.Fusion:Component {
       @apply.props = ${props}
 
-      logoImageSource = Neos.Neos:Component.Login.ImageSource {
+      logoImageSource = Neos.Neos:Component.ImageSource {
           path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.logoImage')}
       }
-      backgroundImageSource = Neos.Neos:Component.Login.ImageSource {
+      backgroundImageSource = Neos.Neos:Component.ImageSource {
           path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.backgroundImage')}
       }
       backgroundImageSourceIsWebp = ${this.backgroundImageSource ? String.endsWith(this.backgroundImageSource, '.webp') : null}
@@ -160,22 +160,4 @@ prototype(Neos.Neos:Component.Login.Form) < prototype(Neos.Fusion:Component) {
         </fieldset>
     </Neos.Fusion.Form:Form>
   `
-}
-
-prototype(Neos.Neos:Component.Login.ImageSource) < prototype(Neos.Fusion:Component) {
-    path = ''
-    @if.set = ${this.path}
-    renderer = Neos.Fusion:Case {
-        resourcePath {
-            condition = ${String.indexOf(props.path, 'resource://') == 0}
-            renderer = Neos.Fusion:ResourceUri {
-                path = ${props.path}
-            }
-        }
-
-        default {
-            condition = true
-            renderer = ${props.path}
-        }
-    }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -11,23 +11,11 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
     content = Neos.Fusion:Component {
       @apply.props = ${props}
 
-      backgroundImageSource = Neos.Fusion:Component {
-        @if.set = ${this.path}
-        path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.backgroundImage')}
-
-        renderer = Neos.Fusion:Case {
-          resourcePath {
-            condition = ${String.indexOf(props.path, 'resource://') == 0}
-            renderer = Neos.Fusion:ResourceUri {
-              path = ${props.path}
-            }
-          }
-
-          default {
-            condition = true
-            renderer = ${props.path}
-          }
-        }
+      logoImageSource = Neos.Neos:Component.Login.ImageSource {
+          path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.logoImage')}
+      }
+      backgroundImageSource = Neos.Neos:Component.Login.ImageSource {
+          path = ${Configuration.setting('Neos.Neos.userInterface.backendLoginForm.backgroundImage')}
       }
       backgroundImageSourceIsWebp = ${this.backgroundImageSource ? String.endsWith(this.backgroundImageSource, '.webp') : null}
 
@@ -66,7 +54,7 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
                         <div class={['neos-login-box', props.backgroundImageSource ? 'background-image-active' : null]}>
                             <figure class="neos-login-box-logo">
                                 <img class="neos-login-box-logo-resource" @children="attributes.src" width="200px" height="200px" alt="Neos Logo">
-                                    <Neos.Fusion:ResourceUri path="resource://Neos.Neos/Public/Images/Login/Logo.svg" />
+                                    {props.logoImageSource}
                                 </img>
                             </figure>
 
@@ -172,4 +160,22 @@ prototype(Neos.Neos:Component.Login.Form) < prototype(Neos.Fusion:Component) {
         </fieldset>
     </Neos.Fusion.Form:Form>
   `
+}
+
+prototype(Neos.Neos:Component.Login.ImageSource) < prototype(Neos.Fusion:Component) {
+    path = ''
+    @if.set = ${this.path}
+    renderer = Neos.Fusion:Case {
+        resourcePath {
+            condition = ${String.indexOf(props.path, 'resource://') == 0}
+            renderer = Neos.Fusion:ResourceUri {
+                path = ${props.path}
+            }
+        }
+
+        default {
+            condition = true
+            renderer = ${props.path}
+        }
+    }
 }


### PR DESCRIPTION
Since ages, we are able to configure the background of the login to customize. The logo was often replaced by CSS. With this change, we are able to configure a logo as well.

The new setting is  'Neos.Neos.userInterface.backendLoginForm.logoImage'

**Review instructions**

Configure a new logo and check the login screen.

<img width="1688" alt="Screenshot 2022-10-18 at 10 39 31" src="https://user-images.githubusercontent.com/1014126/196380887-4d52a85a-61d0-4f1b-b24a-e8d070845acb.png">
