### PR TITLE
BUGFIX: 3371 shortcut translations

### DIFF
--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -361,6 +361,9 @@
 			</trans-unit>
 
 			<!-- shortcuts -->
+      <trans-unit id="shortcut.toSpecificTarget" xml:space="preserve">
+        <source>This is a shortcut to a specific target:</source>
+      </trans-unit>
 			<trans-unit id="shortcut.clickToContinueToPage" xml:space="preserve">
 				<source>Click {0} to continue to the page.</source>
 			</trans-unit>

--- a/Neos.Neos/Resources/Private/Translations/es/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/es/Main.xlf
@@ -373,10 +373,10 @@
 			<target state="translated">(no se ha seleccionado ningún destino)</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToFirstChildNode" xml:space="preserve">
 				<source>This is a shortcut to the first child page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="translated">Este es un acceso directo a la primera página hija. &lt; br / &gt; Haga clic en {0} para continuar a la página.</target></trans-unit>
+			<target state="translated">Este es un acceso directo a la primera página hija. &lt;br /&gt; Haga clic en {0} para continuar a la página.</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToParentNode" xml:space="preserve">
 				<source>This is a shortcut to the parent page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="translated">Este es un acceso directo a la página padre. &lt; br / &gt; Haga clic en {0} para continuar a la página.</target></trans-unit>
+			<target state="translated">Este es un acceso directo a la página padre. &lt;br /&gt; Haga clic en {0} para continuar a la página.</target></trans-unit>
       <!-- javascript -->
       <trans-unit id="content.components.contentContextBar.fullScreenButton.title" xml:space="preserve">
 				<source>Full Screen</source>

--- a/Neos.Neos/Resources/Private/Translations/id_ID/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/id_ID/Main.xlf
@@ -373,10 +373,10 @@
 			<target state="translated">(tidak ada target telah dipilih)</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToFirstChildNode" xml:space="preserve">
 				<source>This is a shortcut to the first child page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="translated">Ini adalah shortcut untuk halaman pertama anak. &lt; br / &gt; klik {0} untuk melanjutkan ke halaman.</target></trans-unit>
+			<target state="translated">Ini adalah shortcut untuk halaman pertama anak. &lt;br /&gt; klik {0} untuk melanjutkan ke halaman.</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToParentNode" xml:space="preserve">
 				<source>This is a shortcut to the parent page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="translated">Ini adalah shortcut untuk halaman induk. &lt; br / &gt; klik {0} untuk melanjutkan ke halaman.</target></trans-unit>
+			<target state="translated">Ini adalah shortcut untuk halaman induk. &lt;br /&gt; klik {0} untuk melanjutkan ke halaman.</target></trans-unit>
       <!-- javascript -->
       <trans-unit id="content.components.contentContextBar.fullScreenButton.title" xml:space="preserve">
 				<source>Full Screen</source>

--- a/Neos.Neos/Resources/Private/Translations/it/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/it/Main.xlf
@@ -495,11 +495,11 @@
       </trans-unit>
       <trans-unit id="shortcut.clickToContinueToFirstChildNode" xml:space="preserve">
 				<source>This is a shortcut to the first child page.&lt;br /&gt;Click {0} to continue to the page.</source>
-        <target state="translated">Si tratta di una scorciatoia per la prima pagina figlia. &lt; br / &gt; fare clic su {0} per passare alla pagina.</target>
+        <target state="translated">Si tratta di una scorciatoia per la prima pagina figlia. &lt;br /&gt; fare clic su {0} per passare alla pagina.</target>
       </trans-unit>
       <trans-unit id="shortcut.clickToContinueToParentNode" xml:space="preserve">
 				<source>This is a shortcut to the parent page.&lt;br /&gt;Click {0} to continue to the page.</source>
-        <target state="translated">Si tratta di una scorciatoia per la pagina padre. &lt; br / &gt; fare clic su {0} per passare alla pagina.</target>
+        <target state="translated">Si tratta di una scorciatoia per la pagina padre. &lt;br /&gt; fare clic su {0} per passare alla pagina.</target>
       </trans-unit>
       <!-- javascript -->
       <trans-unit id="content.components.contentContextBar.fullScreenButton.title" xml:space="preserve">

