### PR TITLE
FEATURE: Edit preview mode support for Neos 9

### DIFF
--- a/Neos.Neos/Classes/Controller/Exception/InvalidEditPreviewModeException.php
+++ b/Neos.Neos/Classes/Controller/Exception/InvalidEditPreviewModeException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Controller\Exception;
+
+use Neos\Neos\Controller\Exception;
+
+/**
+ * A "Node Creation" exception
+ *
+ */
+class InvalidEditPreviewModeException extends Exception
+{
+}

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -201,10 +201,13 @@ class NodeController extends ActionController
             $this->handleShortcutNode($nodeAddress, $contentRepository);
         }
 
+        if ($editPreviewMode->fusionPath) {
+            $this->view->setFusionPath($editPreviewMode->fusionPath);
+        }
+
         $this->view->assignMultiple([
             'value' => $nodeInstance,
-            'site' => $site,
-            'editPreviewMode' => $editPreviewMode
+            'site' => $site
         ]);
 
         if (!$nodeAddress->isInLiveWorkspace()) {

--- a/Neos.Neos/Classes/Domain/Model/EditPreviewMode.php
+++ b/Neos.Neos/Classes/Domain/Model/EditPreviewMode.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Model;
+
+final class EditPreviewMode
+{
+    protected function __construct(
+        public readonly string $name,
+        public readonly string $title,
+        public readonly ?string $fusionPath,
+        public readonly bool $isEditMode,
+        public readonly bool $isPreviewMode
+    ) {
+    }
+
+    /**
+     * @param string $name
+     * @param array{'title'?:string, 'fusionRenderingPath'?:string, 'isEditingMode'?:bool, 'isPreviewMode'?:bool} $configuration
+     * @return self
+     */
+    public static function fromNameAndConfiguration(string $name, array $configuration): self
+    {
+        return new static(
+            $name,
+            $configuration['title'] ?? $name,
+            $configuration['fusionRenderingPath'] ?? null,
+            $configuration['isEditingMode'] ?? false,
+            $configuration['isPreviewMode'] ?? false
+        );
+    }
+}

--- a/Neos.Neos/Classes/Domain/Repository/EditPreviewModeRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/EditPreviewModeRepository.php
@@ -36,7 +36,7 @@ class EditPreviewModeRepository
 
     public function findByName(string $name): EditPreviewMode
     {
-        if (array_key_exists($name,$this->editPreviewModeConfigurations)) {
+        if (array_key_exists($name, $this->editPreviewModeConfigurations)) {
             return EditPreviewMode::fromNameAndConfiguration($name, $this->editPreviewModeConfigurations[$name]);
         }
         throw new InvalidEditPreviewModeException(sprintf('"%s" is not a valid editPreviewMode', $name), 1683790077);

--- a/Neos.Neos/Classes/Domain/Repository/EditPreviewModeRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/EditPreviewModeRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Repository;
+
+use Neos\Neos\Controller\Exception\InvalidEditPreviewModeException;
+use Neos\Neos\Domain\Model\EditPreviewMode;
+use Neos\Flow\Annotations as Flow;
+
+class EditPreviewModeRepository
+{
+    #[Flow\InjectConfiguration(path:"userInterface.defaultEditPreviewMode")]
+    protected string $defaultEditPreviewMode;
+
+    /**
+     * @var array<string, array{'title'?:string, 'fusionRenderingPath'?:string, 'isEditingMode'?:bool, 'isPreviewMode'?:bool}>
+     */
+    #[Flow\InjectConfiguration(path:"userInterface.editPreviewModes")]
+    protected array $editPreviewModeConfigurations;
+
+    public function findDefault(): EditPreviewMode
+    {
+        return EditPreviewMode::fromNameAndConfiguration($this->defaultEditPreviewMode, $this->editPreviewModeConfigurations[$this->defaultEditPreviewMode]);
+    }
+
+    public function findByName(string $name): EditPreviewMode
+    {
+        if (array_key_exists($name,$this->editPreviewModeConfigurations)) {
+            return EditPreviewMode::fromNameAndConfiguration($name, $this->editPreviewModeConfigurations[$name]);
+        }
+        throw new InvalidEditPreviewModeException(sprintf('"%s" is not a valid editPreviewMode', $name), 1683790077);
+    }
+}

--- a/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
@@ -66,13 +66,16 @@ final class NodeUriBuilder
     {
         if (!$nodeAddress->isInLiveWorkspace()) {
             $request = $this->uriBuilder->getRequest();
-            if ($request->getControllerPackageKey() === 'Neos.Neos'
+            if (
+                $request->getControllerPackageKey() === 'Neos.Neos'
                 && $request->getControllerName() === "Frontend\Node"
             ) {
                 if ($request->getControllerActionName() == 'edit') {
-                    return $this->editUriFor($nodeAddress, $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null);
+                    $editPreviewModeArgument = $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null;
+                    return $this->editUriFor($nodeAddress, is_string($editPreviewModeArgument) ? $editPreviewModeArgument : null);
                 } elseif ($request->getControllerActionName() == 'preview') {
-                    return $this->previewUriFor($nodeAddress, $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null);
+                    $editPreviewModeArgument = $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null;
+                    return $this->previewUriFor($nodeAddress, is_string($editPreviewModeArgument) ? $editPreviewModeArgument : null);
                 }
             }
 

--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Fusion\Helper;
 
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Neos\Service\UserService;
 
 /**
@@ -38,6 +39,34 @@ class BackendHelper implements ProtectedContextAwareInterface
         $currentUser = $this->userService->getBackendUser();
         assert($currentUser !== null, "No backend user");
         return $this->userService->getInterfaceLanguage();
+    }
+
+    public function isEditMode(ActionRequest $request): bool
+    {
+        return ($request->getControllerPackageKey() === 'Neos.Neos'
+            && $request->getControllerName() === "Frontend\Node"
+            && $request->getControllerActionName() === 'edit'
+        );
+    }
+
+    public function isPreviewMode(ActionRequest $request): bool
+    {
+        return ($request->getControllerPackageKey() === 'Neos.Neos'
+            && $request->getControllerName() === "Frontend\Node"
+            && $request->getControllerActionName() === 'preview'
+        );
+    }
+
+    public function editPreviewModeCacheIdentifier(ActionRequest $request): string
+    {
+        if ($request->getControllerPackageKey() === 'Neos.Neos'
+            && $request->getControllerName() === "Frontend\Node"
+            && ($request->getControllerActionName() === 'edit' || $request->getControllerActionName() === 'preview')
+        ) {
+            return $request->getControllerActionName() . ($request->hasArgument('editPreviewMode') ? ':' . $request->getArgument('editPreviewMode') : '');
+        } else {
+            return "";
+        }
     }
 
     public function allowsCallOfMethod($methodName)

--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -57,15 +57,20 @@ class BackendHelper implements ProtectedContextAwareInterface
         );
     }
 
-    public function editPreviewModeCacheIdentifier(ActionRequest $request): string
+    public function renderingModeCacheIdentifier(ActionRequest $request): string
     {
-        if ($request->getControllerPackageKey() === 'Neos.Neos'
+        if (
+            $request->getControllerPackageKey() === 'Neos.Neos'
             && $request->getControllerName() === "Frontend\Node"
             && ($request->getControllerActionName() === 'edit' || $request->getControllerActionName() === 'preview')
         ) {
-            return $request->getControllerActionName() . ($request->hasArgument('editPreviewMode') ? ':' . $request->getArgument('editPreviewMode') : '');
+            $editPreviewModeArgument = $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null;
+            if (is_string($editPreviewModeArgument)) {
+                return $request->getControllerActionName() . ':' . $editPreviewModeArgument;
+            }
+            return $request->getControllerActionName();
         } else {
-            return "";
+            return "show";
         }
     }
 

--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -41,36 +41,32 @@ class BackendHelper implements ProtectedContextAwareInterface
         return $this->userService->getInterfaceLanguage();
     }
 
-    public function isEditMode(ActionRequest $request): bool
+    public static function isEditMode(ActionRequest $request): bool
     {
         return ($request->getControllerPackageKey() === 'Neos.Neos'
-            && $request->getControllerName() === "Frontend\Node"
+            && $request->getControllerName() === 'Frontend\\Node'
             && $request->getControllerActionName() === 'edit'
         );
     }
 
-    public function isPreviewMode(ActionRequest $request): bool
+    public static function isPreviewMode(ActionRequest $request): bool
     {
         return ($request->getControllerPackageKey() === 'Neos.Neos'
-            && $request->getControllerName() === "Frontend\Node"
+            && $request->getControllerName() === 'Frontend\\Node'
             && $request->getControllerActionName() === 'preview'
         );
     }
 
-    public function renderingModeCacheIdentifier(ActionRequest $request): string
+    public static function renderingModeCacheIdentifier(ActionRequest $request): string
     {
-        if (
-            $request->getControllerPackageKey() === 'Neos.Neos'
-            && $request->getControllerName() === "Frontend\Node"
-            && ($request->getControllerActionName() === 'edit' || $request->getControllerActionName() === 'preview')
-        ) {
+        if (self::isEditMode($request) || self::isPreviewMode($request)) {
             $editPreviewModeArgument = $request->hasArgument('editPreviewMode') ? $request->getArgument('editPreviewMode') : null;
             if (is_string($editPreviewModeArgument)) {
                 return $request->getControllerActionName() . ':' . $editPreviewModeArgument;
             }
             return $request->getControllerActionName();
         } else {
-            return "show";
+            return 'show';
         }
     }
 

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -84,13 +84,6 @@ class NodeHelper implements ProtectedContextAwareInterface
         return new NodeLabelToken($node);
     }
 
-    public function inBackend(Node $node): bool
-    {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return !$nodeAddressFactory->createFromNode($node)->isInLiveWorkspace();
-    }
-
     /**
      * @param Node $node
      * @return int

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -391,7 +391,7 @@ class LinkingService
             ->setArgumentsToBeExcludedFromQueryString($argumentsToBeExcludedFromQueryString)
             ->setFormat($format ?: $request->getFormat())
             ->setCreateAbsoluteUri($absolute)
-            ->uriFor($action, ['node' => $node], 'Frontend\Node', 'Neos.Neos') . '&grrr';
+            ->uriFor($action, ['node' => $node], 'Frontend\Node', 'Neos.Neos');
     }
 
     /**

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -370,12 +370,13 @@ class LinkingService
         $uriBuilder = clone $controllerContext->getUriBuilder();
         $uriBuilder->setRequest($request);
 
-        if ($request->getControllerPackageKey() === 'Neos.Neos'
+        if (
+            $request->getControllerPackageKey() === 'Neos.Neos'
             && $request->getControllerName() === "Frontend\Node"
             && in_array($request->getControllerActionName(), ['edit', 'preview'])
         ) {
             $action = $request->getControllerActionName();
-            if ( $request->hasArgument('editPreviewMode')) {
+            if ($request->hasArgument('editPreviewMode')) {
                 $arguments['editPreviewMode'] = $request->getArgument('editPreviewMode');
             }
         } else {

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -39,6 +39,7 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Exception as NeosException;
 use Neos\Neos\FrontendRouting\NodeShortcutResolver;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
+use Neos\Neos\Fusion\Helper\BackendHelper;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 
@@ -370,11 +371,7 @@ class LinkingService
         $uriBuilder = clone $controllerContext->getUriBuilder();
         $uriBuilder->setRequest($request);
 
-        if (
-            $request->getControllerPackageKey() === 'Neos.Neos'
-            && $request->getControllerName() === "Frontend\Node"
-            && in_array($request->getControllerActionName(), ['edit', 'preview'])
-        ) {
+        if (BackendHelper::isEditMode($request) || BackendHelper::isPreviewMode($request)) {
             $action = $request->getControllerActionName();
             if ($request->hasArgument('editPreviewMode')) {
                 $arguments['editPreviewMode'] = $request->getArgument('editPreviewMode');

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -27,6 +27,10 @@ privilegeTargets:
       label: Access to the backend content preview
       matcher: 'method(Neos\Neos\Controller\Frontend\NodeController->previewAction())'
 
+    'Neos.Neos:ContentEdit':
+      label: Access to the backend edit mode
+      matcher: 'method(Neos\Neos\Controller\Frontend\NodeController->editAction())'
+
     'Neos.Neos:BackendLogin':
       label: General access to the backend login
       matcher: 'method(Neos\Neos\Controller\LoginController->(index|tokenLogin|authenticate)Action()) || method(Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController->authenticateAction())'
@@ -223,6 +227,10 @@ roles:
 
       -
         privilegeTarget: 'Neos.Neos:ContentPreview'
+        permission: GRANT
+
+      -
+        privilegeTarget: 'Neos.Neos:ContentEdit'
         permission: GRANT
 
       -

--- a/Neos.Neos/Configuration/Routes.Frontend.yaml
+++ b/Neos.Neos/Configuration/Routes.Frontend.yaml
@@ -10,6 +10,13 @@
   appendExceedingArguments: true
 
 -
+  name:          'Edit'
+  uriPattern:    'neos/edit'
+  defaults:
+    '@action':   'edit'
+  appendExceedingArguments: true
+
+-
   name: 'Default Frontend'
   uriPattern: '{node}'
   routeParts:

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -278,7 +278,7 @@ Neos:
           title: Live
         inPlace:
           isEditingMode: true
-          isPreviewMode: false
+          isPreviewMode: true
           fusionRenderingPath: ''
           title: 'Neos.Neos:Main:editPreviewModes.inPlace'
           position: 100

--- a/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
@@ -6,5 +6,5 @@
 prototype(Neos.Fusion:GlobalCacheIdentifiers) {
   workspaceChain = ${Array.join(Array.keys(Neos.Caching.getWorkspaceChain(documentNode)), ',')}
   workspaceChain.@if.has = ${!!documentNode}
-  editPreviewMode = ${Neos.Backend.editPreviewModeCacheIdentifier(request)}
+  renderingMode = ${Neos.Backend.renderingModeCacheIdentifier(request)}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
@@ -6,5 +6,5 @@
 prototype(Neos.Fusion:GlobalCacheIdentifiers) {
   workspaceChain = ${Array.join(Array.keys(Neos.Caching.getWorkspaceChain(documentNode)), ',')}
   workspaceChain.@if.has = ${!!documentNode}
-  editPreviewMode = ${editPreviewMode}
+  editPreviewMode = ${Neos.Backend.editPreviewModeCacheIdentifier(request)}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCollection.fusion
@@ -27,7 +27,7 @@ prototype(Neos.Neos:ContentCollection) < prototype(Neos.Fusion:Tag) {
   attributes {
     class.@process.collectionClass = ${Array.push(value, 'neos-contentcollection')}
     data-__neos-insertion-anchor = true
-    data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${Neos.Node.inBackend(documentNode) && node.context.currentRenderingMode.edit}
+    data-__neos-insertion-anchor.@if.onlyRenderInBackend = ${Neos.Backend.isEditMode(request)}
   }
 
   # Doesn't need to be set, if the node is a content collection.

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentElementWrapping.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentElementWrapping.fusion
@@ -5,6 +5,7 @@
 #
 prototype(Neos.Neos:ContentElementWrapping) {
   @class = 'Neos\\Neos\\Fusion\\ContentElementWrappingImplementation'
+  @if.inEditMode = ${Neos.Backend.isEditMode(request)}
   node = ${node}
   value = ${value}
   # Additional attributes in the form '<attribute-name>': '<attribute-value>' that will be rendered in the ContentElementWrapping

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Editable.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Editable.fusion
@@ -12,9 +12,7 @@ prototype(Neos.Neos:Editable) < prototype(Neos.Fusion:Component) {
 
   renderer = Neos.Fusion:Case {
     editable {
-      // TODO: add props.node.context.currentRenderingMode.edit
-      // condition = ${Neos.Node.inBackend(props.node) && props.node.context.currentRenderingMode.edit}
-      condition = ${Neos.Node.inBackend(props.node)}
+      condition = ${!Neos.Node.isLive(props.node) && Neos.Backend.isEditMode(request)}
 
       renderer = Neos.Fusion:Tag {
         tagName = ${props.block ? 'div' : 'span'}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/FallbackNode.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/FallbackNode.fusion
@@ -1,4 +1,4 @@
 prototype(Neos.Neos:FallbackNode) < prototype(Neos.Neos:Content) {
   templatePath = 'resource://Neos.Neos/Private/Templates/FusionObjects/FallbackNode.html'
-  @if.onlyRenderInBackend = ${Neos.Node.inBackend(node)}
+  @if.onlyRenderInBackend = ${Neos.Backend.isEditMode(request) || Neos.Backend.isPreviewMode(request)}
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -64,7 +64,7 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
     tagName = 'body'
     omitClosingTag = true
     attributes.class.@process.addNeosBackendClass = ${Array.push(value, 'neos-backend')}
-    attributes.class.@process.addNeosBackendClass.@if.onlyRenderWhenNotInLiveWorkspace = ${Neos.Node.inBackend(documentNode)}
+    attributes.class.@process.addNeosBackendClass.@if.onlyRenderWhenNotInLiveWorkspace = ${Neos.Backend.isEditMode(request) || Neos.Backend.isPreviewMode(request)}
   }
 
   # Content of the body tag. To be defined by the integrator.

--- a/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContentMode.fusion
@@ -1,3 +1,20 @@
 include: RawContent/*.fusion
 
-rawContent = Neos.Neos:RawContent.Document
+rawContent = Neos.Fusion:Case
+rawContent {
+  shortcut {
+    prototype(Neos.Neos:Page) {
+      body = Neos.Neos:Shortcut
+    }
+
+    @position = 'start'
+    condition = ${q(node).is('[instanceof Neos.Neos:Shortcut]')}
+    type = 'Neos.Neos:Page'
+  }
+
+  default {
+    @position = 'end'
+    condition = true
+    renderer = Neos.Neos:RawContent.Document
+  }
+}

--- a/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
@@ -17,9 +17,8 @@ root {
 
   editPreviewMode {
     @position = 'end 9996'
-    possibleEditPreviewModePath = ${documentNode.context.currentRenderingMode.fusionPath}
-    condition = ${Neos.Node.inBackend(documentNode) && this.possibleEditPreviewModePath != null && this.possibleEditPreviewModePath != ''}
-    renderPath = ${'/' + this.possibleEditPreviewModePath}
+    condition = ${Neos.Node.inBackend(documentNode) && editPreviewMode.fusionPath}
+    renderPath = ${'/' + editPreviewMode.fusionPath}
   }
 
   format {

--- a/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
@@ -15,12 +15,6 @@ root {
     type = 'Neos.Neos:Page'
   }
 
-  editPreviewMode {
-    @position = 'end 9996'
-    condition = ${Neos.Node.inBackend(documentNode) && editPreviewMode.fusionPath}
-    renderPath = ${'/' + editPreviewMode.fusionPath}
-  }
-
   format {
     @position = 'end 9997'
     condition = ${request.format != 'html'}

--- a/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
@@ -39,7 +39,7 @@ root {
 
   rawContent {
     @position = 'end 10000'
-    condition = ${Neos.Node.inBackend(documentNode) && Neos.Backend.isEditMode(request)}
+    condition = ${Neos.Backend.isEditMode(request)}
     renderer = Neos.Neos:RawContent.Document
   }
 

--- a/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RootCase.fusion
@@ -39,8 +39,8 @@ root {
 
   rawContent {
     @position = 'end 10000'
-    condition = ${Neos.Node.inBackend(documentNode) && documentNode.context.currentRenderingMode.edit}
-    renderPath = '/rawContent'
+    condition = ${Neos.Node.inBackend(documentNode) && Neos.Backend.isEditMode(request)}
+    renderer = Neos.Neos:RawContent.Document
   }
 
   # Fail but create a helpful error message


### PR DESCRIPTION
The main change is that `edit` and `preview` action of the node controller are now separated with distinct constraints. This now allows for an mode to be edit and preview mode at the same time which is allowed by the configuration anyways.

- NodeController: has separate edit and preview actions that take the previewMode as argument
- NodeUriBuilder and LinkingService: will use preview / edit action once the main request is from the same action
- Neos.BackendHelper: has additional methods isEditMode, isPreviewMode and renderingModeCacheIdentifier

!!! The Neos.UI needs a change to provide the `editPreviewMode` parameter and call the edit or the preview action !!!

!!! This pr changes some behaviors slightly:

1. The distinction between edit and preview mode is now made based on the called action of the nodeController
2. The eel method `Neos.Node.inBackend(node)` is removed and is replaced with `Neos.Backend.isEditMode(request) || Neos.Backend.isPreviewMode(request)` this is non breaky as this method was never in an official release

Resolves: [#4086](https://github.com/neos/neos-development-collection/issues/4086)
Resolves partly: https://github.com/neos/neos-development-collection/issues/4396

**Upgrade instructions**

If fusion code relies on the edit preview mode beeing available via `node.context.currentRenderingMode` it has to be adjusted. Usually this means adjusting from code like `${node.context.currentRenderingMode.edit}` to `${Neos.Backend.isEditMode(request)}`.

**Review instructions**

Until the ui is adjusted this will always the preview as this was the existing method of the node controller. By setting the default value of the `editPreviewMode` on the `previewAction` to `rawContent` you can verify the rendering via different fusion pathes.

For now you can use the console to call the edit preview modes in your browser. You will have to replace the `node` with a node-address for your setup. You can then verify that the edit / preview mode is persisted during navigation after the initial call.

1. Open document in default preview mode `document.querySelector('iframe').src = "https://neos-development-distribution-9-0.ddev.site/neos/preview?node=user-admin__eyJsYW5ndWFnZSI6ImVuX1VTIn0%3D__995c9174-ddd6-4d5c-cfc0-1ffc82184677" `
2. Open document default edit mode `document.querySelector('iframe').src = "https://neos-development-distribution-9-0.ddev.site/neos/edit?node=user-admin__eyJsYW5ndWFnZSI6ImVuX1VTIn0%3D__995c9174-ddd6-4d5c-cfc0-1ffc82184677" `
3. Open document in rawContent mode (edit)
`document.querySelector('iframe').src = "https://neos-development-distribution-9-0.ddev.site/neos/edit?node=user-admin__eyJsYW5ndWFnZSI6ImVuX1VTIn0%3D__995c9174-ddd6-4d5c-cfc0-1ffc82184677&editPreviewMode=rawContent"` 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions

**Todos**
- [ ] required UI change https://github.com/neos/neos-ui/pull/3411
- [ ] `Neos.Backend.isEditMode` automated migration https://github.com/neos/rector/issues/21
- [ ] `Neos.Backend.isEditMode` migration in the UI https://github.com/neos/neos-ui/pull/3571

