### PR TITLE
BUGFIX: Provide replacement/insertion as array

### DIFF
--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/NodeAggregateIds.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/NodeAggregateIds.php
@@ -76,7 +76,7 @@ final class NodeAggregateIds implements \IteratorAggregate
         $nodeAggregateIds = $this->ids;
         if ($succeedingSibling) {
             $pivot = (int)array_search($succeedingSibling, $nodeAggregateIds);
-            array_splice($nodeAggregateIds, $pivot, 0, $nodeAggregateId);
+            array_splice($nodeAggregateIds, $pivot, 0, [$nodeAggregateId]);
         } else {
             $nodeAggregateIds[$nodeAggregateId->value] = $nodeAggregateId;
         }


### PR DESCRIPTION
PHPStan complained about wrong array value types. 

```
Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/NodeAggregateIds.php
Line 85

Parameter #1 $identifiers of class Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\NodeAggregateIds constructor expects array<string, Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId>, array<string, Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId|string> given. 
```

As array_splice seems to converts single replacement values to strings, the nodeAggregateId to insert needs to wrapped with an array.

> If replacement is just one element it is not necessary to put array() or square brackets around it, unless the element is an array itself, an object or null.

See issue: https://3v4l.org/nsDcc
See solution: https://3v4l.org/3VM0E

Fixes: current 9.0 pipelines.