### PR TITLE
DOCS: Add import example to the 9.0 readme

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -162,7 +162,11 @@ Migrating an existing (Neos < 9.0) Site
 Importing an existing (Neos >= 9.0) Site from an Export
 -------------------------------------------------------
 
-tbd
+.. code-block:: bash
+
+    # import the event stream from the Neos.Demo package
+    ./flow cr:import Packages/Sites/Neos.Demo/Resources/Private/Content
+
 
 Running Neos
 ============


### PR DESCRIPTION
Add the command to import Neos.Demo to the 9.0 readme.