### PR TITLE
BUGFIX: Fusion Component declaration `renderer=null`

### DIFF
--- a/Neos.Fusion/Resources/Private/Fusion/Prototypes/Component.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Prototypes/Component.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Fusion:Component) {
   @class = 'Neos\\Fusion\\FusionObjects\\ComponentImplementation'
   @sortProperties = false
-  renderer = ''
+  renderer = null
 }


### PR DESCRIPTION
followup for #3915

fixes: https://github.com/neos/neos-development-collection/pull/3915#discussion_r1011450134


otherwise when the renderer is misspelled, the evaluation wouldnt notice it as we would have the fallback to `renderer=""` 

(fyi assigning a path to null in fusion, is like it doesnt exist - the runtime wouldnt know)

![image](https://user-images.githubusercontent.com/85400359/199457646-d09dfaeb-e1cf-479f-860a-8c51821db2be.png)


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
