### PR TITLE
FEATURE: Merge CR preset and settings in the CR Registry

### DIFF
--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/Helpers/FakeClockFactory.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/Helpers/FakeClockFactory.php
@@ -10,7 +10,7 @@ use Psr\Clock\ClockInterface;
 final class FakeClockFactory implements ClockFactoryInterface
 {
 
-    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings, array $contentRepositoryPreset): ClockInterface
+    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $options): ClockInterface
     {
         return new FakeClock();
     }

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/Helpers/FakeUserIdProviderFactory.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/Helpers/FakeUserIdProviderFactory.php
@@ -10,7 +10,7 @@ use Neos\ContentRepositoryRegistry\Factory\UserIdProvider\UserIdProviderFactoryI
 final class FakeUserIdProviderFactory implements UserIdProviderFactoryInterface
 {
 
-    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings, array $projectionCatchUpTriggerPreset): UserIdProviderInterface
+    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $options): UserIdProviderInterface
     {
         return new FakeUserIdProvider();
     }

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -15,7 +15,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ProjectionCatchUpTriggerInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
-use Neos\ContentRepository\Core\SharedModel\User\UserId;
 use Neos\ContentRepositoryRegistry\Exception\ContentRepositoryNotFound;
 use Neos\ContentRepositoryRegistry\Exception\InvalidConfigurationException;
 use Neos\ContentRepositoryRegistry\Factory\Clock\ClockFactoryInterface;
@@ -29,6 +28,7 @@ use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
 use Neos\EventStore\EventStoreInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Utility\Arrays;
 use Neos\Utility\PositionalArraySorter;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -120,25 +120,33 @@ final class ContentRepositoryRegistry
      */
     private function buildFactory(ContentRepositoryId $contentRepositoryId): ContentRepositoryFactory
     {
-        assert(is_array($this->settings['contentRepositories']));
-        assert(isset($this->settings['contentRepositories'][$contentRepositoryId->value]) && is_array($this->settings['contentRepositories'][$contentRepositoryId->value]), ContentRepositoryNotFound::notConfigured($contentRepositoryId));
-        $contentRepositorySettings = $this->settings['contentRepositories'][$contentRepositoryId->value];
-        assert(is_string($contentRepositorySettings['preset']));
+        if (!is_array($this->settings['contentRepositories'] ?? null)) {
+            throw InvalidConfigurationException::fromMessage('No Content Repositories are configured');
+        }
 
-        assert(isset($this->settings['presets']) && is_array($this->settings['presets']), InvalidConfigurationException::fromMessage('Content repository settings "%s" refer to a preset "%s", but there are not presets configured', $contentRepositoryId->value, $contentRepositorySettings['preset']));
-        assert(isset($this->settings['presets'][$contentRepositorySettings['preset']]) && is_array($this->settings['presets'][$contentRepositorySettings['preset']]), InvalidConfigurationException::missingPreset($contentRepositoryId, $contentRepositorySettings['preset']));
-        $contentRepositoryPreset = $this->settings['presets'][$contentRepositorySettings['preset']];
+        if (!isset($this->settings['contentRepositories'][$contentRepositoryId->value]) || !is_array($this->settings['contentRepositories'][$contentRepositoryId->value])) {
+            throw ContentRepositoryNotFound::notConfigured($contentRepositoryId);
+        }
+        $contentRepositorySettings = $this->settings['contentRepositories'][$contentRepositoryId->value];
+        if (isset($contentRepositorySettings['preset'])) {
+            is_string($contentRepositorySettings['preset']) || throw InvalidConfigurationException::fromMessage('Invalid "preset" configuration for Content Repository "%s". Expected string, got: %s', $contentRepositoryId->value, get_debug_type($contentRepositorySettings['preset']));
+            if (!isset($this->settings['presets'][$contentRepositorySettings['preset']]) || !is_array($this->settings['presets'][$contentRepositorySettings['preset']])) {
+                throw InvalidConfigurationException::fromMessage('Content Repository settings "%s" refer to a preset "%s", but there are not presets configured', $contentRepositoryId->value, $contentRepositorySettings['preset']);
+            }
+            $contentRepositorySettings = Arrays::arrayMergeRecursiveOverrule($this->settings['presets'][$contentRepositorySettings['preset']], $contentRepositorySettings);
+            unset($contentRepositorySettings['preset']);
+        }
         try {
-            $clock = $this->buildClock($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset);
+            $clock = $this->buildClock($contentRepositoryId, $contentRepositorySettings);
             return new ContentRepositoryFactory(
                 $contentRepositoryId,
-                $this->buildEventStore($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset, $clock),
-                $this->buildNodeTypeManager($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset),
-                $this->buildContentDimensionSource($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset),
-                $this->buildPropertySerializer($contentRepositorySettings, $contentRepositoryPreset),
-                $this->buildProjectionsFactory($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset),
-                $this->buildProjectionCatchUpTrigger($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset),
-                $this->buildUserIdProvider($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset),
+                $this->buildEventStore($contentRepositoryId, $contentRepositorySettings, $clock),
+                $this->buildNodeTypeManager($contentRepositoryId, $contentRepositorySettings),
+                $this->buildContentDimensionSource($contentRepositoryId, $contentRepositorySettings),
+                $this->buildPropertySerializer($contentRepositoryId, $contentRepositorySettings),
+                $this->buildProjectionsFactory($contentRepositoryId, $contentRepositorySettings),
+                $this->buildProjectionCatchUpTrigger($contentRepositoryId, $contentRepositorySettings),
+                $this->buildUserIdProvider($contentRepositoryId, $contentRepositorySettings),
                 $clock,
             );
         } catch (\Exception $exception) {
@@ -146,78 +154,73 @@ final class ContentRepositoryRegistry
         }
     }
 
