### PR TITLE
FEATURE: 9.0 Implement `ContentSubgraphInterface::findAncestorNodes` and `countAncestorNodes`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -644,7 +644,6 @@ final class ContentSubgraph implements ContentSubgraphInterface
     private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter $filter): array
     {
         $queryBuilderInitial = $this->createQueryBuilder()
-            // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
             ->select('n.*, ph.name, ph.contentstreamid, ph.parentnodeanchor')
             ->from($this->tableNamePrefix . '_node', 'n')
             // we need to join with the hierarchy relation, because we need the node name.

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -24,10 +24,12 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
@@ -303,6 +305,43 @@ final class ContentSubgraph implements ContentSubgraphInterface
             $subtreesByNodeId[$nodeData['nodeaggregateid']] = $subtree;
         }
         return $rootSubtrees->first();
+    }
+
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter $filter): Nodes
+    {
+        [
+            'queryBuilderInitial' => $queryBuilderInitial,
+            'queryBuilderRecursive' => $queryBuilderRecursive,
+            'queryBuilderCte' => $queryBuilderCte
+        ] = $this->buildAncestorNodesQueries($entryNodeAggregateId, $filter);
+        $nodeRows = $this->fetchCteResults(
+            $queryBuilderInitial,
+            $queryBuilderRecursive,
+            $queryBuilderCte,
+            'ancestry'
+        );
+
+        return $this->nodeFactory->mapNodeRowsToNodes(
+            $nodeRows,
+            $this->dimensionSpacePoint,
+            $this->visibilityConstraints
+        );
+    }
+
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, CountAncestorNodesFilter $filter): int
+    {
+        [
+            'queryBuilderInitial' => $queryBuilderInitial,
+            'queryBuilderRecursive' => $queryBuilderRecursive,
+            'queryBuilderCte' => $queryBuilderCte
+        ] = $this->buildAncestorNodesQueries($entryNodeAggregateId, $filter);
+
+        return $this->fetchCteCountResult(
+            $queryBuilderInitial,
+            $queryBuilderRecursive,
+            $queryBuilderCte,
+            'ancestry'
+        );
     }
 
     public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter $filter): Nodes
@@ -597,6 +636,48 @@ final class ContentSubgraph implements ContentSubgraphInterface
             $this->applyPagination($queryBuilder, $filter->pagination);
         }
         return $queryBuilder;
