### PR TITLE
BUGFIX: Hackily fix FusionService for auto included multisite package #3835 #3834

### DIFF
--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -62,16 +62,29 @@ class FilePatternResolver
         if ($filePattern === '') {
             throw new Fusion\Exception("cannot resolve empty pattern: '$filePattern'", 1636144288);
         }
-        if ($filePattern[0] === '/') {
-            throw new Fusion\Exception("cannot resolve absolute pattern: '$filePattern'", 1636144292);
+        if (self::isPatternAbsolute($filePattern)) {
+            if (self::isPatternGlob($filePattern)) {
+                throw new Fusion\Exception("cannot resolve absolute glob pattern: '$filePattern'", 1636144292);
+            }
+            return [$filePattern];
         }
         if (self::isPatternStreamWrapper($filePattern) === false) {
             $filePattern = self::resolveRelativePath($filePattern, $filePathForRelativeResolves);
         }
-        if (str_contains($filePattern, '*') === false) {
+        if (self::isPatternGlob($filePattern) === false) {
             return [$filePattern];
         }
         return self::parseGlobPatternAndResolveFiles($filePattern, $defaultFileEndForUnspecificGlobbing);
+    }
+
+    protected static function isPatternGlob(string $filePattern): bool
+    {
+        return str_contains($filePattern, '*');
+    }
+
+    protected static function isPatternAbsolute(string $filePattern): bool
+    {
+        return $filePattern[0] === '/';
     }
 
     protected static function isPatternStreamWrapper(string $filePattern): bool


### PR DESCRIPTION
Originally i was scared to write such unholy code but with a better future in sight: https://github.com/neos/neos-development-collection/pull/3839
I found this dirty solution :D

This fix will apply for 8.0 - 8.2. With 8.3 the Fusion Service will get some fresh paint.

Fixes: #3835 A previous workaround was to disable the `Neos_Fusion_ParsePartials` cache via `Neos.Fusion.enableParsePartialsCache`
Fixes: #3834 


Maybe fixes also #3985 would be cool if @kdambekalns or @breadlesscode could tell me ^^

One opening/non breaking change in behaviour had to occour to let our tests pass: Absolute, non glob, fusion paths are now allowed in fusions include:
```
include: /var/www/html/Packages/Neos/Neos.Neos/Tests/Functional/Fusion/Fixtures/Base.fusion
```

**Upgrade instructions**

**Review instructions**

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
