### PR TITLE
9.0: BUGFIX: fix selecting node(s) in `ReferenceEditor` / `ReferencesEditor`

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -26,9 +26,9 @@
                             </f:if>
                         </f:alias>
                         <label class="node-label">{node.label}</label>
-                        (<span class="node-identifier">{node.identifier}</span>)
+                        (<span class="node-identifier">{node.nodeAggregateId}</span>)
                         [<span class="node-type">{node.nodeType.name}</span>]
-                        <f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.identifier}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
+                        <f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.nodeAggregateId}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
                     </li>
                 </f:for>
             </ul>

--- a/Neos.Neos/Resources/Private/Templates/Service/Nodes/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Nodes/Show.html
@@ -13,7 +13,7 @@
                     <caption>{neos:backend.translate(id: 'service.nodes.nodeProperties', value: 'Node Properties')}</caption>
                     <tr>
                         <th>_identifier</th>
-                        <td class="node-identifier">{node.identifier}</td>
+                        <td class="node-identifier">{node.nodeAggregateId}</td>
                     </tr>
                     <tr>
                         <th>_path</th>


### PR DESCRIPTION
**Review instructions**

Steps to Reproduce:
1. Define NodeType with property of type `reference` or `references` (restirct `nodeTypes` e.g. to `Neos.Neos:Document`) 
2. Search for a page in your installation

Before bugfix: Throws an error while trying to render the `Show` template file.

After bugfix: Will show list of search results as in previous Neos versions. 

Additional changes: I search for additional usages of `node.identifier` in templates of `Neos\Neos\Controller\Service\NodesController`.

⚠️ Needs to be merged before/together with neos/neos-ui#3432

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
