### PR TITLE
BUGFIX: Add dependency from CR registry to CG PostgreSQL adapter

### DIFF
--- a/Neos.ContentRepositoryRegistry/composer.json
+++ b/Neos.ContentRepositoryRegistry/composer.json
@@ -7,6 +7,7 @@
     ],
     "require": {
         "neos/flow": "*",
+        "neos/contentgraph-postgresqladapter": "self.version",
         "neos/contentrepository-core": "*",
         "symfony/property-access": "*",
         "psr/clock": "^1"


### PR DESCRIPTION
The `PostgresDbalClient` relies on `PostgresDbalClientInterface` from `neos/contentgraph-postgresqladapter`.

**Review instructions**

Discuss: Should the client implementations maybe removed from the registry? Or made optional?

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [ ] ~The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)~
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
