### PR TITLE
BUGFIX: Fix annotation to enable creation / update of user (settings)

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -187,9 +187,9 @@ class UsersController extends AbstractModuleController
      * Create a new user
      *
      * @param string $username The user name (ie. account identifier) of the new user
-     * @param array<int,string> $password Expects an array in the format array('<password>', '<password confirmation>')
+     * @param array<string> $password Expects an array in the format array('<password>', '<password confirmation>')
      * @param User $user The user to create
-     * @param array<int,string> $roleIdentifiers A list of roles (role identifiers) to assign to the new user
+     * @param array<string> $roleIdentifiers A list of roles (role identifiers) to assign to the new user
      * @param string $authenticationProviderName Optional name of the authentication provider.
      *                                         If not provided the user server uses the default authentication provider
      * @return void
@@ -377,8 +377,8 @@ class UsersController extends AbstractModuleController
      * Update a given account
      *
      * @param Account $account The account to update
-     * @param array<int,string> $roleIdentifiers A possibly updated list of roles for the user's primary account
-     * @param array<int,string> $password Expects an array in the format array('<password>', '<password confirmation>')
+     * @param array<string> $roleIdentifiers A possibly updated list of roles for the user's primary account
+     * @param array<string> $password Expects an array in the format array('<password>', '<password confirmation>')
      * @return void
      * @throws StopActionException
      * @throws ForwardException

--- a/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
+++ b/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
@@ -154,7 +154,7 @@ class UserSettingsController extends AbstractModuleController
     /**
      * Update a given account, ie. the password
      *
-     * @param array<int,string> $password Expects an array in the format array('<password>', '<password confirmation>')
+     * @param array<string> $password Expects an array in the format array('<password>', '<password confirmation>')
      * @codingStandardsIgnoreStart
      * @Flow\Validate(argumentName="password", type="\Neos\Neos\Validation\Validator\PasswordValidator", options={ "allowEmpty"=1, "minimum"=1, "maximum"=255 })
      * @codingStandardsIgnoreEnd


### PR DESCRIPTION
- Using previous array annotation leads to error `Could not convert target type "array<int,string>": Found an invalid element type declaration.`
- Introduced with: neos/neos-development-collection@a5724819695f43832cac14be18439c5ade69e748
