### PR TITLE
BUGFIX: Fix .composer.json which was not updated via jenkins job

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -4,7 +4,7 @@
   "license": ["GPL-3.0-or-later"],
   "type": "neos-package-collection",
   "require": {
-    "neos/flow-development-collection": "8.2.x-dev",
+    "neos/flow-development-collection": "8.3.x-dev",
     "neos/neos-setup": "^1.0"
   },
   "replace": {


### PR DESCRIPTION
The jenkins job which created the 8.3 branch did not update the composer manifest file with the correct `neos/flow-development-collection` requirement.

related: neos/neos-development-distribution#85

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
