### PR TITLE
DOCS: Add missing colons in code examples throughout property editor reference

### DIFF
--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -14,7 +14,7 @@ Property Type: boolean ``BooleanEditor`` -- Checkbox editor
 
 A ``boolean`` value is rendered using a checkbox in the inspector::
 
-    'isActive'
+    'isActive':
       type: boolean
       ui:
         label: 'is active'
@@ -624,7 +624,7 @@ For properties of type ``Neos\Media\Domain\Model\ImageInterface``, an image edit
 and resizing functionality, you need to set ``features.crop`` and ``features.resize`` to ``true``, as in the following
 example::
 
-    'teaserImage'
+    'teaserImage':
       type: 'Neos\Media\Domain\Model\ImageInterface'
       ui:
         label: 'Teaser Image'
@@ -639,7 +639,7 @@ If cropping is enabled, you might want to enforce a certain aspect ratio, which 
 ``crop.aspectRatio.locked.width`` and ``crop.aspectRatio.locked.height``. To show the crop dialog automatically on image upload, configure the ``crop.aspectRatio.forceCrop`` option. In the following example, the
 image format must be ``16:9``::
 
-    'teaserImage'
+    'teaserImage':
       type: 'Neos\Media\Domain\Model\ImageInterface'
       ui:
         label: 'Teaser Image'
@@ -662,7 +662,7 @@ added or removed from this list underneath ``crop.aspectRatio.options``. If the 
 shall be added to the list, ``crop.aspectRatio.enableOriginal`` must be set to ``true``. If the user should be allowed
 to choose a custom aspect ratio, set ``crop.aspectRatio.allowCustom`` to ``true``::
 
-    'teaserImage'
+    'teaserImage':
       type: 'Neos\Media\Domain\Model\ImageInterface'
       ui:
         label: 'Teaser Image'
@@ -774,7 +774,7 @@ Property Type: asset (Neos\\Media\\Domain\\Model\\Asset / array<Neos\\Media\\Dom
 If an asset, i.e. ``Neos\Media\Domain\Model\Asset``, shall be uploaded or selected, the following configuration
 is an example::
 
-    'caseStudyPdf'
+    'caseStudyPdf':
       type: 'Neos\Media\Domain\Model\Asset'
       ui:
         label: 'Case Study PDF'
@@ -783,7 +783,7 @@ is an example::
 
 Conversely, if multiple assets shall be uploaded, use ``array<Neos\Media\Domain\Model\Asset>`` as type::
 
-    'caseStudies'
+    'caseStudies':
       type: 'array<Neos\Media\Domain\Model\Asset>'
       ui:
         label: 'Case Study PDF'


### PR DESCRIPTION
I noticed upon copy-pasting some of the examples in the property editor reference, that colons were missing, so that the pasted code broke my configuration.

This PR fixes all occasions of such missing colons in the property editor reference.
