### PR TITLE
Bugfix: `migratelegacydata` warn if no valid content dimension configuration

### DIFF
--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/NodeDataToEventsProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/NodeDataToEventsProcessor.php
@@ -234,7 +234,7 @@ final class NodeDataToEventsProcessor implements ProcessorInterface
         $nodePath = NodePath::fromString(strtolower($nodeDataRow['path']));
         $parentNodeAggregate = $this->visitedNodes->findMostSpecificParentNodeInDimensionGraph($nodePath, $originDimensionSpacePoint, $this->interDimensionalVariationGraph);
         if ($parentNodeAggregate === null) {
-            $this->dispatch(Severity::ERROR, 'Failed to find parent node for node with id "%s" and dimensions: %s. The old CR can sometimes have orphaned nodes.', $nodeAggregateId->value, $originDimensionSpacePoint->toJson());
+            $this->dispatch(Severity::ERROR, 'Failed to find parent node for node with id "%s" and dimensions: %s. Please ensure that the new content repository has a valid content dimension configuration. Also note that the old CR can sometimes have orphaned nodes.', $nodeAggregateId->value, $originDimensionSpacePoint->toJson());
             return;
         }
         $pathParts = $nodePath->getParts();


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

@grebaldi stumbled upon this while migrating the Neos UI testing distribution. https://neos-project.slack.com/archives/C3MCBK6S2/p1688648280110549

in case you dindt migrate your dimensions first (eg the `default` repository doesnt have a dimension configuration) but you previously used dimensions in neos 8, then you will face this error:

> Failed to find parent node for node with id "f676459d-ca77-44bc-aeea-44114814c279" and dimensions: {"language":"fr"}. The old CR can sometimes have orphaned nodes.

@grebaldi wrote
> After running through, I export via `./flow cr:export`. In the resulting file, I find only two events: `ContentStreamWasCreated` and `RootNodeAggregateWithNodeWasCreated`. Looks to me as if the legacy migration mistook every node of the test site for an orphaned node.

we debugged the `NodeDataToEventsProcessor` and after some time had the correct guess that we need to first configure the dimensions.

A few hours of debugging can save us 5 minutes of reading the documentation ^^ (well there is no documentation yet also ^^)

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