+    }
+
+    /**
+     * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
+     */
+    private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter $filter): array
+    {
+        $queryBuilderInitial = $this->createQueryBuilder()
+            // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
+            ->select('n.*, ph.name, ph.contentstreamid, ph.parentnodeanchor')
+            ->from($this->tableNamePrefix . '_node', 'n')
+            // we need to join with the hierarchy relation, because we need the node name.
+            ->innerJoin('n', $this->tableNamePrefix . '_hierarchyrelation', 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
+            ->innerJoin('ch', $this->tableNamePrefix . '_node', 'c', 'c.relationanchorpoint = ch.childnodeanchor')
+            ->innerJoin('n', $this->tableNamePrefix . '_hierarchyrelation', 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
+            ->where('ch.contentstreamid = :contentStreamId')
+            ->andWhere('ch.dimensionspacepointhash = :dimensionSpacePointHash')
+            ->andWhere('ph.contentstreamid = :contentStreamId')
+            ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
+            ->andWhere('c.nodeaggregateid = :entryNodeAggregateId');
+        $this->addRestrictionRelationConstraints($queryBuilderInitial, 'n', 'ph');
+        $this->addRestrictionRelationConstraints($queryBuilderInitial, 'c', 'ch');
+
+        $queryBuilderRecursive = $this->createQueryBuilder()
+            ->select('p.*, h.name, h.contentstreamid, h.parentnodeanchor')
+            ->from('ancestry', 'c')
+            ->innerJoin('c', $this->tableNamePrefix . '_node', 'p', 'p.relationanchorpoint = c.parentnodeanchor')
+            ->innerJoin('p', $this->tableNamePrefix . '_hierarchyrelation', 'h', 'h.childnodeanchor = p.relationanchorpoint')
+            ->where('h.contentstreamid = :contentStreamId')
+            ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
+        $this->addRestrictionRelationConstraints($queryBuilderRecursive, 'p');
+
+        $queryBuilderCte = $this->createQueryBuilder()
+            ->select('*')
+            ->from('ancestry', 'p')
+            ->setParameter('contentStreamId', $this->contentStreamId->value)
+            ->setParameter('dimensionSpacePointHash', $this->dimensionSpacePoint->hash)
+            ->setParameter('entryNodeAggregateId', $entryNodeAggregateId->value);
+        if ($filter->nodeTypeConstraints !== null) {
+            $this->addNodeTypeConstraints($queryBuilderCte, $filter->nodeTypeConstraints, 'p');
+        }
+        return compact('queryBuilderInitial', 'queryBuilderRecursive', 'queryBuilderCte');
     }
 
     /**

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
@@ -426,13 +426,26 @@ final class ContentSubhypergraph implements ContentSubgraphInterface
         return $this->nodeFactory->mapNodeRowsToSubtree($nodeRows, $this->visibilityConstraints);
     }
 
+    public function findAncestorNodes(
+        NodeAggregateId $entryNodeAggregateId,
+        Filter\FindAncestorNodesFilter $filter
+    ): Nodes {
+        return Nodes::createEmpty();
+    }
+
+    public function countAncestorNodes(
+        NodeAggregateId $entryNodeAggregateId,
+        Filter\CountAncestorNodesFilter $filter
+    ): int {
+        return 0;
+    }
+
     public function findDescendantNodes(
         NodeAggregateId $entryNodeAggregateId,
         FindDescendantNodesFilter $filter
     ): Nodes {
         return Nodes::createEmpty();
     }
-
 
     public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int
     {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -88,6 +88,8 @@ class FeatureContext implements \Behat\Behat\Context\Context
      */
     protected $behatTestHelperObjectName = BehatTestHelper::class;
 
+    protected ?ContentRepositoryRegistry $contentRepositoryRegistry = null;
+
     public function __construct()
     {
         if (self::$bootstrap === null) {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -3,8 +3,7 @@
 Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes queries
 
   Background:
-    Given the current date and time is "2023-03-16T12:00:00+01:00"
-    And I have the following content dimensions:
+    Given I have the following content dimensions:
       | Identifier | Values          | Generalizations      |
       | language   | mul, de, en, ch | ch->de->mul, en->mul |
     And I have the following NodeTypes configuration:
@@ -12,19 +11,6 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
     'Neos.ContentRepository:Root': []
     'Neos.ContentRepository.Testing:AbstractPage':
       abstract: true
-      properties:
-        text:
-          type: string
-        'stringProperty':
-          type: string
-        booleanProperty:
-          type: boolean
-        floatProperty:
-          type: float
-        integerProperty:
-          type: integer
-        dateProperty:
-          type: DateTime
     'Neos.ContentRepository.Testing:SomeMixin':
       abstract: true
     'Neos.ContentRepository.Testing:Homepage':
@@ -71,28 +57,27 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues                                                                                             | tetheredDescendantNodeAggregateIds       |
-      | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                                                                                                                | {"terms": "terms", "contact": "contact"} |
-      | a               | a        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a", "booleanProperty": true}                                                                            | {}                                       |
-      | a1              | a1       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1", "integerProperty": 123}                                                                            | {}                                       |
-      | a2              | a2       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2", "integerProperty": 124}                                                                            | {}                                       |
-      | a2a             | a2a      | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a", "floatProperty": 123.45}                                                                          | {}                                       |
-      | a2a1            | a2a1     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1", "floatProperty": 123.46, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}} | {}                                       |
-      | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2", "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13 00:00:01"}}                 | {}                                       |
-      | a2a2a           | a2a2a    | Neos.ContentRepository.Testing:Page        | a2a2                   | {"text": "a2a2a"}                                                                                                 | {}                                       |
-      | a2a2b           | a2a2b    | Neos.ContentRepository.Testing:Page        | a2a2                   | {"text": "a2a2b", "integerProperty": 125, "booleanProperty": true}                                                | {}                                       |
-      | a3              | a3       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a3", "booleanProperty": false}                                                                          | {}                                       |
-      | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b", "stringProperty": "späCial characters"}                                                             | {}                                       |
-      | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1", "stringProperty": "true"}                                                                          | {}                                       |
-    And the current date and time is "2023-03-16T13:00:00+01:00"
-    And the command SetNodeProperties is executed with payload:
-      | Key             | Value                   |
-      | contentStreamId | "cs-identifier"         |
-      | nodeAggregateId | "a2a2b"                 |
-      | propertyValues  | {"integerProperty": 20} |
+      | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
+      | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
+      | a               | a        | Neos.ContentRepository.Testing:Page        | home                   | {}                    | {}                                       |
+      | a1              | a1       | Neos.ContentRepository.Testing:Page        | a                      | {}                    | {}                                       |
+      | a2              | a2       | Neos.ContentRepository.Testing:Page        | a                      | {}                    | {}                                       |
+      | a2a             | a2a      | Neos.ContentRepository.Testing:SpecialPage | a2                     | {}                    | {}                                       |
+      | a2a1            | a2a1     | Neos.ContentRepository.Testing:Page        | a2a                    | {}                    | {}                                       |
+      | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {}                    | {}                                       |
+      | a2a2a           | a2a2a    | Neos.ContentRepository.Testing:Page        | a2a2                   | {}                    | {}                                       |
+      | a2a2b           | a2a2b    | Neos.ContentRepository.Testing:Page        | a2a2                   | {}                    | {}                                       |
+      | a2b             | a2b      | Neos.ContentRepository.Testing:Page        | a2                     | {}                    | {}                                       |
+      | a2b1            | a2b1     | Neos.ContentRepository.Testing:Page        | a2b                     | {}                    | {}                                       |
+      | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {}                    | {}                                       |
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And the graph projection is fully up to date
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2b"        |
       | nodeVariantSelectionStrategy | "allVariants" |
     And the graph projection is fully up to date
 
@@ -101,6 +86,8 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
     When I execute the findAncestorNodes query for entry node aggregate id "non-existing" I expect no nodes to be returned
     # a2a2a is disabled
     When I execute the findAncestorNodes query for entry node aggregate id "a2a2a" I expect no nodes to be returned
+    # a2b is disabled
+    When I execute the findAncestorNodes query for entry node aggregate id "a2b1" I expect no nodes to be returned
 
     # findAncestorNodes queries with results
     When I execute the findAncestorNodes query for entry node aggregate id "a2a2b" I expect the nodes "a2a2,a2a,a2,a,home,lady-eleonode-rootford" to be returned and the total count to be 6

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -1,0 +1,107 @@
+@contentrepository @adapters=DoctrineDBAL
+  # TODO implement for Postgres
+Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes queries
+
+  Background:
+    Given the current date and time is "2023-03-16T12:00:00+01:00"
+    And I have the following content dimensions:
+      | Identifier | Values          | Generalizations      |
+      | language   | mul, de, en, ch | ch->de->mul, en->mul |
+    And I have the following NodeTypes configuration:
+    """
+    'Neos.ContentRepository:Root': []
+    'Neos.ContentRepository.Testing:AbstractPage':
+      abstract: true
+      properties:
+        text:
+          type: string
+        'stringProperty':
+          type: string
+        booleanProperty:
+          type: boolean
+        floatProperty:
+          type: float
+        integerProperty:
+          type: integer
+        dateProperty:
+          type: DateTime
+    'Neos.ContentRepository.Testing:SomeMixin':
+      abstract: true
+    'Neos.ContentRepository.Testing:Homepage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      childNodes:
+        terms:
+          type: 'Neos.ContentRepository.Testing:Terms'
+        contact:
+          type: 'Neos.ContentRepository.Testing:Contact'
+
+    'Neos.ContentRepository.Testing:Terms':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      properties:
+        text:
+          defaultValue: 'Terms default'
+    'Neos.ContentRepository.Testing:Contact':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+        'Neos.ContentRepository.Testing:SomeMixin': true
+      properties:
+        text:
+          defaultValue: 'Contact default'
+    'Neos.ContentRepository.Testing:Page':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    'Neos.ContentRepository.Testing:SpecialPage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    """
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues                                                                                             | tetheredDescendantNodeAggregateIds       |
+      | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                                                                                                                | {"terms": "terms", "contact": "contact"} |
+      | a               | a        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a", "booleanProperty": true}                                                                            | {}                                       |
+      | a1              | a1       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1", "integerProperty": 123}                                                                            | {}                                       |
+      | a2              | a2       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2", "integerProperty": 124}                                                                            | {}                                       |
+      | a2a             | a2a      | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a", "floatProperty": 123.45}                                                                          | {}                                       |
+      | a2a1            | a2a1     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1", "floatProperty": 123.46, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}} | {}                                       |
+      | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2", "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13 00:00:01"}}                 | {}                                       |
+      | a2a2a           | a2a2a    | Neos.ContentRepository.Testing:Page        | a2a2                   | {"text": "a2a2a"}                                                                                                 | {}                                       |
+      | a2a2b           | a2a2b    | Neos.ContentRepository.Testing:Page        | a2a2                   | {"text": "a2a2b", "integerProperty": 125, "booleanProperty": true}                                                | {}                                       |
+      | a3              | a3       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a3", "booleanProperty": false}                                                                          | {}                                       |
+      | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b", "stringProperty": "späCial characters"}                                                             | {}                                       |
+      | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1", "stringProperty": "true"}                                                                          | {}                                       |
+    And the current date and time is "2023-03-16T13:00:00+01:00"
+    And the command SetNodeProperties is executed with payload:
+      | Key             | Value                   |
+      | contentStreamId | "cs-identifier"         |
+      | nodeAggregateId | "a2a2b"                 |
+      | propertyValues  | {"integerProperty": 20} |
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2a2a"       |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And the graph projection is fully up to date
+
+  Scenario:
+    # findAncestorNodes queries without results
+    When I execute the findAncestorNodes query for entry node aggregate id "non-existing" I expect no nodes to be returned
+    # a2a2a is disabled
+    When I execute the findAncestorNodes query for entry node aggregate id "a2a2a" I expect no nodes to be returned
+
+    # findAncestorNodes queries with results
+    When I execute the findAncestorNodes query for entry node aggregate id "a2a2b" I expect the nodes "a2a2,a2a,a2,a,home,lady-eleonode-rootford" to be returned and the total count to be 6
+    When I execute the findAncestorNodes query for entry node aggregate id "a2a2b" and filter '{"nodeTypeConstraints": "Neos.ContentRepository.Testing:Page"}' I expect the nodes "a2a2,a2,a" to be returned and the total count to be 3

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -201,6 +201,18 @@ final class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
         // TODO populate NodeByNodeAggregateIdCache and ParentNodeIdByChildNodeIdCache from result
     }
 
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindAncestorNodesFilter $filter): Nodes
+    {
+        // TODO: implement runtime caches
+        return $this->wrappedContentSubgraph->findAncestorNodes($entryNodeAggregateId, $filter);
+    }
+
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountAncestorNodesFilter $filter): int
+    {
+        // TODO: Implement countAncestorNodes() method.
+        return $this->wrappedContentSubgraph->countAncestorNodes($entryNodeAggregateId, $filter);
+    }
+
     public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter $filter): Nodes
     {
         // TODO: implement runtime caches

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
@@ -89,6 +89,17 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findChildNodeConnectedThroughEdgeName(NodeAggregateId $parentNodeAggregateId, NodeName $edgeName): ?Node;
 
     /**
+     * Recursively find all nodes above the $entryNodeAggregateId that match the specified $filter and return them as a flat list
+     */
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindAncestorNodesFilter $filter): Nodes;
+
+    /**
+     * Count all nodes above the $entryNodeAggregateId that match the specified $filter
+     * @see findAncestorNodes
+     */
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountAncestorNodesFilter $filter): int;
+
+    /**
      * Recursively find all nodes underneath the $entryNodeAggregateId that match the specified $filter and return them as a flat list
      *
      * Note: This is basically a set-based view of descendant nodes; so the ordering should not be relied upon

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountAncestorNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountAncestorNodesFilter.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::countAncestorNodes()}
+ *
+ * Example:
+ *
+ * FindAncestorNodesFilter::create(nodeTypeConstraints: 'Some.Included:NodeType,!Some.Excluded:NodeType');
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class CountAncestorNodesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?NodeTypeConstraints $nodeTypeConstraints
+    ) {
+    }
+
+    /**
+     * Creates an instance with the specified filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public static function create(
+        NodeTypeConstraints|string $nodeTypeConstraints = null
+    ): self {
+        if (is_string($nodeTypeConstraints)) {
+            $nodeTypeConstraints = NodeTypeConstraints::fromFilterString($nodeTypeConstraints);
+        }
+        return new self($nodeTypeConstraints);
+    }
+
+    public static function fromFindAncestorNodesFilter(FindAncestorNodesFilter $filter): self
+    {
+        return new self($filter->nodeTypeConstraints);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        NodeTypeConstraints|string $nodeTypeConstraints = null
+    ): self {
+        return self::create(
+            $nodeTypeConstraints ?? $this->nodeTypeConstraints,
+        );
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindAncestorNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindAncestorNodesFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
+
+/**
+ * Immutable filter DTO for {@see ContentSubgraphInterface::findAncestorNodes()}
+ *
+ * Example:
+ *
+ * FindAncestorNodesFilter::create(nodeTypeConstraints: 'Some.Included:NodeType,!Some.Excluded:NodeType');
+ *
+ * @api for the factory methods; NOT for the inner state.
+ */
+final class FindAncestorNodesFilter
+{
+    /**
+     * @internal (the properties themselves are readonly; only the write-methods are API.
+     */
+    private function __construct(
+        public readonly ?NodeTypeConstraints $nodeTypeConstraints
+    ) {
+    }
+
+    /**
+     * Creates an instance with the specified filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public static function create(
+        NodeTypeConstraints|string $nodeTypeConstraints = null
+    ): self {
+        if (is_string($nodeTypeConstraints)) {
+            $nodeTypeConstraints = NodeTypeConstraints::fromFilterString($nodeTypeConstraints);
+        }
+        return new self($nodeTypeConstraints);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     */
+    public function with(
+        NodeTypeConstraints|string $nodeTypeConstraints = null
+    ): self {
+        return self::create(
+            $nodeTypeConstraints ?? $this->nodeTypeConstraints,
+        );
+    }
+}

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
@@ -52,6 +52,7 @@ use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceFinder;
 use Neos\ContentRepository\Core\Service\ContentStreamPruner;
 use Neos\ContentRepository\Core\Service\ContentStreamPrunerFactory;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\User\UserId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\Tests\Behavior\Features\Bootstrap\Features\ContentStreamForking;
