### PR TITLE
FEATURE: Allow including resources for all backend modules

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -294,9 +294,15 @@ Neos:
       widgetTemplatePathAndFileName: 'resource://Neos.Neos/Private/Templates/Module/Widget.html'
       # This stylesheet can be overriden in the configuration of a submodule to reference a reduced stylesheet.
       # Use `Main` for backwards compatibility
-      # Use `Lite` for a reduced variant with a less aggressive reset and other non essential styles removed.
+      # Use `Lite` for a reduced variant with a less aggressive reset and other non-essential styles removed.
       # Use `Minimal` when your module provides its own styles and Neos only needs to show the top and bottom bar.
       mainStylesheet: 'Main'
+
+      # Define additional stylesheets and javascript for all backend modules
+      additionalResources:
+        styleSheets: {}
+        javaScripts:
+          'Neos.Neos': 'resource://Neos.Neos/Public/JavaScript/Main.min.js'
 
       preferredStartModules: [ 'content','user/usersettings' ]
 

--- a/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html
@@ -22,6 +22,16 @@
 		</f:for>
 	</f:if>
 
+	<f:for
+		each="{settings.moduleConfiguration.additionalResources.styleSheets}"
+		as="additionalResource"
+	>
+		<link
+			rel="stylesheet"
+			href="{f:uri.resource(path: additionalResource)}"
+		/>
+	</f:for>
+
 	<f:if condition="{moduleConfiguration.additionalResources.javaScripts}">
 		<f:for
 			each="{moduleConfiguration.additionalResources.javaScripts}"
@@ -94,8 +104,11 @@
 				/>
 			</div>
 		</div>
-		<script
-			src="{f:uri.resource(path: 'JavaScript/Main.min.js', package: 'Neos.Neos')}"
-		></script>
+		<f:for
+			each="{settings.moduleConfiguration.additionalResources.javaScripts}"
+			as="additionalResource"
+		>
+			<script src="{f:uri.resource(path: additionalResource)}"></script>
+		</f:for>
 	</body>
 </f:section>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "type": "neos-package-collection",
     "require": {
-        "neos/flow-development-collection": "8.2.x-dev",
+        "neos/flow-development-collection": "8.3.x-dev",
         "neos/neos-setup": "^1.0",
         "php": "^8.0",
         "neos/flow": "*",


### PR DESCRIPTION
With this change it’s now possible to add stylesheets and javascript to all backend modules at the same time 
without requiring to add the resources to each module separately.

Example:

```yaml
Neos:
  Neos:
    moduleConfiguration:
      additionalResources:
        styleSheets:
          'My.Package': 'resource://My.Package/Public/JavaScript/Main.css'
        javaScripts:
          'My.Package': 'resource://My.Package/Public/JavaScript/Main.js'
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
