### PR TITLE
BUGFIX: RenderAttributesTrait allows Stringable objects

### DIFF
--- a/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
+++ b/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
@@ -22,7 +22,7 @@ trait RenderAttributesTrait
      * Render the tag attributes for the given key->values as string,
      * if a value is an iterable it will be concatenated with spaces as separator
      *
-     * @param iterable<mixed,int|string|null|bool|array<mixed,string|bool|null>> $attributes
+     * @param iterable<mixed,int|string|null|bool|array<string|bool|null|\Stringable>> $attributes
      * @param bool $allowEmpty
      */
     protected function renderAttributes(iterable $attributes, bool $allowEmpty = true): string
@@ -46,7 +46,7 @@ trait RenderAttributesTrait
                     $joinedAttributeValue .= match (gettype($attributeValuePart)) {
                         'boolean', 'NULL' => '',
                         'string' => ' ' . trim($attributeValuePart),
-                        default => throw new \InvalidArgumentException('$attributes may contain values of type array<string|bool|null> type: array<' . get_debug_type($attributeValuePart) . '> given')
+                        default => throw new \InvalidArgumentException('$attributes may contain values of type array<string|bool|null|\Stringable> type: array<' . get_debug_type($attributeValuePart) . '> given')
                     };
                 }
                 $attributeValue = trim($joinedAttributeValue);

--- a/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
+++ b/Neos.Fusion/Classes/Service/RenderAttributesTrait.php
@@ -40,6 +40,9 @@ trait RenderAttributesTrait
                 // [""] => empty attribute
                 $joinedAttributeValue = '';
                 foreach ($attributeValue as $attributeValuePart) {
+                    if ($attributeValuePart instanceof \Stringable) {
+                        $attributeValuePart = $attributeValuePart->__toString();
+                    }
                     $joinedAttributeValue .= match (gettype($attributeValuePart)) {
                         'boolean', 'NULL' => '',
                         'string' => ' ' . trim($attributeValuePart),

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -327,14 +327,45 @@ class HtmlAugmenterTest extends UnitTestCase
                 'allowEmpty' => false,
                 'expectedResult' => '<p>Null attribute</p>',
             ],
-            // Adding of array attributes
+            // Adding of Stringable attributes
             [
-                'html' => '<p>Array attribute</p>',
-                'attributes' => ['class' => ["Hello", "world"]],
+                'html' => '<p>Stringable attribute</p>',
+                'attributes' => ['data-stringable' => new class {
+                    public function __toString(): string
+                    {
+                        return 'toString';
+                    }
+                }],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'allowEmpty' => true,
-                'expectedResult' => '<p class="Hello world">Array attribute</p>',
+                'expectedResult' => '<p data-stringable="toString">Stringable attribute</p>',
+            ],
+            [
+                'html' => '<p>Stringable attribute</p>',
+                'attributes' => ['data-stringable' => new class {
+                    public function __toString(): string
+                    {
+                        return 'toString';
+                    }
+                }],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => false,
+                'expectedResult' => '<p data-stringable="toString">Stringable attribute</p>',
+            ],
+            // Adding of array attributes
+            [
+                'html' => '<p>Array attribute</p>',
+                'attributes' => ['class' => ["Hello", "world", new class {
+                    public function __toString(){
+                        return "toString";
+                    }
+                }]],
+                'fallbackTagName' => null,
+                'exclusiveAttributes' => null,
+                'allowEmpty' => true,
+                'expectedResult' => '<p class="Hello world toString">Array attribute</p>',
             ],
             [
                 'html' => '<p>Array attribute</p>',

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -330,42 +330,28 @@ class HtmlAugmenterTest extends UnitTestCase
             // Adding of Stringable attributes
             [
                 'html' => '<p>Stringable attribute</p>',
-                'attributes' => ['data-stringable' => new class {
-                    public function __toString(): string
-                    {
-                        return 'toString';
-                    }
-                }],
+                'attributes' => ['data-stringable' => $mockObject],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'allowEmpty' => true,
-                'expectedResult' => '<p data-stringable="toString">Stringable attribute</p>',
+                'expectedResult' => '<p data-stringable="casted value">Stringable attribute</p>',
             ],
             [
                 'html' => '<p>Stringable attribute</p>',
-                'attributes' => ['data-stringable' => new class {
-                    public function __toString(): string
-                    {
-                        return 'toString';
-                    }
-                }],
+                'attributes' => ['data-stringable' => $mockObject],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'allowEmpty' => false,
-                'expectedResult' => '<p data-stringable="toString">Stringable attribute</p>',
+                'expectedResult' => '<p data-stringable="casted value">Stringable attribute</p>',
             ],
             // Adding of array attributes
             [
                 'html' => '<p>Array attribute</p>',
-                'attributes' => ['class' => ["Hello", "world", new class {
-                    public function __toString(){
-                        return "toString";
-                    }
-                }]],
+                'attributes' => ['class' => ["Hello", "world", $mockObject]],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
                 'allowEmpty' => true,
-                'expectedResult' => '<p class="Hello world toString">Array attribute</p>',
+                'expectedResult' => '<p class="Hello world casted value">Array attribute</p>',
             ],
             [
                 'html' => '<p>Array attribute</p>',


### PR DESCRIPTION
RenderAttributesTrait converts Stringable objects to strings via `__toString()`

related: #4225 

**Upgrade instructions**

Not sure what to write here :thinking: 

**Review instructions**

Up until 8.3 it was possible to use EelHelpers with a fluent interface like API for attributes. E.g. the following was working fine in fusion afx:
```
class={[block.element('subline').modifier('light')]}
```
The variable `block` is an EelHelper which returns `self`. In 8.3 this fails with an Exception
```
$attributes may contain values of type array<string|bool|null> type: array...
```
The reason is, that with PR #4225, in `RenderAttributesTrait` there are two different ways the object is processed:
1. In case `$attributeValue` is not an array, e.g. an object, it is basically converted to a string
2. In case of an array it is checked if `$attributeValuePart` is actually of type plain string, boolean or null. In case  of an object an exception is raised. This exception then breaks the previous behaviour in case of a `\Stringable` object.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
