### PR TITLE
FEATURE: Add Fusion EEL Helper `${Neos.Backend.interfaceLanguage()}`

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -34,6 +34,8 @@ class BackendHelper implements ProtectedContextAwareInterface
      */
     public function interfaceLanguage(): string
     {
+        $currentUser = $this->userService->getBackendUser();
+        assert($currentUser !== null, "No backend user");
         return $this->userService->getInterfaceLanguage();
     }
 

--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -18,18 +18,18 @@ use Neos\Neos\Service\UserService;
 /**
  * BackendUser helper for translations in the backend
  */
-class BackendUserHelper implements ProtectedContextAwareInterface
+class BackendHelper implements ProtectedContextAwareInterface
 {
     #[Flow\Inject(lazy: false)]
     protected UserService $userService;
 
     /**
-     * The interface language the user selected
-     * Falls back to the default language defined in the settings
+     * The interface language the user selected or the default language defined in the settings
+     * Formatted as {@see \Neos\Flow\I18n\Locale} identifier, eg "de", "en", ...
      *
      * Example::
      *
-     *     Translation.id("mh").locale(Neos.BackendUser.interfaceLanguage()).translate()
+     *     Translation.id("mh").locale(Neos.Backend.interfaceLanguage()).translate()
      *
      */
     public function interfaceLanguage(): string

--- a/Neos.Neos/Classes/Fusion/Helper/BackendUserHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendUserHelper.php
@@ -16,28 +16,29 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Service\UserService;
 
 /**
- * BackendUser helper for translations in backend.
+ * BackendUser helper for translations in the backend
  */
 class BackendUserHelper implements ProtectedContextAwareInterface
 {
-    private const FROM_EEL_DIRECTLY_CALLABLE_METHODS = [];
-
     #[Flow\Inject(lazy: false)]
     protected UserService $userService;
 
     /**
-     * Returns the interface language the user selected. Will fall back to the default language defined in settings.
+     * The interface language the user selected
+     * Falls back to the default language defined in the settings
      *
-     * @example Neos.BackendUser.interfaceLanguage
+     * Example::
+     *
+     *     Translation.id("mh").locale(Neos.BackendUser.interfaceLanguage()).translate()
+     *
      */
-    public function getInterfaceLanguage(): string
+    public function interfaceLanguage(): string
     {
         return $this->userService->getInterfaceLanguage();
     }
 
     public function allowsCallOfMethod($methodName)
     {
-        // checks if method is allowed to be called from EEL directly or should use property access notation
-        return in_array($methodName, self::FROM_EEL_DIRECTLY_CALLABLE_METHODS, true);
+        return true;
     }
 }

--- a/Neos.Neos/Classes/Fusion/Helper/BackendUserHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendUserHelper.php
@@ -1,0 +1,43 @@
+<?php
+namespace Neos\Neos\Fusion\Helper;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Service\UserService;
+
+/**
+ * BackendUser helper for translations in backend.
+ */
+class BackendUserHelper implements ProtectedContextAwareInterface
+{
+    private const FROM_EEL_DIRECTLY_CALLABLE_METHODS = [];
+
+    #[Flow\Inject(lazy: false)]
+    protected UserService $userService;
+
+    /**
+     * Returns the interface language the user selected. Will fall back to the default language defined in settings.
+     *
+     * @example Neos.BackendUser.interfaceLanguage
+     */
+    public function getInterfaceLanguage(): string
+    {
+        return $this->userService->getInterfaceLanguage();
+    }
+
+    public function allowsCallOfMethod($methodName)
+    {
+        // checks if method is allowed to be called from EEL directly or should use property access notation
+        return in_array($methodName, self::FROM_EEL_DIRECTLY_CALLABLE_METHODS, true);
+    }
+}

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -552,7 +552,7 @@ Neos:
       Neos.Array: Neos\Neos\Fusion\Helper\ArrayHelper
       Neos.Rendering: Neos\Neos\Fusion\Helper\RenderingHelper
       Neos.Caching: Neos\Neos\Fusion\Helper\CachingHelper
-      Neos.BackendUser: Neos\Neos\Fusion\Helper\BackendUserHelper
+      Neos.Backend: Neos\Neos\Fusion\Helper\BackendHelper
 
   # DocTools is a tool used by Neos Developers to help with a variety of documentation tasks.
   # These settings are only used in generating Documentation.

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -552,6 +552,7 @@ Neos:
       Neos.Array: Neos\Neos\Fusion\Helper\ArrayHelper
       Neos.Rendering: Neos\Neos\Fusion\Helper\RenderingHelper
       Neos.Caching: Neos\Neos\Fusion\Helper\CachingHelper
+      Neos.BackendUser: Neos\Neos\Fusion\Helper\BackendUserHelper
 
   # DocTools is a tool used by Neos Developers to help with a variety of documentation tasks.
   # These settings are only used in generating Documentation.

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1425,6 +1425,28 @@ Render a human-readable description for the passed $dimensions
 
 
 
+.. _`Eel Helpers Reference: Neos.BackendUser`:
+
+Neos.BackendUser
+--------------
+
+BackendUser helper for translations in the backend
+
+Implemented in: ``Neos\Neos\Fusion\Helper\BackendUserHelper``
+
+Neos.BackendUser.interfaceLanguage()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The interface language the user selected
+Falls back to the default language defined in the settings
+
+**Return** (string)
+
+
+
+
+
+
 .. _`Eel Helpers Reference: Neos.Seo.Image`:
 
 Neos.Seo.Image

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1425,20 +1425,20 @@ Render a human-readable description for the passed $dimensions
 
 
 
-.. _`Eel Helpers Reference: Neos.BackendUser`:
+.. _`Eel Helpers Reference: Neos.Backend`:
 
-Neos.BackendUser
---------------
+Neos.Backend
+------------
 
-BackendUser helper for translations in the backend
+Backend helper eg. for translations in the backend
 
-Implemented in: ``Neos\Neos\Fusion\Helper\BackendUserHelper``
+Implemented in: ``Neos\Neos\Fusion\Helper\BackendHelper``
 
-Neos.BackendUser.interfaceLanguage()
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Neos.Backend.interfaceLanguage()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The interface language the user selected
-Falls back to the default language defined in the settings
+The interface language the user selected or the default language defined in the settings
+Formatted as {@see \Neos\Flow\I18n\Locale} identifier, eg "de", "en", ...
 
 **Return** (string)
 


### PR DESCRIPTION
closes #3638
implemented as discussed in #3638

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->


```
Neos.Backend
------------

Backend helper eg. for translations in the backend

Implemented in: ``Neos\Neos\Fusion\Helper\BackendHelper``

Neos.Backend.interfaceLanguage()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

The interface language the user selected or the default language defined in the settings
Formatted as {@see \Neos\Flow\I18n\Locale} identifier, eg "de", "en", ...

**Return** (string)
```


If no user is available. `assert` https://www.php.net/manual/de/function.assert.php will fail and depending on you php config - throw an error 


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

use this helper in your fusion and check if it correctly reflects you backend user language.
Try to switch your language via user-settings (possibly flush the fusion cache) and see it correctly reflected

```
root >
root = ${Neos.Backend.interfaceLanguage()}
``` 


<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
