### PR TITLE
BUGFIX: Consistently initialize asset sources via `createFromConfiguration`

### DIFF
--- a/Neos.Media/Classes/Domain/Service/AssetSourceService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetSourceService.php
@@ -175,7 +175,7 @@ final class AssetSourceService
         if ($this->assetSources === []) {
             foreach ($this->assetSourcesConfiguration as $assetSourceIdentifier => $assetSourceConfiguration) {
                 if (is_array($assetSourceConfiguration)) {
-                    $this->assetSources[$assetSourceIdentifier] = new $assetSourceConfiguration['assetSource']($assetSourceIdentifier, $assetSourceConfiguration['assetSourceOptions'] ?? []);
+                    $this->assetSources[$assetSourceIdentifier] = $assetSourceConfiguration['assetSource']::createFromConfiguration($assetSourceIdentifier, $assetSourceConfiguration['assetSourceOptions'] ?? []);
                 }
             }
         }


### PR DESCRIPTION
fixes: #3965 

**The Problem**

The case at hand was an asset source that uses a value object to validate the incoming asset source options. I expected to be able to define a promoted constructor property with said value object as its declared type:

```php
final class MyAssetSource implements AssetSourceInterface
{
    public function __construct(
        private readonly string $assetSourceIdentifier,
        private readonly Options $options
    ) {
    }

   /* ... */
}
```

...and initialize the value object in the `createFromConfiguration` static factory method defined by the `AssetSourceInterface`:

```php
final class MyAssetSource implements AssetSourceInterface
{
   /* ... */

    public static function createFromConfiguration(string $assetSourceIdentifier, array $assetSourceOptions): AssetSourceInterface
    {
        return new static(
            $assetSourceIdentifier,
            Options::fromArray($assetSourceOptions)
        );
    }
}
```

This failed with a Type Error, because the `AssetSourceService`, which is responsible for initializing asset sources, at one point does not utilize `createFromConfiguration` to perform initialization, but calls the asset source constructor directly:

https://github.com/neos/neos-development-collection/blob/a4791b623161259b31d2d11b343310bd7ef76507/Neos.Media/Classes/Domain/Service/AssetSourceService.php#L178

**The Solution**

I adjusted the aforementioned routine of the `AssetSourceService` to use the `AssetSourceInterface`-defined `createFromConfiguration` static factory method instead of the asset source's constructor.

Even though the pattern I described above only makes sense in a PHP >8.0 environment, I decided to target Neos 7.3 with this PR, because it should constitute a non-breaking bugfix.