### PR TITLE
BUGFIX: prevent backend crash when using % as identifier #3898

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetCollectionController.php
@@ -72,7 +72,7 @@ class AssetCollectionController extends ActionController
     public function createAction($title)
     {
         $this->assetCollectionRepository->add(new AssetCollection($title));
-        $this->addFlashMessage('collectionHasBeenCreated', '', Message::SEVERITY_OK, [htmlspecialchars($title)]);
+        $this->addFlashMessage('collectionHasBeenCreated', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($title, '%', '%%'))]);
         $this->redirectToAssetIndex();
     }
 
@@ -95,7 +95,7 @@ class AssetCollectionController extends ActionController
     public function updateAction(AssetCollection $assetCollection)
     {
         $this->assetCollectionRepository->update($assetCollection);
-        $this->addFlashMessage('collectionHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($assetCollection->getTitle())]);
+        $this->addFlashMessage('collectionHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($assetCollection->getTitle(), '%', '%%'))]);
         $this->redirectToAssetIndex();
     }
 
@@ -114,7 +114,7 @@ class AssetCollectionController extends ActionController
             $this->browserState->set('activeAssetCollection', null);
         }
         $this->assetCollectionRepository->remove($assetCollection);
-        $this->addFlashMessage('collectionHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars($assetCollection->getTitle())]);
+        $this->addFlashMessage('collectionHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($assetCollection->getTitle(), '%', '%%'))]);
         $this->redirectToAssetIndex();
     }
 

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -490,7 +490,7 @@ class AssetController extends ActionController
     public function updateAction(Asset $asset): void
     {
         $this->assetRepository->update($asset);
-        $this->addFlashMessage('assetHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
+        $this->addFlashMessage('assetHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($asset->getLabel(), '%', '%%'))]);
         $this->redirectToIndex();
     }
 
@@ -521,7 +521,7 @@ class AssetController extends ActionController
         if ($this->persistenceManager->isNewObject($asset)) {
             $this->assetRepository->add($asset);
         }
-        $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
+        $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($asset->getLabel(), '%', '%%'))]);
         $this->redirectToIndex();
     }
 
@@ -562,7 +562,7 @@ class AssetController extends ActionController
             $this->assetCollectionRepository->update($assetCollection);
         }
 
-        $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars($asset->getLabel())]);
+        $this->addFlashMessage('assetHasBeenAdded', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($asset->getLabel(), '%', '%%'))]);
         $this->response->setStatusCode(201);
         return '';
     }
@@ -623,7 +623,7 @@ class AssetController extends ActionController
         }
 
         $this->assetRepository->remove($asset);
-        $this->addFlashMessage('assetHasBeenDeleted', '', Message::SEVERITY_OK, [$asset->getLabel()], 1412375050);
+        $this->addFlashMessage('assetHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($asset->getLabel(), '%', '%%'))], 1412375050);
         $this->redirectToIndex();
     }
 
@@ -663,7 +663,7 @@ class AssetController extends ActionController
         }
 
         $assetLabel = (method_exists($asset, 'getLabel') ? $asset->getLabel() : $resource->getFilename());
-        $this->addFlashMessage('assetHasBeenReplaced', '', Message::SEVERITY_OK, [htmlspecialchars($assetLabel)]);
+        $this->addFlashMessage('assetHasBeenReplaced', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($assetLabel, '%', '%%'))]);
         $this->redirectToIndex();
     }
 

--- a/Neos.Media.Browser/Classes/Controller/TagController.php
+++ b/Neos.Media.Browser/Classes/Controller/TagController.php
@@ -83,7 +83,7 @@ class TagController extends ActionController
             if (($assetCollection = $this->browserState->get('activeAssetCollection')) !== null && $assetCollection->addTag($tag)) {
                 $this->assetCollectionRepository->update($assetCollection);
             }
-            $this->addFlashMessage('tagHasBeenCreated', '', Message::SEVERITY_OK, [htmlspecialchars($label)]);
+            $this->addFlashMessage('tagHasBeenCreated', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($label, '%', '%%'))]);
         }
         $this->redirectToAssetIndex();
     }
@@ -107,7 +107,7 @@ class TagController extends ActionController
     public function updateAction(Tag $tag)
     {
         $this->tagRepository->update($tag);
-        $this->addFlashMessage('tagHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars($tag->getLabel())]);
+        $this->addFlashMessage('tagHasBeenUpdated', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($tag->getLabel(), '%', '%%'))]);
         $this->redirectToAssetIndex();
     }
 
@@ -123,7 +123,7 @@ class TagController extends ActionController
             $this->assetRepository->update($asset);
         }
         $this->tagRepository->remove($tag);
-        $this->addFlashMessage('tagHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars($tag->getLabel())]);
+        $this->addFlashMessage('tagHasBeenDeleted', '', Message::SEVERITY_OK, [htmlspecialchars(str_replace($tag->getLabel(), '%', '%%'))]);
         $this->redirectToAssetIndex();
     }
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

resolves: #3898

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

~


**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

But to be honest, I'm not sure if this is really the right solution. Since this option feels rather unattractive. 

But what I noticed, there is a label validator with a regex validation, which is also executed for example when I create a tag or collection with the identifier `^` in the media browser. Then, it throws an error message that this identifier is not allowed here. But I was not sure if it would be a breaking change in other places, if i would change the regex validator.

https://github.com/neos/flow-development-collection/blob/f0673f341ff3fea1e294549e45627d2fec5ea400/Neos.Flow/Classes/Validation/Validator/LabelValidator.php#L28

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions