### PR TITLE
FEATURE: Add count* queries to Content Subgraph

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -472,6 +472,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $queryBuilder;
     }
 
+    /**
+     * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
+     */
     private function buildDescendantNodesQueries(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter|CountDescendantNodesFilter $filter): array
     {
         $queryBuilderInitial = $this->createQueryBuilder()

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
@@ -26,6 +26,7 @@ use Neos\ContentGraph\PostgreSQLAdapter\Infrastructure\PostgresDbalClientInterfa
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
@@ -127,6 +128,12 @@ final class ContentSubhypergraph implements ContentSubgraphInterface
         );
     }
 
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\CountChildNodesFilter $filter): int
+    {
+        // TODO: Implement countChildNodes() method.
+        return 0;
+    }
+
     public function findReferences(
         NodeAggregateId $nodeAggregateId,
         FindReferencesFilter $filter
@@ -156,6 +163,12 @@ final class ContentSubhypergraph implements ContentSubgraphInterface
             $referenceRows,
             $this->visibilityConstraints
         );
+    }
+
+    public function countReferences(NodeAggregateId $nodeAggregateId, Filter\CountReferencesFilter $filter): int
+    {
+        // TODO: Implement countReferences() method.
+        return 0;
     }
 
     public function findBackReferences(
@@ -188,6 +201,12 @@ final class ContentSubhypergraph implements ContentSubgraphInterface
             $referenceRows,
             $this->visibilityConstraints
         );
+    }
+
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, Filter\CountBackReferencesFilter $filter): int
+    {
+        // TODO: Implement countBackReferences() method.
+        return 0;
     }
 
     public function findParentNode(NodeAggregateId $childNodeAggregateId): ?Node
