### PR TITLE
BUGFIX: Add translation keys in translation files

### DIFF
--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -839,6 +839,12 @@
 			<trans-unit id="login.loggedOut.body" xml:space="preserve">
 				<source>Successfully logged out</source>
 			</trans-unit>
+			<trans-unit id="documentTree" xml:space="preserve">
+				<source>Document Tree</source>
+			</trans-unit>
+			<trans-unit id="contentTree" xml:space="preserve">
+				<source>Content Tree</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
The following translation keys are missing their translation in the Main.xlf file.

https://github.com/neos/neos-ui/blob/7.3/packages/neos-ui/src/Containers/LeftSideBar/index.js#L82
https://github.com/neos/neos-ui/blob/7.3/packages/neos-ui/src/Containers/LeftSideBar/NodeTreeToolBar/Buttons/ToggleContentTree/index.js#L39