### PR TITLE
BUGFIX: DI conflict in DataSource `Call to a member function log Throwable() on null`

### DIFF
--- a/Neos.Neos/Classes/Service/Controller/AbstractServiceController.php
+++ b/Neos.Neos/Classes/Service/Controller/AbstractServiceController.php
@@ -34,10 +34,12 @@ abstract class AbstractServiceController extends ActionController
     protected $supportedMediaTypes = ['application/json'];
 
     /**
+     * Cant be named here $throwableStorage see https://github.com/neos/neos-development-collection/issues/3858
+     *
      * @Flow\Inject
      * @var ThrowableStorageInterface
      */
-    protected $throwableStorage;
+    protected $throwableStorageLogger;
 
     /**
      * A preliminary error action for handling validation errors
@@ -98,7 +100,7 @@ abstract class AbstractServiceController extends ActionController
                 $response->setStatusCode(500);
             }
             $response->setContent(json_encode(['error' => $exceptionData]));
-            $this->logger->error($this->throwableStorage->logThrowable($exception), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger->error($this->throwableStorageLogger->logThrowable($exception), LogEnvironment::fromMethodName(__METHOD__));
         }
     }
 

--- a/Neos.Neos/Classes/Service/Controller/AbstractServiceController.php
+++ b/Neos.Neos/Classes/Service/Controller/AbstractServiceController.php
@@ -39,7 +39,7 @@ abstract class AbstractServiceController extends ActionController
      * @Flow\Inject
      * @var ThrowableStorageInterface
      */
-    protected $throwableStorageLogger;
+    protected $throwableStorage2;
 
     /**
      * A preliminary error action for handling validation errors
@@ -100,7 +100,7 @@ abstract class AbstractServiceController extends ActionController
                 $response->setStatusCode(500);
             }
             $response->setContent(json_encode(['error' => $exceptionData]));
-            $this->logger->error($this->throwableStorageLogger->logThrowable($exception), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger->error($this->throwableStorage2->logThrowable($exception), LogEnvironment::fromMethodName(__METHOD__));
         }
     }
 


### PR DESCRIPTION
closes #3858

when one throws an exception in a datasource, it fails logging it and an uncaught error is thrown, because the `ThrowableStorage` is not injected:

`Call to a member function log Throwable() on null`

this seems due to a dependency injection conflict with inheritance.

this pr only prevents this conflict from happening

the controller that handles datasources extends the `AbstractServiceController`
which injects the `throwableStorage`

```php
  /**
   * @Flow\Inject
   * @var ThrowableStorageInterface
   */
  protected $throwableStorage;
```

but the  `AbstractServiceController` also extends the `ActionController` which injects the `throwableStorage` via an inject method into a private property

```php
    /**
     * @var ThrowableStorageInterface
     */
    private $throwableStorage;

    /**
     * Injects the throwable storage.
     *
     * @param ThrowableStorageInterface $throwableStorage
     * @return void
     */
    public function injectThrowableStorage(ThrowableStorageInterface $throwableStorage)
    {
        $this->throwableStorage = $throwableStorage;
    }

```

this combined doesnt work and results in the `@Flow\Inject` in the `AbstractServiceController` not working

solutions are:

- fix the flow DI? (assuming this is a issue)
- rename the variable (what id did now)
- use also `AbstractServiceController::injectThrowableStorage` and call parent / not the `@Flow\Inject` annotation
- use a protected property in `ActionController` and reuse it


## update 1
this is indeed defined behaviour from flow: https://flowframework.readthedocs.io/en/8.1/TheDefinitiveGuide/PartIII/ObjectManagement.html#property-injection
> If a setter method exists for the same property, it has precedence.



<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
