### PR TITLE
FEATURE: Allow non eel labels in nodetypes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
@@ -66,7 +66,7 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
     }
 
     /**
-     * Render a node label
+     * Render a node label based on an eel expression or return the expression if it is not valid eel.
      *
      * @param \Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node
      * @return string
@@ -74,6 +74,9 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
      */
     public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node): string
     {
+        if (Utility::parseEelExpression($this->getExpression()) === null) {
+            return $this->getExpression();
+        }
         return (string)Utility::evaluateEelExpression($this->getExpression(), $this->eelEvaluator, ['node' => $node], $this->defaultContextConfiguration);
     }
 }

--- a/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.ContentRepository/Configuration/Testing/NodeTypes.yaml
@@ -199,3 +199,9 @@
       type: string
     someDate:
       type: DateTime
+
+'Neos.ContentRepository.Testing:NodeTypeWithPlainLabel':
+  label: 'Test nodetype'
+
+'Neos.ContentRepository.Testing:NodeTypeWithEelExpressionLabel':
+  label: '${"Test" + " " + "nodetype"}'

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -1063,6 +1063,23 @@ class NodesTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function getLabelReturnsParsedEelExpressionOrFallback()
+    {
+        $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $nodeTypeWithPlainLabel = $nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithPlainLabel');
+        $nodeTypeWithEelExpressionLabel = $nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithEelExpressionLabel');
+
+        $rootNode = $this->context->getNode('/');
+        $nodeWithPlainLabel = $rootNode->createNode('node-plain', $nodeTypeWithPlainLabel, '30e893c1-caef-0ca5-b53d-e5699bb8e506');
+        $nodeWithEelExpressionLabel = $rootNode->createNode('node-eel', $nodeTypeWithEelExpressionLabel, '81c848ed-abb5-7608-a5db-7eea0331ccfa');
+
+        self::assertEquals('Test nodetype', $nodeWithPlainLabel->getLabel());
+        self::assertEquals('Test nodetype', $nodeWithEelExpressionLabel->getLabel());
+    }
+
+    /**
+     * @test
+     */
     public function nodesCanBeCopiedAfterAndBeforeAndKeepProperties()
     {
         $rootNode = $this->context->getNode('/');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -371,7 +371,7 @@ class NodeDataTest extends UnitTestCase
 
         self::assertEquals('unstructured', $this->nodeData->getNodeType()->getName());
 
-        $myNodeType = $mockNodeTypeManager->getNodeType('typo3:mycontent');
+        $myNodeType = $mockNodeTypeManager->getNodeType('neos:mycontent');
         $this->nodeData->setNodeType($myNodeType);
         self::assertEquals($myNodeType, $this->nodeData->getNodeType());
     }


### PR DESCRIPTION
Previously only valid eel expressions were allowed as the main label for a nodetypes.
Now the label just be returned if it doesn’t match the eel pattern and not throw an eel exception anymore.

Resolves: #4082

**Upgrade instructions**

n/a

**Review instructions**

Set a plain label in a nodetype instead of an eel expression (not ui.label)

```yaml
My.Vendor:NodeType:
  label: 'Hello world'
```

And check the included tests

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
