### PR TITLE
BUGFIX: `nodetypes://` normalize the path to unix

### DIFF
--- a/Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
+++ b/Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
@@ -489,6 +489,8 @@ class NodeTypesStreamWrapper implements StreamWrapperInterface
      */
     protected function evaluateNodeTypesPath($requestedPath, $checkForExistence = true)
     {
+        // we normalize the path first, as `nodetypes://Foo.Bar\SomeFile.bar` might be requested on windows, and we split later on unix slash `/`
+        $requestedPath = Files::getUnixStylePath($requestedPath);
         $requestPathParts = explode('://', $requestedPath, 2);
         if ($requestPathParts[0] !== self::SCHEME) {
             throw new \InvalidArgumentException('The ' . __CLASS__ . ' only supports the \'' . self::SCHEME . '\' scheme.', 1256052544);


### PR DESCRIPTION
as `nodetypes://Foo.Bar\SomeFile.bar` might be requested on windows, and we split later on unix slash `/`

resolves: #4358 in combination with #4359

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
