### PR TITLE
FEATURE: Assets Eel helper for Neos.Media

### DIFF
--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -51,10 +51,15 @@ class AssetsHelper implements ProtectedContextAwareInterface
     protected $assetCollectionRepository;
 
     /**
-     * @return QueryResultInterface<AssetInterface> | null
+     * @return QueryResultInterface | null
+     * @throws InvalidQueryException
      */
-    public function findByTag(?Tag $tag): ?QueryResultInterface
+    public function findByTag(Tag|string|null $tag): ?QueryResultInterface
     {
+        if (is_string($tag)) {
+            $tag = $this->tagRepository->findOneByLabel($tag);
+        }
+
         if (!$tag) {
             return null;
         }
@@ -64,43 +69,24 @@ class AssetsHelper implements ProtectedContextAwareInterface
     /**
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function findByTagLabel(?string $tagLabel): ?QueryResultInterface
+    public function findByCollection(AssetCollection|string|null $collection): ?QueryResultInterface
     {
-        if (!$tagLabel) {
-            return null;
+        if (is_string($collection)) {
+            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
         }
-        $tag = $this->tagRepository->findOneByLabel($tagLabel);
-        return $this->findByTag($tag);
-    }
 
-    /**
-     * @return QueryResultInterface<AssetInterface> | null
-     */
-    public function findByCollection(?AssetCollection $collection): ?QueryResultInterface
-    {
         if (!$collection) {
             return null;
         }
+
         return $this->assetRepository->findByAssetCollection($collection);
     }
 
     /**
+     * @param Tag[]|string[] $tags
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function findByCollectionTitle(?string $collectionTitle): ?QueryResultInterface
-    {
-        if (!$collectionTitle) {
-            return null;
-        }
-        $collection = $this->assetCollectionRepository->findOneByTitle($collectionTitle);
-        return $this->findByCollection($collection);
-    }
-
-    /**
-     * @param Tag[] $tags
-     * @return QueryResultInterface<AssetInterface> | null
-     */
-    public function search(string $searchTerm, array $tags = [], AssetCollection $collection = null): ?QueryResultInterface
+    public function search(?string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface
     {
         if (!$searchTerm) {
             return null;

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -83,7 +83,7 @@ class AssetsHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * @param Tag[]|string[] $tags
+     * @param Tag[] $tags
      * @return QueryResultInterface<AssetInterface> | null
      */
     public function search(?string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -32,7 +32,6 @@ use Neos\Media\Domain\Repository\TagRepository;
  */
 class AssetsHelper implements ProtectedContextAwareInterface
 {
-
     /**
      * @Flow\Inject
      * @var AssetRepository
@@ -54,55 +53,55 @@ class AssetsHelper implements ProtectedContextAwareInterface
     /**
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function findByTag(Tag|string $tag): ?QueryResultInterface
+    public function findByTag(?Tag $tag): ?QueryResultInterface
     {
-        if (is_string($tag)) {
-            $tag = $this->tagRepository->findOneByLabel($tag);
-        }
-
         if (!$tag) {
             return null;
         }
-
-        try {
-            return $this->assetRepository->findByTag($tag);
-        } catch (InvalidQueryException) {
-        }
-
-        return null;
+        return $this->assetRepository->findByTag($tag);
     }
 
     /**
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function findByCollection(AssetCollection|string $collection): ?QueryResultInterface
+    public function findByTagLabel(?string $tagLabel): ?QueryResultInterface
     {
-        if (is_string($collection)) {
-            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
+        if (!$tagLabel) {
+            return null;
         }
+        $tag = $this->tagRepository->findOneByLabel($tagLabel);
+        return $this->findByTag($tag);
+    }
 
+    /**
+     * @return QueryResultInterface<AssetInterface> | null
+     */
+    public function findByCollection(?AssetCollection $collection): ?QueryResultInterface
+    {
         if (!$collection) {
             return null;
         }
+        return $this->assetRepository->findByAssetCollection($collection);
+    }
 
-        try {
-            return $this->assetRepository->findByAssetCollection($collection);
-        } catch (InvalidQueryException) {
+    /**
+     * @return QueryResultInterface<AssetInterface> | null
+     */
+    public function findByCollectionTitle(?string $collectionTitle): ?QueryResultInterface
+    {
+        if (!$collectionTitle) {
+            return null;
         }
-
-        return null;
+        $collection = $this->assetCollectionRepository->findOneByTitle($collectionTitle);
+        return $this->findByCollection($collection);
     }
 
     /**
      * @param Tag[] $tags
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function findBySearchTerm(string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface
+    public function search(string $searchTerm, array $tags = [], AssetCollection $collection = null): ?QueryResultInterface
     {
-        if (is_string($collection)) {
-            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
-        }
-
         if (!$searchTerm) {
             return null;
         }

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -83,7 +83,7 @@ class AssetsHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * @param Tag[] $tags
+     * @param Tag[]|string[] $tags
      * @return QueryResultInterface<AssetInterface> | null
      */
     public function search(?string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface
@@ -91,6 +91,13 @@ class AssetsHelper implements ProtectedContextAwareInterface
         if (!$searchTerm) {
             return null;
         }
+
+        $tags = array_map(function ($tag) {
+            if (is_string($tag)) {
+                return $this->tagRepository->findOneByLabel($tag);
+            }
+            return $tag;
+        }, $tags);
 
         if (is_string($collection)) {
             $collection = $this->assetCollectionRepository->findOneByTitle($collection);

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -92,6 +92,10 @@ class AssetsHelper implements ProtectedContextAwareInterface
             return null;
         }
 
+        if (is_string($collection)) {
+            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
+        }
+
         try {
             return $this->assetRepository->findBySearchTermOrTags($searchTerm, $tags, $collection);
         } catch (InvalidQueryException) {

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Media\Eel;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Exception\InvalidQueryException;
+use Neos\Flow\Persistence\QueryResultInterface;
+use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\Tag;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
+use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Media\Domain\Repository\TagRepository;
+
+/**
+ * This is a helper for accessing assets from the media library
+ *
+ * @api
+ */
+class AssetsHelper implements ProtectedContextAwareInterface
+{
+
+    /**
+     * @Flow\Inject
+     * @var AssetRepository
+     */
+    protected $assetRepository;
+
+    /**
+     * @Flow\Inject
+     * @var TagRepository
+     */
+    protected $tagRepository;
+
+    /**
+     * @Flow\Inject
+     * @var AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+    /**
+     * @return QueryResultInterface<AssetInterface> | null
+     */
+    public function findByTag(Tag|string $tag): ?QueryResultInterface
+    {
+        if (is_string($tag)) {
+            $tag = $this->tagRepository->findOneByLabel($tag);
+        }
+
+        if (!$tag) {
+            return null;
+        }
+
+        try {
+            return $this->assetRepository->findByTag($tag);
+        } catch (InvalidQueryException) {
+        }
+
+        return null;
+    }
+
+    /**
+     * @return QueryResultInterface<AssetInterface> | null
+     */
+    public function findByCollection(AssetCollection|string $collection): ?QueryResultInterface
+    {
+        if (is_string($collection)) {
+            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
+        }
+
+        if (!$collection) {
+            return null;
+        }
+
+        try {
+            return $this->assetRepository->findByAssetCollection($collection);
+        } catch (InvalidQueryException) {
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Tag[] $tags
+     * @return QueryResultInterface<AssetInterface> | null
+     */
+    public function findBySearchTerm(string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface
+    {
+        if (is_string($collection)) {
+            $collection = $this->assetCollectionRepository->findOneByTitle($collection);
+        }
+
+        if (!$searchTerm) {
+            return null;
+        }
+
+        try {
+            return $this->assetRepository->findBySearchTermOrTags($searchTerm, $tags, $collection);
+        } catch (InvalidQueryException) {
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $methodName
+     */
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -119,3 +119,7 @@ Neos:
           options:
             namespaces:
               neos.media: Neos\Media\ViewHelpers
+
+  Fusion:
+    defaultContext:
+      Neos.Media.Assets: 'Neos\Media\Eel\AssetsHelper'

--- a/Neos.Media/Tests/Functional/Eel/AssetHelperTest.php
+++ b/Neos.Media/Tests/Functional/Eel/AssetHelperTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Neos\Media\Tests\Functional\Eel;
+
+/*
+ * This file is part of the Neos.Media package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
+use Neos\Media\Eel\AssetsHelper;
+use Neos\Utility\Files;
+use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\Tag;
+use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Media\Domain\Repository\TagRepository;
+use Neos\Media\Tests\Functional\AbstractTest;
+
+/**
+ * Testcase for the asset helper
+ *
+ */
+class AssetHelperTest extends AbstractTest
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var AssetRepository
+     */
+    protected $assetRepository;
+
+    /**
+     * @var TagRepository
+     */
+    protected $tagRepository;
+
+    /**
+     * @var AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        if (!$this->persistenceManager instanceof PersistenceManager) {
+            $this->markTestSkipped('Doctrine persistence is not enabled');
+        }
+        $this->prepareTemporaryDirectory();
+        $this->prepareResourceManager();
+
+        $this->assetRepository = $this->objectManager->get(AssetRepository::class);
+        $this->tagRepository = $this->objectManager->get(TagRepository::class);
+        $this->assetCollectionRepository = $this->objectManager->get(AssetCollectionRepository::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Files::removeDirectoryRecursively($this->temporaryDirectory);
+    }
+
+    /**
+     * @test
+     */
+    public function findByTagFindAssetsByTagLabel()
+    {
+        $fooTag = new Tag('foo');
+        $this->tagRepository->add($fooTag);
+
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for homepage');
+        $asset->addTag($fooTag);
+
+        $this->assetRepository->add($asset);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->findByTag('foo'));
+        self::assertNull($helper->findByTag('bar'));
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function findByTagFindAssetsByTagInstace()
+    {
+        $fooTag = new Tag('foo');
+        $this->tagRepository->add($fooTag);
+
+        $barTag = new Tag('bar');
+        $this->tagRepository->add($barTag);
+
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for homepage');
+        $asset->addTag($fooTag);
+
+        $this->assetRepository->add($asset);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->findByTag($fooTag));
+        self::assertCount(0, $helper->findByTag($barTag));
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function findByTagReturnsNullIfTagIsNull()
+    {
+        $helper = new AssetsHelper();
+        self::assertNull($helper->findByTag(null));
+    }
+
+    /**
+     * @test
+     */
+    public function findByCollectionReturnsAssetsForCollectionLabel()
+    {
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for foo');
+        $this->assetRepository->add($asset);
+
+        $fooCollection = new AssetCollection('foo');
+        $barCollection = new AssetCollection('bar');
+        $fooCollection->addAsset($asset);
+        $this->assetCollectionRepository->add($fooCollection);
+        $this->assetCollectionRepository->add($barCollection);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->findByCollection('foo'));
+        self::assertCount(0, $helper->findByCollection('bar'));
+        self::assertNull($helper->findByCollection(''));
+    }
+
+    /**
+     * @test
+     */
+    public function findByCollectionReturnsAssetsForCollectionInstace()
+    {
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for foo');
+        $this->assetRepository->add($asset);
+
+        $fooCollection = new AssetCollection('foo');
+        $barCollection = new AssetCollection('bar');
+        $fooCollection->addAsset($asset);
+        $this->assetCollectionRepository->add($fooCollection);
+        $this->assetCollectionRepository->add($barCollection);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->findByCollection($fooCollection));
+        self::assertCount(0, $helper->findByCollection($barCollection));
+        self::assertNull($helper->findByCollection(null));
+    }
+
+    /**
+     * @test
+     */
+    public function findByCollectionReturnsNullIfCollectionIsNull()
+    {
+        $helper = new AssetsHelper();
+        self::assertNull($helper->findByCollection(null));
+        self::assertNull($helper->findByCollection(''));
+    }
+
+    /**
+     * @test
+     */
+    public function searchWithoutSearchTermReturnsNull()
+    {
+        $helper = new AssetsHelper();
+        self::assertNull($helper->search(null));
+        self::assertNull($helper->search(''));
+    }
+
+    /**
+     * @test
+     */
+    public function searchWithSearchTermAndTagFindsAsset()
+    {
+        $fooTag = new Tag('foo');
+        $this->tagRepository->add($fooTag);
+
+        $barTag = new Tag('bar');
+        $this->tagRepository->add($barTag);
+
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $resource2 = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for foo');
+        $asset->addTag($fooTag);
+        $asset2 = new Asset($resource2);
+        $asset2->setTitle('Another asset');
+        $asset2->addTag($barTag);
+
+        $this->assetRepository->add($asset);
+        $this->assetRepository->add($asset2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->search('foo', [$fooTag]));
+        self::assertCount(2, $helper->search('asset', [$fooTag]));
+        self::assertCount(2, $helper->search('asset'));
+        self::assertCount(1, $helper->search('bar', [$barTag]));
+        self::assertCount(1, $helper->search('baz', [$barTag]));
+        self::assertCount(0, $helper->search('baz'));
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function searchWithSearchTermAndCollectionFindsAsset()
+    {
+        $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
+        $asset = new Asset($resource);
+        $asset->setTitle('asset for foo');
+        $this->assetRepository->add($asset);
+
+        $fooCollection = new AssetCollection('foo');
+        $barCollection = new AssetCollection('bar');
+        $fooCollection->addAsset($asset);
+        $this->assetCollectionRepository->add($fooCollection);
+        $this->assetCollectionRepository->add($barCollection);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $helper = new AssetsHelper();
+        self::assertCount(1, $helper->search('foo', [], $fooCollection));
+        self::assertCount(1, $helper->search('foo', [], 'foo'));
+        self::assertCount(0, $helper->search('foo', [], $barCollection));
+        self::assertCount(1, $helper->search('asset', [], null));
+        self::assertCount(1, $helper->search('asset'));
+        self::assertCount(0, $helper->search('baz'));
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+}

--- a/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
+++ b/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
@@ -27,7 +27,7 @@ use Neos\Media\Tests\Functional\AbstractTest;
  * Testcase for the asset helper
  *
  */
-class AssetHelperTest extends AbstractTest
+class AssetsHelperTest extends AbstractTest
 {
     /**
      * @var boolean
@@ -49,9 +49,6 @@ class AssetHelperTest extends AbstractTest
      */
     protected $assetCollectionRepository;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -66,9 +63,6 @@ class AssetHelperTest extends AbstractTest
         $this->assetCollectionRepository = $this->objectManager->get(AssetCollectionRepository::class);
     }
 
-    /**
-     * @return void
-     */
     public function tearDown(): void
     {
         parent::tearDown();
@@ -79,15 +73,15 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function findByTagFindAssetsByTagLabel()
+    public function findByTagFindAssetsByTagLabel(): void
     {
-        $fooTag = new Tag('foo');
-        $this->tagRepository->add($fooTag);
+        $tagA = new Tag('tagA');
+        $this->tagRepository->add($tagA);
 
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $asset = new Asset($resource);
         $asset->setTitle('asset for homepage');
-        $asset->addTag($fooTag);
+        $asset->addTag($tagA);
 
         $this->assetRepository->add($asset);
 
@@ -95,8 +89,8 @@ class AssetHelperTest extends AbstractTest
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->findByTag('foo'));
-        self::assertNull($helper->findByTag('bar'));
+        self::assertCount(1, $helper->findByTag('tagA'));
+        self::assertNull($helper->findByTag('tagB'));
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {
@@ -107,18 +101,18 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function findByTagFindAssetsByTagInstace()
+    public function findByTagFindAssetsByTagInstance(): void
     {
-        $fooTag = new Tag('foo');
-        $this->tagRepository->add($fooTag);
+        $tagA = new Tag('tagA');
+        $this->tagRepository->add($tagA);
 
-        $barTag = new Tag('bar');
-        $this->tagRepository->add($barTag);
+        $tagB = new Tag('tagB');
+        $this->tagRepository->add($tagB);
 
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $asset = new Asset($resource);
         $asset->setTitle('asset for homepage');
-        $asset->addTag($fooTag);
+        $asset->addTag($tagA);
 
         $this->assetRepository->add($asset);
 
@@ -126,8 +120,8 @@ class AssetHelperTest extends AbstractTest
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->findByTag($fooTag));
-        self::assertCount(0, $helper->findByTag($barTag));
+        self::assertCount(1, $helper->findByTag($tagA));
+        self::assertCount(0, $helper->findByTag($tagB));
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {
@@ -138,7 +132,7 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function findByTagReturnsNullIfTagIsNull()
+    public function findByTagReturnsNullIfTagIsNull(): void
     {
         $helper = new AssetsHelper();
         self::assertNull($helper->findByTag(null));
@@ -147,57 +141,57 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function findByCollectionReturnsAssetsForCollectionLabel()
+    public function findByCollectionReturnsAssetsForCollectionLabel(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $asset = new Asset($resource);
-        $asset->setTitle('asset for foo');
+        $asset->setTitle('asset for tagA');
         $this->assetRepository->add($asset);
 
-        $fooCollection = new AssetCollection('foo');
-        $barCollection = new AssetCollection('bar');
-        $fooCollection->addAsset($asset);
-        $this->assetCollectionRepository->add($fooCollection);
-        $this->assetCollectionRepository->add($barCollection);
+        $tagACollection = new AssetCollection('tagA');
+        $tagBCollection = new AssetCollection('tagB');
+        $tagACollection->addAsset($asset);
+        $this->assetCollectionRepository->add($tagACollection);
+        $this->assetCollectionRepository->add($tagBCollection);
 
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->findByCollection('foo'));
-        self::assertCount(0, $helper->findByCollection('bar'));
+        self::assertCount(1, $helper->findByCollection('tagA'));
+        self::assertCount(0, $helper->findByCollection('tagB'));
         self::assertNull($helper->findByCollection(''));
     }
 
     /**
      * @test
      */
-    public function findByCollectionReturnsAssetsForCollectionInstace()
+    public function findByCollectionReturnsAssetsForCollectionInstace(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $asset = new Asset($resource);
-        $asset->setTitle('asset for foo');
+        $asset->setTitle('asset for tagA');
         $this->assetRepository->add($asset);
 
-        $fooCollection = new AssetCollection('foo');
-        $barCollection = new AssetCollection('bar');
-        $fooCollection->addAsset($asset);
-        $this->assetCollectionRepository->add($fooCollection);
-        $this->assetCollectionRepository->add($barCollection);
+        $tagACollection = new AssetCollection('tagA');
+        $tagBCollection = new AssetCollection('tagB');
+        $tagACollection->addAsset($asset);
+        $this->assetCollectionRepository->add($tagACollection);
+        $this->assetCollectionRepository->add($tagBCollection);
 
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->findByCollection($fooCollection));
-        self::assertCount(0, $helper->findByCollection($barCollection));
+        self::assertCount(1, $helper->findByCollection($tagACollection));
+        self::assertCount(0, $helper->findByCollection($tagBCollection));
         self::assertNull($helper->findByCollection(null));
     }
 
     /**
      * @test
      */
-    public function findByCollectionReturnsNullIfCollectionIsNull()
+    public function findByCollectionReturnsNullIfCollectionIsNull(): void
     {
         $helper = new AssetsHelper();
         self::assertNull($helper->findByCollection(null));
@@ -207,7 +201,7 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function searchWithoutSearchTermReturnsNull()
+    public function searchWithoutSearchTermReturnsNull(): void
     {
         $helper = new AssetsHelper();
         self::assertNull($helper->search(null));
@@ -217,22 +211,25 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function searchWithSearchTermAndTagFindsAsset()
+    public function searchWithSearchTermAndTagFindsAsset(): void
     {
-        $fooTag = new Tag('foo');
-        $this->tagRepository->add($fooTag);
+        $tagA = new Tag('tagA');
+        $this->tagRepository->add($tagA);
 
-        $barTag = new Tag('bar');
-        $this->tagRepository->add($barTag);
+        $tagB = new Tag('tagB');
+        $this->tagRepository->add($tagB);
+
+        $tagC = new Tag('tagC');
+        $this->tagRepository->add($tagC);
 
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $resource2 = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
         $asset = new Asset($resource);
-        $asset->setTitle('asset for foo');
-        $asset->addTag($fooTag);
+        $asset->setTitle('asset for tagA');
+        $asset->addTag($tagA);
         $asset2 = new Asset($resource2);
         $asset2->setTitle('Another asset');
-        $asset2->addTag($barTag);
+        $asset2->addTag($tagB);
 
         $this->assetRepository->add($asset);
         $this->assetRepository->add($asset2);
@@ -241,12 +238,12 @@ class AssetHelperTest extends AbstractTest
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->search('foo', [$fooTag]));
-        self::assertCount(2, $helper->search('asset', [$fooTag]));
+        self::assertCount(1, $helper->search('tagA', [$tagA]));
+        self::assertCount(2, $helper->search('asset', [$tagA->getLabel()]));
         self::assertCount(2, $helper->search('asset'));
-        self::assertCount(1, $helper->search('bar', [$barTag]));
-        self::assertCount(1, $helper->search('baz', [$barTag]));
-        self::assertCount(0, $helper->search('baz'));
+        self::assertCount(1, $helper->search('tagB', [$tagB]));
+        self::assertCount(1, $helper->search('tagB', [$tagB->getLabel()]));
+        self::assertCount(0, $helper->search('tagD'));
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {
@@ -257,29 +254,29 @@ class AssetHelperTest extends AbstractTest
     /**
      * @test
      */
-    public function searchWithSearchTermAndCollectionFindsAsset()
+    public function searchWithSearchTermAndCollectionFindsAsset(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
         $asset = new Asset($resource);
-        $asset->setTitle('asset for foo');
+        $asset->setTitle('asset for tagA');
         $this->assetRepository->add($asset);
 
-        $fooCollection = new AssetCollection('foo');
-        $barCollection = new AssetCollection('bar');
-        $fooCollection->addAsset($asset);
-        $this->assetCollectionRepository->add($fooCollection);
-        $this->assetCollectionRepository->add($barCollection);
+        $tagACollection = new AssetCollection('tagA');
+        $tagBCollection = new AssetCollection('tagB');
+        $tagACollection->addAsset($asset);
+        $this->assetCollectionRepository->add($tagACollection);
+        $this->assetCollectionRepository->add($tagBCollection);
 
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
         $helper = new AssetsHelper();
-        self::assertCount(1, $helper->search('foo', [], $fooCollection));
-        self::assertCount(1, $helper->search('foo', [], 'foo'));
-        self::assertCount(0, $helper->search('foo', [], $barCollection));
+        self::assertCount(1, $helper->search('tagA', [], $tagACollection));
+        self::assertCount(1, $helper->search('tagA', [], 'tagA'));
+        self::assertCount(0, $helper->search('tagA', [], $tagBCollection));
         self::assertCount(1, $helper->search('asset', [], null));
         self::assertCount(1, $helper->search('asset'));
-        self::assertCount(0, $helper->search('baz'));
+        self::assertCount(0, $helper->search('tagC'));
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1449,6 +1449,46 @@ Render a human-readable description for the passed $dimensions
 
 
 
+
+
+
+.. _`Eel Helpers Reference: Neos.Media.Assets`:
+
+Neos.Media.Assets
+-----------------
+
+Implemented in: ``Neos\Media\Eel\AssetsHelper``
+
+Neos.Media.Assets.findByTag(tag)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``tag`` (Neos\Media\Domain\Model\Tag|string) The label of a tag or a ``Tag`` object
+
+**Return** (null|QueryResultInterface<AssetInterface>)
+
+Neos.Media.Assets.findByCollection(collection)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``collection`` (Neos\Media\Domain\Model\AssetCollection|string) The title of a collection or a ``AssetCollection`` object
+
+**Return** (null|QueryResultInterface<AssetInterface>)
+
+Neos.Media.Assets.findBySearchTerm(searchTerm, tags, collection)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``searchTerm`` (string) The search term to look for in the title, filename and caption of assets
+* ``tags`` (Neos\Media\Domain\Model\Tag[], optional) A list of ``Tag`` objects
+* ``collection`` (Neos\Media\Domain\Model\AssetCollection|string, optional) The title of a collection or a ``AssetCollection`` object
+
+**Return** (null|QueryResultInterface<AssetInterface>)
+
+
+
+
+
+
+
+
 .. _`Eel Helpers Reference: Neos.Seo.Image`:
 
 Neos.Seo.Image

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1462,28 +1462,14 @@ Implemented in: ``Neos\Media\Eel\AssetsHelper``
 Neos.Media.Assets.findByTag(tag)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``tag`` (Neos\Media\Domain\Model\Tag) A ``Tag`` instance
-
-**Return** (null|QueryResultInterface<AssetInterface>)
-
-Neos.Media.Assets.findByTagLabel(label)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``label`` (string) The label of a tag
+* ``tag`` (Neos\Media\Domain\Model\Tag|string) The label of a tag or an ``Tag`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)
 
 Neos.Media.Assets.findByCollection(collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``collection`` (Neos\Media\Domain\Model\AssetCollection) An ``AssetCollection`` instance
-
-**Return** (null|QueryResultInterface<AssetInterface>)
-
-Neos.Media.Assets.findByCollectionTitle(title)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``title`` (string) The title of a collection
+* ``collection`` (Neos\Media\Domain\Model\AssetCollection|string) The title of a collection or an ``AssetCollection`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)
 
@@ -1491,7 +1477,7 @@ Neos.Media.Assets.search(searchTerm, tags, collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``searchTerm`` (string) The search term to look for in the title, filename and caption of assets
-* ``tags`` (Neos\Media\Domain\Model\Tag[], optional) A list of ``Tag`` instances
+* ``tags`` (Neos\Media\Domain\Model\Tag[]|string[], optional) A list of ``Tag`` instances or tag labels as strings
 * ``collection`` (Neos\Media\Domain\Model\AssetCollection, optional) An ``AssetCollection`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1462,23 +1462,37 @@ Implemented in: ``Neos\Media\Eel\AssetsHelper``
 Neos.Media.Assets.findByTag(tag)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``tag`` (Neos\Media\Domain\Model\Tag|string) The label of a tag or a ``Tag`` object
+* ``tag`` (Neos\Media\Domain\Model\Tag) A ``Tag`` instance
+
+**Return** (null|QueryResultInterface<AssetInterface>)
+
+Neos.Media.Assets.findByTagLabel(label)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``label`` (string) The label of a tag
 
 **Return** (null|QueryResultInterface<AssetInterface>)
 
 Neos.Media.Assets.findByCollection(collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``collection`` (Neos\Media\Domain\Model\AssetCollection|string) The title of a collection or a ``AssetCollection`` object
+* ``collection`` (Neos\Media\Domain\Model\AssetCollection) An ``AssetCollection`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)
 
-Neos.Media.Assets.findBySearchTerm(searchTerm, tags, collection)
+Neos.Media.Assets.findByCollectionTitle(title)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``title`` (string) The title of a collection
+
+**Return** (null|QueryResultInterface<AssetInterface>)
+
+Neos.Media.Assets.search(searchTerm, tags, collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``searchTerm`` (string) The search term to look for in the title, filename and caption of assets
-* ``tags`` (Neos\Media\Domain\Model\Tag[], optional) A list of ``Tag`` objects
-* ``collection`` (Neos\Media\Domain\Model\AssetCollection|string, optional) The title of a collection or a ``AssetCollection`` object
+* ``tags`` (Neos\Media\Domain\Model\Tag[], optional) A list of ``Tag`` instances
+* ``collection`` (Neos\Media\Domain\Model\AssetCollection, optional) An ``AssetCollection`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)
 

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1477,7 +1477,7 @@ Neos.Media.Assets.search(searchTerm, tags, collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``searchTerm`` (string) The search term to look for in the title, filename and caption of assets
-* ``tags`` (Neos\Media\Domain\Model\Tag[]|string[], optional) A list of ``Tag`` instances or tag labels as strings
+* ``tags`` (Neos\Media\Domain\Model\Tag[], optional) A list of ``Tag`` instances
 * ``collection`` (Neos\Media\Domain\Model\AssetCollection, optional) An ``AssetCollection`` instance
 
 **Return** (null|QueryResultInterface<AssetInterface>)


### PR DESCRIPTION
This helper provides access to assets in Neos by either searching by Tag, AssetCollection, or
a searchTerm combined with optionally Tags and an AssetCollection.

**Review instructions**

Add some assets to collections and tag them, then use the helpers in Fusion like this:

```
assetsByTag = ${Neos.Media.Assets.findByTag('MyTag')}
assetsByCollection = ${Neos.Media.Assets.findByCollection('MyCollection')}
assetsBySearchTerm = ${Neos.Media.Assets.findBySearchTerm('alice')}
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
