### PR TITLE
TASK: Unify fusion tag attribute rendering

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AttributesImplementation.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Service\RenderAttributesTrait;
 
 /**
  * Renders a string of xml attributes from the properties of this Fusion object.
@@ -28,40 +29,22 @@ namespace Neos\Fusion\FusionObjects;
  */
 class AttributesImplementation extends AbstractArrayFusionObject
 {
+    use RenderAttributesTrait;
+
     /**
      * @return string
      */
     public function evaluate()
     {
         $allowEmpty = $this->getAllowEmpty();
-
-        $renderedAttributes = '';
+        $attributes = [];
         foreach (array_keys($this->properties) as $attributeName) {
             if ($attributeName === '__meta' || in_array($attributeName, $this->ignoreProperties)) {
                 continue;
             }
-
-            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
-            $attributeValue = $this->fusionValue($attributeName);
-            if ($attributeValue === null || $attributeValue === false) {
-                // No op
-            } elseif ($attributeValue === true || $attributeValue === '') {
-                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
-            } else {
-                if (is_array($attributeValue)) {
-                    $joinedAttributeValue = '';
-                    foreach ($attributeValue as $attributeValuePart) {
-                        if ((string)$attributeValuePart !== '') {
-                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
-                        }
-                    }
-                    $attributeValue = trim($joinedAttributeValue);
-                }
-                $encodedAttributeValue = htmlspecialchars($attributeValue, ENT_COMPAT, 'UTF-8', false);
-                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
-            }
+            $attributes[$attributeName] = $this->fusionValue($attributeName);
         }
-        return $renderedAttributes;
+        return $this->renderAttributes($attributes, $allowEmpty);
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/AugmenterImplementation.php
@@ -35,7 +35,22 @@ class AugmenterImplementation extends AbstractArrayFusionObject
      *
      * @var array
      */
-    protected $ignoreProperties = ['__meta', 'fallbackTagName', 'content'];
+    protected $ignoreProperties = ['__meta', 'fallbackTagName', 'content', 'allowEmptyAttributes'];
+
+    /**
+     * Whether empty attributes (HTML5 syntax) should be allowed
+     *
+     * @return boolean
+     */
+    protected function getAllowEmptyAttributes()
+    {
+        $allowEmpty = $this->fusionValue('allowEmptyAttributes');
+        if ($allowEmpty === null) {
+            return true;
+        } else {
+            return (boolean)$allowEmpty;
+        }
+    }
 
     /**
      * @return void|string
@@ -44,11 +59,12 @@ class AugmenterImplementation extends AbstractArrayFusionObject
     {
         $content = $this->fusionValue('content');
         $fallbackTagName = $this->fusionValue('fallbackTagName');
+        $allowEmptyAttributes = $this->getAllowEmptyAttributes();
 
-        $attributes = array_filter($this->evaluateNestedProperties());
+        $attributes = $this->evaluateNestedProperties();
 
         if ($attributes && is_array($attributes) && count($attributes) > 0) {
-            return $this->htmlAugmenter->addAttributes($content, $attributes, $fallbackTagName);
+            return $this->htmlAugmenter->addAttributes($content, $attributes, $fallbackTagName, null, $allowEmptyAttributes);
         } else {
             return $content;
         }

--- a/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/TagImplementation.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\FusionObjects;
  * source code.
  */
 
+use Neos\Fusion\Service\RenderAttributesTrait;
 
 /**
  * A Fusion object for tag based content
@@ -21,6 +22,8 @@ namespace Neos\Fusion\FusionObjects;
  */
 class TagImplementation extends AbstractFusionObject
 {
+    use RenderAttributesTrait;
+
     /**
      * List of self-closing tags
      *
@@ -122,39 +125,5 @@ class TagImplementation extends AbstractFusionObject
             $renderedAttributes = (string)$attributes;
         }
         return '<' . $tagName . $renderedAttributes . ($selfClosingTag ? ' /' : '') . '>' . (!$omitClosingTag && !$selfClosingTag ? $content . '</' . $tagName . '>' : '');
-    }
-
-    /**
-     * Render the tag attributes for the given key->values as atring,
-     * if an value is an iterable it will be concatenated with spaces as seperator
-     *
-     * @param iterable $attributes
-     * @param bool $allowEmpty
-     */
-    protected function renderAttributes(iterable $attributes, $allowEmpty = true): string
-    {
-        $renderedAttributes = '';
-        foreach ($attributes as $attributeName => $attributeValue) {
-            if ($attributeValue === null || $attributeValue === false) {
-                continue;
-            }
-            $encodedAttributeName = htmlspecialchars($attributeName, ENT_COMPAT, 'UTF-8', false);
-            if ($attributeValue === true || $attributeValue === '') {
-                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
-            } else {
-                if (is_array($attributeValue)) {
-                    $joinedAttributeValue = '';
-                    foreach ($attributeValue as $attributeValuePart) {
-                        if ((string)$attributeValuePart !== '') {
-                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
-                        }
-                    }
-                    $attributeValue = trim($joinedAttributeValue);
-                }
-                $encodedAttributeValue = htmlspecialchars($attributeValue, ENT_COMPAT, 'UTF-8', false);
-                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
-            }
-        }
-        return $renderedAttributes;
     }
 }

--- a/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
+++ b/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Fusion\Service;
+
+/*
+ * This file is part of the Neos.Fusion package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * @internal
+ */
+trait RenderAttributesTrait
+{
+    /**
+     * Render the tag attributes for the given key->values as atring,
+     * if an value is an iterable it will be concatenated with spaces as seperator
+     *
+     * @param iterable $attributes a
+     * @param bool $allowEmpty
+     */
+    protected function renderAttributes(iterable $attributes, $allowEmpty = true): string
+    {
+        $renderedAttributes = '';
+        foreach ($attributes as $attributeName => $attributeValue) {
+            if ($attributeValue === null || $attributeValue === false) {
+                continue;
+            }
+            $encodedAttributeName = htmlspecialchars((string)$attributeName, ENT_COMPAT, 'UTF-8', false);
+            if ($attributeValue === true || $attributeValue === '') {
+                $renderedAttributes .= ' ' . $encodedAttributeName . ($allowEmpty ? '' : '=""');
+            } else {
+                if (is_array($attributeValue)) {
+                    $joinedAttributeValue = '';
+                    foreach ($attributeValue as $attributeValuePart) {
+                        if ((string)$attributeValuePart !== '') {
+                            $joinedAttributeValue .= ' ' . trim($attributeValuePart);
+                        }
+                    }
+                    $attributeValue = trim($joinedAttributeValue);
+                }
+                $encodedAttributeValue = htmlspecialchars((string)$attributeValue, ENT_COMPAT, 'UTF-8', false);
+                $renderedAttributes .= ' ' . $encodedAttributeName . '="' . $encodedAttributeValue . '"';
+            }
+        }
+        return $renderedAttributes;
+    }
+}

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -13,7 +13,6 @@ namespace Neos\Fusion\Tests\Unit\Service;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Service\HtmlAugmenter;
-use Neos\Neos\Exception;
 
 /**
  * Testcase for the HTML Augmenter
@@ -59,6 +58,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['object' => $mockObject],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div object="casted value"></div>'
             ],
 
@@ -68,6 +68,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div class="new-class"></div>',
             ],
             [
@@ -75,6 +76,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div class="new-class">   	' . chr(10) . '  </div>',
             ],
 
@@ -84,6 +86,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'some-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div class="some-class">Plain Text without html</div>',
             ],
 
@@ -93,6 +96,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p class="new-class">Simple HTML with unique root element</p>',
             ],
             [
@@ -100,6 +104,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div class="new-class"><p>Simple HTML without</p><p> unique root element</p></div>',
             ],
             [
@@ -107,6 +112,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<div class="new-class">Plain text and simple HTML without<p> unique root element</p></div>',
             ],
             [
@@ -114,6 +120,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'some-class'],
                 'fallbackTagName' => 'fallback-tag',
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '   <p class="some-class">Simple HTML with unique root element in whitespace</p>   ',
             ],
             [
@@ -121,6 +128,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'some-class'],
                 'fallbackTagName' => 'fallback-tag',
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<fallback-tag class="some-class"><p class="some-class">Simple HTML without</p><p> unique root element</p></fallback-tag>',
             ],
             [
@@ -128,6 +136,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['type' => 'new-type'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<script type="new-type">console.log("Script tag with unique root element");</script>',
             ],
 
@@ -137,6 +146,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'new-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<root class="new-class some-class">merging attributes</root>',
             ],
             [
@@ -144,35 +154,40 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['class' => 'some-class'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<root class="some-class">similar attribute value</root>',
             ],
             [
                 'html' => '<root data-foo="">empty attribute value</root>',
-                'attributes' => ['data-bar' => null],
+                'attributes' => ['data-bar' => true],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
-                'expectedResult' => '<root data-bar data-foo="">empty attribute value</root>',
+                'allowEmpty' => true,
+                'expectedResult' => '<root data-bar data-foo>empty attribute value</root>',
             ],
             [
                 'html' => '<root data-foo="">empty attribute value, overridden</root>',
-                'attributes' => ['data-foo' => null],
+                'attributes' => ['data-foo' => true],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => false,
                 'expectedResult' => '<root data-foo="">empty attribute value, overridden</root>',
             ],
             [
                 'html' => '<root data-foo>omitted attribute value</root>',
-                'attributes' => ['data-bar' => null],
+                'attributes' => ['data-bar' => true],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<root data-bar data-foo>omitted attribute value</root>',
             ],
             [
                 'html' => '<root data-foo>omitted attribute value, overridden</root>',
-                'attributes' => ['data-foo' => ''],
+                'attributes' => ['data-foo' => true],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
-                'expectedResult' => '<root data-foo="">omitted attribute value, overridden</root>',
+                'allowEmpty' => true,
+                'expectedResult' => '<root data-foo>omitted attribute value, overridden</root>',
             ],
 
             // attribute encoding
@@ -181,13 +196,15 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-bar' => '<&"'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p data-bar="&lt;&amp;&quot;" data-foo="&amp;">invalid characters are encoded</p>',
             ],
             [
                 'html' => '<p data-foo="&quot;&gt;&amp;">encoded entities are preserved</p>',
-                'attributes' => ['data-bar' => null],
+                'attributes' => ['data-bar' => true],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p data-bar data-foo="&quot;&gt;&amp;">encoded entities are preserved</p>',
             ],
             [
@@ -196,6 +213,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-bar' => 'öäüß'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p data-bar="öäüß" data-foo="öäüß">valid characters are decoded</p>',
             ],
             [
@@ -203,6 +221,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-bar' => 'öäüß🦆'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p data-bar="öäüß🦆" data-foo="öäüß🦆">valid characters are untouched</p>',
             ],
 
@@ -212,6 +231,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-foo' => 'bar'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => ['data-foo'],
+                'allowEmpty' => true,
                 'expectedResult' => '<div data-foo="bar"><p data-foo="foo">exclusive attributes force new root element</p></div>',
             ],
             [
@@ -219,6 +239,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['dAtA-fOO' => 'bar'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => ['data-foo'],
+                'allowEmpty' => true,
                 'expectedResult' => '<div dAtA-fOO="bar"><p DaTa-Foo="foo">exclusive attributes are checked case insensitive</p></div>',
             ],
             [
@@ -226,6 +247,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['some-attribute' => 'value'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => ['some-attribute'],
+                'allowEmpty' => true,
                 'expectedResult' => '<div some-attribute="value"><div some-attribute>no attribute value is required to make an attribute exclusive</div></div>',
             ],
             // Escaping possible preg_replace placeholders in attributes
@@ -234,7 +256,93 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-label' => 'Cost $0.00'],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
+                'allowEmpty' => true,
                 'expectedResult' => '<p data-label="Cost $0.00">Simple HTML with unique root element</p>',
+            ],
+            // Adding of empty string attributes
+            [
+                'html' => '<p>Empty attribute</p>',
+                'attributes' => ['data-att' => ''],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-att>Empty attribute</p>',
+            ],
+            // Adding of empty string attributes
+            [
+                'html' => '<p>Empty attribute</p>',
+                'attributes' => ['data-att' => ''],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => false,
+                'expectedResult' => '<p data-att="">Empty attribute</p>',
+            ],
+            // Adding of boolean attributes
+            [
+                'html' => '<p>Boolean attribute</p>',
+                'attributes' => ['data-bool' => true],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-bool>Boolean attribute</p>',
+            ],
+            [
+                'html' => '<p>Boolean attribute</p>',
+                'attributes' => ['data-bool' => true],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => false,
+                'expectedResult' => '<p data-bool="">Boolean attribute</p>',
+            ],
+            [
+                'html' => '<p>Boolean attribute</p>',
+                'attributes' => ['data-bool' => false],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p>Boolean attribute</p>',
+            ],
+            [
+                'html' => '<p>Boolean attribute</p>',
+                'attributes' => ['data-bool' => false],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => false,
+                'expectedResult' => '<p>Boolean attribute</p>',
+            ],
+            // Adding of null attributes
+            [
+                'html' => '<p>Null attribute</p>',
+                'attributes' => ['data-null' => null],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p>Null attribute</p>',
+            ],
+            [
+                'html' => '<p>Null attribute</p>',
+                'attributes' => ['data-null' => null],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => false,
+                'expectedResult' => '<p>Null attribute</p>',
+            ],
+            // Adding of array attributes
+            [
+                'html' => '<p>Array attribute</p>',
+                'attributes' => ['class' => ["Hello", "world"]],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p class="Hello world">Array attribute</p>',
+            ],
+            [
+                'html' => '<p>Array attribute</p>',
+                'attributes' => ['class' => []],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p class="">Array attribute</p>',
             ]
         ];
     }
@@ -243,13 +351,6 @@ class HtmlAugmenterTest extends UnitTestCase
     {
         return [
             // invalid attributes
-            [
-                'html' => '',
-                'attributes' => ['data-foo' => []],
-                'fallbackTagName' => null,
-                'exclusiveAttributes' => null,
-                'expectedResult' => '<root>array value ignored</root>',
-            ],
             [
                 'html' => '',
                 'attributes' => ['data-foo' => (object)[]],
@@ -265,16 +366,17 @@ class HtmlAugmenterTest extends UnitTestCase
      * @param array $attributes
      * @param string $fallbackTagName
      * @param string $expectedResult
+     * @param bool $allowEmpty
      * @param array $exclusiveAttributes
      * @test
      * @dataProvider addAttributesDataProvider
      */
-    public function addAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes, $expectedResult)
+    public function addAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty, $expectedResult)
     {
         if ($fallbackTagName === null) {
             $fallbackTagName = 'div';
         }
-        $actualResult = $this->htmlAugmenter->addAttributes($html, $attributes, $fallbackTagName, $exclusiveAttributes);
+        $actualResult = $this->htmlAugmenter->addAttributes($html, $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty);
         self::assertSame($expectedResult, $actualResult);
     }
 
