### PR TITLE
BUGFIX: Manually add dissociated asset collections to persistence manager

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Asset.php
+++ b/Neos.Media/Classes/Domain/Model/Asset.php
@@ -448,19 +448,20 @@ class Asset implements AssetInterface
     public function setAssetCollections(Collection $assetCollections)
     {
         $this->lastModified = new \DateTime();
+
         foreach ($this->assetCollections as $existingAssetCollection) {
             if (!$assetCollections->contains($existingAssetCollection)) {
                 $existingAssetCollection->removeAsset($this);
+                $this->persistenceManager->update($existingAssetCollection);
             }
         }
+
         foreach ($assetCollections as $newAssetCollection) {
-            $newAssetCollection->addAsset($this);
-        }
-        foreach ($this->assetCollections as $assetCollection) {
-            if (!$assetCollections->contains($assetCollection)) {
-                $assetCollections->add($assetCollection);
+            if (!$this->assetCollections->contains($newAssetCollection)) {
+                $newAssetCollection->addAsset($this);
             }
         }
+
         $this->assetCollections = $assetCollections;
     }
 


### PR DESCRIPTION
Formerly, when removing asset collections from an asset, the respective asset collection needed to be retained, because Doctrine would otherwise not consider it during persistence.

This has been fixed by adding the dissociated asset collection manually to the persistence manager.

fixes: #2107 

**Upgrade instructions**

-None-

**Review instructions**

1. You'll need a Neos 7.3 setup with `Flowpack.Media.Ui` installed
2. Follow the reproduction steps described in https://github.com/Flowpack/media-ui/issues/56
3. With this fix applied, the issue should no longer appear

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
