### PR TITLE
FEATURE: Add Neos.Fusion:Wrapper

### DIFF
--- a/Neos.Fusion/Resources/Private/Fusion/Prototypes/Wrapper.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Prototypes/Wrapper.fusion
@@ -1,0 +1,21 @@
+prototype(Neos.Fusion:Wrapper) < prototype(Neos.Fusion:Component) {
+    tagName = null
+    attributes = Neos.Fusion:DataStructure
+    omitClosingTag = false
+    selfClosingTag = false
+    content = null
+    allowEmptyAttributes = true
+
+    renderer = Neos.Fusion:Case {
+        hasTagName {
+            condition = ${props.tagName && Type.isString(props.tagName)}
+            renderer = Neos.Fusion:Tag {
+                @apply.props = ${props}
+            }
+        }
+        justContent {
+            condition = true
+            renderer = ${props.content}
+        }
+    }
+}

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -588,7 +588,7 @@ Evaluates to::
 Neos.Fusion:Wrapper
 -------------------
 
-If a ``tagName`` is given the ``content`` is wrapped in an HTML tag with the given tag. Otherwise the content is returned as is.
+If a ``tagName`` is given the ``content`` is wrapped in an HTML tag with the given tag. Otherwise, the content is returned as is.
 
 :tagName: (string) Tag name of the HTML element, defaults to ``null``
 :omitClosingTag: (boolean) Whether to render the element ``content`` and the closing tag, defaults to ``FALSE``

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -583,6 +583,46 @@ Evaluates to::
 
 	<html version="HTML+RDFa 1.1" xmlns="http://www.w3.org/1999/xhtml">
 
+.. _Neos_Fusion__Wrapper:
+
+Neos.Fusion:Wrapper
+-------------------
+
+If a ``tagName`` is given the ``content`` is wrapped in an HTML tag with the given tag. Otherwise the content is returned as is.
+
+:tagName: (string) Tag name of the HTML element, defaults to ``null``
+:omitClosingTag: (boolean) Whether to render the element ``content`` and the closing tag, defaults to ``FALSE``
+:selfClosingTag: (boolean) Whether the tag is a self-closing tag with no closing tag. Will be resolved from ``tagName`` by default, so default HTML tags are treated correctly.
+:content: (string) The inner content of the element, will only be rendered if the tag is not self-closing and the closing tag is not omitted
+:attributes: (iterable) Tag attributes as key-value pairs. Default is ``Neos.Fusion:DataStructure``. If a non iterable is returned the value is casted to string.
+:allowEmptyAttributes: (boolean) Whether empty attributes (HTML5 syntax) should be used for empty, false or null attribute values. By default this is ``true``
+
+Example:
+^^^^^^^^
+
+::
+
+	content = Neos.Fusion:Wrapper {
+    attributes.class = 'foo bar'
+		content = 'Hello World'
+	}
+
+Evaluates to::
+
+	Hello World
+
+::
+
+	content = Neos.Fusion:Wrapper {
+    tagName = 'div'
+    attributes.class = 'foo bar'
+		content = 'Hello World'
+	}
+
+Evaluates to::
+
+	<div class="foo bar">Hello World</div>
+
 .. _Neos_Fusion__Attributes:
 
 Neos.Fusion:Attributes


### PR DESCRIPTION
If a `tagName` is given the `content` is wrapped in an HTML tag with the given tag. Otherwise, the content is returned as is.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
