### PR TITLE
BUGFIX: HtmlAugmenter & Attributes Rendering

### DIFF
--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -99,7 +99,7 @@ class HtmlAugmenter
         /** @var $attribute \DOMAttr */
         foreach ($element->attributes as $attribute) {
             $oldAttributeValue = $attribute->hasChildNodes() ? $attribute->value : true;
-            $hasNewAttributeValue = array_key_exists($attribute->name, $newAttributes);
+            $hasNewAttributeValue = isset($newAttributes[$attribute->name]);
             $newAttributeValue = $newAttributes[$attribute->name] ?? null;
 
             if ($hasNewAttributeValue === false) {

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -342,7 +342,54 @@ class HtmlAugmenterTest extends UnitTestCase
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'allowEmpty' => true,
-                'expectedResult' => '<p class="">Array attribute</p>',
+                'expectedResult' => '<p class>Array attribute</p>',
+            ],
+
+            // https://github.com/neos/neos-development-collection/issues/3582
+            'empty string rendered as empty attribute' => [
+                'html' => '<p>text</p>',
+                'attributes' => ['data-bla' => ''],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-bla>text</p>',
+            ],
+
+            // https://github.com/neos/neos-development-collection/issues/4213
+            'null should not remove existing attribute' => [
+                'html' => '<p data-bla>text</p>',
+                'attributes' => ['data-bla' => null],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-bla>text</p>',
+            ],
+
+            'apply empty string on existing empty attribute' => [
+                'html' => '<p data-bla>text</p>',
+                'attributes' => ['data-bla' => ''],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-bla>text</p>',
+            ],
+
+            'apply string on existing empty attribute' => [
+                'html' => '<p data-bla>text</p>',
+                'attributes' => ['data-bla' => 'foobar'],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p data-bla="foobar">text</p>',
+            ],
+
+            'false removes attribute' => [
+                'html' => '<p data-bla>text</p>',
+                'attributes' => ['data-bla' => false],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p>text</p>',
             ]
         ];
     }


### PR DESCRIPTION
Regression: https://github.com/neos/neos-development-collection/pull/4081

Fixes #4213 - null should not remove existing attribute

Fixes applying string on existing empty attribute
(or empty string)

Thanks to @tellenrieder @ClaraRuna and @KommunikativCh and @fcool  ;) 

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
