### PR TITLE
TASK: Remove setting autoCreateImageVariantPresets

### DIFF
--- a/Neos.Media/Configuration/Settings.yaml
+++ b/Neos.Media/Configuration/Settings.yaml
@@ -16,8 +16,6 @@ Neos:
     asyncThumbnails: true
     # Thumbnail presets
     thumbnailPresets: {  }
-    # Automatically create thumbnails for configured presets when assets are added
-    autoCreateThumbnailPresets: true
 
     iconSet:
       path: 'resource://Neos.Media/Public/IconSets/vivid'

--- a/Neos.Media/Documentation/VariantPresets.rst
+++ b/Neos.Media/Documentation/VariantPresets.rst
@@ -92,15 +92,6 @@ The following example shows the required structure and possible fields of the pr
                   options:
                     aspectRatio: '1:1'
 
-The automatic variant generation for new assets has to be enabled via setting as
-by default this feature is disabled.
-
-.. code-block:: yaml
-
-  Neos:
-    Media:
-      autoCreateImageVariantPresets: true
-
 To show and edit the variants in the media module the variants tab has to be enabled.
 
 .. code-block:: yaml


### PR DESCRIPTION
The setting autoCreateImageVariantPresets was introduced in 510ff3fa4222d7ed97a7ff67ccc137ea639409e6, however it was never evaluated. Instead, the creation of asset variants is triggered automatically when an Asset is created.

Related: #4300