### PR TITLE
FEATURE: Restrict NodeAggregateId and ContentStreamId to proper length

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -35,7 +35,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(false);
         $table->addColumn('origindimensionspacepoint', Types::TEXT)
             ->setNotnull(false);
@@ -77,7 +77,7 @@ class DoctrineDbalContentGraphSchemaBuilder
         $table->addColumn('position', Types::INTEGER)
             ->setNotnull(true);
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $table->addColumn('dimensionspacepoint', Types::TEXT)
             ->setNotnull(true);
@@ -111,7 +111,7 @@ class DoctrineDbalContentGraphSchemaBuilder
         $table->addColumn('properties', Types::TEXT)
             ->setNotnull(false);
         $table->addColumn('destinationnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
 
         $table
@@ -122,16 +122,16 @@ class DoctrineDbalContentGraphSchemaBuilder
     {
         $table = $schema->createTable($this->tableNamePrefix . '_restrictionrelation');
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $table->addColumn('dimensionspacepointhash', Types::STRING)
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('originnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
         $table->addColumn('affectednodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
 
         $table

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/HypergraphSchemaBuilder.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/HypergraphSchemaBuilder.php
@@ -49,7 +49,7 @@ class HypergraphSchemaBuilder
         $table->addColumn('relationanchorpoint', 'hypergraphuuid')
             ->setNotnull(true);
         $table->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
         $table->addColumn('origindimensionspacepoint', Types::JSON)
             ->setNotnull(true);
@@ -79,7 +79,7 @@ class HypergraphSchemaBuilder
     {
         $table = $schema->createTable($this->tableNamePrefix . '_hierarchyhyperrelation');
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $table->addColumn('parentnodeanchor', 'hypergraphuuid')
             ->setNotnull(true);
@@ -112,7 +112,7 @@ class HypergraphSchemaBuilder
         $table->addColumn('properties', 'hypergraphjsonb')
             ->setNotnull(false);
         $table->addColumn('targetnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
 
         $table
@@ -125,13 +125,13 @@ class HypergraphSchemaBuilder
     {
         $table = $schema->createTable($this->tableNamePrefix . '_restrictionhyperrelation');
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $table->addColumn('dimensionspacepointhash', Types::STRING)
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('originnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
         $table->addColumn('affectednodeaggregateids', 'hypergraphvarchars')
             ->setNotnull(true);

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentStream/ContentStreamProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentStream/ContentStreamProjection.php
@@ -96,12 +96,12 @@ class ContentStreamProjection implements ProjectionInterface
         $schema = new Schema();
         $contentStreamTable = $schema->createTable($this->tableName);
         $contentStreamTable->addColumn('contentStreamId', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $contentStreamTable->addColumn('version', Types::INTEGER)
             ->setNotnull(true);
         $contentStreamTable->addColumn('sourceContentStreamId', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(false);
         $contentStreamTable->addColumn('state', Types::STRING)
             ->setLength(20)

--- a/Neos.ContentRepository.Core/Classes/Projection/NodeHiddenState/NodeHiddenStateProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/NodeHiddenState/NodeHiddenStateProjection.php
@@ -73,10 +73,10 @@ class NodeHiddenStateProjection implements ProjectionInterface
         $schema = new Schema();
         $contentStreamTable = $schema->createTable($this->tableName);
         $contentStreamTable->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $contentStreamTable->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
         $contentStreamTable->addColumn('dimensionspacepointhash', Types::STRING)
             ->setLength(255)

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
@@ -104,7 +104,7 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
             ->setLength(255)
             ->setNotnull(false);
         $workspaceTable->addColumn('currentcontentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(false);
         $workspaceTable->addColumn('status', Types::STRING)
             ->setLength(50)

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateId.php
@@ -26,7 +26,7 @@ final class NodeAggregateId implements \JsonSerializable
     /**
      * A preg pattern to match against node aggregate identifiers
      */
-    public const PATTERN = '/^([a-z0-9\-]{1,255})$/';
+    public const PATTERN = '/^([a-z0-9\-]{1,64})$/';
 
     private function __construct(
         public readonly string $value

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/ContentStreamId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/ContentStreamId.php
@@ -25,6 +25,11 @@ use Neos\Flow\Utility\Algorithms;
 final class ContentStreamId implements \JsonSerializable
 {
     /**
+     * A preg pattern to match against content stream identifiers
+     */
+    public const PATTERN = '/^([a-z0-9\-]{1,40})$/';
+
+    /**
      * @var array<string,self>
      */
     private static array $instances = [];
@@ -32,6 +37,13 @@ final class ContentStreamId implements \JsonSerializable
     private function __construct(
         public string $value
     ) {
+        if (!preg_match(self::PATTERN, $value)) {
+            throw new \InvalidArgumentException(
+                'Invalid content stream identifier "' . $value
+                . '" (a content stream identifier must only contain lowercase characters, numbers and the "-" sign).',
+                1505840197862
+            );
+        }
     }
 
     private static function instance(string $value): self

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -62,11 +62,11 @@ final class AssetUsageRepository
             ->setNotnull(false)
             ->setDefault(null);
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true)
             ->setDefault('');
         $table->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true)
             ->setDefault('');
         $table->addColumn('origindimensionspacepoint', Types::TEXT)

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
@@ -27,7 +27,7 @@ class DocumentUriPathSchemaBuilder
 
         $table = $schema->createTable($this->tableNamePrefix . '_uri');
         $table->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setDefault('')
             ->setNotnull(true);
         $table->addColumn('uripath', Types::STRING)
@@ -56,13 +56,13 @@ class DocumentUriPathSchemaBuilder
             ->setDefault('')
             ->setNotnull(true);
         $table->addColumn('parentnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(false);
         $table->addColumn('precedingnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(false);
         $table->addColumn('succeedingnodeaggregateid', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(false);
         $table->addColumn('shortcuttarget', Types::STRING)
             ->setLength(1000)
@@ -82,7 +82,7 @@ class DocumentUriPathSchemaBuilder
     {
         $table = $schema->createTable($this->tableNamePrefix . '_livecontentstreams');
         $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setDefault('')
             ->setNotnull(true);
         $table->addColumn('workspacename', Types::STRING)

--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
@@ -106,7 +106,7 @@ class ChangeProjection implements ProjectionInterface
         $schema = new Schema();
         $changeTable = $schema->createTable($this->tableName);
         $changeTable->addColumn('contentStreamId', Types::STRING)
-            ->setLength(255)
+            ->setLength(40)
             ->setNotnull(true);
         $changeTable->addColumn('changed', Types::BOOLEAN)
             ->setNotnull(true);
@@ -114,7 +114,7 @@ class ChangeProjection implements ProjectionInterface
             ->setNotnull(true);
 
         $changeTable->addColumn('nodeAggregateId', Types::STRING)
-            ->setLength(255)
+            ->setLength(64)
             ->setNotnull(true);
         $changeTable->addColumn('originDimensionSpacePoint', Types::TEXT)
             ->setNotnull(false);


### PR DESCRIPTION
Restricts `NodeAggregateId` to 64 character and `ContentStreamId` to 40 character.

Fixes #4133 