### PR TITLE
BUGFIX: Specify default values for the creation timestamp columns

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -51,8 +51,10 @@ class DoctrineDbalContentGraphSchemaBuilder
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('created', Types::DATETIME_IMMUTABLE)
+            ->setDefault('CURRENT_TIMESTAMP')
             ->setNotnull(true);
         $table->addColumn('originalcreated', Types::DATETIME_IMMUTABLE)
+            ->setDefault('CURRENT_TIMESTAMP')
             ->setNotnull(true);
         $table->addColumn('lastmodified', Types::DATETIME_IMMUTABLE)
             ->setNotnull(false)


### PR DESCRIPTION
Makes the columns `created` and `originalcreated` to default to the current timestamp in order to prevent issues with values of `0000-00-00 00:00:00` when migrating from a version without those columns

Related: #4092