### PR TITLE
BUGFIX: Fix usage of `node.nodeAggregateId` in fluid

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -26,7 +26,7 @@
                             </f:if>
                         </f:alias>
                         <label class="node-label">{node.label}</label>
-                        (<span class="node-identifier">{node.nodeAggregateId}</span>)
+                        (<span class="node-identifier">{node.nodeAggregateId.value}</span>)
                         [<span class="node-type">{node.nodeType.name}</span>]
                         <f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.nodeAggregateId.value}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
                     </li>


### PR DESCRIPTION
Fix usage in `Index` fluid template of `Neos\Neos\Controller\Service\NodesController`

Relates: https://github.com/neos/neos-development-collection/pull/4156

**Review instructions**

* Try to set a link to a node in a text block OR
* Try to search for a node in the `reference` or `references` editor

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
