### PR TITLE
FEATURE: Support `iterables` that do not implement `countable` in `Neos.Fusion:Map`, `Neos.Fusion:Loop` and `Neos.Fusion:Reduce`

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/MapImplementation.php
@@ -84,7 +84,7 @@ class MapImplementation extends AbstractFusionObject
         }
         $itemKey = $this->getItemKey();
         $iterationName = $this->getIterationName();
-        $collectionTotalCount = count($collection);
+        $collectionTotalCount = is_countable($collection) ? count($collection) : null;
 
         $keyRenderPath = $this->path . '/keyRenderer';
         $keyRendererIsAvailable = $this->runtime->canRender($keyRenderPath);
@@ -124,7 +124,7 @@ class MapImplementation extends AbstractFusionObject
     }
 
     /**
-     * @param integer $collectionCount
+     * @param integer|null $collectionCount
      * @return array
      */
     protected function prepareIterationInformation($collectionCount)
@@ -141,7 +141,7 @@ class MapImplementation extends AbstractFusionObject
         if ($this->numberOfRenderedNodes === 0) {
             $iteration['isFirst'] = true;
         }
-        if (($this->numberOfRenderedNodes + 1) === $collectionCount) {
+        if ($collectionCount && ($this->numberOfRenderedNodes + 1) === $collectionCount) {
             $iteration['isLast'] = true;
         }
         if (($this->numberOfRenderedNodes + 1) % 2 === 0) {

--- a/Neos.Fusion/Classes/FusionObjects/ReduceImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ReduceImplementation.php
@@ -105,7 +105,7 @@ class ReduceImplementation extends AbstractFusionObject
         }
         $itemKeyName = $this->getItemKey();
         $iterationName = $this->getIterationName();
-        $collectionTotalCount = count($items);
+        $collectionTotalCount = is_countable($items) ? count($items) : null;
         foreach ($items as $itemKey => $item) {
             $context = $this->runtime->getCurrentContext();
             $context[$itemName] = $item;
@@ -125,7 +125,7 @@ class ReduceImplementation extends AbstractFusionObject
     }
 
     /**
-     * @param integer $collectionCount
+     * @param integer|null $collectionCount
      * @return array
      */
     protected function prepareIterationInformation($collectionCount)
@@ -142,7 +142,7 @@ class ReduceImplementation extends AbstractFusionObject
         if ($this->numberOfRenderedNodes === 0) {
             $iteration['isFirst'] = true;
         }
-        if (($this->numberOfRenderedNodes + 1) === $collectionCount) {
+        if ($collectionCount && ($this->numberOfRenderedNodes + 1) === $collectionCount) {
             $iteration['isLast'] = true;
         }
         if (($this->numberOfRenderedNodes + 1) % 2 === 0) {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
@@ -31,7 +31,7 @@ class LoopTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function basicLoopWorkWithIterator()
+    public function basicLoopWorksWithIterator()
     {
         $view = $this->buildView();
         $view->assign('items', new \ArrayIterator(['element1', 'element2']));
@@ -42,15 +42,10 @@ class LoopTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function basicLoopWorkWithIteratorThatDoesNotImplementCount()
+    public function basicLoopWorksWithIteratorThatDoesNotImplementCount()
     {
-        $generator = function (): iterable {
-            yield 'element1';
-            yield 'element2';
-        };
-
         $view = $this->buildView();
-        $view->assign('items', $generator);
+        $view->assign('items', new \IteratorIterator(new \ArrayIterator(['element1', 'element2'])));
         $view->setFusionPath('loop/basicLoop');
         self::assertEquals('Xelement1Xelement2', $view->render());
     }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
@@ -31,6 +31,33 @@ class LoopTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function basicLoopWorkWithIterator()
+    {
+        $view = $this->buildView();
+        $view->assign('items', new \ArrayIterator(['element1', 'element2']));
+        $view->setFusionPath('loop/basicLoop');
+        self::assertEquals('Xelement1Xelement2', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicLoopWorkWithIteratorThatDoesNotImplementCount()
+    {
+        $generator = function (): iterable {
+            yield 'element1';
+            yield 'element2';
+        };
+
+        $view = $this->buildView();
+        $view->assign('items', $generator);
+        $view->setFusionPath('loop/basicLoop');
+        self::assertEquals('Xelement1Xelement2', $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function basicLoopWorksWithGlue()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -31,6 +31,33 @@ class MapTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function basicMapWorkWithIterator()
+    {
+        $view = $this->buildView();
+        $view->assign('items', new \ArrayIterator(['element1', 'element2']));
+        $view->setFusionPath('map/basicLoop');
+        self::assertEquals(['Xelement1','Xelement2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicMapWorkWithIteratorThatDoesNotImplementCount()
+    {
+        $generator = function (): iterable {
+            yield 'element1';
+            yield 'element2';
+        };
+
+        $view = $this->buildView();
+        $view->assign('items', $generator);
+        $view->setFusionPath('map/basicLoop');
+        self::assertEquals(['Xelement1','Xelement2'], $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function basicMapWorksWithContentRenderer()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -31,7 +31,7 @@ class MapTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function basicMapWorkWithIterator()
+    public function basicMapWorksWithIterator()
     {
         $view = $this->buildView();
         $view->assign('items', new \ArrayIterator(['element1', 'element2']));
@@ -42,15 +42,10 @@ class MapTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function basicMapWorkWithIteratorThatDoesNotImplementCount()
+    public function basicMapWorksWithIteratorThatDoesNotImplementCount()
     {
-        $generator = function (): iterable {
-            yield 'element1';
-            yield 'element2';
-        };
-
         $view = $this->buildView();
-        $view->assign('items', $generator);
+        $view->assign('items', new \IteratorIterator(new \ArrayIterator(['element1', 'element2'])));
         $view->setFusionPath('map/basicLoop');
         self::assertEquals(['Xelement1','Xelement2'], $view->render());
     }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
@@ -32,6 +32,30 @@ class ReduceTest extends AbstractFusionObjectTest
     /**
      * @test
      */
+    public function basicReductionWorksWithIterator()
+    {
+        $view = $this->buildView();
+        $view->assign('items', new \ArrayIterator(['element1', 'element2']));
+        $view->assign('initialValue', 'InitialValue::');
+        $view->setFusionPath('reduce/basicLoop');
+        self::assertEquals('XXInitialValue::element1element2', $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function basicReductionWorksWithIteratorThatDoesNotImplementCount()
+    {
+        $view = $this->buildView();
+        $view->assign('items', new \IteratorIterator(new \ArrayIterator(['element1', 'element2'])));
+        $view->assign('initialValue', 'InitialValue::');
+        $view->setFusionPath('reduce/basicLoop');
+        self::assertEquals('XXInitialValue::element1element2', $view->render());
+    }
+
+    /**
+     * @test
+     */
     public function basicReductionAddsNumbers()
     {
         $view = $this->buildView();

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -162,7 +162,7 @@ Neos.Fusion:Loop
 
 Render each item in ``items`` using ``itemRenderer``.
 
-:items: (array/Iterable, **required**) The array or iterable to iterate over
+:items: (array/Iterable, **required**) The array or iterable to iterate over (to calculate ``iterator.isLast`` items have to be ``countable``)
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
@@ -196,7 +196,7 @@ Neos.Fusion:Map
 
 Render each item in ``items`` using ``itemRenderer`` and return the result as an array (opposed to *string* for :ref:`Neos_Fusion__Collection`)
 
-:items: (array/Iterable, **required**) The array or iterable to iterate over
+:items: (array/Iterable, **required**) The array or iterable to iterate over (to calculate ``iterator.isLast`` items have to be ``countable``)
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :iterationName: (string, defaults to ``iterator``) A context variable with iteration information will be available under the given name: ``index`` (zero-based), ``cycle`` (1-based), ``isFirst``, ``isLast``
@@ -210,7 +210,7 @@ Neos.Fusion:Reduce
 
 Reduce the given items to a single value by using ``itemRenderer``.
 
-:items: (array/Iterable, **required**) The array or iterable to iterate over
+:items: (array/Iterable, **required**) The array or iterable to iterate over (to calculate ``iterator.isLast`` items have to be ``countable``)
 :itemName: (string, defaults to ``item``) Context variable name for each item
 :itemKey: (string, defaults to ``itemKey``) Context variable name for each item key, when working with array
 :carryName: (string, defaults to ``carry``) Context variable that contains the result of the last iteration


### PR DESCRIPTION
Previously passing an object to a Map or a loop that did not implement countable lead to an error. Since we the only value that cannot be calculated is the isLast the code is adjusted to skip the calculation of isLast in that case.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
