### PR TITLE
BUGFIX: Fix type errors for configuration backend module

### DIFF
--- a/Neos.Neos/Classes/ViewHelpers/Backend/ConfigurationTreeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/ConfigurationTreeViewHelper.php
@@ -59,7 +59,7 @@ class ConfigurationTreeViewHelper extends AbstractViewHelper
     /**
      * Recursive function rendering configuration and adding it to $this->output
      *
-     * @param array<string,mixed> $configuration
+     * @param array<string|int,mixed> $configuration
      * @param string $relativePath the path up-to-now
      * @return void
      */
@@ -67,9 +67,9 @@ class ConfigurationTreeViewHelper extends AbstractViewHelper
     {
         $this->output .= '<ul>';
         foreach ($configuration as $key => $value) {
-            $path = ($relativePath ? $relativePath . '.' . $key : $key);
+            $path = ($relativePath ? $relativePath . '.' . $key : (string)$key);
             $pathEscaped = htmlspecialchars($path);
-            $keyEscaped = htmlspecialchars($key);
+            $keyEscaped = htmlspecialchars((string)$key);
 
             $typeEscaped = htmlspecialchars(gettype($value));
             if ($typeEscaped === 'array') {
@@ -83,7 +83,7 @@ class ConfigurationTreeViewHelper extends AbstractViewHelper
                 $this->output .= match ($typeEscaped) {
                     'boolean' => ($value ? 'true' : 'false'),
                     'NULL' => 'NULL',
-                    default => htmlspecialchars($value),
+                    default => htmlspecialchars((string)$value),
                 };
                 $this->output .= '</div>';
             }

--- a/Neos.Neos/Classes/ViewHelpers/Backend/TranslateViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/TranslateViewHelper.php
@@ -95,7 +95,7 @@ class TranslateViewHelper extends FluidTranslateViewHelper
         $value = $this->arguments['value'];
         $locale = $this->arguments['locale'];
 
-        if (preg_match(TranslationHelper::I18N_LABEL_ID_PATTERN, $id) === 1) {
+        if (is_string($id) && preg_match(TranslationHelper::I18N_LABEL_ID_PATTERN, $id) === 1) {
             // In the longer run, this "extended ID" format should directly be resolved in the localization service
             list($package, $source, $id) = explode(':', $id, 3);
             $this->arguments['id'] = $id;


### PR DESCRIPTION
**Review instructions**

- the simple attempt to access /neos/administration/configuration leads to an error as the configuration tree might contain integer keys
- trying to access the `NodeTypes` tab will also throw a type error as there are integer based language keys

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
