### PR TITLE
BUGFIX: re-fix content stream cleanup

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -588,6 +588,12 @@ final class WorkspaceCommandHandler implements CommandHandlerInterface
             ),
         );
 
+        // to avoid dangling content streams, we need to remove our temporary content stream (whose events
+        // have already been published)
+        $contentRepository->handle(new RemoveContentStream(
+            $matchingContentStream
+        ));
+
         // It is safe to only return the last command result,
         // as the commands which were rebased are already executed "synchronously"
         return new EventsToPublish(


### PR DESCRIPTION
originally implemented by https://github.com/neos/neos-development-collection/pull/4143/files\#diff-3e5de1a138586c8c85cdd71ed1a765ecc0ba0d79ab2579a6000475d427cefda2 but removed by 6f6f5e881613c8b84510ffeddd96dbfa67897d8a (merge error)

Related: #4088