### PR TITLE
BUGFIX: Disable content element wrapping and inline editable for references in content reference list

### DIFF
--- a/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
+++ b/Neos.NodeTypes.ContentReferences/Resources/Private/Fusion/Root.fusion
@@ -6,6 +6,15 @@ prototype(Neos.NodeTypes.ContentReferences:ContentReferences) < prototype(Neos.N
     items = ${referenceNodesArray}
     itemRenderer = Neos.Neos:ContentCase
     itemName = 'node'
+
+    // Disable ContentElementWrapping for references itself
+    prototype(Neos.Neos:ContentElementWrapping) {
+      @if.render = false
+    }
+    // Disable InlineEditable for references itself
+    prototype(Neos.Neos:Editable) {
+      renderer.editable.condition = false
+    }
   }
   hasReferences = ${!!referenceNodesArray}
   @cache {


### PR DESCRIPTION
The NeosUI tries to initialize the inline editor for rendered references in content reference list. But they are not accessable at this moment. As references shouldn't get edited anyways, we can simple disable the content element wrapping for these references.

Fixes https://github.com/neos/neos-ui/issues/3574