### PR TITLE
BUGFIX: enable defaultValue for DateTime properties

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -101,15 +101,9 @@ trait NodeCreation
                 $nodeTypeName
             );
 
-            if ($defaultValue instanceof \DateTimeInterface) {
-                // In NodeType::getDefaultValuesForProperties, DateTime objects are handled specially :(
-                // That's why we also need to take care of them here.
-                $defaultValues[$propertyName] =  $defaultValue;
-            } else {
-                $defaultValues[$propertyName] = $this->getPropertyConverter()->deserializePropertyValue(
-                    new SerializedPropertyValue($defaultValue, $propertyType->getSerializationType())
-                );
-            }
+            $defaultValues[$propertyName] = $this->getPropertyConverter()->deserializePropertyValue(
+                new SerializedPropertyValue($defaultValue, $propertyType->getSerializationType())
+            );
         }
 
         return PropertyValuesToWrite::fromArray($defaultValues);
@@ -152,8 +146,9 @@ trait NodeCreation
      */
     private function handleCreateNodeAggregateWithNodeAndSerializedProperties(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        ContentRepository $contentRepository
-    ): EventsToPublish {
+        ContentRepository                                  $contentRepository
+    ): EventsToPublish
+    {
         $this->requireContentStreamToExist($command->contentStreamId, $contentRepository);
         $this->requireDimensionSpacePointToExist($command->originDimensionSpacePoint->toDimensionSpacePoint());
         $nodeType = $this->requireNodeType($command->nodeTypeName);
@@ -261,9 +256,10 @@ trait NodeCreation
      */
     private function createRegularWithNode(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        DimensionSpacePointSet $coveredDimensionSpacePoints,
-        SerializedPropertyValues $initialPropertyValues
-    ): NodeAggregateWithNodeWasCreated {
+        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
+        SerializedPropertyValues                           $initialPropertyValues
+    ): NodeAggregateWithNodeWasCreated
+    {
         return new NodeAggregateWithNodeWasCreated(
             $command->contentStreamId,
             $command->nodeAggregateId,
@@ -286,13 +282,14 @@ trait NodeCreation
      */
     private function handleTetheredChildNodes(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        NodeType $nodeType,
-        DimensionSpacePointSet $coveredDimensionSpacePoints,
-        NodeAggregateId $parentNodeAggregateId,
-        NodeAggregateIdsByNodePaths $nodeAggregateIds,
-        ?NodePath $nodePath,
-        ContentRepository $contentRepository,
-    ): Events {
+        NodeType                                           $nodeType,
+        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
+        NodeAggregateId                                    $parentNodeAggregateId,
+        NodeAggregateIdsByNodePaths                        $nodeAggregateIds,
+        ?NodePath                                          $nodePath,
+        ContentRepository                                  $contentRepository,
+    ): Events
+    {
         $events = [];
         foreach ($nodeType->getAutoCreatedChildNodes() as $rawNodeName => $childNodeType) {
             assert($childNodeType instanceof NodeType);
@@ -335,14 +332,15 @@ trait NodeCreation
      */
     private function createTetheredWithNode(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        NodeAggregateId $nodeAggregateId,
-        NodeTypeName $nodeTypeName,
-        DimensionSpacePointSet $coveredDimensionSpacePoints,
-        NodeAggregateId $parentNodeAggregateId,
-        NodeName $nodeName,
-        SerializedPropertyValues $initialPropertyValues,
-        NodeAggregateId $precedingNodeAggregateId = null
-    ): NodeAggregateWithNodeWasCreated {
+        NodeAggregateId                                    $nodeAggregateId,
+        NodeTypeName                                       $nodeTypeName,
+        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
+        NodeAggregateId                                    $parentNodeAggregateId,
+        NodeName                                           $nodeName,
+        SerializedPropertyValues                           $initialPropertyValues,
+        NodeAggregateId                                    $precedingNodeAggregateId = null
+    ): NodeAggregateWithNodeWasCreated
+    {
         return new NodeAggregateWithNodeWasCreated(
             $command->contentStreamId,
             $nodeAggregateId,
@@ -358,10 +356,11 @@ trait NodeCreation
     }
 
     protected static function populateNodeAggregateIds(
-        NodeType $nodeType,
+        NodeType                     $nodeType,
         ?NodeAggregateIdsByNodePaths $nodeAggregateIds,
-        NodePath $childPath = null
-    ): NodeAggregateIdsByNodePaths {
+        NodePath                     $childPath = null
+    ): NodeAggregateIdsByNodePaths
+    {
         if ($nodeAggregateIds === null) {
             $nodeAggregateIds = NodeAggregateIdsByNodePaths::createEmpty();
         }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -146,9 +146,8 @@ trait NodeCreation
      */
     private function handleCreateNodeAggregateWithNodeAndSerializedProperties(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        ContentRepository                                  $contentRepository
-    ): EventsToPublish
-    {
+        ContentRepository $contentRepository
+    ): EventsToPublish {
         $this->requireContentStreamToExist($command->contentStreamId, $contentRepository);
         $this->requireDimensionSpacePointToExist($command->originDimensionSpacePoint->toDimensionSpacePoint());
         $nodeType = $this->requireNodeType($command->nodeTypeName);
@@ -256,10 +255,9 @@ trait NodeCreation
      */
     private function createRegularWithNode(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
-        SerializedPropertyValues                           $initialPropertyValues
-    ): NodeAggregateWithNodeWasCreated
-    {
+        DimensionSpacePointSet $coveredDimensionSpacePoints,
+        SerializedPropertyValues $initialPropertyValues
+    ): NodeAggregateWithNodeWasCreated {
         return new NodeAggregateWithNodeWasCreated(
             $command->contentStreamId,
             $command->nodeAggregateId,
@@ -282,14 +280,13 @@ trait NodeCreation
      */
     private function handleTetheredChildNodes(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        NodeType                                           $nodeType,
-        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
-        NodeAggregateId                                    $parentNodeAggregateId,
-        NodeAggregateIdsByNodePaths                        $nodeAggregateIds,
-        ?NodePath                                          $nodePath,
-        ContentRepository                                  $contentRepository,
-    ): Events
-    {
+        NodeType $nodeType,
+        DimensionSpacePointSet $coveredDimensionSpacePoints,
+        NodeAggregateId $parentNodeAggregateId,
+        NodeAggregateIdsByNodePaths $nodeAggregateIds,
+        ?NodePath $nodePath,
+        ContentRepository $contentRepository,
+    ): Events {
         $events = [];
         foreach ($nodeType->getAutoCreatedChildNodes() as $rawNodeName => $childNodeType) {
             assert($childNodeType instanceof NodeType);
@@ -332,15 +329,14 @@ trait NodeCreation
      */
     private function createTetheredWithNode(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        NodeAggregateId                                    $nodeAggregateId,
-        NodeTypeName                                       $nodeTypeName,
-        DimensionSpacePointSet                             $coveredDimensionSpacePoints,
-        NodeAggregateId                                    $parentNodeAggregateId,
-        NodeName                                           $nodeName,
-        SerializedPropertyValues                           $initialPropertyValues,
-        NodeAggregateId                                    $precedingNodeAggregateId = null
-    ): NodeAggregateWithNodeWasCreated
-    {
+        NodeAggregateId $nodeAggregateId,
+        NodeTypeName $nodeTypeName,
+        DimensionSpacePointSet $coveredDimensionSpacePoints,
+        NodeAggregateId $parentNodeAggregateId,
+        NodeName $nodeName,
+        SerializedPropertyValues $initialPropertyValues,
+        NodeAggregateId $precedingNodeAggregateId = null
+    ): NodeAggregateWithNodeWasCreated {
         return new NodeAggregateWithNodeWasCreated(
             $command->contentStreamId,
             $nodeAggregateId,
@@ -356,11 +352,10 @@ trait NodeCreation
     }
 
     protected static function populateNodeAggregateIds(
-        NodeType                     $nodeType,
+        NodeType $nodeType,
         ?NodeAggregateIdsByNodePaths $nodeAggregateIds,
-        NodePath                     $childPath = null
-    ): NodeAggregateIdsByNodePaths
-    {
+        NodePath $childPath = null
+    ): NodeAggregateIdsByNodePaths {
         if ($nodeAggregateIds === null) {
             $nodeAggregateIds = NodeAggregateIdsByNodePaths::createEmpty();
         }

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
@@ -467,11 +467,7 @@ class NodeType
         $defaultValues = [];
         foreach ($this->fullConfiguration['properties'] as $propertyName => $propertyConfiguration) {
             if (is_string($propertyName) && isset($propertyConfiguration['defaultValue'])) {
-                $type = $propertyConfiguration['type'] ?? '';
-                $defaultValues[$propertyName] = match ($type) {
-                    'DateTime' => new \DateTime($propertyConfiguration['defaultValue']),
-                    default => $propertyConfiguration['defaultValue'],
-                };
+                $defaultValues[$propertyName] =  $propertyConfiguration['defaultValue'];
             }
         }
 


### PR DESCRIPTION
 - remove type matching for defaultValues in DateTime properties in getDefaultValuesForProperties()
- remove if condition for DateTime properties in deserializeDefaultProperties()

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**
Adding a defaultValue to a dateTime property wasn't possible so far. There was some special case handling in the code for these properties, but it wasn't working. Removing this special case handling fixed the problem.

**Review instructions**
How to check the correct behaviour:
- add a property of type DateTime to your page/module
- give it a defaultValue, for example 'now'
- the defaultValue should work correctly (previously you would get an error)

FYI: The test did not need to be changed, because it didn't even match the previous case. The test is running correctly, though.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
