### PR TITLE
TASK: Update .styleci.yml to use PHP 8.2

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,6 @@
 preset: psr2
 
-version: 8.1
+version: 8.2
 
 finder:
   path:


### PR DESCRIPTION
Make sure StyleCI can parse code using PHP 8.2 features (like `readonly` classes.)

**Review instructions**

Nothing should happen, but when PHP 8.2 features are in the code (like `readonly` classes), StyleCI should still be working.

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [ ] ~The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)~
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
