### PR TITLE
9.0: Stringable property values

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -34,6 +34,12 @@ Feature: Create a node aggregate with complex default values
             postalCode: '12345'
             addressLocality: 'City'
             addressCountry: 'Country'
+        price:
+          type: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification
+          defaultValue:
+            price: 13.37
+            priceCurrency: 'EUR'
+
     """
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
@@ -67,14 +73,15 @@ Feature: Create a node aggregate with complex default values
       | now           | Date:now                                        |
       | date          | Date:2020-08-20T18:56:15+00:00                  |
       | uri           | URI:https://neos.io                             |
+      | price         | PriceSpecification:dummy                        |
 
   Scenario: Create a node aggregate with complex initial and default values
     When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                   | Value                                                                                                                    |
-      | nodeAggregateId       | "nody-mc-nodeface"                                                                                                       |
-      | nodeTypeName          | "Neos.ContentRepository.Testing:Node"                                                                                    |
-      | parentNodeAggregateId | "lady-eleonode-rootford"                                                                                                 |
-      | initialPropertyValues | {"dayOfWeek":"DayOfWeek:https://schema.org/Friday","postalAddress":"PostalAddress:anotherDummy", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io"} |
+      | Key                   | Value                                                                                                                                                                                                                 |
+      | nodeAggregateId       | "nody-mc-nodeface"                                                                                                                                                                                                    |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:Node"                                                                                                                                                                                 |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                                                                                                                                                                                              |
+      | initialPropertyValues | {"dayOfWeek":"DayOfWeek:https://schema.org/Friday","postalAddress":"PostalAddress:anotherDummy", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "price":"PriceSpecification:anotherDummy"} |
     And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
     And I expect this node to have the following properties:
@@ -85,3 +92,4 @@ Feature: Create a node aggregate with complex default values
       | now           | Date:now                                        |
       | date          | Date:2021-03-13T17:33:17+00:00                  |
       | uri           | URI:https://www.neos.io                         |
+      | price         | PriceSpecification:anotherDummy                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -49,46 +49,51 @@ Feature: Set properties
             postalCode: '12345'
             addressLocality: 'City'
             addressCountry: 'Country'
+        price:
+          type: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification
+          defaultValue:
+            price: 13.37
+            priceCurrency: 'EUR'
     """
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
-      | Key                        | Value                |
-      | workspaceName              | "live"               |
-      | workspaceTitle             | "Live"               |
-      | workspaceDescription       | "The live workspace" |
-      | newContentStreamId | "cs-identifier"      |
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
     And I am in content stream "cs-identifier" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
-      | Key                     | Value                         |
+      | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
-      | nodeTypeName            | "Neos.ContentRepository:Root" |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | nodeName | parentNodeAggregateId | nodeTypeName                            |
-      | nody-mc-nodeface        | document | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document |
+      | nodeAggregateId  | nodeName | parentNodeAggregateId  | nodeTypeName                            |
+      | nody-mc-nodeface | document | lady-eleonode-rootford | Neos.ContentRepository.Testing:Document |
     And the command CreateNodeVariant is executed with payload:
-      | Key                     | Value              |
+      | Key             | Value              |
       | nodeAggregateId | "nody-mc-nodeface" |
-      | sourceOrigin            | {"language":"mul"} |
-      | targetOrigin            | {"language":"de"}  |
+      | sourceOrigin    | {"language":"mul"} |
+      | targetOrigin    | {"language":"de"}  |
     And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
-      | Key                     | Value              |
+      | Key             | Value              |
       | nodeAggregateId | "nody-mc-nodeface" |
-      | sourceOrigin            | {"language":"mul"} |
-      | targetOrigin            | {"language":"gsw"} |
+      | sourceOrigin    | {"language":"mul"} |
+      | targetOrigin    | {"language":"gsw"} |
     And the graph projection is fully up to date
 
   Scenario: Set node properties
     And the command SetNodeProperties is executed with payload:
