### PR TITLE
BUGFIX: Undefined array key "ui" in nodeType creationDialog

### DIFF
--- a/Neos.Neos/Classes/NodeTypePostprocessor/DefaultPropertyEditorPostprocessor.php
+++ b/Neos.Neos/Classes/NodeTypePostprocessor/DefaultPropertyEditorPostprocessor.php
@@ -107,7 +107,7 @@ class DefaultPropertyEditorPostprocessor implements NodeTypePostprocessorInterfa
                 // - take configuration from creationDialog elements (NodeTypes)
                 $mergedUiConfiguration = $this->editorDefaultConfiguration[$editor] ?? [];
                 $mergedUiConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedUiConfiguration, $defaultConfigurationFromDataType);
-                $mergedUiConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedUiConfiguration, $elementConfiguration['ui']);
+                $mergedUiConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedUiConfiguration, $elementConfiguration['ui'] ?? []);
                 $elementConfiguration['ui'] = $mergedUiConfiguration;
                 $elementConfiguration['ui']['editor'] = $editor;
             }

--- a/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
@@ -399,6 +399,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
                             'type' => 'TypeWithDataTypeConfig',
                             'ui' => [
                                 'editor' => 'EditorFromDataTypeConfig',
+                                'value' => 'fromDataTypeConfig',
                                 'dataTypeValue' => 'fromDataTypeConfig',
                             ]
                         ],

--- a/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
@@ -303,6 +303,9 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
                                 'elementValue' => 'fromPropertyConfig',
                             ]
                         ],
+                        'elementWithEditorFromDataTypeConfigWithoutUiConfig' => [
+                            'type' => 'TypeWithDataTypeConfig'
+                        ],
                         'elementWithOverriddenEditorConfig' => [
                             'type' => 'TypeWithDataTypeConfig',
                             'ui' => [
@@ -390,6 +393,13 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
                                 'value' => 'fromPropertyConfig',
                                 'dataTypeValue' => 'fromDataTypeConfig',
                                 'elementValue' => 'fromPropertyConfig',
+                            ]
+                        ],
+                        'elementWithEditorFromDataTypeConfigWithoutUiConfig' => [
+                            'type' => 'TypeWithDataTypeConfig',
+                            'ui' => [
+                                'editor' => 'EditorFromDataTypeConfig',
+                                'dataTypeValue' => 'fromDataTypeConfig',
                             ]
                         ],
                         'elementWithOverriddenEditorConfig' => [


### PR DESCRIPTION
Currently, its not possible to use the shorthand
```yaml
    creationDialog:
      elements:
        hasFoo:
          type: boolean
          # ui: {} # this must be set to an empty array
```

as there is an unsafe access on the ui property
> Warning: Undefined array key "ui" in /Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Neos_NodeTypePostprocessor_DefaultPropertyEditorPostprocessor.php line 110



regression from #3473

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
