### PR TITLE
BUGFIX NodeMigrations with PropertyValue Filter

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
+++ b/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
@@ -48,7 +48,7 @@ class PropertyValue implements DoctrineFilterInterface
      * @param string|bool|int $propertyValue
      * @return void
      */
-    public function setPropertyValue(string $propertyValue): void
+    public function setPropertyValue($propertyValue): void
     {
         $this->propertyValue = $propertyValue;
     }

--- a/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
+++ b/Neos.ContentRepository/Classes/Migration/Filters/PropertyValue.php
@@ -45,7 +45,7 @@ class PropertyValue implements DoctrineFilterInterface
     /**
      * Sets the property value to be checked against.
      *
-     * @param string $propertyValue
+     * @param string|bool|int $propertyValue
      * @return void
      */
     public function setPropertyValue(string $propertyValue): void
@@ -64,10 +64,10 @@ class PropertyValue implements DoctrineFilterInterface
     {
         // Build the like parameter as "key": "value" to search by a specific key and value
         // See NodeDataRepository.findByProperties() for the "inspiration"
-        $likeParameter = trim(json_encode(
+        $likeParameter = sprintf("%%%s%%", trim(json_encode(
             [$this->propertyName => $this->propertyValue],
             JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE
-        ), "{}\n\t ");
+        ), "{}\n\t "));
 
         return [$baseQuery->like('properties', $likeParameter, false)];
     }

--- a/Neos.ContentRepository/Classes/Migration/Service/NodeMigration.php
+++ b/Neos.ContentRepository/Classes/Migration/Service/NodeMigration.php
@@ -93,12 +93,11 @@ class NodeMigration
     protected function executeSingle(array $migrationDescription)
     {
         $filterExpressions = [];
-        $baseQuery = new Query(NodeData::class);
-        foreach ($this->nodeFilterService->getFilterExpressions($migrationDescription['filters'], $baseQuery) as $filterExpression) {
+        $query = new Query(NodeData::class);
+        foreach ($this->nodeFilterService->getFilterExpressions($migrationDescription['filters'], $query) as $filterExpression) {
             $filterExpressions[] = $filterExpression;
         }
 
-        $query = new Query(NodeData::class);
         if ($filterExpressions !== []) {
             $query->matching(call_user_func_array([new Expr(), 'andX'], $filterExpressions));
         }


### PR DESCRIPTION
The PropertyValue Filter uses a like-query, which internally replaces values with needled parameters. The parameters get stored within the query, which is used to create the expression. If you do not use the same query to execute the query with given expressions, the needled parameters are missing.

* Now the NodeMigration uses same query for creating the expressions and executing the query.
* Also the like parameter of PropertyValue is fixed and surrounded by '%' placeholders.
* The removeded type hint of the values setter allows to use also boolean and integer values to query for.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions

Fixes #3816 