### PR TITLE
BUGFIX: do not crash when node already disabled/enabled

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -55,12 +55,19 @@ Feature: Constraint checks on node aggregate disabling
       | nodeVariantSelectionStrategy | "allVariants"                          |
     And the graph projection is fully up to date
 
-    When the command DisableNodeAggregate is executed with payload and exceptions are caught:
+      # Note: The behavior has been changed with https://github.com/neos/neos-development-collection/pull/4284 and the test was adjusted accordingly
+    When the command DisableNodeAggregate is executed with payload:
       | Key                          | Value                                  |
       | nodeAggregateId      | "sir-david-nodenborough"               |
       | coveredDimensionSpacePoint   | {"language": "de"}                                     |
       | nodeVariantSelectionStrategy | "allVariants"                          |
-    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDisablesDimensionSpacePoint"
+    Then I expect exactly 4 events to be published on stream with prefix "ContentStream:cs-identifier"
+    And event at index 3 is of type "NodeAggregateWasDisabled" with payload:
+      | Key                          | Expected                               |
+      | contentStreamId              | "cs-identifier"                        |
+      | nodeAggregateId              | "sir-david-nodenborough"               |
+      | affectedDimensionSpacePoints | [{"language":"de"},{"language":"gsw"}] |
+
 
   Scenario: Try to disable a node aggregate in a non-existing dimension space point
     When the command DisableNodeAggregate is executed with payload and exceptions are caught:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
@@ -47,12 +47,13 @@ Feature: Enable a node aggregate
       | nodeVariantSelectionStrategy | "allVariants"    |
     Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist"
 
+    # Note: The behavior has been changed with https://github.com/neos/neos-development-collection/pull/4284 and the test was adjusted accordingly
   Scenario: Try to enable an already enabled node aggregate
-    When the command EnableNodeAggregate is executed with payload and exceptions are caught:
+    When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId      | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotDisableDimensionSpacePoint"
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-identifier"
 
   Scenario: Try to enable a node aggregate in a non-existing dimension space point
     When the command EnableNodeAggregate is executed with payload and exceptions are caught:

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
@@ -7,6 +7,7 @@ namespace Neos\ContentRepository\Core\CommandHandler;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\EventStore\Model\Event\Version;
 use Neos\EventStore\Model\EventStore\CommitResult;
 use Neos\EventStore\Model\Event\SequenceNumber;
 
