### PR TITLE
BUGFIX: Adjust allowed workspaces list

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -721,15 +721,20 @@ class WorkspacesController extends AbstractModuleController
      * Creates an array of workspace names and their respective titles which are possible base workspaces for other
      * workspaces.
      *
-     * @param Workspace $excludedWorkspace If set, this workspace will be excluded from the list of returned workspaces
+     * @param Workspace $excludedWorkspace If set, this workspace and all its child workspaces will be excluded from the list of returned workspaces
      * @return array
      */
     protected function prepareBaseWorkspaceOptions(Workspace $excludedWorkspace = null)
     {
         $baseWorkspaceOptions = [];
+
         foreach ($this->workspaceRepository->findAll() as $workspace) {
             /** @var Workspace $workspace */
-            if (!$workspace->isPersonalWorkspace() && $workspace !== $excludedWorkspace && ($workspace->isPublicWorkspace() || $workspace->isInternalWorkspace() || $this->userService->currentUserCanManageWorkspace($workspace))) {
+            if (!$workspace->isPersonalWorkspace() &&
+                $workspace !== $excludedWorkspace &&
+                ($workspace->isPublicWorkspace() || $workspace->isInternalWorkspace() || $this->userService->currentUserCanManageWorkspace($workspace)) &&
+                (!$excludedWorkspace || !isset($workspace->getBaseWorkspaces()[$excludedWorkspace->getName()]))
+            ) {
                 $baseWorkspaceOptions[$workspace->getName()] = $workspace->getTitle();
             }
         }


### PR DESCRIPTION
resolved: #4001 

**Review instructions**
I adjusted the function for the base workspace options list so that if an excluded workspace is set, all of its child workspaces cannot be shown as well. 
The query should check for each workspace if the excluded workspace is one of its base workspaces.
If the excluded workspace is one of its base workspaces, the workspace will not be shown in the options. 

For testing: This change could influence the Edit-view and the New-view of the workspace module. 

I am unsure if I should rename the variable $excludedWorkspace or if I should add a new variable $excludeChildWorkspaces to the method.


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