@@ -406,6 +425,13 @@ final class ContentSubhypergraph implements ContentSubgraphInterface
         FindDescendantNodesFilter $filter
     ): Nodes {
         return Nodes::createEmpty();
+    }
+
+
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int
+    {
+        // TODO: Implement countDescendantNodes() method.
+        return 0;
     }
 
     /**

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountBackReferences.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountBackReferences.feature
@@ -1,5 +1,6 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
-Feature: Find nodes using the findBackReferences query
+@contentrepository @adapters=DoctrineDBAL
+ # TODO implement for Postgres
+Feature: Count nodes using the countBackReferences query
 
   Background:
     Given I have the following content dimensions:
@@ -123,16 +124,16 @@ Feature: Find nodes using the findBackReferences query
       | nodeVariantSelectionStrategy | "allVariants" |
     And the graph projection is fully up to date
 
-  Scenario: findBackReferences queries without results
-    When I execute the findBackReferences query for node aggregate id "non-existing" I expect no references to be returned
-    When I execute the findBackReferences query for node aggregate id "home" I expect no references to be returned
+  Scenario: countBackReferences queries with empty results
+    When I execute the countBackReferences query for node aggregate id "non-existing" I expect the result 0
+    When I execute the countBackReferences query for node aggregate id "home" I expect the result 0
     # "a2" is references node "a2a3" but "a2a3" is disabled so this reference should be ignored
-    When I execute the findBackReferences query for node aggregate id "a2" I expect no references to be returned
+    When I execute the countBackReferences query for node aggregate id "a2" I expect the result 0
     # "a2a3" is references node "a2" but "a2a3" is disabled so this reference should be ignored
-    When I execute the findBackReferences query for node aggregate id "a2a3" I expect no references to be returned
-    When I execute the findBackReferences query for node aggregate id "a" and filter '{"referenceName": "non-existing"}' I expect no references to be returned
+    When I execute the countBackReferences query for node aggregate id "a2a3" I expect the result 0
+    When I execute the countBackReferences query for node aggregate id "a" and filter '{"referenceName": "non-existing"}' I expect the result 0
 
-  Scenario: findBackReferences queries with results
-    When I execute the findBackReferences query for node aggregate id "a" I expect the references '[{"nodeAggregateId": "b1", "name": "ref", "properties": null}]' to be returned
-    When I execute the findBackReferences query for node aggregate id "a3" and filter '{"referenceName": "refs"}' I expect the references '[{"nodeAggregateId": "b", "name": "refs", "properties": {"foo": {"value": "bar", "type": "string"}}}]' to be returned
-    When I execute the findBackReferences query for node aggregate id "b1" I expect the references '[{"nodeAggregateId": "a", "name": "refs", "properties": {"foo": {"value": "bar", "type": "string"}}}, {"nodeAggregateId": "c", "name": "refs", "properties": {"foo": {"value": "foos", "type": "string"}}}]' to be returned
+  Scenario: countBackReferences queries with results
+    When I execute the countBackReferences query for node aggregate id "a" I expect the result 1
+    When I execute the countBackReferences query for node aggregate id "a3" and filter '{"referenceName": "refs"}' I expect the result 1
+    When I execute the countBackReferences query for node aggregate id "b1" I expect the result 2

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountChildNodes.feature
@@ -1,0 +1,91 @@
+@contentrepository @adapters=DoctrineDBAL
+ # TODO implement for Postgres
+Feature: Count nodes using the countChildNodes query
+
+  Background:
+    Given I have the following content dimensions:
+      | Identifier | Values          | Generalizations      |
+      | language   | mul, de, en, ch | ch->de->mul, en->mul |
+    And I have the following NodeTypes configuration:
+    """
+    'Neos.ContentRepository:Root': []
+    'Neos.ContentRepository.Testing:AbstractPage':
+      abstract: true
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:SomeMixin':
+      abstract: true
+    'Neos.ContentRepository.Testing:Homepage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      childNodes:
+        terms:
+          type: 'Neos.ContentRepository.Testing:Terms'
+        contact:
+          type: 'Neos.ContentRepository.Testing:Contact'
+
+    'Neos.ContentRepository.Testing:Terms':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      properties:
+        text:
+          defaultValue: 'Terms default'
+    'Neos.ContentRepository.Testing:Contact':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+        'Neos.ContentRepository.Testing:SomeMixin': true
+      properties:
+        text:
+          defaultValue: 'Contact default'
+    'Neos.ContentRepository.Testing:Page':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    'Neos.ContentRepository.Testing:SpecialPage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    """
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
+      | home            | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
+      | a               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a"}         | {}                                       |
+      | a1              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1"}        | {}                                       |
+      | a2              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2"}        | {}                                       |
+      | a2a             | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}       | {}                                       |
+      | a2a1            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1"}      | {}                                       |
+      | a2a2            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2"}      | {}                                       |
+      | a2a3            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a3"}      | {}                                       |
+      | b               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
+      | b1              | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "a2a3"             |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+    And the graph projection is fully up to date
+
+  Scenario: Child nodes without filter
+    When I execute the countChildNodes query for parent node aggregate id "home" I expect the result 4
+    When I execute the countChildNodes query for parent node aggregate id "a" I expect the result 2
+    When I execute the countChildNodes query for parent node aggregate id "a1" I expect the result 0
+    When I execute the countChildNodes query for parent node aggregate id "a2a" I expect the result 2
+
+  Scenario: Child nodes filtered by node type
+    When I execute the countChildNodes query for parent node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:AbstractPage"}' I expect the result 4
+    When I execute the countChildNodes query for parent node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:SomeMixin"}' I expect the result 1
+    When I execute the countChildNodes query for parent node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:SomeMixin"}' I expect the result 1
+    When I execute the countChildNodes query for parent node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:AbstractPage,!Neos.ContentRepository.Testing:SomeMixin"}' I expect the result 3
+    When I execute the countChildNodes query for parent node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:NonExistingNodeType"}' I expect the result 0

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountDescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountDescendantNodes.feature
@@ -1,0 +1,90 @@
+@contentrepository @adapters=DoctrineDBAL
+  # TODO implement for Postgres
+Feature: Count nodes using the countDescendantNodes query
+
+  Background:
+    Given I have the following content dimensions:
+      | Identifier | Values          | Generalizations      |
+      | language   | mul, de, en, ch | ch->de->mul, en->mul |
+    And I have the following NodeTypes configuration:
+    """
+    'Neos.ContentRepository:Root': []
+    'Neos.ContentRepository.Testing:AbstractPage':
+      abstract: true
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:SomeMixin':
+      abstract: true
+    'Neos.ContentRepository.Testing:Homepage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      childNodes:
+        terms:
+          type: 'Neos.ContentRepository.Testing:Terms'
+        contact:
+          type: 'Neos.ContentRepository.Testing:Contact'
+
+    'Neos.ContentRepository.Testing:Terms':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      properties:
+        text:
+          defaultValue: 'Terms default'
+    'Neos.ContentRepository.Testing:Contact':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+        'Neos.ContentRepository.Testing:SomeMixin': true
+      properties:
+        text:
+          defaultValue: 'Contact default'
+    'Neos.ContentRepository.Testing:Page':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    'Neos.ContentRepository.Testing:SpecialPage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    """
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
+      | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
+      | a               | a        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a"}         | {}                                       |
+      | a1              | a1       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1"}        | {}                                       |
+      | a2              | a2       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2"}        | {}                                       |
+      | a2a             | a2a      | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}       | {}                                       |
+      | a2a1            | a2a1     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1"}      | {}                                       |
+      | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2"}      | {}                                       |
+      | a2a2a           | a2a2a    | Neos.ContentRepository.Testing:Page        | a2a2                   | {"text": "a2a2a"}     | {}                                       |
+      | a3              | a3       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a3"}        | {}                                       |
+      | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
+      | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2a2a"       |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And the graph projection is fully up to date
+
+
+  Scenario: countDescendantNodes queries with empty results
+    When I execute the countDescendantNodes query for entry node aggregate id "non-existing" I expect the result to be 0
+    When I execute the countDescendantNodes query for entry node aggregate id "home" and filter '{"searchTerm": "a2a2a"}' I expect the result to be 0
+    When I execute the countDescendantNodes query for entry node aggregate id "home" and filter '{"searchTerm": "string"}' I expect the result to be 0
+
+  Scenario: countDescendantNodes queries with results
+    When I execute the countDescendantNodes query for entry node aggregate id "home" I expect the result to be 11
+    When I execute the countDescendantNodes query for entry node aggregate id "home" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:Page"}' I expect the result to be 8
+    When I execute the countDescendantNodes query for entry node aggregate id "home" and filter '{"searchTerm": "a2"}' I expect the result to be 4

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountReferences.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountReferences.feature
@@ -1,0 +1,142 @@
+@contentrepository @adapters=DoctrineDBAL
+ # TODO implement for Postgres
+Feature: Count nodes using the countReferences query
+
+  Background:
+    Given I have the following content dimensions:
+      | Identifier | Values          | Generalizations      |
+      | language   | mul, de, en, ch | ch->de->mul, en->mul |
+    And I have the following NodeTypes configuration:
+    """
+    'Neos.ContentRepository:Root': []
+    'Neos.ContentRepository.Testing:AbstractPage':
+      abstract: true
+      properties:
+        text:
+          type: string
+        refs:
+          type: references
+          properties:
+            foo:
+              type: string
+        ref:
+          type: reference
+          properties:
+            foo:
+              type: string
+    'Neos.ContentRepository.Testing:SomeMixin':
+      abstract: true
+    'Neos.ContentRepository.Testing:Homepage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      childNodes:
+        terms:
+          type: 'Neos.ContentRepository.Testing:Terms'
+        contact:
+          type: 'Neos.ContentRepository.Testing:Contact'
+
+    'Neos.ContentRepository.Testing:Terms':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      properties:
+        text:
+          defaultValue: 'Terms default'
+    'Neos.ContentRepository.Testing:Contact':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+        'Neos.ContentRepository.Testing:SomeMixin': true
+      properties:
+        text:
+          defaultValue: 'Contact default'
+    'Neos.ContentRepository.Testing:Page':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    'Neos.ContentRepository.Testing:SpecialPage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    """
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
+      | home            | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
+      | c               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "c"}         | {}                                       |
+      | a               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a"}         | {}                                       |
+      | a1              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1"}        | {}                                       |
+      | a2              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2"}        | {}                                       |
+      | a2a             | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}       | {}                                       |
+      | a2a1            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1"}      | {}                                       |
+      | a2a2            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2"}      | {}                                       |
+      | a2a3            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a3"}      | {}                                       |
+      | b               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
+      | b1              | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                |
+      | sourceNodeAggregateId | "a"                                  |
+      | referenceName         | "refs"                               |
+      | references            | [{"target":"b1"}, {"target":"a2a2"}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value            |
+      | sourceNodeAggregateId | "b1"             |
+      | referenceName         | "ref"            |
+      | references            | [{"target":"a"}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                                                                            |
+      | sourceNodeAggregateId | "b"                                                                                              |
+      | referenceName         | "refs"                                                                                           |
+      | references            | [{"target":"a2", "properties": {"foo": "bar"}}, {"target":"a2a1", "properties": {"foo": "baz"}}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                           |
+      | sourceNodeAggregateId | "a"                                             |
+      | referenceName         | "ref"                                           |
+      | references            | [{"target":"b1", "properties": {"foo": "bar"}}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value               |
+      | sourceNodeAggregateId | "a2"                |
+      | referenceName         | "ref"               |
+      | references            | [{"target":"a2a3"}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value             |
+      | sourceNodeAggregateId | "a2a3"            |
+      | referenceName         | "ref"             |
+      | references            | [{"target":"a2"}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                            |
+      | sourceNodeAggregateId | "c"                                              |
+      | referenceName         | "refs"                                           |
+      | references            | [{"target":"b1", "properties": {"foo": "foos"}}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value            |
+      | sourceNodeAggregateId | "c"              |
+      | referenceName         | "ref"            |
+      | references            | [{"target":"b"}] |
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2a3"        |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And the graph projection is fully up to date
+
+  Scenario: countReferences queries with empty results
+    When I execute the countReferences query for node aggregate id "a" and filter '{"referenceName": "non-existing"}' I expect the result 0
+    When I execute the countReferences query for node aggregate id "non-existing" I expect the result 0
+    # "a2" is referenced by "a2a3" but "a2a3" is disabled so this reference should be ignored
+    When I execute the countReferences query for node aggregate id "a2" I expect the result 0
+    # "a2a3" is referenced by "a2" but "a2a3" is disabled so this reference should be ignored
+    When I execute the countReferences query for node aggregate id "a2a3" I expect the result 0
+
+  Scenario: countReferences queries with results
+    When I execute the countReferences query for node aggregate id "a" I expect the result 3
+    When I execute the countReferences query for node aggregate id "a" and filter '{"referenceName": "ref"}' I expect the result 1
+    When I execute the countReferences query for node aggregate id "c" I expect the result 2

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphWithRuntimeCaches;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
@@ -69,16 +70,37 @@ final class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
         return $childNodes;
     }
 
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\CountChildNodesFilter $filter): int
+    {
+        $childNodesCache = $this->inMemoryCache->getAllChildNodesByNodeIdCache();
+        if ($childNodesCache->contains($parentNodeAggregateId, $filter->nodeTypeConstraints)) {
+            return $childNodesCache->countChildNodes($parentNodeAggregateId, $filter->nodeTypeConstraints);
+        }
+        return $this->wrappedContentSubgraph->countChildNodes($parentNodeAggregateId, $filter);
+    }
+
     public function findReferences(NodeAggregateId $nodeAggregateId, FindReferencesFilter $filter): References
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findReferences($nodeAggregateId, $filter);
     }
 
+    public function countReferences(NodeAggregateId $nodeAggregateId, Filter\CountReferencesFilter $filter): int
+    {
+        // TODO: implement runtime caches
+        return $this->wrappedContentSubgraph->countReferences($nodeAggregateId, $filter);
+    }
+
     public function findBackReferences(NodeAggregateId $nodeAggregateId, FindBackReferencesFilter $filter): References
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findBackReferences($nodeAggregateId, $filter);
+    }
+
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, Filter\CountBackReferencesFilter $filter): int
+    {
+        // TODO: implement runtime caches
+        return $this->wrappedContentSubgraph->countBackReferences($nodeAggregateId, $filter);
     }
 
     public function findNodeById(NodeAggregateId $nodeAggregateId): ?Node
@@ -178,6 +200,12 @@ final class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findDescendantNodes($entryNodeAggregateId, $filter);
+    }
+
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int
+    {
+        // TODO: implement runtime caches
+        return $this->wrappedContentSubgraph->countDescendantNodes($entryNodeAggregateId, $filter);
     }
 
     public function countNodes(): int

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/InMemoryCache/AllChildNodesByNodeIdCache.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/InMemoryCache/AllChildNodesByNodeIdCache.php
@@ -68,4 +68,11 @@ final class AllChildNodesByNodeIdCache
         $nodeTypeConstraintsKey = $nodeTypeConstraints !== null ? (string)$nodeTypeConstraints : '*';
         return $this->childNodes[$parentNodeAggregateId->value][$nodeTypeConstraintsKey] ?? Nodes::createEmpty();
     }
+
+    public function countChildNodes(
+        NodeAggregateId $parentNodeAggregateId,
+        ?NodeTypeConstraints $nodeTypeConstraints
+    ): int {
+        return $this->findChildNodes($parentNodeAggregateId, $nodeTypeConstraints)->count();
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
@@ -54,9 +54,15 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findNodeById(NodeAggregateId $nodeAggregateId): ?Node;
 
     /**
-     * Find direct child nodes of the specified parent node
+     * Find direct child nodes of the specified parent node that match the given $filter
      */
     public function findChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\FindChildNodesFilter $filter): Nodes;
