### PR TITLE
FEATURE: Introduce catchup hook for DocumentUriPath projection

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentNodeInfos.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentNodeInfos.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\FrontendRouting\Projection;
+
+use Traversable;
+
+/**
+ * @implements \IteratorAggregate<DocumentNodeInfo>
+ */
+final class DocumentNodeInfos implements \IteratorAggregate
+{
+    /**
+     * @param array<DocumentNodeInfo> $documentNodeInfos
+     */
+    private function __construct(
+        private readonly array $documentNodeInfos
+    ) {
+    }
+
+    /**
+     * @param array<DocumentNodeInfo> $documentNodeInfos
+     * @return static
+     */
+    public static function create(array $documentNodeInfos): static
+    {
+        return new static($documentNodeInfos);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator($this->documentNodeInfos);
+    }
+}

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -48,6 +48,8 @@ use Neos\EventStore\Model\EventStream\EventStreamInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\FrontendRouting\Exception\NodeNotFoundException;
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
+use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 
 /**
  * @implements ProjectionInterface<DocumentUriPathFinder>
@@ -66,6 +68,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly Connection $dbal,
         private readonly string $tableNamePrefix,
+        private readonly CatchUpHookFactoryInterface $catchUpHookFactory
     ) {
         $this->checkpointStorage = new DoctrineCheckpointStorage(
             $this->dbal,
@@ -141,17 +144,25 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
 
     public function catchUp(EventStreamInterface $eventStream, ContentRepository $contentRepository): void
     {
-        $catchUp = CatchUp::create($this->apply(...), $this->checkpointStorage);
+        $catchUpHook = $this->catchUpHookFactory->build($contentRepository);
+        $catchUpHook->onBeforeCatchUp();
+        $catchUp = CatchUp::create(
+            fn(EventEnvelope $eventEnvelope) => $this->apply($eventEnvelope, $catchUpHook),
+            $this->checkpointStorage
+        );
+        $catchUp = $catchUp->withOnBeforeBatchCompleted(fn() => $catchUpHook->onBeforeBatchCompleted());
         $catchUp->run($eventStream);
+        $catchUpHook->onAfterCatchUp();
     }
 
-    private function apply(\Neos\EventStore\Model\EventEnvelope $eventEnvelope): void
+    private function apply(\Neos\EventStore\Model\EventEnvelope $eventEnvelope, CatchUpHookInterface $catchUpHook): void
     {
         if (!$this->canHandle($eventEnvelope->event)) {
             return;
         }
 
         $eventInstance = $this->eventNormalizer->denormalize($eventEnvelope->event);
+        $catchUpHook->onBeforeEvent($eventInstance, $eventEnvelope);
 
         $this->dbal->beginTransaction();
 
@@ -177,6 +188,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
 
         try {
             $this->dbal->commit();
+            $catchUpHook->onAfterEvent($eventInstance, $eventEnvelope);
         } catch (ConnectionException $e) {
             throw new \RuntimeException(sprintf(
                 'Failed to commit transaction in %s: %s',
@@ -536,6 +548,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
                 'nodeAggregateId' => $node->getNodeAggregateId()->value,
                 'childNodeAggregateIdPathPrefix' => $node->getNodeAggregateIdPath() . '/%',
             ]);
+            $this->getState()->purgeCacheFor($node);
         }
     }
 
@@ -604,6 +617,8 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
                     'childNodeAggregateIdPathPrefix' => $node->getNodeAggregateIdPath() . '/%',
                 ]
             );
+            $this->getState()->purgeCacheFor($node);
+
             $this->emitDocumentUriPathChanged($oldUriPath, $newUriPath, $event, $eventEnvelope);
         }
     }
@@ -639,6 +654,8 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
                         null
                     ),
                 };
+
+                $this->getState()->purgeCacheFor($node);
             }
         }
     }

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjectionFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjectionFactory.php
@@ -47,7 +47,8 @@ final class DocumentUriPathProjectionFactory implements ProjectionFactoryInterfa
             $projectionFactoryDependencies->eventNormalizer,
             $projectionFactoryDependencies->nodeTypeManager,
             $this->dbal,
-            self::projectionTableNamePrefix($projectionFactoryDependencies->contentRepositoryId)
+            self::projectionTableNamePrefix($projectionFactoryDependencies->contentRepositoryId),
+            $catchUpHookFactory
         );
     }
 }

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -148,22 +148,6 @@ class Package extends BasePackage
                 /** @var RouterCachingService $routerCachingService */
                 $routerCachingService = $bootstrap->getObjectManager()->get(RouterCachingService::class);
                 $routerCachingService->flushCachesForUriPath($oldUriPath);
-
-                if (class_exists(RedirectStorageInterface::class)) {
-                    if (!$bootstrap->getObjectManager()->isRegistered(RedirectStorageInterface::class)) {
-                        return;
-                    }
-                    /** @var RedirectStorageInterface $redirectStorage */
-                    $redirectStorage = $bootstrap->getObjectManager()->get(RedirectStorageInterface::class);
-                    $redirectStorage->addRedirect(
-                        $oldUriPath,
-                        $newUriPath,
-                        301,
-                        [],
-                        (string)$eventEnvelope->event->metadata->get('initiatingUserId'),
-                        'via DocumentUriPathProjector'
-                    );
-                }
             }
         );
 


### PR DESCRIPTION
Allows to hook into the DocumentUriPath projection during event handling. This enables the `Neos.Redirect.NeosAdapter` to react on the events accordingly.

Also the finder got a new method to query for children of a given DocumentNodeInfo.