### PR TITLE
BUGFIX: fix `./flow site:create` command

### DIFF
--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -99,7 +99,7 @@ class SiteCommandController extends CommandController
             );
             $this->quit(1);
         } catch (SiteNodeNameIsAlreadyInUseByAnotherSite | NodeNameIsAlreadyOccupied $exception) {
-            $this->outputLine('<error>A site with siteNodeName "%s" already exists</error>', [$nodeName]);
+            $this->outputLine('<error>A site with siteNodeName "%s" already exists</error>', [$nodeName ?: $name]);
             $this->quit(1);
         }
 

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -177,7 +177,7 @@ class SiteService
             $site->getConfiguration()->contentRepositoryId,
             new SiteServiceInternalsFactory()
         );
-        $siteServiceInternals->createSiteNode($site, $nodeTypeName);
+        $siteServiceInternals->createSiteNodeIfNotExists($site, $nodeTypeName);
 
         return $site;
     }

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -110,7 +110,7 @@ class SiteServiceInternals implements ContentRepositoryServiceInterface
             $sitesNodeIdentifier,
             $site->getNodeName()->toNodeName(),
         );
-        if (iterator_count($siteNodeAggregate) > 0) {
+        foreach ($siteNodeAggregate as $_) {
             // Site node already exists
             return;
         }

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -110,7 +110,7 @@ class SiteServiceInternals implements ContentRepositoryServiceInterface
             $sitesNodeIdentifier,
             $site->getNodeName()->toNodeName(),
         );
-        if (count(iterator_to_array($siteNodeAggregate)) > 0) {
+        if (iterator_count($siteNodeAggregate) > 0) {
             // Site node already exists
             return;
         }

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -89,7 +89,7 @@ class SiteServiceInternals implements ContentRepositoryServiceInterface
         }
     }
 
-    public function createSiteNode(Site $site, string $nodeTypeName): void
+    public function createSiteNodeIfNotExists(Site $site, string $nodeTypeName): void
     {
         $bootstrapper = ContentRepositoryBootstrapper::create($this->contentRepository);
         $liveContentStreamId = $bootstrapper->getOrCreateLiveContentStream();
@@ -104,6 +104,15 @@ class SiteServiceInternals implements ContentRepositoryServiceInterface
                 'Cannot create a site using a non-existing node type.',
                 1412372375
             );
+        }
+        $siteNodeAggregate = $this->contentRepository->getContentGraph()->findChildNodeAggregatesByName(
+            $liveContentStreamId,
+            $sitesNodeIdentifier,
+            $site->getNodeName()->toNodeName(),
+        );
+        if (count(iterator_to_array($siteNodeAggregate)) > 0) {
+            // Site node already exists
+            return;
         }
 
         $rootDimensionSpacePoints = $this->interDimensionalVariationGraph->getRootGeneralizations();


### PR DESCRIPTION
- refactor `createSiteNode` to `createSiteNodeIfNotExists`
- use `name` as fallback in exception message for `SiteNodeNameIsAlreadyInUseByAnotherSite`

In cooperation with @skurfuerst  and @ahaeslich.

**Review instructions**

Reproduce by adding a site with a name that is already in use with `./flow site:create`

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
