### PR TITLE
BUGFIX: Display flash messages in Fusion based backend modules

### DIFF
--- a/Neos.Neos/Resources/Private/Layouts/BackendModule.html
+++ b/Neos.Neos/Resources/Private/Layouts/BackendModule.html
@@ -2,8 +2,6 @@
 <div class="neos-content neos-indented neos-fluid-container">
 	<f:render section="subtitle" optional="1" />
 
-	<f:render partial="Module/FlashMessages" />
-
 	<f:validation.results>
 		<f:if condition="{validationResults.flattenedErrors}">
 			<ul class="neos-error">

--- a/Neos.Neos/Resources/Private/Layouts/BackendSubModule.html
+++ b/Neos.Neos/Resources/Private/Layouts/BackendSubModule.html
@@ -1,10 +1,6 @@
 <div class="neos-content neos-container-fluid">
 	<f:render section="subtitle" optional="1" />
 
-	<div class="neos-module-container">
-		<f:render partial="Module/FlashMessages" />
-	</div>
-
 	<f:render section="validationResults" optional="1" />
 
 	<f:render section="content" />

--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -77,6 +77,7 @@
 					</f:if>
 				</f:for>
 			</ul>
+			<f:render partial="Module/FlashMessages" />
 			<f:if condition="{moduleContents}">
 				{moduleContents -> f:format.raw()}
 			</f:if>


### PR DESCRIPTION
Previously flash messages were not displayed in fusion based backend modules because the rendering was implemented in the BackendSubModule. This layout which was used by all BackendSubModules which had to use the same or a cloned layout.

This change moves the rendering to the template of the backend module controller which renders around all modules. This makes sense because first this is not a layout task at all and second it makes sense to always render flash messages in the backend.

Resolves. #3998


**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
