### PR TITLE
WIP: FEATURE: Fallback to rawContent mode in the backend if contents have no renderer

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -21,9 +21,8 @@ prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
         <Neos.Neos:RawContent.Node />
       </template>
       <neos-raw-content
-        styles={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css') + ',' + StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css')}
+        styles={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css') + ',' + StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css') + ',' + StaticResource.uri(Neos.Ui.StaticResources.compiledResourcePackage(), 'Public/Build/Host.css')}
         target={'raw_' + node.identifier}
-        style="all: unset;"
       ></neos-raw-content>
 
     `

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -16,12 +16,13 @@ prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
     @position = 'end 10000'
     condition = ${documentNode.context.inBackend && documentNode.context.currentRenderingMode.edit}
     renderer = afx`
-      <div style="all:unset;">
-        <link rel="stylesheet" type="text/css" href={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css')}/>
-        <link rel="stylesheet" type="text/css" href={StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css')}/>
-        <p>FALLBACK: Please implement the fusion prototype "{node.nodeType.name}" for frontend rendering.</p>
+      <script src={StaticResource.uri('Neos.Neos', 'Public/JavaScript/RawContent.js')}></script>
+      <neos-raw-content
+        styles={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css') + ',' + StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css')}
+        style="all: unset;"
+      >
         <Neos.Neos:RawContent.Node />
-      </div>
+      </neos-raw-content>
     `
   }
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -3,9 +3,32 @@
 # the name of the current nodes' node type
 #
 prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
+
   default {
-    @position = 'end'
-    condition = true
+    @position = 'end 9999'
+    condition = Neos.Fusion:CanRender {
+      type = ${node.nodeType.name}
+    }
     type = ${node.nodeType.name}
+  }
+
+  rawContent {
+    @position = 'end 10000'
+    condition = ${documentNode.context.inBackend && documentNode.context.currentRenderingMode.edit}
+    renderer = afx`
+      <div style="all:unset;">
+        <link rel="stylesheet" type="text/css" href={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css')}/>
+        <link rel="stylesheet" type="text/css" href={StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css')}/>
+        <p>FALLBACK: Please implement the fusion prototype "{node.nodeType.name}" for frontend rendering.</p>
+        <Neos.Neos:RawContent.Node />
+      </div>
+    `
+  }
+
+  # Fail but create a helpful error message
+  error {
+    @position = 'end 10001'
+    condition = true
+    type = ${documentNode.nodeType.name}
   }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -17,12 +17,15 @@ prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
     condition = ${documentNode.context.inBackend && documentNode.context.currentRenderingMode.edit}
     renderer = afx`
       <script src={StaticResource.uri('Neos.Neos', 'Public/JavaScript/RawContent.js')}></script>
+      <template id={'raw_' + node.identifier}>
+        <Neos.Neos:RawContent.Node />
+      </template>
       <neos-raw-content
         styles={StaticResource.uri('Neos.Neos', 'Public/Styles/Minimal.css') + ',' + StaticResource.uri('Neos.Neos', 'Public/Styles/RawContentMode.css')}
+        target={'raw_' + node.identifier}
         style="all: unset;"
-      >
-        <Neos.Neos:RawContent.Node />
-      </neos-raw-content>
+      ></neos-raw-content>
+
     `
   }
 

--- a/Neos.Neos/Resources/Public/JavaScript/RawContent.js
+++ b/Neos.Neos/Resources/Public/JavaScript/RawContent.js
@@ -1,0 +1,36 @@
+class Neos_RawContentMode extends HTMLElement {
+
+	constructor() {
+		super();
+	}
+
+	render() {
+
+		// Create a shadow root
+		const shadow = this.attachShadow({mode: 'open'});
+
+		// Create styles
+		const styles = this.getAttribute("styles");
+		if (styles) {
+			const styleItems = styles.split(",");
+			for (var styleItem in styleItems) {
+				const link = document.createElement("link");
+				link.setAttribute("rel", "stylesheet");
+				link.setAttribute("href", styleItems[styleItem]);
+				shadow.appendChild(link);
+			}
+		}
+
+		// Render slot
+		const slot = document.createElement('slot');
+		shadow.appendChild(slot);
+	}
+
+	connectedCallback() {
+			this.render();
+	}
+}
+
+if (customElements.get('neos-raw-content') === undefined) {
+	customElements.define('neos-raw-content', Neos_RawContentMode);
+}

--- a/Neos.Neos/Resources/Public/JavaScript/RawContent.js
+++ b/Neos.Neos/Resources/Public/JavaScript/RawContent.js
@@ -13,12 +13,9 @@ class Neos_RawContentMode extends HTMLElement {
 		const styles = this.getAttribute("styles");
 		if (styles) {
 			const styleItems = styles.split(",");
-			for (var styleItem in styleItems) {
-				const link = document.createElement("link");
-				link.setAttribute("rel", "stylesheet");
-				link.setAttribute("href", styleItems[styleItem]);
-				shadow.appendChild(link);
-			}
+			const style = document.createElement('style');
+			style.innerHTML = '@import ' + styleItems.join(';\n @import ') + ';\n';
+			shadow.appendChild(style);
 		}
 
 		// Render slot

--- a/Neos.Neos/Resources/Public/JavaScript/RawContent.js
+++ b/Neos.Neos/Resources/Public/JavaScript/RawContent.js
@@ -13,14 +13,17 @@ class Neos_RawContentMode extends HTMLElement {
 		const styles = this.getAttribute("styles");
 		if (styles) {
 			const styleItems = styles.split(",");
-			const style = document.createElement('style');
-			style.innerHTML = '@import ' + styleItems.join(';\n @import ') + ';\n';
-			shadow.appendChild(style);
+			for (var styleItem in styleItems) {
+				const link = document.createElement("link");
+				link.setAttribute("rel", "stylesheet");
+				link.setAttribute("href", styleItems[styleItem]);
+				shadow.appendChild(link);
+			}
 		}
 
-		// Render slot
-		const slot = document.createElement('slot');
-		shadow.appendChild(slot);
+		// Clone template
+		const template = document.getElementById(this.getAttribute("target"));
+		shadow.appendChild(template.content.cloneNode(true));
 	}
 
 	connectedCallback() {


### PR DESCRIPTION
If a node has no fusion renderer the raw content mode is rendered in the backend together with a hint to implement the needed fusion prototype.

**Review instructions**

This is possibly a first step for a switch between default and rawContent mode for contents (hust sliders) which are hard to edit inline.

To test you can comment out the rendering fusion prototype of any content. You should see the raw content mode for this node instead in the backend.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
