### PR TITLE
FEATURE: Add inspector group `default` to `Neos.Neos:Node`

### DIFF
--- a/Neos.Neos/Configuration/NodeTypes.Node.yaml
+++ b/Neos.Neos/Configuration/NodeTypes.Node.yaml
@@ -27,6 +27,10 @@
           position: 20
           icon: 'icon-cog'
       groups:
+        default:
+          label: i18n
+          position: 10
+          icon: 'icon-pencil'
         type:
           label: i18n
           tab: 'meta'

--- a/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Node.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Node.xlf
@@ -11,6 +11,9 @@
 			<trans-unit id="views.nodeInfo" xml:space="preserve">
 				<source>Metadata</source>
 			</trans-unit>
+			<trans-unit id="groups.default" xml:space="preserve">
+				<source>General</source>
+			</trans-unit>
 			<trans-unit id="groups.nodeInfo" xml:space="preserve">
 				<source>Additional info</source>
 			</trans-unit>


### PR DESCRIPTION
The group `default` can be used for basic properties instead introducing a custom group.

Resolves: #4060

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
