### PR TITLE
TASK: Make language dimension key `="language"` configurable (for `NodeUriPathSegmentGenerator`)

### DIFF
--- a/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
@@ -10,6 +10,7 @@ Neos:
     contentRepositories:
       default:
         preset: default
+        # localeDimensionKey: "language"
         contentDimensions:
           # NOTE: Dimensions Config follows here
 

--- a/Neos.Neos/Classes/Utility/LocaleUtility.php
+++ b/Neos.Neos/Classes/Utility/LocaleUtility.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Utility;
+
+use Neos\ContentRepository\Core\Dimension\ContentDimensionId;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
+use Neos\Flow\I18n\Locale;
+
+class LocaleUtility
+{
+    /**
+     * @Flow\InjectConfiguration(package="Neos.ContentRepositoryRegistry", "contentRepositories")
+     */
+    protected $crSettings;
+
+    public function createForDimensionSpacePoint(DimensionSpacePoint $dimensionSpacePoint, ContentRepositoryId $contentRepositoryId): ?Locale
+    {
+        $localeDimensionKey = $this->crSettings[$contentRepositoryId->value]['localeDimensionKey'] ?? 'language';
+        $languageDimensionValue = $dimensionSpacePoint->getCoordinate(new ContentDimensionId($localeDimensionKey));
+        if ($languageDimensionValue !== null) {
+            try {
+                return new Locale($languageDimensionValue);
+            } catch (InvalidLocaleIdentifierException $e) {
+                // since we dont enforce a specific locale format in the dsp we will silently ignore this
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Solves https://github.com/neos/neos-development-collection/pull/4324#discussion_r1243500163

and should also remove duplicate code here https://github.com/neos/neos-ui/blob/375b20ad77f8dacdb6d4f736568a31edda78c0ee/Classes/NodeCreationHandler/DocumentTitleNodeCreationHandler.php#L82-L93

--------


## Outdated

We extract logic into new public method
```php
Neos\Neos\Utility\NodeUriPathSegmentGenerator::generateUriPathSegmentFromTextForDimension($text, $dsp);
```

this is done so in case one does not has the full node at hand (but only information to create a node, so a DimensionSpacePoint), you can still transliterate text based on the language dimension.

This usecase appears in the Neos Ui, when we want to generate a uri path segment based on the creation dialog "title".

Currently one needs to create their own `generateUriPathSegmentFromTextForDimension` helper.

See the pr for the Neos Ui https://github.com/neos/neos-ui/pull/3521 where i was able replace the custom helper with this newly introduced method.

Also by putting it as api into neos other people can use it easily (like myself in the node-templates package)




**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
