### PR TITLE
FEATURE: Improve behavior of workspace review buttons

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -115,9 +115,13 @@
 							var value = false;
 							if (jQuery(this).is(':checked')) {
 								value = true;
-								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled');
+								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-discardAllChanges').removeClass('neos-disabled').removeAttr('disabled');
+								jQuery('.publish-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.discard-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
 							} else {
 								jQuery('.batch-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.publish-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
+								jQuery('.discard-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
 							}
 							jQuery('tbody input[type="checkbox"]').prop('checked', value);
 						});
@@ -145,9 +149,13 @@
 							}
 
 							if (jQuery('tbody input[type="checkbox"]:checked').length > 0) {
-								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled')
+								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled');
+								jQuery('.publish-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.discard-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
 							} else {
 								jQuery('.batch-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.publish-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
+								jQuery('.discard-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
 							}
 						});
 
@@ -180,15 +188,36 @@
 		<div class="neos-pull-right">
 			<f:if condition="{canPublishToBaseWorkspace}">
 				<f:then>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button class="neos-button neos-button-danger" data-toggle="modal" href="#discard">{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}</button>
+					<button class="discard-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+						<i class="fas fa-trash-alt icon-white"></i>
+						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="publish-action neos-button neos-button-primary">
+						<i class="fas fa-check-double icon-white"></i>
+						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
+					</button>
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-trash-alt icon-white"></i>
+						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
+						<li class="fas fa-check icon-white"></li>
+						{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
 				</f:then>
 				<f:else>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
-					<button class="neos-button neos-button-danger" data-toggle="modal" href="#discard">{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}</button>
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-trash-alt icon-white"></i>
+						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
+						<li class="fas fa-check icon-white"></li>
+						{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
+					<button class="discard-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+						<i class="fas fa-trash-alt icon-white"></i>
+						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
+					</button>
 				</f:else>
 			</f:if>
 		</div>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -225,10 +225,6 @@
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
-						<i class="fas fa-check icon-white"></i>
-						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
-					</button>
 					<button type="submit" class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -8,7 +8,7 @@
 
 	<f:if condition="{siteChanges}">
 		<f:then>
-			<f:form action="publishOrDiscardNodes">
+			<f:form id="publishOrDiscardNodes" action="publishOrDiscardNodes">
 				<f:form.hidden name="selectedWorkspace" value="{selectedWorkspace}"/>
 				<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
 				<br />
@@ -106,6 +106,25 @@
 				<div class="neos-modal-backdrop neos-in"></div>
 			</div>
 
+			<div class="neos-hide" id="discardSelected">
+				<div class="neos-modal-centered">
+					<div class="neos-modal-content">
+						<div class="neos-modal-header">
+							<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardSelectedChangesInWorkspaceConfirmation', arguments: {0: selectedWorkspaceLabel}, source: 'Modules', package: 'Neos.Neos')}</div>
+						</div>
+						<div class="neos-modal-footer">
+							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</a>
+							<button form="publishOrDiscardNodes" name="moduleArguments[action]" value="discard" type="submit" class="neos-button neos-button-danger">
+								<i class="fas fa-trash-alt icon-white"></i>
+								{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="neos-modal-backdrop neos-in"></div>
+			</div>
+
 			<f:form action="index" id="postHelper" method="post"></f:form>
 
 			<script>
@@ -188,26 +207,26 @@
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-primary">
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-success">
 						<i class="fas fa-check-double icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discardSelected">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
-						<li class="fas fa-check icon-white"></li>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 				</f:then>
 				<f:else>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discardSelected">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
-						<li class="fas fa-check icon-white"></li>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -95,7 +95,7 @@
 							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardAllChangesInWorkspaceConfirmation', arguments: {0: selectedWorkspaceLabel}, source: 'Modules', package: 'Neos.Neos')}</div>
 						</div>
 						<div class="neos-modal-footer">
-							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</a>
+							<button href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</button>
 							<button form="postHelper" formaction="{f:uri.action(action: 'discardWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-danger">
 								<i class="fas fa-trash-alt icon-white"></i>
 								{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
@@ -114,7 +114,7 @@
 							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardSelectedChangesInWorkspaceConfirmation', arguments: {0: selectedWorkspaceLabel}, source: 'Modules', package: 'Neos.Neos')}</div>
 						</div>
 						<div class="neos-modal-footer">
-							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</a>
+							<button href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</button>
 							<button form="publishOrDiscardNodes" name="moduleArguments[action]" value="discard" type="submit" class="neos-button neos-button-danger">
 								<i class="fas fa-trash-alt icon-white"></i>
 								{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
@@ -203,7 +203,7 @@
 		<div class="neos-pull-right">
 			<f:if condition="{canPublishToBaseWorkspace}">
 				<f:then>
-					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+					<button type="submit" class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
@@ -229,7 +229,7 @@
 						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
-					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+					<button type="submit" class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -202,7 +202,7 @@
 					</button>
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
 						<li class="fas fa-check icon-white"></li>
-						{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 				</f:then>
 				<f:else>
@@ -212,7 +212,7 @@
 					</button>
 					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
 						<li class="fas fa-check icon-white"></li>
-						{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 					<button class="discard-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -69,7 +69,7 @@
 										</td>
 										<td class="neos-action">
 											<f:if condition="{canPublishToBaseWorkspace}">
-												<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-success neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
+												<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
 													<i class="fas fa-check icon-white"></i>
 												</button>
 											</f:if>
@@ -207,7 +207,7 @@
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-success">
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-primary">
 						<i class="fas fa-check-double icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
@@ -215,7 +215,7 @@
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
 						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -196,7 +196,7 @@
 						<i class="fas fa-check-double icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
@@ -206,7 +206,7 @@
 					</button>
 				</f:then>
 				<f:else>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -116,12 +116,10 @@
 							if (jQuery(this).is(':checked')) {
 								value = true;
 								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-discardAllChanges').removeClass('neos-disabled').removeAttr('disabled');
-								jQuery('.publish-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
-								jQuery('.discard-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.review-button-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
 							} else {
 								jQuery('.batch-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
-								jQuery('.publish-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
-								jQuery('.discard-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
+								jQuery('.review-button-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
 							}
 							jQuery('tbody input[type="checkbox"]').prop('checked', value);
 						});
@@ -150,12 +148,10 @@
 
 							if (jQuery('tbody input[type="checkbox"]:checked').length > 0) {
 								jQuery('.batch-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled');
-								jQuery('.publish-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
-								jQuery('.discard-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
+								jQuery('.review-button-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
 							} else {
 								jQuery('.batch-action').addClass('neos-hidden').addClass('neos-disabled').attr('disabled', 'disabled');
-								jQuery('.publish-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
-								jQuery('.discard-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
+								jQuery('.review-button-action').removeClass('neos-hidden').removeClass('neos-disabled').removeAttr('disabled', 'disabled');
 							}
 						});
 
@@ -188,11 +184,11 @@
 		<div class="neos-pull-right">
 			<f:if condition="{canPublishToBaseWorkspace}">
 				<f:then>
-					<button class="discard-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="publish-action neos-button neos-button-primary">
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-primary">
 						<i class="fas fa-check-double icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
@@ -214,7 +210,7 @@
 						<li class="fas fa-check icon-white"></li>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
-					<button class="discard-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
+					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -204,8 +204,8 @@
         <target state="final">In diesem Arbeitsbereich gibt es keine unveröffentlichten Änderungen.</target>
       </trans-unit>
       <trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
-				<source>Do you really want to discard all changes in the "{0}" workspace?</source>
-        <target state="final">Möchten Sie wirklich alle Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
+				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
+        <target state="final">Möchten Sie die Änderungen im Arbeitsbereich "{0}" wirklich verwerfen?</target>
       </trans-unit>
       <trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists" approved="yes">
         <source>A workspace with this title already exists.</source>

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -204,7 +204,7 @@
         <target state="final">In diesem Arbeitsbereich gibt es keine unveröffentlichten Änderungen.</target>
       </trans-unit>
       <trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
-        <source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+        <source>Do you really want to discard the selected changes in the "{0}" workspace?</source>
         <target state="final">Möchten Sie wirklich die ausgewählten Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
       </trans-unit>
       <trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -159,9 +159,9 @@
 				<source>Discard selected changes</source>
         <target state="final">Ausgewählte Änderungen verwerfen</target>
       </trans-unit>
-      <trans-unit id="workspaces.publishSelectedChanges" xml:space="preserve" approved="yes">
-				<source>Publish selected changes</source>
-        <target state="final">Ausgewählte Änderungen veröffentlichen</target>
+      <trans-unit id="workspaces.publishSelectedChangesTo" xml:space="preserve" approved="yes">
+				<source>Publish selected changes to {0}</source>
+        <target state="final">Ausgewählte Änderungen nach {0} veröffentlichen</target>
       </trans-unit>
       <trans-unit id="workspaces.discardAllChanges" xml:space="preserve" approved="yes">
 				<source>Discard all changes</source>

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -203,9 +203,13 @@
 				<source>There are no unpublished changes in this workspace.</source>
         <target state="final">In diesem Arbeitsbereich gibt es keine unveröffentlichten Änderungen.</target>
       </trans-unit>
+      <trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
+        <source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+        <target state="final">Möchten Sie wirklich die ausgewählten Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
+      </trans-unit>
       <trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
-				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
-        <target state="final">Möchten Sie die Änderungen im Arbeitsbereich "{0}" wirklich verwerfen?</target>
+        <source>Do you really want to discard all changes in the "{0}" workspace?</source>
+        <target state="final">Möchten Sie wirklich alle Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
       </trans-unit>
       <trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists" approved="yes">
         <source>A workspace with this title already exists.</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -119,8 +119,8 @@
 			<trans-unit id="workspaces.discardSelectedChanges" xml:space="preserve">
 				<source>Discard selected changes</source>
 			</trans-unit>
-			<trans-unit id="workspaces.publishSelectedChanges" xml:space="preserve">
-				<source>Publish selected changes</source>
+			<trans-unit id="workspaces.publishSelectedChangesTo" xml:space="preserve">
+				<source>Publish selected changes to {0}</source>
 			</trans-unit>
 			<trans-unit id="workspaces.discardAllChanges" xml:space="preserve">
 				<source>Discard all changes</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -153,7 +153,7 @@
 				<source>There are no unpublished changes in this workspace.</source>
 			</trans-unit>
 			<trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve">
-				<source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+				<source>Do you really want to discard the selected changes in the "{0}" workspace?</source>
 			</trans-unit>
 			<trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve">
 				<source>Do you really want to discard all changes in the "{0}" workspace?</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -152,8 +152,11 @@
 			<trans-unit id="workspaces.thereAreNoUnpublishedChanges" xml:space="preserve">
 				<source>There are no unpublished changes in this workspace.</source>
 			</trans-unit>
+			<trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve">
+				<source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+			</trans-unit>
 			<trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve">
-				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
+				<source>Do you really want to discard all changes in the "{0}" workspace?</source>
 			</trans-unit>
 			<trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists">
 				<source>A workspace with this title already exists.</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -153,7 +153,7 @@
 				<source>There are no unpublished changes in this workspace.</source>
 			</trans-unit>
 			<trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve">
-				<source>Do you really want to discard all changes in the "{0}" workspace?</source>
+				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
 			</trans-unit>
 			<trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists">
 				<source>A workspace with this title already exists.</source>


### PR DESCRIPTION
**Upgrade instructions**

_Empty_

**Review instructions**

Resolves: #4003 

# Description

My pull request is about improving the behavior of the workspace review buttons.
When I look at the change in a workspace, I don't always want to publish, or discard all changes. Because I also have the option to discard, or publish individual changes. But if I don't do that regularly, it could happen that you accidentally press the wrong button.

## Solution

The behavior should be such that when I select a single change, or all changes, the respective buttons should not be displayed. This provides better clarity, and less confusion for the backend user. Thanks to @bwaidelich for the idea regarding the new behavior ❤️ !

### Demos

Here I have included two examples to show the new behavior of the review buttons.

#### Publish to Live Priviliges


https://user-images.githubusercontent.com/39345336/214127918-96f6370e-66fb-40f5-a735-5769f323c7b0.mov


#### No Publish to Live Priviliges



https://user-images.githubusercontent.com/39345336/214128277-b9421ab7-d99d-4348-8db4-328d10d52b8c.mov


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