+
+    /**
+     * Count direct child nodes of the specified parent node that match the given $filter
+     * @see findChildNodes
+     */
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\CountChildNodesFilter $filter): int;
 
     /**
      * Find the direct parent of a node specified by its aggregate id
@@ -90,6 +96,12 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindDescendantNodesFilter $filter): Nodes;
 
     /**
+     * Count all nodes underneath the $entryNodeAggregateId that match the specified $filter
+     * @see findDescendantNodes
+     */
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int;
+
+    /**
      * Recursively find all nodes underneath the $entryNodeAggregateId that match the specified $filter and return them as a tree
      *
      * Note: This returns a fragment of the existing tree structure. The structure is kept intact but nodes might be missing depending on the specified filter
@@ -109,12 +121,24 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findReferences(NodeAggregateId $nodeAggregateId, Filter\FindReferencesFilter $filter): References;
 
     /**
+     * Count all "outgoing" references of a given node that match the specified $filter
+     * @see findReferences
+     */
+    public function countReferences(NodeAggregateId $nodeAggregateId, Filter\CountReferencesFilter $filter): int;
+
+    /**
      * Find all "incoming" references of a given node that match the specified $filter
      * If nodes "A" and "B" both have a reference to "C", the node "C" has two incoming references.
      *
      * @see findReferences
      */
     public function findBackReferences(NodeAggregateId $nodeAggregateId, Filter\FindBackReferencesFilter $filter): References;
