### PR TITLE
BUGFIX: Use `position` from inspector config for `showInCreationDialog` properties

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -255,7 +255,7 @@ class NodeTypeConfigurationEnrichmentAspect
                     };
                     $this->applyEditorLabels($nodeTypeLabelIdPrefix, $elementName, $elementConfiguration['ui']['editor'], $elementConfiguration['ui']['editorOptions'], $translationIdGenerator);
                 }
-                if (!is_array($elementConfiguration) || !$this->shouldFetchTranslation($elementConfiguration['ui'])) {
+                if (!is_array($elementConfiguration) || !$this->shouldFetchTranslation($elementConfiguration['ui'] ?? [])) {
                     continue;
                 }
                 $elementConfiguration['ui']['label'] = $this->getInspectorElementTranslationId($nodeTypeLabelIdPrefix, 'creationDialog', $elementName);

--- a/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/CreationDialogPostprocessor.php
@@ -117,8 +117,8 @@ class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
         if (isset($propertyConfiguration['validation'])) {
             $convertedConfiguration['validation'] = $propertyConfiguration['validation'];
         }
-        if (isset($propertyConfiguration['position'])) {
-            $convertedConfiguration['position'] = $propertyConfiguration['position'];
+        if (isset($propertyConfiguration['ui']['inspector']['position'])) {
+            $convertedConfiguration['position'] = $propertyConfiguration['ui']['inspector']['position'];
         }
 
         $editor = $propertyConfiguration['ui']['inspector']['editor'] ?? $dataTypeDefaultConfiguration['editor'] ?? 'Neos.Neos/Inspector/Editors/TextFieldEditor';

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -36,6 +36,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
                     'ui' => [
                         'showInCreationDialog' => true,
                         'inspector' => [
+                            'position' => 123,
                             'editor' => 'Some\Editor',
                             'editorOptions' => ['some' => 'option'],
                         ],
@@ -47,7 +48,6 @@ class CreationDialogPostprocessorTest extends UnitTestCase
                             'maximum' => 255,
                         ]
                     ],
-                    'position' => 123,
                 ],
             ],
         ];


### PR DESCRIPTION
Hi there,

this is a small fix regarding the behavior of the `CreationDialogPostprocessor` (The related issue has been opened over at `Neos.Neos.Ui`: https://github.com/neos/neos-ui/issues/3280).

Currently, the sorting position within the node creation dialog of a property with `showInCreationDialog: true` is read from a supposed `position` configuration key at the top level of the property configuration. Such a key, however, does not exist. The sorting position for inspector properties is set at the `ui.inspector.position` path within the property configuration.

This PR makes sure that the sorting position is read from `ui.inspector.position`, so properties in the creation dialog are sorted similarly to their inspector counterparts.

**How to verify**

For a reproduction, please follow the instructions given here: https://github.com/neos/neos-ui/issues/3280

With this PR checked out, you should see that the properties in the creation dialog are sorted in a similar fashion as their inspector counterparts. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
