### PR TITLE
SiteKickstarter: remove package sugestion for neos/seo

### DIFF
--- a/Neos.SiteKickstarter/Classes/Generator/AfxTemplateGenerator.php
+++ b/Neos.SiteKickstarter/Classes/Generator/AfxTemplateGenerator.php
@@ -67,9 +67,6 @@ class AfxTemplateGenerator extends GeneratorService implements SitePackageGenera
             'type' => 'neos-site',
             "require" => [
                 "neos/neos" => "*"
-            ],
-            "suggest" => [
-                "neos/seo" => "*"
             ]
         ]);
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->
We tried to reproduce #4053.
We can't reproduce this issue, but while reproducing we found a code snippet, which is suggesting `neos/seo`. 

A suggestion of `neos/seo` isn't require at this point anymore.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