@@ -116,6 +117,8 @@ trait EventSourcedTrait
     private ContentRepositoryId $contentRepositoryId;
     private ContentRepository $contentRepository;
     private ContentRepositoryInternals $contentRepositoryInternals;
+
+    protected ?UserId $currentUserId = null;
 
     protected function getContentRepositoryId(): ContentRepositoryId
     {

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -165,7 +165,6 @@ trait NodeOperationsTrait
         ObjectAccess::setProperty($interDimensionalVariationGraph, 'weightedGeneralizations', null, true);
         ObjectAccess::setProperty($interDimensionalVariationGraph, 'weightedSpecializations', null, true);
         ObjectAccess::setProperty($interDimensionalVariationGraph, 'primaryGeneralizations', null, true);
-        ObjectAccess::setProperty($interDimensionalVariationGraph, 'rootGeneralizations', null, true);
         ObjectAccess::setProperty($interDimensionalVariationGraph, 'weightNormalizationBase', null, true);
     }
 }

--- a/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -15,10 +15,12 @@ namespace Neos\ContentRepository\Core\Tests\Behavior\Features\Bootstrap;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
@@ -276,6 +278,23 @@ trait NodeTraversalTrait
             Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
             $actualCount = $subgraph->countDescendantNodes($entryNodeAggregateId, CountDescendantNodesFilter::fromFindDescendantNodesFilter($filter));
             Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countDescendantNodes returned an unexpected result');