+
+    /**
+     * Count all "incoming" references of a given node that match the specified $filter
+     * @see findBackReferences
+     */
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, Filter\CountBackReferencesFilter $filter): int;
 
     /**
      * Find a single node underneath $startingNodeAggregateId that matches the specified $path

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::countBackReferences()}
+ *
+ * Example:
+ *
+ * // create a new instance and set reference name filter
+ * CountBackReferencesFilter::create()->with(referenceName: 'someName');
+ *
+ * // create an instance from an existing FindBackReferencesFilter instance
+ * CountBackReferencesFilter::fromFindBackReferencesFilter($filter);
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class CountBackReferencesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?ReferenceName $referenceName,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self(null);
+    }
+
+    public static function fromFindBackReferencesFilter(FindBackReferencesFilter $filter): self
+    {
+        return new self($filter->referenceName);
+    }
+
+    public static function referenceName(ReferenceName|string $referenceName): self
+    {
+        return self::create()->with(referenceName: $referenceName);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        ReferenceName|string $referenceName = null,
+    ): self {
+        if (is_string($referenceName)) {
+            $referenceName = ReferenceName::fromString($referenceName);
+        }
+        return new self(
+            $referenceName ?? $this->referenceName,
+        );
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
@@ -31,7 +31,7 @@ final class CountChildNodesFilter
 
     public static function create(): self
     {
-        return new self(null, null, null);
+        return new self(null);
     }
 
     public static function fromFindChildNodesFilter(FindChildNodesFilter $filter): self

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::countChildNodes()}
+ *
+ * Example:
+ *
+ * // create a new instance and set node type constraints
+ * CountChildNodesFilter::create()->with(nodeTypeConstraint: 'Some.Included:NodeType,!Some.Excluded:NodeType');
+ *
+ * // create an instance from an existing FindChildNodesFilter instance
+ * CountChildNodesFilter::fromFindChildNodesFilter($filter);
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class CountChildNodesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?NodeTypeConstraints $nodeTypeConstraints,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self(null, null, null);
+    }
+
+    public static function fromFindChildNodesFilter(FindChildNodesFilter $filter): self
+    {
+        return new self($filter->nodeTypeConstraints);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        NodeTypeConstraints|string $nodeTypeConstraints = null,
+    ): self {
+        if (is_string($nodeTypeConstraints)) {
+            $nodeTypeConstraints = NodeTypeConstraints::fromFilterString($nodeTypeConstraints);
+        }
+        return new self(
+            $nodeTypeConstraints ?? $this->nodeTypeConstraints,
+        );
+    }
+
+    public function withNodeTypeConstraints(NodeTypeConstraints|string $nodeTypeConstraints): self
+    {
+        return $this->with(nodeTypeConstraints: $nodeTypeConstraints);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
+use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::countDescendantNodes()}
+ *
+ * Example:
+ *
+ * // create a new instance and set node type constraints and search term
+ * CountDescendantNodesFilter::create()->with(nodeTypeConstraint: 'Some.Included:NodeType,!Some.Excluded:NodeType', searchTerm: 'foo');
+ *
+ * // create an instance from an existing FindChildNodesFilter instance
+ * CountDescendantNodesFilter::fromFindChildNodesFilter($filter);
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class CountDescendantNodesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?NodeTypeConstraints $nodeTypeConstraints,
+        public readonly ?SearchTerm $searchTerm,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self(null, null);
+    }
+
+    public static function fromFindDescendantNodesFilter(FindDescendantNodesFilter $filter): self
+    {
+        return new self($filter->nodeTypeConstraints, $filter->searchTerm);
+    }
+
+    public static function nodeTypeConstraints(NodeTypeConstraints|string $nodeTypeConstraints): self
+    {
+        return self::create()->with(nodeTypeConstraints: $nodeTypeConstraints);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        NodeTypeConstraints|string $nodeTypeConstraints = null,
+        SearchTerm|string $searchTerm = null,
+    ): self {
+        if (is_string($nodeTypeConstraints)) {
+            $nodeTypeConstraints = NodeTypeConstraints::fromFilterString($nodeTypeConstraints);
+        }
+        if (is_string($searchTerm)) {
+            $searchTerm = SearchTerm::fulltext($searchTerm);
+        }
+        return new self(
+            $nodeTypeConstraints ?? $this->nodeTypeConstraints,
+            $searchTerm ?? $this->searchTerm,
+        );
+    }
+
+    public function withSearchTerm(SearchTerm|string $searchTerm): self
+    {
+        return $this->with(searchTerm: $searchTerm);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::countReferences()}
+ *
+ * Example:
+ *
+ * // create a new instance and set reference name filter
+ * CountReferencesFilter::create()->with(referenceName: 'someName');
+ *
+ * // create an instance from an existing FindReferencesFilter instance
+ * CountReferencesFilter::fromFindReferencesFilter($filter);
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class CountReferencesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?ReferenceName $referenceName,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self(null);
+    }
+
+    public static function fromFindReferencesFilter(FindReferencesFilter $filter): self
+    {
+        return new self($filter->referenceName);
+    }
+
+    public static function referenceName(ReferenceName|string $referenceName): self
+    {
+        return self::create()->with(referenceName: $referenceName);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        ReferenceName|string $referenceName = null,
+    ): self {
+        if (is_string($referenceName)) {
+            $referenceName = ReferenceName::fromString($referenceName);
+        }
+        return new self(
+            $referenceName ?? $this->referenceName,
+        );
+    }
+}


### PR DESCRIPTION
Extends the `ContentSubgraphInterface` by the following four methods:
* `countChildNodes()`
* `countDescendantNodes()`
* `countReferences()`
* `countBackReferences()`

## Example

```php
$filter = FindChildNodesFilter::create()
    ->with(nodeTypeConstraint: 'Some.Included:NodeType')
    ->withPagination($limit, $offset);

$countFilter = CountChildNodesFilter::fromFindChildNodesFilter($filter);

$totalResults = $subgraph->countChildNodes($parentNodeAggregateId, $countFilter);
$paginatedNodes = $subgraph->findChildNodes($parentNodeAggregateId, $filter);
```

Related: #4075