### PR TITLE
BUGFIX: Add user module icon and description

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -363,6 +363,7 @@ Neos:
         label: 'Neos.Neos:Modules:user.label'
         controller: \Neos\Neos\Controller\Module\UserController
         hideInMenu: true
+        icon: fas fa-users
         mainStylesheet: 'Lite'
         submodules:
           usersettings:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -363,6 +363,7 @@ Neos:
         label: 'Neos.Neos:Modules:user.label'
         controller: \Neos\Neos\Controller\Module\UserController
         hideInMenu: true
+        description: 'Neos.Neos:Modules:user.description'
         icon: fas fa-users
         mainStylesheet: 'Lite'
         submodules:

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -895,6 +895,10 @@ Klicken Sie auf einen der Knoten um nur die Fallbacks und Varianten für diesen 
 				<source>User</source>
         <target state="final">Benutzer</target>
       </trans-unit>
+      <trans-unit id="user.description" xml:space="preserve">
+        <source>Contains modules related to management of users</source>
+        <target>Enthält Module für die Verwaltung von Benutzern</target>
+      </trans-unit>
       <trans-unit id="userSettings.label" xml:space="preserve" approved="yes">
 				<source>User Settings</source>
         <target state="final">Benutzereinstellungen</target>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -684,6 +684,9 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 			<trans-unit id="user.label" xml:space="preserve">
 				<source>User</source>
 			</trans-unit>
+      <trans-unit id="user.description" xml:space="preserve">
+				<source>Contains modules related to management of users</source>
+			</trans-unit>
 			<trans-unit id="userSettings.label" xml:space="preserve">
 				<source>User Settings</source>
 			</trans-unit>


### PR DESCRIPTION
**Review instructions**

To see the icon and to view the description the easiest way is to set `Neos.Neos.modules.user.hideInMenu` to `false`.
Then the module shows up in the modules list with its icon and when hovering the title the description is shown.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
