### PR TITLE
BUGFIX: Neos.Neos Fusion ErrorCase wrongly included

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Error/Root.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Error/Root.fusion
@@ -5,28 +5,3 @@ Neos.Fusion.FusionParserException = Neos.Neos:Error.View.FusionParserException {
   exception = ${exception}
   flowPathRoot = ${flowPathRoot}
 }
-
-# The error matcher used to render errors that are configured for fusion rendering
-#
-# The matcher receives the context values `exception`, `renderingOptions`, `statusCode`,
-# `statusMessage` and `referenceCode`.
-#
-# By default the standard error template is rendered, but by extending the matcher
-# custom rendering can be implemented
-#
-error = Neos.Fusion:Case {
-  default {
-    @position = 'end 9999'
-    condition = true
-    renderer = Neos.Fusion:Template {
-      templatePath = 'resource://Neos.Neos/Private/Templates/Error/Index.html'
-      layoutRootPath = 'resource://Neos.Neos/Private/Layouts/'
-
-      exception = ${exception}
-      renderingOptions = ${renderingOptions}
-      statusCode = ${statusCode}
-      statusMessage = ${statusMessage}
-      referenceCode = ${referenceCode}
-    }
-  }
-}

--- a/Neos.Neos/Resources/Private/Fusion/ErrorCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/ErrorCase.fusion
@@ -1,0 +1,24 @@
+# The error matcher used to render errors that are configured for fusion rendering
+#
+# The matcher receives the context values `exception`, `renderingOptions`, `statusCode`,
+# `statusMessage` and `referenceCode`.
+#
+# By default the standard error template is rendered, but by extending the matcher
+# custom rendering can be implemented
+#
+error = Neos.Fusion:Case {
+  default {
+    @position = 'end 9999'
+    condition = true
+    renderer = Neos.Fusion:Template {
+      templatePath = 'resource://Neos.Neos/Private/Templates/Error/Index.html'
+      layoutRootPath = 'resource://Neos.Neos/Private/Layouts/'
+
+      exception = ${exception}
+      renderingOptions = ${renderingOptions}
+      statusCode = ${statusCode}
+      statusMessage = ${statusMessage}
+      referenceCode = ${referenceCode}
+    }
+  }
+}

--- a/Neos.Neos/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Root.fusion
@@ -1,5 +1,5 @@
 include: Prototypes/*.fusion
-include: Error/*.fusion
+include: ErrorCase.fusion
 include: RootCase.fusion
 include: RawContentMode.fusion
 include: Override/*.fusion


### PR DESCRIPTION
Fixes: #4035


https://github.com/neos/neos-development-collection/pull/3915 introduced a regression, that the errorCase was not included at all. With https://github.com/neos/neos-development-collection/pull/3996 this was hotfixed but lead to another regression that i am here to fix.


If we include `Neos.Neos/Resources/Private/Fusion/Error/Root.fusion` we also re include `include: resource://Neos.Fusion/Private/Fusion/Root.fusion` which is not optimal.

The errorCase is now (again) on its own and doesnt belong to the `Error` folder anymore but like the RootCase, sits on top.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
