### PR TITLE
BUGFIX: Adjust version and release variables

### DIFF
--- a/Neos.Neos/Documentation/conf.py
+++ b/Neos.Neos/Documentation/conf.py
@@ -27,9 +27,9 @@ copyright = '2006 and onwards by the authors'
 author = 'Neos Team and Contributors'
 
 # The short X.Y version.
-version = 'dev-master'
+version = '8.0'
 # The full version, including alpha/beta/rc tags.
-release = 'dev-master'
+release = '8.0.x'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Without the change, the docs will render a wrong version information on the index page.

<img width="1108" alt="Screenshot 2023-04-23 at 21 16 52" src="https://user-images.githubusercontent.com/1014126/233860295-8da2a358-a3c8-420b-bee0-fd61ba1dec59.png">

