### PR TITLE
BUGFIX Fusion error-message for brace on next line

### DIFF
--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageCreator.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageCreator.php
@@ -32,9 +32,9 @@ class MessageCreator
             case '\'':
                 return "Unclosed quoted path.";
             case '{':
-                return "Unexpected block start out of context. Check your number of curly braces.";
+                return "Unexpected block start. The opening brace must be on the same line with its declaration, like: 'path {' or 'prototype(Foo:Bar) {'.";
             case '}':
-                return "Unexpected block end out of context. Check your number of curly braces.";
+                return "Unexpected block end. Check your number of curly braces.";
         }
         return "Unexpected statement starting with: {$next->charPrint()}. " . self::VALID_OBJECT_PATH;
     }

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -222,12 +222,12 @@ class ParserExceptionTest extends UnitTestCase
 
         yield 'unexpected block start' => [
             '{',
-            "Unexpected block start out of context. Check your number of curly braces."
+            "Unexpected block start. The opening brace must be on the same line with its declaration, like: 'path {' or 'prototype(Foo:Bar) {'."
         ];
 
         yield 'unexpected block end' => [
             '}',
-            "Unexpected block end out of context. Check your number of curly braces."
+            "Unexpected block end. Check your number of curly braces."
         ];
     }
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

fixes https://github.com/neos/neos-development-collection/issues/1104


faulty fusion code:
```
prototype(YourVendor:FusionPrototype) < prototype(Neos.Fusion:Component)
{
}
```


previous:
![image](https://user-images.githubusercontent.com/85400359/199519945-be597336-8d06-497e-8185-34523b634ea5.png)


now:
![image](https://user-images.githubusercontent.com/85400359/199590314-7961b367-405f-4ddd-b0ea-d9dc643e4e2f.png)



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
