### PR TITLE
BUGFIX: (Neos.Neos) Restore `show` action of `ContentDimensionsController`

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/ContentDimensionsController.php
+++ b/Neos.Neos/Classes/Controller/Service/ContentDimensionsController.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Controller\Service;
 
-use Neos\ContentRepository\Core\DimensionSpace\ContentDimensionZookeeper;
+use Neos\ContentRepository\Core\Dimension\ContentDimensionId;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
@@ -74,6 +75,75 @@ class ContentDimensionsController extends ActionController
                 'contentDimensionsPresets',
                 $controllerInternals->interDimensionalVariationGraph->getDimensionSpacePoints()
             );
+        }
+    }
+
+    /**
+     * Returns only presets of the dimension specified by $dimensionName. But even though only one dimension is returned,
+     * the output follows the structure as described in ContentDimensionPresetSourceInterface::getAllPresets().
+     *
+     * It is possible to pass a selection of presets as a filter. In that case, $chosenDimensionPresets must be an array
+     * of one or more dimension names (key) and preset names (value). The returned list will then only contain dimension
+     * presets which are allowed in combination with the given presets.
+     *
+     * Example: Given that $chosenDimensionPresets = array('country' => 'US') and that a second dimension "language"
+     * exists and $dimensionName is "language. This method will now display a list of dimension presets for the dimension
+     * "language" which are allowed in combination with the country "US".
+     *
+     * @param string $dimensionName Name of the dimension to return presets for
+     * @param array $chosenDimensionPresets An optional array of dimension names and a single preset per dimension
+     * @phpstan-param array<string,string> $chosenDimensionPresets
+     * @return void
+     */
+    public function showAction($dimensionName, $chosenDimensionPresets = []): void
+    {
+        $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())
+            ->contentRepositoryId;
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+
+        $contentDimensionSource = $contentRepository->getContentDimensionSource();
+
+        $contentDimensionId = new ContentDimensionId($dimensionName);
+        $contentDimension = $contentDimensionSource->getDimension($contentDimensionId);
+        if (is_null($contentDimension)) {
+            $this->throwStatus(404, sprintf('The dimension %s does not exist.', $dimensionName));
+        }
+
+        $interDimensionalVariationGraph = $contentRepository->getVariationGraph();
+        $allowedSubSpace = $interDimensionalVariationGraph->getDimensionSpacePoints();
+
+        $selectedDimensionSpacepoint = DimensionSpacePoint::fromArray($chosenDimensionPresets);
+        $allowedDimensionValues = [];
+        foreach ($contentDimension->values as $contentDimensionValue) {
+            $probeDimensionSpacepoint = $selectedDimensionSpacepoint->vary(
+                $contentDimensionId,
+                $contentDimensionValue->value
+            );
+
+            if ($allowedSubSpace->contains($probeDimensionSpacepoint)) {
+                $allowedDimensionValues[] = $contentDimensionValue;
+            }
+        }
+
+        // Build Legacy Response Shape
+        $contentDimensionsAndPresets = [
+            $contentDimensionId->value => [
+                'label' => $contentDimension->getConfigurationValue('label'),
+                'icon' => $contentDimension->getConfigurationValue('icon'),
+                'presets' => []
+            ]
+        ];
+        foreach ($allowedDimensionValues as $allowedDimensionValue) {
+            $contentDimensionsAndPresets[$contentDimensionId->value]['presets'][$allowedDimensionValue->value] = [
+                'label' => $allowedDimensionValue->getConfigurationValue('label')
+            ];
+        }
+
+        if ($this->view instanceof JsonView) {
+            $this->view->assign('value', $contentDimensionsAndPresets);
+        } else {
+            $this->view->assign('dimensionName', $dimensionName);
+            $this->view->assign('contentDimensionsPresets', $contentDimensionsAndPresets);
         }
     }
 }

--- a/Neos.Neos/Configuration/Routes.Service.yaml
+++ b/Neos.Neos/Configuration/Routes.Service.yaml
@@ -172,3 +172,14 @@
     '@action':     'index'
   appendExceedingArguments: true
   httpMethods: ['GET']
+
+-
+  name: 'Services - ContentDimensionController->show()'
+  uriPattern: 'content-dimensions/{dimensionName}(.{@format})'
+  defaults:
+    '@package':    'Neos.Neos'
+    '@controller': 'Service\ContentDimensions'
+    '@action':     'show'
+    '@format':     'html'
+  appendExceedingArguments: true
+  httpMethods: ['GET']


### PR DESCRIPTION
**The problem**

The `show` endpoint for content dimensions has been removed via https://github.com/neos/neos-development-collection/pull/3848.

The UI relies on that endpoint to populate the `<DimensionSelector/>` with plausible values. Without the endpoint it breaks down:
![image](https://github.com/neos/neos-development-collection/assets/2522299/ef816bcf-be7c-42b2-b5d5-83f929f98a15)

**The solution**

I restored the endpoint as far as possible, keeping the necessary semantics required by the UI.

I believe this will only serve as a temporary solution, because this particular concern should be handled inside the UI package.