### PR TITLE
 BUGFIX: Order NodeTypes found inside `NodeTypes` folder

### DIFF
--- a/Neos.ContentRepository/Classes/Configuration/NodeTypesLoader.php
+++ b/Neos.ContentRepository/Classes/Configuration/NodeTypesLoader.php
@@ -43,7 +43,11 @@ class NodeTypesLoader implements LoaderInterface
         foreach ($packages as $package) {
             $nodeTypesDirectory = Files::concatenatePaths([$package->getPackagePath(), 'NodeTypes']);
             if (\is_dir($nodeTypesDirectory)) {
-                $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($nodeTypesDirectory));
+                $iterator = new \RecursiveIteratorIterator(
+                    new RecursiveDirectoryIteratorWithSorting(
+                        new \RecursiveDirectoryIterator($nodeTypesDirectory)
+                    )
+                );
                 $allYamlFilesIterator = new \CallbackFilterIterator($iterator, static function (\SplFileInfo $fileInfo) {
                     return $fileInfo->isFile() && $fileInfo->getExtension() === 'yaml';
                 });

--- a/Neos.ContentRepository/Classes/Configuration/RecursiveDirectoryIteratorWithSorting.php
+++ b/Neos.ContentRepository/Classes/Configuration/RecursiveDirectoryIteratorWithSorting.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Configuration;
+
+/**
+ * The {@see \RecursiveDirectoryIterator} doesn't order the returned files.
+ *
+ * https://www.php.net/manual/en/class.recursivedirectoryiterator.php#120971
+ * > On Windows, you will get the files ordered by name. On Linux they are not ordered.
+ *
+ * To enforce a deterministic behavior, we wrap the RecursiveDirectoryIterator and sort the files level per level.
+ *
+ * This iterator is not lazy, as the construction alone will evaluate the inner RecursiveDirectoryIterator
+ *
+ * The sorting strategy is as follows:
+ *
+ * We sort directory by directory via the base name.
+ *
+ * This structure (unordered, so show how it might be scanned by the RecursiveDirectoryIterator)
+ *
+ * Content/
+ * ├─ Z.yaml
+ * ├─ A.yaml
+ * ├─ Columns/
+ * │  ├─ B.yaml
+ * │  ├─ A.yaml
+ *
+ * Will be sorted into
+ *
+ * Content/
+ * ├─ A.yaml
+ * ├─ Columns/
+ * │  ├─ A.yaml
+ * │  ├─ B.yaml
+ * ├─ Z.yaml
+ *
+ * so after applying an {@see \RecursiveIteratorIterator} one will get
+ *
+ * Content/A.yaml
+ * Content/Columns/A.yaml
+ * Content/Columns/B.yaml
+ * Content/Z.yaml
+ *
+ */
+class RecursiveDirectoryIteratorWithSorting implements \RecursiveIterator
+{
+    private const KEY = 0;
+
+    private const FILE_INFO = 1;
+
+    private const CHILDREN = 2;
+
+    private \RecursiveDirectoryIterator $recursiveDirectoryIterator;
+
+    private array $files;
+
+    public function __construct(\RecursiveDirectoryIterator $recursiveDirectoryIterator)
+    {
+        $this->recursiveDirectoryIterator = $recursiveDirectoryIterator;
+        $files = [];
+        foreach ($this->recursiveDirectoryIterator as $fileInfo) {
+            $files[$fileInfo->getFilename()] = [
+                self::FILE_INFO => $fileInfo,
+                self::CHILDREN => $this->recursiveDirectoryIterator->hasChildren() ? $this->recursiveDirectoryIterator->getChildren() : null,
+                self::KEY => $this->recursiveDirectoryIterator->key()
+            ];
+        }
+        ksort($files);
+        $this->files = $files;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
+        if (($c = current($this->files)) === false) {
+            return false;
+        }
+        return $c[self::FILE_INFO];
+    }
+
+    public function next(): void
+    {
+        next($this->files);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
+        if (($c = current($this->files)) === false) {
+            throw new \OutOfBoundsException();
+        }
+        return $c[self::KEY];
+    }
+
+    public function valid(): bool
+    {
+        return current($this->files) !== false;
+    }
+
+    public function rewind(): void
+    {
+        reset($this->files);
+    }
+
+    public function hasChildren(): bool
+    {
+        if (($c = current($this->files)) === false) {
+            throw new \OutOfBoundsException();
+        }
+        return $c[self::CHILDREN] !== null;
+    }
+
+    public function getChildren(): \RecursiveIterator
+    {
+        if (!$this->hasChildren()) {
+            throw new \UnexpectedValueException(sprintf('Cannot recurse into %s', current($this->files)[self::FILE_INFO]->getFilename()));
+        }
+        $c = current($this->files);
+        return new self($c[self::CHILDREN]);
+    }
+}


### PR DESCRIPTION
 Placing NodeTypes into the `NodeTypes` folder will currently yield a non-deterministic order when they are scanned.

 One can observe this when running `flow configuration:show --type NodeTypes`.
 The order might change from installation to installation with the same sources.
 Also you can observe that with this fix, the order is influenced by the file name.

 Thats because the underling directory scan via the `RecursiveDirectoryIterator` doesn't enforce a specific order, but will return the files how the underlying file system returns them - on linux - unordered.

 The `NodeTypes` configuration folder was introduces with #3332.

 This was first noticed, when the nodeTypes would show up in a different order in the "Create New" dialog in the Neos UI:

 https://github.com/neos/neos-ui/pull/3560#issuecomment-1624214622

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
