### PR TITLE
FEATURE: Get ContentRepositoryId of a ContentRepository by ContentRepositoryRegistry

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryIdNotFoundException.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryIdNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+namespace Neos\ContentRepositoryRegistry\Exception;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class ContentRepositoryIdNotFoundException extends \InvalidArgumentException
+{
+
+    public static function notFound(): self
+    {
+        return new self('No ContentRepositoryId found for given ContentRepository', 1684865162);
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryNotFoundException.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryNotFoundException.php
@@ -5,7 +5,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 
 #[Flow\Proxy(false)]
-final class ContentRepositoryNotFound extends \InvalidArgumentException
+final class ContentRepositoryNotFoundException extends \InvalidArgumentException
 {
 
     public static function notConfigured(ContentRepositoryId $contentRepositoryId): self


### PR DESCRIPTION
This allows to figure out the ContentRepositoryId of a given ContentRepository without adding this information to the ContentRepository itself. This keeps the logic of the ContentRepositoryId within the registry.