### PR TITLE
BUGFIX: Don’t use legcy editor name in example

### DIFF
--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -276,7 +276,7 @@ the key/value pairs can be accessed in the ``$arguments`` array passed to ``getD
     questions:
       ui:
         inspector:
-          editor: 'Content/Inspector/Editors/SelectBoxEditor'
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             dataSourceIdentifier: 'questions'
             # alternatively using a custom uri:


### PR DESCRIPTION
When someone uses the old name the editor is still mapped correctly but the `i18n` labels are not properly localised.