### PR TITLE
BUGFIX: Allow to skip slow sub-item calculation for breadcrumb items

### DIFF
--- a/Neos.Neos/Classes/Fusion/BreadcrumbMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/BreadcrumbMenuItemsImplementation.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Neos\Fusion;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+/**
+ * A Fusion BreadcrumbMenuItems object
+ */
+class BreadcrumbMenuItemsImplementation extends MenuItemsImplementation
+{
+    /**
+     * Internal cache for the includeSubItems value.
+     *
+     * @var bool|null
+     */
+    protected $includeSubItems;
+
+    public function getIncludeSubItems()
+    {
+        if ($this->includeSubItems === null) {
+            $this->includeSubItems = $this->fusionValue('includeSubItems');
+        }
+
+        return $this->includeSubItems;
+    }
+
+    /**
+     * Prepare the menu item with state and label (and ignore sub items,
+     * unless includeSubItems is set to true).
+     *
+     * @param NodeInterface $currentNode
+     * @return array
+     * @TODO Remove this with Neos 9.0 and leave out the sub-items in any case.
+     * @see https://github.com/neos/neos-development-collection/issues/1438
+     */
+    protected function buildMenuItemRecursive(NodeInterface $currentNode)
+    {
+        if ($this->isNodeHidden($currentNode)) {
+            $item = null;
+        } else {
+            $item = [
+                'node' => $currentNode,
+                'state' => $this->calculateItemState($currentNode),
+                'label' => $currentNode->getLabel(),
+                'menuLevel' => $this->currentLevel,
+                'linkTitle' => $currentNode->getLabel()
+            ];
+
+            if ($this->getIncludeSubItems() && !$this->isOnLastLevelOfMenu($currentNode)) {
+                $this->currentLevel++;
+                $item['subItems'] = $this->buildMenuLevelRecursive($currentNode->getChildNodes($this->getFilter()));
+                $this->currentLevel--;
+            }
+        }
+
+        return $item;
+    }
+}

--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -26,7 +26,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
     const MAXIMUM_LEVELS_LIMIT = 100;
 
     /**
-     * Internal cache for the startingPoint tsValue.
+     * Internal cache for the startingPoint value.
      *
      * @var NodeInterface
      */
@@ -191,12 +191,11 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
 
         $item = [
             'node' => $currentNode,
-            'state' => self::STATE_NORMAL,
+            'state' => $this->calculateItemState($currentNode),
             'label' => $currentNode->getLabel(),
             'menuLevel' => $this->currentLevel
         ];
 
-        $item['state'] = $this->calculateItemState($currentNode);
         if (!$this->isOnLastLevelOfMenu($currentNode)) {
             $this->currentLevel++;
             $item['subItems'] = $this->buildMenuLevelRecursive($currentNode->getChildNodes($this->getFilter()));

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1034,12 +1034,25 @@ Neos.Neos:BreadcrumbMenu
 
 Render a breadcrumb (ancestor documents), based on :ref:`Neos_Neos__Menu`.
 
-Example::
+Examples:
+^^^^^^^^^
+
+::
 
 	breadcrumb = Neos.Neos:BreadcrumbMenu
 
 .. note:: The ``items`` of the ``BreadcrumbMenu`` are internally calculated with the prototype :ref:`Neos_Neos__BreadcrumbMenuItems` which
-   you can use directly as well.
+   you can use directly as well. Also, you probably want to exclude
+   sub-items for the breadcrumb.
+
+Breadcrumb menu excluding sub-items:
+""""""""""""""""""""""""""""""""""""
+
+::
+
+	breadcrumb = Neos.Neos:BreadcrumbMenu {
+	  items.includeSubItems = false
+	}
 
 .. _Neos_Neos__DimensionMenu:
 .. _Neos_Neos__DimensionsMenu:
@@ -1185,6 +1198,12 @@ Neos.Neos:BreadcrumbMenuItems
 -----------------------------
 
 Create a list of of menu-items for a breadcrumb (ancestor documents), based on :ref:`Neos_Neos__MenuItems`.
+
+Usually sub-items (children) of nodes are not needed for a breadcrumb, so you should
+set `includeSubItems` to false. It is true by default, to keep the behaviour the
+implementation used to have before this flag was added.
+
+:includeSubItems: (boolean, default **true**) Include sub-items of the items
 
 Example::
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1038,8 +1038,8 @@ Example::
 
 	breadcrumb = Neos.Neos:BreadcrumbMenu
 
-.. note:: The ``items`` of the ``BreadcrumbMenu`` are internally calculated with the prototype :ref:`Neos_Neos__MenuItems` which
-   you can use directly aswell.
+.. note:: The ``items`` of the ``BreadcrumbMenu`` are internally calculated with the prototype :ref:`Neos_Neos__BreadcrumbMenuItems` which
+   you can use directly as well.
 
 .. _Neos_Neos__DimensionMenu:
 .. _Neos_Neos__DimensionsMenu:

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
@@ -3,15 +3,7 @@
 prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Neos:Menu) {
   templatePath = 'resource://Neos.Neos/Private/Templates/FusionObjects/BreadcrumbMenu.html'
 
-  itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
-  // Show always the current node, event when it is hidden in index
-  items.@process.addCurrent = Neos.Fusion:Value {
-      currentItem = Neos.Neos:MenuItems {
-        renderHiddenInIndex = true
-        itemCollection = ${[documentNode]}
-      }
-      value = ${Array.concat(this.currentItem, value)}
-  }
+  items = Neos.Neos:BreadcrumbMenuItems
 
   attributes.class = 'breadcrumb'
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,4 +1,8 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
+  // TODO Remove for Neos 9.0
+  @class = 'Neos\\Neos\\Fusion\\BreadcrumbMenuItemsImplementation'
+  includeSubItems = true
+
   itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
   @process {
     // Show always the current node, event when it is hidden in index

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -6,7 +6,7 @@ prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
   itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
   @process {
     // Show always the current node, event when it is hidden in index
-        addCurrent = Neos.Fusion:Value {
+    addCurrent = Neos.Fusion:Value {
       currentItem = Neos.Neos:MenuItems {
         renderHiddenInIndex = true
         itemCollection = ${[documentNode]}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,15 +1,15 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-    itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
-    @process {
-        // Show always the current node, event when it is hidden in index
+  itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
+  @process {
+    // Show always the current node, event when it is hidden in index
         addCurrent = Neos.Fusion:Value {
-            currentItem = Neos.Neos:MenuItems {
-                renderHiddenInIndex = true
-                itemCollection = ${[documentNode]}
-            }
-            value = ${Array.concat(this.currentItem, value)}
-        }
-
-        reverseOrder = ${Array.reverse(value)}
+      currentItem = Neos.Neos:MenuItems {
+        renderHiddenInIndex = true
+        itemCollection = ${[documentNode]}
+      }
+      value = ${Array.concat(this.currentItem, value)}
     }
+
+    reverseOrder = ${Array.reverse(value)}
+  }
 }


### PR DESCRIPTION
This adds a new flag to the `BreadcrumbMenuItemsImplementation` to
allow exclusion of the sub-items in a breadcrumb menu.

By default they are still included, to keep the previous behaviour.

Fixes #1438

**Upgrade instructions**

To use the optimized calculation, set the new flag to `false`:

    breadcrumb = Neos.Neos:BreadcrumbMenu {
      items.includeSubItems = false
    }

**Review instructions**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
