### PR TITLE
TASK: PHP 8.1 deprecations compatibility

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/ContentSubgraph/NodePath.php
+++ b/Neos.ContentRepository/Classes/Domain/ContentSubgraph/NodePath.php
@@ -103,6 +103,7 @@ final class NodePath implements \JsonSerializable
         return (string) $this === (string) $other;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->path;

--- a/Neos.ContentRepository/Classes/Domain/NodeAggregate/NodeAggregateIdentifier.php
+++ b/Neos.ContentRepository/Classes/Domain/NodeAggregate/NodeAggregateIdentifier.php
@@ -76,6 +76,7 @@ final class NodeAggregateIdentifier implements \JsonSerializable, CacheAwareInte
     /**
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/Neos.ContentRepository/Classes/Domain/NodeType/NodeTypeName.php
+++ b/Neos.ContentRepository/Classes/Domain/NodeType/NodeTypeName.php
@@ -54,6 +54,7 @@ final class NodeTypeName implements \JsonSerializable
         return $this->value === $other->getValue();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractFusionObject.php
@@ -97,6 +97,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param mixed $offset
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($this->fusionValue($offset) !== null);
@@ -108,6 +109,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->fusionValue($offset);
@@ -120,6 +122,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param mixed $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // no op
@@ -131,6 +134,7 @@ abstract class AbstractFusionObject implements \ArrayAccess
      * @param mixed $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // no op

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyProps.php
@@ -56,11 +56,13 @@ final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
         $this->effectiveContext = $effectiveContext;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($path)
     {
         return array_key_exists($path, $this->keys);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($path)
     {
         if (!array_key_exists($path, $this->valueCache)) {
@@ -74,16 +76,19 @@ final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
         return $this->valueCache[$path];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($path, $value)
     {
         throw new BadMethodCallException('Lazy props can not be set.', 1588182804);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($path)
     {
         throw new BadMethodCallException('Lazy props can not be unset.', 1588182805);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $path = key($this->keys);
@@ -93,26 +98,31 @@ final class LazyProps implements \ArrayAccess, \Iterator, \JsonSerializable
         return $this->offsetGet($path);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->keys);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->keys);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return current($this->keys) !== false;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->keys);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return iterator_to_array($this);

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -714,7 +714,7 @@ class ParserTest extends UnitTestCase
     public function parserCorrectlyParsesFixture16()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture16.fusion';
-        $sourceCode = file_get_contents($fixture, FILE_TEXT);
+        $sourceCode = file_get_contents($fixture);
 
         $expectedParseTree = $this->getExpectedParseTreeForFixture16();
 
@@ -729,7 +729,7 @@ class ParserTest extends UnitTestCase
     {
         $this->expectException(Exception::class);
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture16b.fusion';
-        $sourceCode = file_get_contents($fixture, FILE_TEXT);
+        $sourceCode = file_get_contents($fixture);
 
         $this->parser->parse($sourceCode, $fixture);
     }
@@ -740,7 +740,7 @@ class ParserTest extends UnitTestCase
     public function parserCorrectlyParsesFixture17()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture17.fusion';
-        $sourceCode = file_get_contents($fixture, FILE_TEXT);
+        $sourceCode = file_get_contents($fixture);
 
         $expectedParseTree = $this->getExpectedParseTreeForFixture16();
 
@@ -1005,6 +1005,6 @@ class ParserTest extends UnitTestCase
      */
     protected function readFusionFixture($fixtureName)
     {
-        return file_get_contents(__DIR__ . '/Fixtures/' . $fixtureName . '.fusion', FILE_TEXT);
+        return file_get_contents(__DIR__ . '/Fixtures/' . $fixtureName . '.fusion');
     }
 }

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyQueryResult.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyQueryResult.php
@@ -124,6 +124,7 @@ final class NeosAssetProxyQueryResult implements AssetProxyQueryResultInterface
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->flowPersistenceQueryResult->rewind();

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -136,8 +136,8 @@ class ConvertUrisImplementation extends AbstractFusionObject
     protected function replaceLinkTargets($processedContent)
     {
         $setNoOpener = $this->fusionValue('setNoOpener');
-        $externalLinkTarget = \trim($this->fusionValue('externalLinkTarget'));
-        $resourceLinkTarget = \trim($this->fusionValue('resourceLinkTarget'));
+        $externalLinkTarget = \trim((string)$this->fusionValue('externalLinkTarget'));
+        $resourceLinkTarget = \trim((string)$this->fusionValue('resourceLinkTarget'));
         $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
         $processedContent = \preg_replace_callback(

--- a/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -44,12 +44,11 @@ class DomainMatchingStrategyTest extends UnitTestCase
             $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
             $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
             $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
         ];
 
         $mockDomains[0]->setHostname('neos.io');
         $mockDomains[1]->setHostname('flow.neos.io');
-        $mockDomains[3]->setHostname('yacumboolu.neos.io');
+        $mockDomains[2]->setHostname('yacumboolu.neos.io');
 
         $expectedDomains = [
             $mockDomains[1],


### PR DESCRIPTION
This tweaks the code so that it runs without deprecations on PHP 8.1.

**Upgrade instructions**

None.

**Review instructions**

None.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
