### PR TITLE
BUGFIX: Fusion's FilePatternResolver windows compatible

### DIFF
--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -59,11 +59,14 @@ class FilePatternResolver
      */
     public static function resolveFilesByPattern(string $filePattern, ?string $filePathForRelativeResolves, string $defaultFileEndForUnspecificGlobbing): array
     {
-        $filePattern = Files::getUnixStylePath(trim($filePattern));
+        $filePattern = trim($filePattern);
         if ($filePattern === '') {
             throw new Fusion\Exception("cannot resolve empty pattern: '$filePattern'", 1636144288);
         }
-        $isAbsoluteWindowsPath = str_contains($filePattern, ':') && preg_match('`^[a-zA-Z]:/[^/]`', $filePattern) === 1;
+        if (str_contains($filePattern, '\\')) {
+            throw new Fusion\Exception("cannot resolve non-unix style pattern: '$filePattern'", 1688112067799);
+        }
+        $isAbsoluteWindowsPath = preg_match('`^[a-zA-Z]:/[^/]`', $filePattern) === 1;
         if ($filePattern[0] === '/' || $isAbsoluteWindowsPath) {
             throw new Fusion\Exception("cannot resolve absolute pattern: '$filePattern'", 1636144292);
         }
@@ -142,7 +145,7 @@ class FilePatternResolver
             $pathAndFilename = $fileInfo->getPathname();
 
             if (str_ends_with($pathAndFilename, $fileNameEnd)) {
-                $files[] = Files::getUnixStylePath($pathAndFilename);
+                $files[] = $pathAndFilename;
             }
         }
         return $files;

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -99,17 +99,18 @@ class FilePatternResolver
     protected static function parseGlobPatternAndResolveFiles(string $filePattern, string $defaultFileNameEnd): array
     {
         $fileIteratorCreator = match (1) {
-            // We SKIP_DOTS, as it might not be allowed to access `..` and we only are interested in files
+            // We use the flag SKIP_DOTS, as it might not be allowed to access `..` and we only are interested in files
+            // We use the flag UNIX_PATHS, so that stream wrapper paths are always valid on windows https://github.com/neos/neos-development-collection/issues/4358
 
             // Match recursive wildcard globbing '<base>/**/*<end>?'
             preg_match(self::RECURSIVE_GLOB_PATTERN, $filePattern, $matches) => static function (string $dir): \Iterator {
-                $recursiveDirectoryIterator = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS);
+                $recursiveDirectoryIterator = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS|\FilesystemIterator::UNIX_PATHS);
                 return new \RecursiveIteratorIterator($recursiveDirectoryIterator);
             },
 
             // Match simple wildcard globbing '<base>/*<end>?'
             preg_match(self::SIMPLE_GLOB_PATTERN, $filePattern, $matches) => static function (string $dir): \Iterator {
-                return new \FilesystemIterator($dir, \FilesystemIterator::SKIP_DOTS);
+                return new \FilesystemIterator($dir, \FilesystemIterator::SKIP_DOTS|\FilesystemIterator::UNIX_PATHS);
             },
 
             default => throw new Fusion\Exception("The include glob pattern '$filePattern' is invalid. Only globbing with /**/* or /* is supported.", 1636144713),

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -99,15 +99,17 @@ class FilePatternResolver
     protected static function parseGlobPatternAndResolveFiles(string $filePattern, string $defaultFileNameEnd): array
     {
         $fileIteratorCreator = match (1) {
+            // We SKIP_DOTS, as it might not be allowed to access `..` and we only are interested in files
+
             // Match recursive wildcard globbing '<base>/**/*<end>?'
             preg_match(self::RECURSIVE_GLOB_PATTERN, $filePattern, $matches) => static function (string $dir): \Iterator {
-                $recursiveDirectoryIterator = new \RecursiveDirectoryIterator($dir);
+                $recursiveDirectoryIterator = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS);
                 return new \RecursiveIteratorIterator($recursiveDirectoryIterator);
             },
 
             // Match simple wildcard globbing '<base>/*<end>?'
             preg_match(self::SIMPLE_GLOB_PATTERN, $filePattern, $matches) => static function (string $dir): \Iterator {
-                return new \DirectoryIterator($dir);
+                return new \FilesystemIterator($dir, \FilesystemIterator::SKIP_DOTS);
             },
 
             default => throw new Fusion\Exception("The include glob pattern '$filePattern' is invalid. Only globbing with /**/* or /* is supported.", 1636144713),


### PR DESCRIPTION
resolves #4358 in combination with #4374


The FilePatternResolver is responsible to handle glob patterns in includes in fusion.
For more in depth information see the test: https://github.com/neos/neos-development-collection/blob/a461dbc8f976588b30f34a5ed34f1eeebf5a0cd2/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php#L156-L167

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
