### PR TITLE
BUGFIX: Fix User CLI commands

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -839,7 +839,6 @@ class UserService
     /**
      * @param User $user
      * @param bool $keepCurrentSession
-     * @throws SessionNotStartedException
      */
     private function destroyActiveSessionsForUser(User $user, bool $keepCurrentSession = false): void
     {
@@ -849,7 +848,13 @@ class UserService
             $activeSessions = $this->sessionManager->getSessionsByTag($this->securityContext->getSessionTagForAccount($account));
             foreach ($activeSessions as $activeSession) {
                 /** @var SessionInterface $activeSession */
-                if ($sessionToKeep instanceof SessionInterface && $activeSession->getId() === $sessionToKeep->getId()) {
+                if (!$activeSession->isStarted()) {
+                    continue;
+                }
+                if ($sessionToKeep instanceof SessionInterface
+                    && $sessionToKeep->isStarted()
+                    && $activeSession->getId() === $sessionToKeep->getId()
+                ) {
                     continue;
                 }
                 $activeSession->destroy('Requested to remove alle sessions for user ' . $account->getAccountIdentifier());


### PR DESCRIPTION
This fixes a regression that was introduced with #3707 and led to exceptions when interacting with the `UserService` via CLI.

## Background:

The `UserService::destroyActiveSessionsForUser()` method invoked methods `getId()` and `destroy()` on Sessions even if they weren't started which leads to an `SessionNotStartedException`.
This change checks whether sessions are started first.

Fixes: #3952