@@ -283,12 +385,13 @@ class HtmlAugmenterTest extends UnitTestCase
      * @param array $attributes
      * @param string $fallbackTagName
      * @param array $exclusiveAttributes
+     * @param bool $allowEmpty
      * @test
      * @dataProvider invalidAttributesDataProvider
      */
-    public function invalidAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes)
+    public function invalidAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty)
     {
-        $this->expectException(Exception::class);
-        $this->addAttributesTests($html, $attributes, $fallbackTagName, $exclusiveAttributes, null);
+        $this->expectException(\Error::class);
+        $this->addAttributesTests($html, $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty, null);
     }
 }


### PR DESCRIPTION
The rendering of html-attributes is centralized with a trait to ensure that Neos.Fusion:Tag, Neos.Fusion:Augmenter and Neos.Fusion:Attributes behave identical.

This causes a minimal change in behavior of the Augmenter for attributes that are set to null. The old implementation created empty tag-attributes for `null` values. Now `null`  and `false` cause an attribute to be omitted while `true` renders an attribute without value or an empty value depending on the `allowEmptyAttributes` setting. 

Since this is quite esoteric we consider the change to be minor and consider the unified behavior correct.

resolves: #3582

**Review instructions**

The tests for the html augmenter are adjusted to since the meaning of null has changed slightly.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