+        }
+    }
+
+    /**
+     * @When /^I execute the findAncestorNodes query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
+     */
+    public function iExecuteTheFindAncestorNodesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', int $expectedTotalCount = null): void
+    {
+        $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
+        $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
+        $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
+        $filter = FindAncestorNodesFilter::create(...$filterValues);
+        foreach ($this->getCurrentSubgraphs() as $subgraph) {
+            $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findAncestorNodes($entryNodeAggregateId, $filter)));
+            Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findAncestorNodes returned an unexpected result');
+            $actualCount = $subgraph->countAncestorNodes($entryNodeAggregateId, CountAncestorNodesFilter::fromFindAncestorNodesFilter($filter));
+            Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countAncestorNodes returned an unexpected result');
         }
     }
 

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -629,11 +629,13 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
 
                 match ($newLocation->destination::class) {
                     SucceedingSiblingNodeMoveDestination::class => $this->moveNode(
+                        /** @var SucceedingSiblingNodeMoveDestination $newLocation->destination */
                         $node,
                         $newLocation->destination->parentNodeAggregateId,
                         $newLocation->destination->nodeAggregateId
                     ),
                     ParentNodeMoveDestination::class => $this->moveNode(
+                        /** @var ParentNodeMoveDestination $newLocation->destination */
                         $node,
                         $newLocation->destination->nodeAggregateId,
                         null

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Fusion\Helper;
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
@@ -98,15 +99,9 @@ class NodeHelper implements ProtectedContextAwareInterface
      */
     public function depth(Node $node): int
     {
-        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
-        $depth = 0;
-        while ($node !== null) {
-            $node = $subgraph->findParentNode($node->nodeAggregateId);
-            $depth++;
-        }
-        return $depth;
+        return $this->contentRepositoryRegistry->subgraphForNode($node)
+            ->countAncestorNodes($node->nodeAggregateId, CountAncestorNodesFilter::create());
     }
-
 
     /**
      * @param Node $node


### PR DESCRIPTION
This adds the (afaik) last missing subgraph queries: findAncestorNodes and countAncestorNodes.

Can lateron be used to refactor lots of stuff, a few demo examples are included.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
