### PR TITLE
BUGFIX: Zero dimensional uri paths

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/AutoUriPathResolverFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/AutoUriPathResolverFactory.php
@@ -56,21 +56,24 @@ final class AutoUriPathResolverFactory implements DimensionResolverFactoryInterf
                     . ' For everything more advanced, please manually configure UriPathResolver in Settings.yaml.'
             );
         }
+        if (count($contentDimensions) === 0) {
+            $segments = Segments::create();
+        } else {
+            $contentDimension = reset($contentDimensions);
+            assert($contentDimension instanceof ContentDimension);
+            $mapping = [];
+            foreach ($contentDimension->values as $value) {
+                // we'll take the Dimension Value as Uri Path Segment value.
+                $mapping[] = SegmentMappingElement::create($value, $value->value);
+            }
 
-        $contentDimension = reset($contentDimensions);
-        assert($contentDimension instanceof ContentDimension);
-        $mapping = [];
-        foreach ($contentDimension->values as $value) {
-            // we'll take the Dimension Value as Uri Path Segment value.
-            $mapping[] = SegmentMappingElement::create($value, $value->value);
+            $segments = Segments::create(
+                Segment::create(
+                    $contentDimension->id,
+                    SegmentMapping::create(...$mapping)
+                )
+            );
         }
-
-        $segments = Segments::create(
-            Segment::create(
-                $contentDimension->id,
-                SegmentMapping::create(...$mapping)
-            )
-        );
 
         return UriPathResolver::create(
             $segments,

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/AutoUriPathResolverFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/AutoUriPathResolverFactory.php
@@ -30,7 +30,6 @@ use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\Segme
 use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\Segments;
 use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\Separator;
 
-
 /**
  * @api
  */
@@ -50,36 +49,35 @@ final class AutoUriPathResolverFactory implements DimensionResolverFactoryInterf
             ->getContentDimensionSource()
             ->getContentDimensionsOrderedByPriority();
 
-        if (count($contentDimensions) >= 2) {
-            throw new AutoUriPathResolverConfigurationException(
-                'The AutoUriPathResolverFactory is only meant for single-dimension use cases.'
+        switch (count($contentDimensions)) {
+            case 0:
+                return UriPathResolver::createForNoDimensions();
+            case 1:
+                $contentDimension = reset($contentDimensions);
+                assert($contentDimension instanceof ContentDimension);
+                $mapping = [];
+                foreach ($contentDimension->values as $value) {
+                    // we'll take the Dimension Value as Uri Path Segment value.
+                    $mapping[] = SegmentMappingElement::create($value, $value->value);
+                }
+
+                $segments = Segments::create(
+                    Segment::create(
+                        $contentDimension->id,
+                        SegmentMapping::create(...$mapping)
+                    )
+                );
+                return UriPathResolver::create(
+                    $segments,
+                    Separator::fromString('-'),
+                    $contentRepository->getContentDimensionSource(),
+                    $siteConfiguration->defaultDimensionSpacePoint
+                );
+            default:
+                throw new AutoUriPathResolverConfigurationException(
+                    'The AutoUriPathResolverFactory is only meant for single-dimension use cases.'
                     . ' For everything more advanced, please manually configure UriPathResolver in Settings.yaml.'
-            );
+                );
         }
-        if (count($contentDimensions) === 0) {
-            $segments = Segments::create();
-        } else {
-            $contentDimension = reset($contentDimensions);
-            assert($contentDimension instanceof ContentDimension);
-            $mapping = [];
-            foreach ($contentDimension->values as $value) {
-                // we'll take the Dimension Value as Uri Path Segment value.
-                $mapping[] = SegmentMappingElement::create($value, $value->value);
-            }
-
-            $segments = Segments::create(
-                Segment::create(
-                    $contentDimension->id,
-                    SegmentMapping::create(...$mapping)
-                )
-            );
-        }
-
-        return UriPathResolver::create(
-            $segments,
-            Separator::fromString('-'),
-            $contentRepository->getContentDimensionSource(),
-            $siteConfiguration->defaultDimensionSpacePoint
-        );
     }
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
@@ -76,6 +76,16 @@ final class UriPathResolver implements DimensionResolverInterface
         );
     }
 
+    public static function createForNoDimensions(): self
+    {
+        return new self(
+            [],
+            [],
+            Segments::create(),
+            DimensionSpacePoint::fromArray([])
+        );
+    }
+
     private static function validate(
         Segments $segments,
         Separator $separator,


### PR DESCRIPTION
This catches the zero-dimensional case in Neos' AutoUriPathResolverFactory so it doesn't break

See slack: https://neos-project.slack.com/archives/C3MCBK6S2/p1686331130861759

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
