### PR TITLE
TASK: Adjust link editor documentation

### DIFF
--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -392,7 +392,7 @@ The searchbox will accept:
 By default, links to generic ``Neos.Neos:Document`` nodes are allowed; but by setting the ``nodeTypes`` option,
 this can be further restricted (like with the ``reference`` editor). Additionally, links to assets can be disabled
 by setting ``assets`` to ``FALSE``. Links to external URLs are always possible. If you need a reference towards
-only an asset, use the ``asset`` property type; for a reference to another node, use the ``reference`` node type.
+only an asset, use the ``asset`` property type; for a reference to another node, use the ``reference`` property type.
 Furthermore, the placeholder text can be customized by setting the ``placeholder`` option::
 
 


### PR DESCRIPTION
Tiny mistake in link editor documentation:
To refer to another node type the reference **property** type is used, not the reference node type.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