-      | Key                       | Value                                                                                                                                                                                                                                                           |
-      | contentStreamId   | "cs-identifier"                                                                                                                                                                                                                                                 |
-      | nodeAggregateId   | "nody-mc-nodeface"                                                                                                                                                                                                                                              |
-      | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                                                                                                              |
-      | propertyValues            | {"string":"My new string", "int":8472, "float":72.84, "bool":true, "array":{"givenName":"David", "familyName":"Nodenborough","age":84}, "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "postalAddress":"PostalAddress:anotherDummy"} |
+      | Key                       | Value                                                                                                                                                                                                                                                                                                                                                         |
+      | contentStreamId           | "cs-identifier"                                                                                                                                                                                                                                                                                                                                               |
+      | nodeAggregateId           | "nody-mc-nodeface"                                                                                                                                                                                                                                                                                                                                            |
+      | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                                                                                                                                                                                                            |
+      | propertyValues            | {"string":"My new string", "int":8472, "float":72.84, "bool":true, "array":{"givenName":"David", "familyName":"Nodenborough","age":84}, "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "postalAddress":"PostalAddress:anotherDummy", "price":"PriceSpecification:anotherDummy"} |
     And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"de"} to exist in the content graph
     And I expect this node to have the following properties:
@@ -102,12 +107,13 @@ Feature: Set properties
       | date          | Date:2021-03-13T17:33:17+00:00                                |
       | uri           | URI:https://www.neos.io                                       |
       | postalAddress | PostalAddress:anotherDummy                                    |
+      | price         | PriceSpecification:anotherDummy                               |
 
   Scenario: Set node properties, partially
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                      |
-      | contentStreamId   | "cs-identifier"            |
-      | nodeAggregateId   | "nody-mc-nodeface"         |
+      | contentStreamId           | "cs-identifier"            |
+      | nodeAggregateId           | "nody-mc-nodeface"         |
       | originDimensionSpacePoint | {"language": "de"}         |
       | propertyValues            | {"string":"My new string"} |
     And the graph projection is fully up to date
@@ -123,3 +129,4 @@ Feature: Set properties
       | date          | Date:2020-08-20T18:56:15+00:00                             |
       | uri           | URI:https://neos.io                                        |
       | postalAddress | PostalAddress:dummy                                        |
+      | price         | PriceSpecification:dummy                                   |

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
@@ -73,6 +73,7 @@ use Neos\ContentRepository\Core\Tests\Behavior\Features\Bootstrap\Helpers\Mutabl
 use Neos\ContentRepository\Core\Tests\Behavior\Features\Helper\ContentGraphs;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress;
+use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\CheckpointException;
 use PHPUnit\Framework\Assert;
@@ -353,6 +354,10 @@ trait EventSourcedTrait
                 $propertyValue = PostalAddress::dummy();
             } elseif ($propertyValue === 'PostalAddress:anotherDummy') {
                 $propertyValue = PostalAddress::anotherDummy();
+            } elseif ($propertyValue === 'PriceSpecification:dummy') {
+                $propertyValue = PriceSpecification::dummy();
+            } elseif ($propertyValue === 'PriceSpecification:anotherDummy') {
+                $propertyValue = PriceSpecification::anotherDummy();
             }
             if (is_string($propertyValue)) {
                 if (\str_starts_with($propertyValue, 'DayOfWeek:')) {

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -36,6 +36,7 @@ use Neos\ContentRepository\Core\Tests\Behavior\Features\Helper\NodeDiscriminator
 use Neos\ContentRepository\Core\Tests\Behavior\Features\Helper\NodesByAdapter;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress;
+use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -315,6 +316,10 @@ trait ProjectedNodeTrait
                 return PostalAddress::dummy();
             case 'PostalAddress:anotherDummy':
                 return PostalAddress::anotherDummy();
+            case 'PriceSpecification:dummy':
+                return PriceSpecification::dummy();
+            case 'PriceSpecification:anotherDummy':
+                return PriceSpecification::anotherDummy();
             case 'Date:now':
                 return new \DateTimeImmutable();
             default:

--- a/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PriceSpecification.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PriceSpecification.php
@@ -14,47 +14,44 @@ namespace Neos\ContentRepository\Core\Tests\Behavior\Fixtures;
  */
 
 /**
- * A postal address value object
+ * A price specification value object as an example for an array-based but stringable property value
  *
- * @see https://schema.org/PostalAddress
+ * @see https://schema.org/PriceSpecification
  */
-final readonly class PostalAddress
+final readonly class PriceSpecification implements \Stringable
 {
     private function __construct(
-        public string $streetAddress,
-        public string $postalCode,
-        public string $addressLocality,
-        public string $addressCountry
+        public float $price,
+        public string $priceCurrency
     ) {
     }
 
     public static function fromArray(array $array): self
     {
         return new self(
-            $array['streetAddress'],
-            $array['postalCode'],
-            $array['addressLocality'],
-            $array['addressCountry']
+            $array['price'],
+            $array['priceCurrency']
         );
     }
 
     public static function dummy(): self
     {
         return new self(
-            '28 31st of February Street',
-            '12345',
-            'City',
-            'Country'
+            13.37,
+            'EUR'
         );
     }
 
     public static function anotherDummy(): self
     {
         return new self(
-            '29 31st of February Street',
-            '12346',
-            'Another city',
-            'Another country'
+            84.72,
+            'EUR'
         );
+    }
+
+    public function __toString(): string
+    {
+        return $this->price . ' ' . $this->priceCurrency;
     }
 }

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
@@ -180,7 +180,6 @@ final class AssetUsageProjection implements ProjectionInterface
     {
         /** @var array<string, array<AssetIdAndOriginalAssetId>> $assetIds */
         $assetIds = [];
-        /** @var SerializedPropertyValue|null $propertyValue */
         foreach ($propertyValues as $propertyName => $propertyValue) {
             // skip removed properties ({@see SerializedPropertyValues})
             if ($propertyValue === null) {
@@ -200,15 +199,14 @@ final class AssetUsageProjection implements ProjectionInterface
     }
 
     /**
-     * @param string $type
-     * @param mixed $value
+     * @param int|float|string|bool|array<int|string,mixed>|\ArrayObject<int|string,mixed>|null $value
      * @return array<string>
      * @throws InvalidTypeException
      */
-    private function extractAssetIds(string $type, mixed $value): array
+    private function extractAssetIds(string $type, int|float|string|bool|array|\ArrayObject|null $value): array
     {
-        if ($type === 'string' || is_subclass_of($type, \Stringable::class)) {
-            preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', (string)$value, $matches, PREG_SET_ORDER);
+        if (is_string($value)) {
+            preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', $value, $matches, PREG_SET_ORDER);
             return array_map(static fn(array $match) => $match['assetId'], $matches);
         }
         if (is_subclass_of($type, ResourceBasedInterface::class)) {

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
@@ -199,11 +199,11 @@ final class AssetUsageProjection implements ProjectionInterface
     }
 
     /**
-     * @param int|float|string|bool|array<int|string,mixed>|\ArrayObject<int|string,mixed>|null $value
+     * @param mixed $value
      * @return array<string>
      * @throws InvalidTypeException
      */
-    private function extractAssetIds(string $type, int|float|string|bool|array|\ArrayObject|null $value): array
+    private function extractAssetIds(string $type, mixed $value): array
     {
         if (is_string($value)) {
             preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', $value, $matches, PREG_SET_ORDER);


### PR DESCRIPTION
This adds support for stringable property values.

Previously, those caused the DocumentUriPathProjection to fail, which is now fixed and covered by tests.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
