### PR TITLE
BUGFIX: Make getParent work in NodeData

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -422,7 +422,7 @@ class NodeData extends AbstractNodeData
             return null;
         }
 
-        return $this->nodeDataRepository->findOneByPath($this->parentPath, $this->workspace);
+        return $this->nodeDataRepository->findOneByPath($this->parentPath, $this->workspace, $this->dimensionValues);
     }
 
     /**


### PR DESCRIPTION
resolved: #4283 

**Review instructions**
I am unsure why the dimensions were not passed to findOneByPath, but without it it does not really work.
Also, it is kind of strange that the dimensions in findOneByPath is optional but returns nothing if it is not set.
This fixes it for now. 

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