-    private function buildEventStore(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset, ClockInterface $clock): EventStoreInterface
+    private function buildEventStore(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, ClockInterface $clock): EventStoreInterface
     {
-        assert(isset($contentRepositoryPreset['eventStore']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have eventStore.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $eventStoreFactory = $this->objectManager->get($contentRepositoryPreset['eventStore']['factoryObjectName']);
+        isset($contentRepositorySettings['eventStore']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have eventStore.factoryObjectName configured.', $contentRepositoryId->value);
+        $eventStoreFactory = $this->objectManager->get($contentRepositorySettings['eventStore']['factoryObjectName']);
         if (!$eventStoreFactory instanceof EventStoreFactoryInterface) {
-            throw new \RuntimeException(sprintf('eventStore.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, EventStoreFactoryInterface::class, get_debug_type($eventStoreFactory)));
+            throw InvalidConfigurationException::fromMessage('eventStore.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, EventStoreFactoryInterface::class, get_debug_type($eventStoreFactory));
         }
-        return $eventStoreFactory->build($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset['eventStore'], $clock);
+        return $eventStoreFactory->build($contentRepositoryId, $contentRepositorySettings['eventStore']['options'] ?? [], $clock);
     }
 
-    private function buildNodeTypeManager(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): NodeTypeManager
+    private function buildNodeTypeManager(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): NodeTypeManager
     {
-        assert(isset($contentRepositoryPreset['nodeTypeManager']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have nodeTypeManager.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $nodeTypeManagerFactory = $this->objectManager->get($contentRepositoryPreset['nodeTypeManager']['factoryObjectName']);
+        isset($contentRepositorySettings['nodeTypeManager']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have nodeTypeManager.factoryObjectName configured.', $contentRepositoryId->value);
+        $nodeTypeManagerFactory = $this->objectManager->get($contentRepositorySettings['nodeTypeManager']['factoryObjectName']);
         if (!$nodeTypeManagerFactory instanceof NodeTypeManagerFactoryInterface) {
-            throw new \RuntimeException(sprintf('nodeTypeManager.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, NodeTypeManagerFactoryInterface::class, get_debug_type($nodeTypeManagerFactory)));
+            throw InvalidConfigurationException::fromMessage('nodeTypeManager.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, NodeTypeManagerFactoryInterface::class, get_debug_type($nodeTypeManagerFactory));
         }
-        return $nodeTypeManagerFactory->build($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset['nodeTypeManager']);
+        return $nodeTypeManagerFactory->build($contentRepositoryId, $contentRepositorySettings['nodeTypeManager']['options'] ?? []);
     }
 
-    private function buildContentDimensionSource(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): ContentDimensionSourceInterface
+    private function buildContentDimensionSource(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): ContentDimensionSourceInterface
     {
-        assert(isset($contentRepositoryPreset['contentDimensionSource']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have contentDimensionSource.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $contentDimensionSourceFactory = $this->objectManager->get($contentRepositoryPreset['contentDimensionSource']['factoryObjectName']);
+        isset($contentRepositorySettings['contentDimensionSource']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have contentDimensionSource.factoryObjectName configured.', $contentRepositoryId->value);
+        $contentDimensionSourceFactory = $this->objectManager->get($contentRepositorySettings['contentDimensionSource']['factoryObjectName']);
         if (!$contentDimensionSourceFactory instanceof ContentDimensionSourceFactoryInterface) {
-            throw new \RuntimeException(sprintf('contentDimensionSource.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, NodeTypeManagerFactoryInterface::class, get_debug_type($contentDimensionSourceFactory)));
+            throw InvalidConfigurationException::fromMessage('contentDimensionSource.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, NodeTypeManagerFactoryInterface::class, get_debug_type($contentDimensionSourceFactory));
         }
-        return $contentDimensionSourceFactory->build($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset['contentDimensionSource']);
+        // Note: contentDimensions can be specified on the top-level for easier use.
+        // They can still be overridden in the specific "contentDimensionSource" options
+        $options = $contentRepositorySettings['contentDimensionSource']['options'] ?? [];
+        if (isset($contentRepositorySettings['contentDimensions'])) {
+            $options['contentDimensions'] = Arrays::arrayMergeRecursiveOverrule($contentRepositorySettings['contentDimensions'], $options['contentDimensions'] ?? []);
+        }
+        return $contentDimensionSourceFactory->build($contentRepositoryId, $options);
 
     }
 
-    private function buildPropertySerializer(array $contentRepositorySettings, array $contentRepositoryPreset): Serializer
+    private function buildPropertySerializer(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): Serializer
     {
-        assert(isset($contentRepositoryPreset['propertyConverters']) && is_array($contentRepositoryPreset['propertyConverters']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have propertyConverters configured, or the value is no array.', $contentRepositorySettings['preset']));
-        $propertyConvertersConfiguration = (new PositionalArraySorter($contentRepositoryPreset['propertyConverters']))
-            ->toArray();
+        (isset($contentRepositorySettings['propertyConverters']) && is_array($contentRepositorySettings['propertyConverters'])) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have propertyConverters configured, or the value is no array.', $contentRepositoryId->value);
+        $propertyConvertersConfiguration = (new PositionalArraySorter($contentRepositorySettings['propertyConverters']))->toArray();
 
         $normalizers = [];
         foreach ($propertyConvertersConfiguration as $propertyConverterConfiguration) {
             $normalizer = new $propertyConverterConfiguration['className'];
             if (!$normalizer instanceof NormalizerInterface && !$normalizer instanceof DenormalizerInterface) {
-                throw new \InvalidArgumentException(
-                    'Serializers can only be created of ' . NormalizerInterface::class
-                    . ' and ' . DenormalizerInterface::class
-                    . ', ' . get_class($normalizer) . ' given.',
-                    1645386698
-                );
+                throw InvalidConfigurationException::fromMessage('Serializers can only be created of %s and %s, %s given', NormalizerInterface::class, DenormalizerInterface::class, get_debug_type($normalizer));
             }
             $normalizers[] = $normalizer;
         }
-
         return new Serializer($normalizers);
     }
 
-    private function buildProjectionsFactory(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): ProjectionsFactory
+    private function buildProjectionsFactory(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): ProjectionsFactory
     {
-        assert(isset($contentRepositoryPreset['projections']) && is_array($contentRepositoryPreset['projections']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have projections configured, or the value is no array.', $contentRepositorySettings['preset']));
+        (isset($contentRepositorySettings['projections']) && is_array($contentRepositorySettings['projections'])) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have projections configured, or the value is no array.', $contentRepositoryId->value);
         $projectionsFactory = new ProjectionsFactory();
-        foreach ((new PositionalArraySorter($contentRepositoryPreset['projections']))->toArray() as $projectionName => $projectionOptions) {
+        foreach ((new PositionalArraySorter($contentRepositorySettings['projections']))->toArray() as $projectionName => $projectionOptions) {
             $projectionFactory = $this->objectManager->get($projectionOptions['factoryObjectName']);
             if (!$projectionFactory instanceof ProjectionFactoryInterface) {
-                throw new \RuntimeException(sprintf('Projection factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s.', $projectionName, $contentRepositoryId->value, ProjectionFactoryInterface::class, get_debug_type($projectionFactory)));
+                throw InvalidConfigurationException::fromMessage('Projection factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s.', $projectionName, $contentRepositoryId->value, ProjectionFactoryInterface::class, get_debug_type($projectionFactory));
             }
-            $projectionsFactory->registerFactory(
-                $projectionFactory,
-                $projectionOptions['options'] ?? []
-            );
-
+            $projectionsFactory->registerFactory($projectionFactory, $projectionOptions['options'] ?? []);
             foreach (($projectionOptions['catchUpHooks'] ?? []) as $catchUpHookOptions) {
                 $catchUpHookFactory = $this->objectManager->get($catchUpHookOptions['factoryObjectName']);
                 if (!$catchUpHookFactory instanceof CatchUpHookFactoryInterface) {
-                    throw new \RuntimeException(sprintf('CatchUpHook factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s', $projectionName, $contentRepositoryId->value, CatchUpHookFactoryInterface::class, get_debug_type($catchUpHookFactory)));
+                    throw InvalidConfigurationException::fromMessage('CatchUpHook factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s', $projectionName, $contentRepositoryId->value, CatchUpHookFactoryInterface::class, get_debug_type($catchUpHookFactory));
                 }
                 $projectionsFactory->registerCatchUpHookFactory($projectionFactory, $catchUpHookFactory);
             }
@@ -225,33 +228,33 @@ final class ContentRepositoryRegistry
         return $projectionsFactory;
     }
 
-    private function buildProjectionCatchUpTrigger(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): ProjectionCatchUpTriggerInterface
+    private function buildProjectionCatchUpTrigger(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): ProjectionCatchUpTriggerInterface
     {
-        assert(isset($contentRepositoryPreset['projectionCatchUpTrigger']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have projectionCatchUpTrigger.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $projectionCatchUpTriggerFactory = $this->objectManager->get($contentRepositoryPreset['projectionCatchUpTrigger']['factoryObjectName']);
+        isset($contentRepositorySettings['projectionCatchUpTrigger']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have projectionCatchUpTrigger.factoryObjectName configured.', $contentRepositoryId->value);
+        $projectionCatchUpTriggerFactory = $this->objectManager->get($contentRepositorySettings['projectionCatchUpTrigger']['factoryObjectName']);
         if (!$projectionCatchUpTriggerFactory instanceof ProjectionCatchUpTriggerFactoryInterface) {
-            throw new \RuntimeException(sprintf('projectionCatchUpTrigger.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, ProjectionCatchUpTriggerFactoryInterface::class, get_debug_type($projectionCatchUpTriggerFactory)));
+            throw InvalidConfigurationException::fromMessage('projectionCatchUpTrigger.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, ProjectionCatchUpTriggerFactoryInterface::class, get_debug_type($projectionCatchUpTriggerFactory));
         }
-        return $projectionCatchUpTriggerFactory->build($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset['projectionCatchUpTrigger'] ?? []);
+        return $projectionCatchUpTriggerFactory->build($contentRepositoryId, $contentRepositorySettings['projectionCatchUpTrigger']['options'] ?? []);
     }
 
-    private function buildUserIdProvider(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): UserIdProviderInterface
+    private function buildUserIdProvider(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): UserIdProviderInterface
     {
-        assert(isset($contentRepositoryPreset['userIdProvider']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have userIdProvider.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $userIdProviderFactory = $this->objectManager->get($contentRepositoryPreset['userIdProvider']['factoryObjectName']);
+        isset($contentRepositorySettings['userIdProvider']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have userIdProvider.factoryObjectName configured.', $contentRepositoryId->value);
+        $userIdProviderFactory = $this->objectManager->get($contentRepositorySettings['userIdProvider']['factoryObjectName']);
         if (!$userIdProviderFactory instanceof UserIdProviderFactoryInterface) {
-            throw new \RuntimeException(sprintf('userIdProvider.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, UserIdProviderFactoryInterface::class, get_debug_type($userIdProviderFactory)));
+            throw InvalidConfigurationException::fromMessage('userIdProvider.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryId->value, UserIdProviderFactoryInterface::class, get_debug_type($userIdProviderFactory));
         }
-        return $userIdProviderFactory->build($contentRepositoryId, $contentRepositorySettings, $contentRepositoryPreset);
+        return $userIdProviderFactory->build($contentRepositoryId, $contentRepositorySettings['userIdProvider']['options'] ?? []);
     }
 
-    private function buildClock(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings, array $contentRepositoryPreset): ClockInterface
+    private function buildClock(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings): ClockInterface
     {
-        assert(isset($contentRepositoryPreset['clock']['factoryObjectName']), InvalidConfigurationException::fromMessage('Content repository preset "%s" does not have clock.factoryObjectName configured.', $contentRepositorySettings['preset']));
-        $clockFactory = $this->objectManager->get($contentRepositoryPreset['clock']['factoryObjectName']);
+        isset($contentRepositorySettings['clock']['factoryObjectName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have clock.factoryObjectName configured.', $contentRepositoryIdentifier->value);
+        $clockFactory = $this->objectManager->get($contentRepositorySettings['clock']['factoryObjectName']);
         if (!$clockFactory instanceof ClockFactoryInterface) {
-            throw new \RuntimeException(sprintf('clock.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryIdentifier->value, ClockFactoryInterface::class, get_debug_type($clockFactory)));
+            throw InvalidConfigurationException::fromMessage('clock.factoryObjectName for content repository "%s" is not an instance of %s but %s.', $contentRepositoryIdentifier->value, ClockFactoryInterface::class, get_debug_type($clockFactory));
         }
-        return $clockFactory->build($contentRepositoryIdentifier, $contentRepositorySettings, $contentRepositoryPreset);
+        return $clockFactory->build($contentRepositoryIdentifier, $contentRepositorySettings['clock']['options'] ?? []);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/Clock/ClockFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/Clock/ClockFactoryInterface.php
@@ -10,5 +10,5 @@ use Psr\Clock\ClockInterface;
  */
 interface ClockFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings, array $contentRepositoryPreset): ClockInterface;
+    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $options): ClockInterface;
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/Clock/SystemClockFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/Clock/SystemClockFactory.php
@@ -10,7 +10,7 @@ use Psr\Clock\ClockInterface;
  */
 final class SystemClockFactory implements ClockFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $contentRepositorySettings, array $contentRepositoryPreset): ClockInterface
+    public function build(ContentRepositoryId $contentRepositoryIdentifier, array $options): ClockInterface
     {
         return new SystemClock();
     }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/ContentDimensionSource/ConfigurationBasedContentDimensionSourceFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/ContentDimensionSource/ConfigurationBasedContentDimensionSourceFactory.php
@@ -13,10 +13,10 @@ class ConfigurationBasedContentDimensionSourceFactory implements ContentDimensio
     {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentDimensionSourcePreset): ContentDimensionSourceInterface
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): ContentDimensionSourceInterface
     {
         return new ConfigurationBasedContentDimensionSource(
-            $contentRepositorySettings['contentDimensions'] ?? []
+            $options['contentDimensions'] ?? []
         );
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/ContentDimensionSource/ContentDimensionSourceFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/ContentDimensionSource/ContentDimensionSourceFactoryInterface.php
@@ -7,5 +7,5 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 
 interface ContentDimensionSourceFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentDimensionSourcePreset): ContentDimensionSourceInterface;
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): ContentDimensionSourceInterface;
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/EventStore/DoctrineEventStoreFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/EventStore/DoctrineEventStoreFactory.php
@@ -17,7 +17,7 @@ class DoctrineEventStoreFactory implements EventStoreFactoryInterface
     {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $eventStorePreset, ClockInterface $clock): EventStoreInterface
+    public function build(ContentRepositoryId $contentRepositoryId, array $options, ClockInterface $clock): EventStoreInterface
     {
         return new DoctrineEventStore(
             $this->connection,

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/EventStore/EventStoreFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/EventStore/EventStoreFactoryInterface.php
@@ -8,5 +8,5 @@ use Psr\Clock\ClockInterface;
 
 interface EventStoreFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $eventStorePreset, ClockInterface $clock): EventStoreInterface;
+    public function build(ContentRepositoryId $contentRepositoryId, array $options, ClockInterface $clock): EventStoreInterface;
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/NodeTypeManager/DefaultNodeTypeManagerFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/NodeTypeManager/DefaultNodeTypeManagerFactory.php
@@ -18,7 +18,7 @@ class DefaultNodeTypeManagerFactory implements NodeTypeManagerFactoryInterface
     {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $nodeTypeManagerPreset): NodeTypeManager
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): NodeTypeManager
     {
         return new NodeTypeManager(
             function() {
@@ -26,7 +26,7 @@ class DefaultNodeTypeManagerFactory implements NodeTypeManagerFactoryInterface
                 return $this->nodeTypeEnrichmentService->enrichNodeTypeLabelsConfiguration($configuration);
             },
             $this->objectManager,
-            $nodeTypeManagerPreset['options']['fallbackNodeTypeName']
+            $options['fallbackNodeTypeName'] ?? null,
         );
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/NodeTypeManager/NodeTypeManagerFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/NodeTypeManager/NodeTypeManagerFactoryInterface.php
@@ -7,5 +7,5 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 
 interface NodeTypeManagerFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $nodeTypeManagerPreset): NodeTypeManager;
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): NodeTypeManager;
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/ProjectionCatchUpTriggerFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/ProjectionCatchUpTriggerFactoryInterface.php
@@ -8,5 +8,5 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 
 interface ProjectionCatchUpTriggerFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $projectionCatchUpTriggerPreset): ProjectionCatchUpTriggerInterface;
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): ProjectionCatchUpTriggerInterface;
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/SubprocessProjectionCatchUpTriggerFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/SubprocessProjectionCatchUpTriggerFactory.php
@@ -11,7 +11,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
  */
 class SubprocessProjectionCatchUpTriggerFactory implements ProjectionCatchUpTriggerFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $projectionCatchUpTriggerPreset): ProjectionCatchUpTriggerInterface
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): ProjectionCatchUpTriggerInterface
     {
         return new CatchUpTriggerWithSynchronousOption(
             $contentRepositoryId,

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/UserIdProvider/StaticUserIdProviderFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/UserIdProvider/StaticUserIdProviderFactory.php
@@ -12,7 +12,7 @@ use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
  */
 final class StaticUserIdProviderFactory implements UserIdProviderFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): UserIdProviderInterface
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): UserIdProviderInterface
     {
         return new StaticUserIdProvider(UserId::forSystemUser());
     }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/UserIdProvider/UserIdProviderFactoryInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/UserIdProvider/UserIdProviderFactoryInterface.php
@@ -10,5 +10,5 @@ use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
  */
 interface UserIdProviderFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, array $contentRepositoryPreset): UserIdProviderInterface;
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): UserIdProviderInterface;
 }


### PR DESCRIPTION
Adjusts the `ContentRepositoryRegistry` such that preset and settings are merged.

This leads to better reusability of presets because options can be overridden selectively.

## Example

To create a copy of the `default` CR with a different "fallback node type" and without the Asset Usage projection:

```yaml
Neos:
  ContentRepositoryRegistry:
    contentRepositories:
      'someId':
        preset: default
        nodeTypeManager:
          options:
            fallbackNodeTypeName: 'Some.Other:Fallback'
        projections:
          'Neos.Neos:AssetUsage': ~
```

Resolves: #4171