### PR TITLE
BUGFIX: Use correct configuration path for enableObjectTreeCache

### DIFF
--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -24,7 +24,7 @@ Neos\Neos\Domain\Service\FusionConfigurationCache:
           1:
             value: Neos_Neos_Fusion
     2:
-      setting: "Neos.Neos:fusion.enableObjectTreeCache"
+      setting: "Neos.Neos.fusion.enableObjectTreeCache"
 
 'Neos\ContentRepository\Domain\Service\ContentDimensionPresetSourceInterface':
   className: Neos\Neos\Domain\Service\ConfigurationContentDimensionPresetSource


### PR DESCRIPTION
Due to the wrong path the value of enableObjectTreeCache was always interpreted as `false`. So in Neos in production context the Cache was disabled.