### PR TITLE
BUGFIX: Allow events with not existing newWorkspaceOwner

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Event/WorkspaceOwnerWasChanged.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Event/WorkspaceOwnerWasChanged.php
@@ -25,7 +25,7 @@ final class WorkspaceOwnerWasChanged implements EventInterface
     {
         return new self(
             WorkspaceName::fromString($values['workspaceName']),
-            $values['newWorkspaceOwner'],
+            $values['newWorkspaceOwner'] ?? null,
         );
     }
 


### PR DESCRIPTION
Prevents warning on projection replays, if newWorkspaceOwner is not set.