### PR TITLE
BUGFIX: Adjust legacy content migration from postgres db

### DIFF
--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/ContentRepositoryMigrateCommandController.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/ContentRepositoryMigrateCommandController.php
@@ -130,7 +130,7 @@ class ContentRepositoryMigrateCommandController extends CommandController
             $this->quit();
         }
 
-        $this->connection->executeStatement('TRUNCATE '. $eventTableName . ';');
+        $this->connection->executeStatement('TRUNCATE ' . $eventTableName);
         $this->outputLine('Truncated events');
 
         $legacyMigrationService = $this->contentRepositoryRegistry->getService(

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/ContentRepositoryMigrateCommandController.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/ContentRepositoryMigrateCommandController.php
@@ -129,7 +129,8 @@ class ContentRepositoryMigrateCommandController extends CommandController
             $this->outputLine('Cancelled...');
             $this->quit();
         }
-        $this->connection->executeStatement('TRUNCATE ' . $connection->quoteIdentifier($eventTableName));
+
+        $this->connection->executeStatement('TRUNCATE '. $eventTableName . ';');
         $this->outputLine('Truncated events');
 
         $legacyMigrationService = $this->contentRepositoryRegistry->getService(

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/NodeDataLoader.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/NodeDataLoader.php
@@ -15,15 +15,22 @@ final class NodeDataLoader implements \IteratorAggregate
 
     public function getIterator(): Traversable
     {
+        $whereClause = [
+            'workspace' => $this->connection->quoteIdentifier("workspace") . ' = ' . $this->connection->quote("live"),
+            'path' => $this->connection->quoteIdentifier("path") . ' != ' . $this->connection->quote("/"),
+            'movedTo' => $this->connection->quoteIdentifier("movedto") . ' IS NULL ',
+            'removed' => $this->connection->quoteIdentifier("removed") . ' = ' . ($this->connection->getDatabasePlatform()->getName() === 'postgresql' ? 'FALSE' : '0')
+        ];
+
         $query = $this->connection->executeQuery('
             SELECT
                 *
             FROM
                 neos_contentrepository_domain_model_nodedata
             WHERE
-                workspace = "live"
-                AND (movedto IS NULL OR removed=0)
-                AND path != "/"
+                ' . $whereClause['workspace'] . ' AND
+                ' . $whereClause['path'] . ' AND
+            (' . $whereClause['movedTo'] . ' OR ' . $whereClause['removed'] . ')
             ORDER BY
                 parentpath, sortingindex, path
         ');


### PR DESCRIPTION
**Review instructions**

The issue mentioned involves migrating data from a PostgreSQL database in a legacy Neos system to a new event source CR on MySQL. However, the migration process encountered errors, specifically with regard to the truncation of the cr_default_events table and issues with the node data loader.

In the Dataloader we now quote everything and switch the data type of the removed column based on the driver. As, PostgreSQL uses boolean and not integer values.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
