### PR TITLE
BUGFIX: Allow installation in Neos < 9.0

### DIFF
--- a/Neos.ContentRepositoryRegistry/composer.json
+++ b/Neos.ContentRepositoryRegistry/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "neos/contentrepositoryregistry",
     "type": "neos-package",
-    "description": "Registry",
+    "description": "Global registry for Neos Content Repository instances",
     "license": [
         "GPL-3.0-or-later"
     ],
@@ -20,10 +20,6 @@
         "psr-4": {
             "Neos\\ContentRepositoryRegistry\\Tests\\": "Tests"
         }
-    },
-    "replace": {
-        "neos/content-repository": "self.version",
-        "neos/contentrepository": "self.version"
     },
     "extra": {
         "applied-flow-migrations": [


### PR DESCRIPTION
Currently the `neos/contentrepositoryregistry` can't be installed alongside the classic `neos/content-repository` because it claims to replace it.

Since it has a different PHP namespace (`Neos\ContentRepositoryRegistry` vs `Neos\ContentRepository`) both implementations can technically be installed and it can be quite useful (i.e. to use the ESCR in Neos < 9.0)