### PR TITLE
BUGFIX: throw exception when creating workspace with invalid name in command controller

### DIFF
--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\Command;
 
 /*
@@ -175,18 +176,27 @@ class WorkspaceCommandController extends CommandController
      *
      * This command creates a new workspace.
      *
-     * @param string $workspace Name of the workspace, for example "christmas-campaign"
+     * @param string $workspaceName Name of the workspace, for example "christmas-campaign"
      * @param string $baseWorkspace Name of the base workspace. If none is specified, "live" is assumed.
      * @param string $title Human friendly title of the workspace, for example "Christmas Campaign"
      * @param string $description A description explaining the purpose of the new workspace
      * @param string $owner The identifier of a User to own the workspace
      * @return void
      */
-    public function createCommand($workspace, $baseWorkspace = 'live', $title = null, $description = null, $owner = '')
+    public function createCommand($workspaceName, $baseWorkspace = 'live', $title = null, $description = null, $owner = '')
     {
-        $workspaceName = $workspace;
-        $workspace = $this->workspaceRepository->findOneByName($workspaceName);
-        if ($workspace instanceof Workspace) {
+        $workspaceNameMatched = preg_match(NodeInterface::MATCH_PATTERN_NAME, $workspaceName);
+        $workspaceNameValid = $workspaceNameMatched === 1;
+        if (!$workspaceNameValid) {
+            $this->outputLine(
+                'The workspace name "%s" is invalid. It must only contain letters, numbers and dashes (Regex: "%s").' . PHP_EOL,
+                [$workspaceName, NodeInterface::MATCH_PATTERN_NAME]
+            );
+            $this->quit(4);
+        }
+
+        $existingWorkspace = $this->workspaceRepository->findOneByName($workspaceName);
+        if ($existingWorkspace instanceof Workspace) {
             $this->outputLine('Workspace "%s" already exists', [$workspaceName]);
             $this->quit(1);
         }

--- a/Neos.Neos/Tests/Functional/Command/BehatTestHelper.php
+++ b/Neos.Neos/Tests/Functional/Command/BehatTestHelper.php
@@ -30,7 +30,7 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
- * A test helper, to include behat step traits, beeing executed by
+ * A test helper, to include behat step traits, being executed by
  * the BehatHelperCommandController.
  *
  * @Flow\Scope("singleton")

--- a/Neos.Neos/Tests/Functional/Command/WorkspaceCommandControllerTest.php
+++ b/Neos.Neos/Tests/Functional/Command/WorkspaceCommandControllerTest.php
@@ -13,7 +13,10 @@ class WorkspaceCommandControllerTest extends FunctionalTestCase
 {
     protected static $testablePersistenceEnabled = true;
 
-    private WorkspaceCommandController $commandController;
+    /**
+     * @var WorkspaceCommandController
+     */
+    private $commandController;
 
     protected function setUp(): void
     {
@@ -26,7 +29,7 @@ class WorkspaceCommandControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function test_createCommand_withInvalidWorkspaceName_throwsException(): void
+    public function test_createCommand_withInvalidWorkspaceName_throwsException()
     {
         $this->expectException(StopCommandException::class);
         $this->commandController->createCommand('invalid_workspace_name');
@@ -35,7 +38,7 @@ class WorkspaceCommandControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function test_createCommand_withValidWorkspaceName_succeeds(): void
+    public function test_createCommand_withValidWorkspaceName_succeeds()
     {
         $workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
         $liveWorkspace = new Workspace('live', null, null);

--- a/Neos.Neos/Tests/Functional/Command/WorkspaceCommandControllerTest.php
+++ b/Neos.Neos/Tests/Functional/Command/WorkspaceCommandControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Neos\Neos\Tests\Functional\Command;
+
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Cli\Response;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Neos\Command\WorkspaceCommandController;
+
+class WorkspaceCommandControllerTest extends FunctionalTestCase
+{
+    protected static $testablePersistenceEnabled = true;
+
+    private WorkspaceCommandController $commandController;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandController = $this->objectManager->get(WorkspaceCommandController::class);
+        $this->inject($this->commandController, 'response', new Response());
+    }
+
+    /**
+     * @test
+     */
+    public function test_createCommand_withInvalidWorkspaceName_throwsException(): void
+    {
+        $this->expectException(StopCommandException::class);
+        $this->commandController->createCommand('invalid_workspace_name');
+    }
+
+    /**
+     * @test
+     */
+    public function test_createCommand_withValidWorkspaceName_succeeds(): void
+    {
+        $workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $liveWorkspace = new Workspace('live', null, null);
+        $liveWorkspace->setDescription('The live workspace');
+        $workspaceRepository->add($liveWorkspace);
+        $this->persistenceManager->persistAll();
+
+        $workspaceName = 'my-new-workspace';
+        $this->commandController->createCommand(
+            $workspaceName,
+            'live',
+            'Test Workspace',
+            'A test workspace'
+        );
+        $this->persistenceManager->persistAll();
+
+
+        $workspace = $workspaceRepository->findOneByName($workspaceName);
+        self::assertNotNull($workspace);
+        self::assertEquals($workspaceName, $workspace->getName());
+    }
+}


### PR DESCRIPTION
resolved: #3504

In the `workspace:create` command there is now an integrated check, to validate, that the provided workspace name matches the workspace-name-regex. When not matching, it will throw an exception.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