@@ -23,6 +24,20 @@ final class CommandResult
         private readonly PendingProjections $pendingProjections,
         public readonly CommitResult $commitResult,
     ) {
+    }
+
+    /**
+     * an empty command result which should not result in projection updates
+     * @return self
+     */
+    public static function empty(): self {
+        return new self(
+            PendingProjections::empty(),
+            new CommitResult(
+                Version::first(),
+                SequenceNumber::none()
+            )
+        );
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
@@ -30,7 +30,8 @@ final class CommandResult
      * an empty command result which should not result in projection updates
      * @return self
      */
-    public static function empty(): self {
+    public static function empty(): self
+    {
         return new self(
             PendingProjections::empty(),
             new CommitResult(

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/PendingProjections.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/PendingProjections.php
@@ -85,8 +85,8 @@ final class PendingProjections
     ) {
     }
 
-    public static function empty(
-    ): self {
+    public static function empty(): self
+    {
         return new self(Projections::create(), []);
     }
 

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/PendingProjections.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/PendingProjections.php
@@ -85,6 +85,11 @@ final class PendingProjections
     ) {
     }
 
+    public static function empty(
+    ): self {
+        return new self(Projections::create(), []);
+    }
+
     public static function fromProjectionsAndEventsAndSequenceNumber(
         Projections $allProjections,
         Events $events,

--- a/Neos.ContentRepository.Core/Classes/EventStore/EventPersister.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventPersister.php
@@ -15,6 +15,7 @@ use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\EventId;
 use Neos\EventStore\Model\Event\EventMetadata;
 use Neos\EventStore\Model\Events;
+use Neos\EventStore\Model\EventStore\CommitResult;
 
 /**
  * Internal service to persist {@see EventInterface} with the proper normalization, and triggering the
@@ -39,6 +40,9 @@ final class EventPersister
      */
     public function publishEvents(EventsToPublish $eventsToPublish): CommandResult
     {
+        if ($eventsToPublish->events->isEmpty()) {
+            return CommandResult::empty();
+        }
         // the following logic could also be done in an AppEventStore::commit method (being called
         // directly from the individual Command Handlers).
         $normalizedEvents = Events::fromArray(

--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -49,4 +49,9 @@ final class Events implements \IteratorAggregate
     {
         return array_map($callback, $this->events);
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->events);
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/EventStore/EventsToPublish.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventsToPublish.php
@@ -24,4 +24,13 @@ final class EventsToPublish
         public readonly ExpectedVersion $expectedVersion,
     ) {
     }
+
+    public static function empty(): self
+    {
+        return new EventsToPublish(
+            StreamName::fromString("empty"),
+            Events::fromArray([]),
+            ExpectedVersion::ANY()
+        );
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -609,39 +609,6 @@ trait ConstraintChecks
         }
     }
 
-    /**
-     * @throws NodeAggregateCurrentlyDoesNotDisableDimensionSpacePoint
-     */
-    protected function requireNodeAggregateToDisableDimensionSpacePoint(
-        NodeAggregate $nodeAggregate,
-        DimensionSpacePoint $dimensionSpacePoint
-    ): void {
-        if (!$nodeAggregate->disablesDimensionSpacePoint($dimensionSpacePoint)) {
-            throw new NodeAggregateCurrentlyDoesNotDisableDimensionSpacePoint(
-                'Node aggregate "' . $nodeAggregate->nodeAggregateId->value
-                    . '" currently does not disable dimension space point '
-                    . json_encode($dimensionSpacePoint) . '.',
-                1557735431
-            );
-        }
-    }
-
-    /**
-     * @throws NodeAggregateCurrentlyDisablesDimensionSpacePoint
-     */
-    protected function requireNodeAggregateToNotDisableDimensionSpacePoint(
-        NodeAggregate $nodeAggregate,
-        DimensionSpacePoint $dimensionSpacePoint
-    ): void {
-        if ($nodeAggregate->disablesDimensionSpacePoint($dimensionSpacePoint)) {
-            throw new NodeAggregateCurrentlyDisablesDimensionSpacePoint(
-                'Node aggregate "' . $nodeAggregate->nodeAggregateId->value
-                    . '" currently disables dimension space point ' . json_encode($dimensionSpacePoint) . '.',
-                1555179563
-            );
-        }
-    }
-
     protected function validateReferenceProperties(
         ReferenceName $referenceName,
         PropertyValuesToWrite $referenceProperties,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/NodeDisabling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/NodeDisabling.php
@@ -60,10 +60,11 @@ trait NodeDisabling
             $nodeAggregate,
             $command->coveredDimensionSpacePoint
         );
-        $this->requireNodeAggregateToNotDisableDimensionSpacePoint(
-            $nodeAggregate,
-            $command->coveredDimensionSpacePoint
-        );
+
+        if ($nodeAggregate->disablesDimensionSpacePoint($command->coveredDimensionSpacePoint)) {
+            // already disabled, so we can return a no-operation.
+            return EventsToPublish::empty();
+        }
 
         $affectedDimensionSpacePoints = $command->nodeVariantSelectionStrategy
             ->resolveAffectedDimensionSpacePoints(
@@ -113,10 +114,11 @@ trait NodeDisabling
             $nodeAggregate,
             $command->coveredDimensionSpacePoint
         );
-        $this->requireNodeAggregateToDisableDimensionSpacePoint(
-            $nodeAggregate,
-            $command->coveredDimensionSpacePoint
-        );
+
+        if (!$nodeAggregate->disablesDimensionSpacePoint($command->coveredDimensionSpacePoint)) {
+            // already enabled, so we can return a no-operation.
+            return EventsToPublish::empty();
+        }
 
         $affectedDimensionSpacePoints = $command->nodeVariantSelectionStrategy
             ->resolveAffectedDimensionSpacePoints(


### PR DESCRIPTION
How to reproduce:

- User A: log into backend
- User B: log into backend
- User A: Hide Node X
- User B: Hide Node X
- User B: Publish
- User A: Publish <-- here the crash has occurred during rebase.

Fix idea: IMHO we can relax the checks in these command handlers a bit, to simply do nothing in this case.
