### PR TITLE
TASK: Change variablename in Neos Fusion documentation

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -67,7 +67,7 @@ Example Ordering::
 	# order (o1 ... o9) is *always* fixed, no matter in which order the
 	# individual statements are defined.
 
-	myArray = Neos.Fusion:Join {
+	myString = Neos.Fusion:Join {
 		o1 = Neos.NodeTypes:Text
 		o1.@position = 'start 12'
 		o2 = Neos.NodeTypes:Text
@@ -99,7 +99,7 @@ to use ``@position`` and meaningful keys in your application, and not numeric on
 
 Example of numeric keys (discouraged)::
 
-	myArray = Neos.Fusion:Join {
+	myString = Neos.Fusion:Join {
 		10 = Neos.NodeTypes:Text
 		20 = Neos.NodeTypes:Text
 	}


### PR DESCRIPTION
Now use "myString" in documentation, because the return value is a string and not an array. This can lead to confusion under certain circumstances.

**Upgrade instructions**

**Review instructions**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