--- a/Neos.Neos/Resources/Private/Translations/nl/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/nl/Main.xlf
@@ -373,10 +373,10 @@
 			<target state="final">(geen doel geselecteerd)</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToFirstChildNode" xml:space="preserve" approved="yes">
 				<source>This is a shortcut to the first child page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="final">Dit is een snelkoppeling naar het eerste onderliggende pagina. &lt; br / &gt; Klik op {0} om door te gaan naar de pagina.</target></trans-unit>
+			<target state="final">Dit is een snelkoppeling naar het eerste onderliggende pagina. &lt;br /&gt; Klik op {0} om door te gaan naar de pagina.</target></trans-unit>
       <trans-unit id="shortcut.clickToContinueToParentNode" xml:space="preserve" approved="yes">
 				<source>This is a shortcut to the parent page.&lt;br /&gt;Click {0} to continue to the page.</source>
-			<target state="final">Dit is een snelkoppeling naar de bovenliggende pagina. &lt; br / &gt; Klik op {0} om door te gaan naar de pagina.</target></trans-unit>
+			<target state="final">Dit is een snelkoppeling naar de bovenliggende pagina. &lt;br /&gt; Klik op {0} om door te gaan naar de pagina.</target></trans-unit>
       <!-- javascript -->
       <trans-unit id="content.components.contentContextBar.fullScreenButton.title" xml:space="preserve" approved="yes">
 				<source>Full Screen</source>

--- a/Neos.Neos/Resources/Private/Translations/zh/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/zh/Main.xlf
@@ -495,11 +495,11 @@
       </trans-unit>
       <trans-unit id="shortcut.clickToContinueToFirstChildNode" xml:space="preserve">
 				<source>This is a shortcut to the first child page.&lt;br /&gt;Click {0} to continue to the page.</source>
-        <target state="translated">这是一个跳转到第一个子页面的链接页面。 &lt; br / &gt; 单击 {0} 跳转到子页面。</target>
+        <target state="translated">这是一个跳转到第一个子页面的链接页面。 &lt;br /&gt; 单击 {0} 跳转到子页面。</target>
       </trans-unit>
       <trans-unit id="shortcut.clickToContinueToParentNode" xml:space="preserve">
 				<source>This is a shortcut to the parent page.&lt;br /&gt;Click {0} to continue to the page.</source>
-        <target state="translated">这是一个跳转到父页的链接页面。 &lt; br / &gt; 单击 {0} 跳转到父页。</target>
+        <target state="translated">这是一个跳转到父页的链接页面。 &lt;br /&gt; 单击 {0} 跳转到父页。</target>
       </trans-unit>
       <!-- javascript -->
       <trans-unit id="content.components.contentContextBar.fullScreenButton.title" xml:space="preserve">


### PR DESCRIPTION
closes: #3371

## 1


> the dutch translation f.x. doesnt have correctly formatted `<br/>` tags. See f.x.: `'shortcut.clickToContinueToParentNode'` and compare the spanish `&lt; br / &gt;` to the english source `&lt;br /&gt;`. A search for `&lt; br / &gt;` reveals multiple cases. The problem is, that this invalid html (due to the space) and will be rendered as text (`< br / >`).


before in NL:
![image](https://user-images.githubusercontent.com/85400359/198111355-d5a4d9f5-f1b5-4b83-8f4a-1f3c914b4955.png)


after:
![image](https://user-images.githubusercontent.com/85400359/198111385-575bd6b0-4044-436d-a145-e14d4934c778.png)

## 2

> this translation id doesnt exist: `'shortcut.toSpecificTarget'` so the value / fallback `This is a shortcut to a specific target:` is always used.

It has been missed in 2014 (since Neos 2) ^^ https://github.com/neos/neos-development-collection/commit/02f8ff96e1ecd3dfbd9a356c4c6f55bb565916c7#diff-d1bec08a4f5050d463e4f7af3d61b767974d858d3d56ced85581ca55c27126dcR6

before in DE (or any other language):
![image](https://user-images.githubusercontent.com/85400359/198111487-39e7c03c-c132-4896-a12d-f25da087e07b.png)

after:
nothing to see here yet - but now we can translate via weblate :D

**Upgrade instructions**

**Review instructions**

Check the shortcode rendering in the backend.
If you switch your user language - flush the fusion cache - as this is not calculated into the shortcut cache:
 `./flow cache:flushone Neos_Fusion_Content`


**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
