### PR TITLE
BUGFIX: Disable publish checkmark for new pages in workspace

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -69,9 +69,19 @@
 										</td>
 										<td class="neos-action">
 											<f:if condition="{canPublishToBaseWorkspace}">
-												<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-success neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
-													<i class="fas fa-check icon-white"></i>
-												</button>
+												<f:if condition="{document.isNew}">
+													<f:then>
+														<div class="neos-button neos-disabled neos-button-primary neos-pull-right"
+																 title="{neos:backend.translate(id: 'cantPublishSingleNodeInNewPage', source: 'Main', package: 'Neos.Neos')}">
+															<i class="fas fa-check icon-white"></i>
+														</div>
+													</f:then>
+													<f:else>
+														<button form="postHelper" formaction="{f:uri.action(action: 'publishNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-primary neos-pull-right" title="{neos:backend.translate(id: 'publish', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip">
+															<i class="fas fa-check icon-white"></i>
+														</button>
+													</f:else>
+												</f:if>
 											</f:if>
 											<button form="postHelper" formaction="{f:uri.action(action: 'discardNode', arguments: {node: change.node.contextPath, selectedWorkspace: selectedWorkspace})}" type="submit" class="neos-button neos-button-danger neos-pull-right" title="{neos:backend.translate(id: 'discard', source: 'Main', package: 'Neos.Neos')}" data-neos-toggle="tooltip" data-placement="bottom">
 												<i class="fas fa-trash-alt icon-white"></i>

--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -147,6 +147,9 @@
 			<trans-unit id="cantPublishBecauseTargetWorkspaceIsReadOnly" xml:space="preserve">
 				<source>Can't publish because the target workspace is read-only</source>
 			</trans-unit>
+			<trans-unit id="cantPublishSingleNodeInNewPage" xml:space="preserve">
+      	<source>Can't publish a single node in a new page</source>
+      </trans-unit>
 			<trans-unit id="selectTargetWorkspace" xml:space="preserve">
 				<source>Select target workspace</source>
 			</trans-unit>


### PR DESCRIPTION
closes #3991 

**Review instructions**
If the document is new, I show a small disabled checkmark instead of the functioning checkmark. This will force the user to use the checkboxes on the left side to publish changes. 
This does not solve the underlying problem but it will at least disable the function for Editors. 

<img width="1240" alt="Bildschirmfoto 2023-05-12 um 11 12 21" src="https://github.com/neos/neos-development-collection/assets/91674611/bc7d0f47-a54b-474d-a74a-230eb3a92546">

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
