### PR TITLE
TASK: Deprecate PluginView

### DIFF
--- a/Neos.Neos/Classes/Aspects/PluginUriAspect.php
+++ b/Neos.Neos/Classes/Aspects/PluginUriAspect.php
@@ -44,6 +44,7 @@ class PluginUriAspect
      * @Flow\Around("method(Neos\Flow\Mvc\Routing\UriBuilder->uriFor())")
      * @param \Neos\Flow\Aop\JoinPointInterface $joinPoint The current join point
      * @return string The result of the target method if it has not been intercepted
+     * @deprecated will be removed with Neos 9
      */
     public function rewritePluginViewUris(JoinPointInterface $joinPoint)
     {

--- a/Neos.Neos/Classes/Domain/Model/PluginViewDefinition.php
+++ b/Neos.Neos/Classes/Domain/Model/PluginViewDefinition.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Domain\Model\NodeType;
  * A plugin view definition
  *
  * @api
+ * @deprecated will be removed with Neos 9
  */
 class PluginViewDefinition
 {

--- a/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginViewImplementation.php
@@ -21,6 +21,7 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 
 /**
  * A Fusion PluginView.
+ * @deprecated will be removed with Neos 9
  */
 class PluginViewImplementation extends PluginImplementation
 {

--- a/Neos.Neos/Classes/NodeTypePostprocessor/PluginNodeTypePostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/PluginNodeTypePostprocessor.php
@@ -20,6 +20,8 @@ use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
 /**
  * This Processor updates the PluginViews NodeType with the existing
  * Plugins and it's corresponding available Views
+ *
+ * @deprecated will be removed with Neos 9
  */
 class PluginNodeTypePostprocessor implements NodeTypePostprocessorInterface
 {

--- a/Neos.Neos/Classes/Service/PluginService.php
+++ b/Neos.Neos/Classes/Service/PluginService.php
@@ -33,6 +33,7 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
  * is available (e.g. for CLI requests) the ContentContextFactory can be used to create a context instance.
  *
  * @Flow\Scope("singleton")
+ * @deprecated will be removed with Neos 9
  */
 class PluginService
 {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/PluginView.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/PluginView.fusion
@@ -2,6 +2,8 @@
 # This represents a View that is always bound to a master Plugin
 # Usually you won't need to extend this
 #
+# @deprecated will be removed with Neos 9
+#
 prototype(Neos.Neos:PluginView) >
 prototype(Neos.Neos:PluginView) < prototype(Neos.Neos:Content) {
   @class = 'Neos\\Neos\\Fusion\\PluginViewImplementation'


### PR DESCRIPTION
The concept of PluginViews which means rendering specific views of a plugin on a different document is deprecated. It has been used in very fews cases and causes trouble in maintenance and thus will be removed without replacement in Neos 9.

Right now no changes are needed. If there are cases where this feature is still used it can be replaced by rendering a url combining the main and the plugin request arguments before upgrading to Neos 9.

Resolves: #4070
Relates: https://github.com/neos/neos-ui/issues/3408

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
