### PR TITLE
BUGFIX: Node::countChildNodes($nodeTypeConstraints) filter doesn't work

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -2081,7 +2081,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      */
     public function countChildNodes(NodeTypeConstraints $nodeTypeConstraints = null): int
     {
-        return count($this->getChildNodes($nodeTypeConstraints));
+        return count($this->findChildNodes($nodeTypeConstraints));
     }
 
     /**


### PR DESCRIPTION
closes #3885

`findChildNodes` is corrently implemented, but `countChildNodes` doesnt transform the argument $nodeTypeConstraints NodeTypeConstraints to a string for the legacy api:

either this snipped must be included:
```php
$filter = $nodeTypeConstraints !== null ? $nodeTypeConstraints->asLegacyNodeTypeFilterString() : null;
```

or we must use `$this->findChildNodes`

without that, the `NodeTypeConstraints` is passed further down, and due to lack of typesafety it fails at the last moment:
```php
Argument 2 passed to Neos\Utility\Arrays::trimExplode() must be of the type string, object given, called in /tmp/neos/Development/SubContextddev/Cache/Code/Flow_Object_Classes/Neos_ContentRepository_Domain_Repository_NodeDataRepository.php on line 1127
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
