### PR TITLE
TASK: add default value for generatorName at kickstart command in SiteKickstarter

### DIFF
--- a/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
@@ -74,8 +74,9 @@ class KickstartCommandController extends CommandController
         }
 
         $generatorName = $this->output->select(
-            'What generator do you want to use?',
-            $selection
+            sprintf('What generator do you want to use? (<info>%s</info>): ', array_key_first($selection)),
+            $selection,
+            array_key_first($selection)
         );
 
         $generatorClass = $nameToClassMap[$generatorName];


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->
We tried to reproduce #4053.
We can't reproduce this issue, but while reproducing we found a flow command prompt, without a default value.

The command `flow kickstart:site AnySite.Site` asks for a site generator.
We added a default value by adding: 
```php
array_key_first($selection)
```

**Review instructions**
At https://github.com/neos/neos-development-collection/blob/79dd4e1a26b7ffceb80cc628fdbe570ff6013b16/Neos.CliSetup/Classes/Command/SetupCommandController.php#L165 `array_key_last` is used. Should we use `array_key_last` too or is `array_key_first` fine for it?

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
