### PR TITLE
BUGFIX: Adopt member types according base class

### DIFF
--- a/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -23,28 +23,28 @@ class ConfigurationValidationTest extends FlowConfigurationValidationTest
      *
      * @var array<string>
      */
-    protected $contextNames = ['Development', 'Production', 'Testing'];
+    protected array $contextNames = ['Development', 'Production', 'Testing'];
 
     /**
      * The configuration-types that are validated
      *
      * @var array<string>
      */
-    protected $configurationTypes = ['Caches', 'Objects', 'Policy', 'Routes', 'Settings', 'NodeTypes'];
+    protected array $configurationTypes = ['Caches', 'Objects', 'Policy', 'Routes', 'Settings', 'NodeTypes'];
 
     /**
      * The packages that are searched for schemas
      *
      * @var array<string>
      */
-    protected $schemaPackageKeys = ['Neos.Flow', 'Neos.Neos', 'Neos.ContentRepository', 'Neos.Fusion'];
+    protected array $schemaPackageKeys = ['Neos.Flow', 'Neos.Neos', 'Neos.ContentRepository', 'Neos.Fusion'];
 
     /**
      * The packages that contain the configuration that is validated
      *
      * @var array<string>
      */
-    protected $configurationPackageKeys = [
+    protected array $configurationPackageKeys = [
         'Neos.Flow', 'Neos.FluidAdaptor', 'Neos.Eel', 'Neos.Kickstart',
         'Neos.ContentRepository', 'Neos.Neos', 'Neos.Fusion', 'Neos.Media',
         'Neos.Media.Browser'


### PR DESCRIPTION
Base class `Neos\Flow\Tests\Functional\Configuration\ConfigurationValidationTest` has concretized the types of there member variables. So we need to adopt this.

See: https://github.com/neos/flow-development-collection/commit/20e284f13a5a3525a763a185b69d72b85ef0d70a#diff-9d880fea73f2904ea4d2b03a6aa1480c5580516e22e4f2c1d3df006e8419b01bR31-R37