### PR TITLE
9.0 TASK: Rename flowQueryOperation `referenceProperty` to `property`

### DIFF
--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
@@ -58,7 +58,7 @@ final class ReferencePropertyOperation implements OperationInterface
 
     public static function getPriority(): int
     {
-        return 100;
+        return 99;
     }
 
     public static function isFinal(): bool

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\OperationInterface;
  *
  * This operation can be used to return the value of a node reference:
  *
- *     ${q(node).references("someReferenceName").referenceProperty("somePropertyName")}
+ *     ${q(node).references("someReferenceName").property("somePropertyName")}
  *
  * @see ReferencesOperation, BackReferencesOperation
  * @api To be used in Fusion, for PHP code {@see Reference::properties} should be used instead
@@ -53,7 +53,7 @@ final class ReferencePropertyOperation implements OperationInterface
 
     public static function getShortName(): string
     {
-        return 'referenceProperty';
+        return 'property';
     }
 
     public static function getPriority(): int


### PR DESCRIPTION
This allows to use the same syntax for accessing reference properties to node properties.

Since the classic `property` operation for nodes is already a node specific implementation of a generic
`property` operation from it makes sense to provide a second reference specific implementation
instead of adding a new syntax.

This code will read the property `somePropertyName` of a reference:
```
${q(node).references("someReferenceName").property("somePropertyName")}
```

While this code will read the property `otherPropertyName` on the referenced node.
```
${q(node).referenceNodes("someReferenceName").property("otherPropertyName")}
```

**Review instructions**

Should be reviewed with the following prs in mind: 
1. #https://github.com/neos/neos-development-collection/pull/4364

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
