### PR TITLE
BUGFIX: Fix missing icon in case of fusion errors

### DIFF
--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
@@ -82,7 +82,7 @@ class HtmlMessageHandler extends AbstractRenderingExceptionHandler
         }
 
         $message = sprintf(
-            '<div class="neos-message-header"><div class="neos-message-icon"><i class="icon-warning-sign"></i></div><h1>An exception was thrown while Neos tried to render your page</h1></div>' .
+            '<div class="neos-message-header"><div class="neos-message-icon"><i class="fa fa-exclamation-triangle"></i></div><h1>An exception was thrown while Neos tried to render your page</h1></div>' .
             '<div class="neos-message-wrapper">%s</div>',
             $messageBody
         );


### PR DESCRIPTION
Change html class for icon which gets rendered if a fusion error occurs.

Closes #4223

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
