### PR TITLE
TASK: Fix MySQL migration differences on fresh setup

### DIFF
--- a/Neos.ContentRepository/Migrations/Mysql/Version20230430183156.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20230430183156.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Make index on movedto unique
+ */
+final class Version20230430183156 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make index on movedto unique';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MysqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX IDX_CE6515692D45FE4D, ADD UNIQUE INDEX UNIQ_CE6515692D45FE4D (movedto)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MysqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX UNIQ_CE6515692D45FE4D, ADD INDEX IDX_CE6515692D45FE4D (movedto)');
+    }
+}

--- a/Neos.Media/Migrations/Mysql/Version20230430183157.php
+++ b/Neos.Media/Migrations/Mysql/Version20230430183157.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adjust key on Tag domain model to ON DELETE SET NULL
+ */
+final class Version20230430183157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adjust key on Tag domain model to ON DELETE SET NULL';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MysqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_tag DROP FOREIGN KEY FK_CA4889693D8E604F');
+        $this->addSql('ALTER TABLE neos_media_domain_model_tag ADD CONSTRAINT FK_CA4889693D8E604F FOREIGN KEY (parent) REFERENCES neos_media_domain_model_tag (persistence_object_identifier) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MysqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_tag DROP FOREIGN KEY FK_CA4889693D8E604F');
+        $this->addSql('ALTER TABLE neos_media_domain_model_tag ADD CONSTRAINT FK_CA4889693D8E604F FOREIGN KEY (parent) REFERENCES neos_media_domain_model_tag (persistence_object_identifier)');
+    }
+}

--- a/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/NodeEvent.php
@@ -35,7 +35,7 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
  *    indexes={
  *      @ORM\Index(name="documentnodeidentifier", columns={"documentnodeidentifier"}),
  *      @ORM\Index(name="workspacename_parentevent", columns={"workspacename", "parentevent"}),
- *      @ORM\Index(name="dimensionshashindex", columns={"dimensionshash"})
+ *      @ORM\Index(name="dimensionshash", columns={"dimensionshash"})
  *    }
  * )
  */


### PR DESCRIPTION
This eliminates some differences in the actual vs the expected DB setup in a fresh
Neos 8.3 installation.

Fixes #3118 (at least partly.)

**Review instructions**

`doctrine:migrationgenerate` should just say `No changes detected` after Neos has been set up.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
