### PR TITLE
BUGFIX: Use $nodeAggregateId->value redirect params in NodesController

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -312,7 +312,7 @@ class NodesController extends ActionController
                 ));
 
             $this->redirect('show', null, null, [
-                'identifier' => $nodeAggregateId,
+                'identifier' => $nodeAggregateId->value,
                 'workspaceName' => $workspaceName,
                 'dimensions' => $dimensions
             ]);


### PR DESCRIPTION
The problematic lines:
https://github.com/neos/neos-development-collection/blob/f4ed8369957209ba689cb2e1d9319e39716d6ac3/Neos.Neos/Classes/Controller/Service/NodesController.php#L314-L318

During testing of https://github.com/neos/neos-ui/pull/3569, I stumbled over this one. The Router gets confused with the `NodeAggregateId` value object, so the resolution to `->value` is needed here for the redirect to work.

After this fix, the UI should be able to switch dimensions smoothly :)