### PR TITLE
BUGFIX: Hide publish button if the user is not allowed to publish to the live workspace

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -186,7 +186,6 @@
 					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}</button>
 				</f:then>
 				<f:else>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.publishSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
 					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-hidden neos-disabled batch-action" disabled="disabled">{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}</button>
 					<button class="neos-button neos-button-danger" data-toggle="modal" href="#discard">{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}</button>
 				</f:else>


### PR DESCRIPTION
resolves: #3615

## Description

As a backend user who cannot publish changes if the base workspace is `live`, the button should not be displayed. However, if the user publishes changes to a workspace where the base workspace is **not** `Live`, the button will still be displayed, and changes can be published as usuall.

currently
![image](https://user-images.githubusercontent.com/85400359/215278066-b1e22059-f131-4532-b97d-6942fc80991d.png)


fixed
![image](https://user-images.githubusercontent.com/85400359/215278073-b98e8303-74de-43bb-b76b-1fbcbbe058cb.png)


thx also to @crydotsnake  and @lorenzulrich for his solution at: https://github.com/neos/neos-development-collection/issues/3615#issuecomment-1048589311


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
