### PR TITLE
TASK: missing documentation about migration commands

### DIFF
--- a/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
+++ b/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
@@ -86,9 +86,9 @@ class NodeCommandController extends CommandController
      * @param boolean $confirmation Confirm application of this migration, only needed if the given migration contains any warnings.
      * @param string $direction The direction to work in, MigrationStatus::DIRECTION_UP or MigrationStatus::DIRECTION_DOWN
      * @return void
-     * @see neos.contentrepository.migration:node:migrationstatus
+     * @see neos.contentrepository.migration:node:migrate
      */
-    public function migrateCommand($version, $confirmation = false, $direction = MigrationStatus::DIRECTION_UP)
+    public function migrateCommand(string $version, bool $confirmation = false, string $direction = MigrationStatus::DIRECTION_UP): void
     {
         try {
             $migrationConfiguration = $direction === MigrationStatus::DIRECTION_UP ?
@@ -123,9 +123,9 @@ class NodeCommandController extends CommandController
      * List available and applied migrations
      *
      * @return void
-     * @see neos.contentrepository.migration:node:migrate
+     * @see neos.contentrepository.migration:node:migrationstatus
      */
-    public function migrationStatusCommand()
+    public function migrationStatusCommand(): void
     {
         $this->outputLine();
 

--- a/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
+++ b/Neos.ContentRepository/Classes/Migration/Command/NodeCommandController.php
@@ -88,7 +88,7 @@ class NodeCommandController extends CommandController
      * @return void
      * @see neos.contentrepository.migration:node:migrate
      */
-    public function migrateCommand(string $version, bool $confirmation = false, string $direction = MigrationStatus::DIRECTION_UP): void
+    public function migrateCommand($version, $confirmation = false, $direction = MigrationStatus::DIRECTION_UP)
     {
         try {
             $migrationConfiguration = $direction === MigrationStatus::DIRECTION_UP ?
@@ -125,7 +125,7 @@ class NodeCommandController extends CommandController
      * @return void
      * @see neos.contentrepository.migration:node:migrationstatus
      */
-    public function migrationStatusCommand(): void
+    public function migrationStatusCommand()
     {
         $this->outputLine();
 

--- a/Neos.Neos/Documentation/References/CommandReference.rst
+++ b/Neos.Neos/Documentation/References/CommandReference.rst
@@ -222,6 +222,57 @@ Options
 
 
 
+.. _`Neos Command Reference: NEOS.CONTENTREPOSITORY.MIGRATION neos.contentrepository.migration:node:migrate`:
+
+``neos.contentrepository.migration:node:migrate``
+*************************
+
+**Execute node migrations**
+
+This command executes pending migrations via the ``Version`` key for content repository nodes. It applies the necessary changes to bring the nodes up-to-date with the current codebase, based on the migration history and the content structure. It ensures that the nodes are correctly migrated to the latest version.
+
+Arguments
+^^^^^^^^^
+``--version``
+The version of the migration configuration you want to use.
+
+Options
+^^^^^^^
+
+``--confirmation``
+Confirm application of this migration, only needed if the given migration contains any warnings.
+
+``--direction``
+The direction to work in, ``MigrationStatus::DIRECTION_UP`` or ``MigrationStatus::DIRECTION_DOWN``
+But by default, the up option is applied.
+
+Example
+^^^^^^^
+
+.. code-block:: bash
+  ./flow node:migrate 20230228123136
+
+.. _`Neos Command Reference: NEOS.CONTENTREPOSITORY.MIGRATION neos.contentrepository.migration:node:migrationstatus`:
+
+``neos.contentrepository.migration:node:migrationstatus``
+*************************
+
+**List of available, and applied migrations**
+
+This command gives you a list of all available node migrations, and shows also which node migrations have been executed already.
+
+Example
+^^^^^^^
+.. code-block:: bash
+  ./flow node:migrationstatus
+
++----------------+---------------------+------------------------+--------------------------------------------------------------+
+| Version        | Date                | Package                | Comments                                                     |
++================+=====================+========================+==============================================================+
+| 20230228123136 | 10-02-2023 12:31:36 | Neos.Demo              | Renames property A to property B in my NodeType             |
+| 20230228143841 | 28-02-2023 14:38:41 | Neos.Demo              | Renames my NodeType Foo to my new NodeType Bar               |
++----------------+---------------------+------------------------+--------------------------------------------------------------+
+
 .. _`Neos Command Reference: NEOS.FLOW`:
 
 Package *NEOS.FLOW*


### PR DESCRIPTION
**Upgrade instructions**

_None_

**Review instructions**

As mentioned in #4038 i noticed that some of the `neos.contentrepository.migration` commands were missing. This PR adds documentation for the following commands:

- neos.contentrepository.migration:node:migrationstatus
- neos.contentrepository.migration:node:migrate

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
