### PR TITLE
BUGFIX: make pagination work with Traversable

### DIFF
--- a/Neos.ContentRepository/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Neos.ContentRepository/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\ViewHelpers\Widget\Controller;
  * source code.
  */
 
+use ArrayIterator;
 use Neos\Utility\Arrays;
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -87,7 +88,11 @@ class PaginateController extends AbstractWidgetController
     protected function initializeAction()
     {
         $this->parentNode = $this->widgetConfiguration['parentNode'];
-        $this->nodes = $this->widgetConfiguration['nodes'];
+        if ($this->widgetConfiguration['nodes'] instanceof ArrayIterator) {
+            $this->nodes = $this->widgetConfiguration['nodes']->getArrayCopy();
+        } else {
+            $this->nodes = $this->widgetConfiguration['nodes'];
+        }
         $this->nodeTypeFilter = $this->widgetConfiguration['nodeTypeFilter'] ?: null;
         $this->configuration = Arrays::arrayMergeRecursiveOverrule($this->configuration, $this->widgetConfiguration['configuration'], true);
         $this->maximumNumberOfNodes = $this->configuration['maximumNumberOfNodes'];

--- a/Neos.ContentRepository/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Neos.ContentRepository/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -121,7 +121,7 @@ class PaginateController extends AbstractWidgetController
         }
         $offset = ($this->currentPage > 1) ? (integer)($itemsPerPage * ($this->currentPage - 1)) : null;
         if ($this->parentNode === null) {
-            $nodes = array_slice($this->nodes, $offset, $itemsPerPage);
+            $nodes = (array) array_slice($this->nodes, $offset, $itemsPerPage);
         } else {
             $nodes = $this->parentNode->getChildNodes($this->nodeTypeFilter, $itemsPerPage, $offset);
         }


### PR DESCRIPTION
Fixes a warning: `array_slice() expects parameter 1 to be array, object given in /…/Neos_ContentRepository_ViewHelpers_Widget_Controller_PaginateController.php line 124`

Variant of [#3891](https://github.com/neos/neos-development-collection/pull/3891) based on the (correct) 7.3 branch.

See #1112 
