### PR TITLE
BUGFIX: Set workspace owner on creation of personal workspace

### DIFF
--- a/Neos.Neos/Classes/Service/EditorContentStreamZookeeper.php
+++ b/Neos.Neos/Classes/Service/EditorContentStreamZookeeper.php
@@ -132,6 +132,7 @@ final class EditorContentStreamZookeeper
                             new WorkspaceTitle((string) $user->getName()),
                             new WorkspaceDescription(''),
                             $editorsNewContentStreamId,
+                            UserId::fromString($this->persistenceManager->getIdentifierByObject($user))
                         )
                     )->block();
                 } else {


### PR DESCRIPTION
Fixes #4163 

Not sure how you like to handle already broken events.