### PR TITLE
BUGFIX: Allow non-entity asset variants

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -283,7 +283,7 @@ class AssetRepository extends Repository
         $variantsConstraints = [];
         $variantClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetVariantInterface::class);
         foreach ($variantClassNames as $variantClassName) {
-            if (!in_array(AssetInterface::class, class_implements($variantClassName), true)) {
+            if (!$this->reflectionService->isClassAnnotatedWith($variantClassName, Flow\Entity::class)) {
                 // ignore non-entity classes to prevent "class schema found" error
                 continue;
             }

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -283,6 +283,10 @@ class AssetRepository extends Repository
         $variantsConstraints = [];
         $variantClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetVariantInterface::class);
         foreach ($variantClassNames as $variantClassName) {
+            if (!in_array(AssetInterface::class, class_implements($variantClassName), true)) {
+                // ignore non-entity classes to prevent "class schema found" error
+                continue;
+            }
             $variantsConstraints[] = 'e NOT INSTANCE OF ' . $variantClassName;
         }
 


### PR DESCRIPTION
Allow implementations of the `AssetVariantInterface` to not be doctrine entities.

Without this fix, all `AssetRepository::find*()` calls lead to an exception when a class implements the interface but is not an entity (for example because it is just used to generate dummy images for Monocle).

## Steps to reproduce

1. Implement the interface with a new custom class like

```php
final class DummyImageVariant implements AssetVariantInterface {
    // ...
}
```

2. Trigger `AssetRepository::find*()` method, eg. by invoking `./ flow media:removeunused`

### Expected result

No error, the custom implementation should be ignored

### Actual result

Exception:

```
Failure while fetching class schema class "Some\Package\DummyImageVariant": No class schema found for "Some\Package\DummyImageVariant".

  Type: Doctrine\ORM\Mapping\MappingException
  Code: 1542792708
  File: Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Flow_Persist
        ence_Doctrine_Mapping_Driver_FlowAnnotationDriver.php
  Line: 187
```