### PR TITLE
FEATURE: media asset collection names hierarchies

### DIFF
--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
@@ -57,4 +57,15 @@ class AssetCollectionConditionGenerator extends EntityConditionGenerator
 
         return $propertyConditionGenerator->equals($collectionIdentifier);
     }
+
+    /**
+     * @param string $collectionTitle
+     * @return PropertyConditionGenerator
+     */
+    public function titleStartsWith($collectionTitle)
+    {
+        $propertyConditionGenerator = new PropertyConditionGenerator('title');
+
+        return $propertyConditionGenerator->like($collectionTitle . '%');
+    }
 }


### PR DESCRIPTION
Introducing matcher method `titleStartsWith()` in class `Neos\Media\Security\Authorization\Privilege\ReadAssetCollectionPrivilege` enables the use of  media asset collection names hierarchies having exactly one privilege definition.

**Review instructions**

In a multi site environment it is preferable to separate the assets for editors per site. Hence an asset collection naming scheme is recommended:
```
Site1
Site1-Dept1
Site1-Dept1-Prod1
```
for Site One and
```
Site2
Site2-Feat1
Site2-Feat1-Detail2
```
for Site Two and so on (of course you may use a different separator character than `-`).

`Policy.yaml`:
```
privilegeTargets:

  'Neos\Media\Security\Authorization\Privilege\ReadAssetCollectionPrivilege':

    'First.Site:AssetPrivilege':
      label: 'Site One asset access'
      matcher: 'titleStartsWith("Site1")'

    'Second.Site:AssetPrivilege':
      label: 'Site Two asset access'
      matcher: 'titleStartsWith("Site2")'

roles:

  'Neos.Neos:Administrator':
    privileges:
      -
        privilegeTarget: 'First.Site:AssetPrivilege'
        permission: GRANT
      -
        privilegeTarget: 'Second.Site:AssetPrivilege'
        permission: GRANT

  'First.Site:MediaAccess':
    label: 'First site Editor'
    description: 'First site media access'
    privileges:
      -
        privilegeTarget: 'First.Site:AssetPrivilege'
        permission: GRANT

  'Second.Site:MediaAccess':
    label: 'Secondsite Editor'
    description: 'Second site media access'
    privileges:
      -
        privilegeTarget: 'Second.Site:AssetPrivilege'
        permission: GRANT
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
