### PR TITLE
BUGFIX: Fix too strict grand-parent NodeType constraints

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -1,0 +1,65 @@
+@contentrepository @adapters=DoctrineDBAL,Postgres
+Feature: Create node aggregate with node
+
+  As a user of the CR I want to define NodeType constraints which will restrict the allowed child nodes
+  in a specific dimension space point.
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:RestrictedCollection':
+      constraints:
+        nodeTypes:
+          # deny all
+          '*': false
+
+    'Neos.ContentRepository.Testing.ConstrainedChildNodes':
+      childNodes:
+        collection:
+          type: 'Neos.ContentRepository.Testing:RestrictedCollection'
+          constraints:
+            nodeTypes:
+              # only allow this type
+              'Neos.ContentRepository.Testing:Node': true
+
+    'Neos.ContentRepository.Testing:Node': {}
+
+    'Neos.ContentRepository.Testing:UglyNode': {}
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier"
+    And I am in dimension space point {}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+
+  Scenario: Direct allowance of grandchild NodeType constraints overrule deny all on NodeType
+    # issue https://github.com/neos/neos-development-collection/issues/4351
+    Given the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                 |
+      | nodeAggregateId       | "sir-david-nodenborough"              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing.ConstrainedChildNodes" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"              |
+      | tetheredDescendantNodeAggregateIds | { "collection": "collection-node-id"} |
+    And the graph projection is fully up to date
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "collection-node-id"                  |
+    And the graph projection is fully up to date
+    And I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect the node aggregate "collection-node-id" to exist
+    And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -11,17 +11,20 @@ Feature: Create node aggregate with node
     'Neos.ContentRepository.Testing:RestrictedCollection':
       constraints:
         nodeTypes:
-          # deny all
+          # deny all except one
           '*': false
+          'Neos.ContentRepository.Testing:PrettyNode': true
 
-    'Neos.ContentRepository.Testing.ConstrainedChildNodes':
+    'Neos.ContentRepository.Testing.TetheredCollection':
       childNodes:
         collection:
           type: 'Neos.ContentRepository.Testing:RestrictedCollection'
           constraints:
             nodeTypes:
-              # only allow this type
+              # additionally allow this type
               'Neos.ContentRepository.Testing:Node': true
+
+    'Neos.ContentRepository.Testing:PrettyNode': {}
 
     'Neos.ContentRepository.Testing:Node': {}
 
@@ -45,21 +48,78 @@ Feature: Create node aggregate with node
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
 
-  Scenario: Direct allowance of grandchild NodeType constraints overrule deny all on NodeType
-    # issue https://github.com/neos/neos-development-collection/issues/4351
+  # Direct allowance via grandchild NodeType constraints overrule deny all on NodeType
+  # issue https://github.com/neos/neos-development-collection/issues/4351
+  Scenario: Tethered restricted collection
     Given the command CreateNodeAggregateWithNode is executed with payload:
       | Key                   | Value                                 |
       | nodeAggregateId       | "sir-david-nodenborough"              |
-      | nodeTypeName          | "Neos.ContentRepository.Testing.ConstrainedChildNodes" |
+      | nodeTypeName          | "Neos.ContentRepository.Testing.TetheredCollection" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
       | tetheredDescendantNodeAggregateIds | { "collection": "collection-node-id"} |
     And the graph projection is fully up to date
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    Then I expect the node aggregate "collection-node-id" to exist
+    # TetheredCollection
+    #  ↳ RestrictedCollection (tethered)
+
+    # allowed via parent node constraints: Node
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                    |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "collection-node-id"                  |
     And the graph projection is fully up to date
-    And I expect the node aggregate "sir-david-nodenborough" to exist
-    And I expect the node aggregate "collection-node-id" to exist
-    And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+
+    # allowed via grant parent node constraints: PrettyNode
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                       |
+      | nodeAggregateId           | "pretty-node"                               |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:PrettyNode" |
+      | parentNodeAggregateId     | "collection-node-id"                        |
+    And the graph projection is fully up to date
+    Then I expect the node aggregate "pretty-node" to exist
+
+    # disallowed via grant parent node constraints: UglyNode
+    And the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                       | Value                                     |
+      | nodeAggregateId           | "nordisch-nodel"                          |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:UglyNode" |
+      | parentNodeAggregateId     | "collection-node-id"                      |
+    Then the last command should have thrown an exception of type "NodeConstraintException" with code 1520011791
+
+  Scenario: Non-tethered restricted collection
+    Given the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                 |
+      | nodeAggregateId       | "sir-david-nodenborough"              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"              |
+    And the graph projection is fully up to date
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                                 |
+      | nodeAggregateId           | "collection-node-id"                                  |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:RestrictedCollection" |
+      | parentNodeAggregateId     | "sir-david-nodenborough"                              |
+    And the graph projection is fully up to date
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    Then I expect the node aggregate "collection-node-id" to exist
+    # Node
+    #  ↳ RestrictedCollection
+
+    # allowed via grant parent node constraints: PrettyNode
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                       |
+      | nodeAggregateId           | "pretty-node"                               |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:PrettyNode" |
+      | parentNodeAggregateId     | "collection-node-id"                        |
+    And the graph projection is fully up to date
+    Then I expect the node aggregate "pretty-node" to exist
+
+    # disallowed via grant parent node constraints: UglyNode
+    And the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                       | Value                                     |
+      | nodeAggregateId           | "nordisch-nodel"                          |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:UglyNode" |
+      | parentNodeAggregateId     | "collection-node-id"                      |
+    Then the last command should have thrown an exception of type "NodeConstraintException" with code 1707561400

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -296,7 +296,8 @@ trait ConstraintChecks
         if (!$parentsNodeType->allowsChildNodeType($nodeType)) {
             throw new NodeConstraintException(
                 'Node type "' . $nodeType->name->value . '" is not allowed for child nodes of type '
-                    . $parentsNodeType->name->value
+                    . $parentsNodeType->name->value,
+                1707561400
             );
         }
         if (
@@ -308,7 +309,8 @@ trait ConstraintChecks
                 'Node type "' . $nodeType->name->value . '" does not match configured "'
                     . $this->getNodeTypeManager()->getTypeOfTetheredNode($parentsNodeType, $nodeName)->name->value
                     . '" for auto created child nodes for parent type "' . $parentsNodeType->name->value
-                    . '" with name "' . $nodeName->value . '"'
+                    . '" with name "' . $nodeName->value . '"',
+                1707561404
             );
         }
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -88,7 +88,7 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
     protected PropertyConverter $propertyConverter;
 
     /**
-     * can be disabled in {@see NodeAggregateCommandHandler::withoutAnchestorNodeTypeConstraintChecks()}
+     * can be disabled in {@see NodeAggregateCommandHandler::withoutAncestorNodeTypeConstraintChecks()}
      */
     private bool $ancestorNodeTypeConstraintChecksEnabled = true;
 


### PR DESCRIPTION
This restores the Neos 8.3 behaviour to only check grand-child NodeType constraints for tethered parent-nodes.

For more information please see the discussion in https://github.com/neos/neos-development-collection/issues/4351.

Without this fix, the added test would fail with this error:
> Node type "Neos.ContentRepository.Testing:Node" is not allowed for child nodes of type Neos.ContentRepository.Testing:RestrictedCollection

Resolves: #4351

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
