### PR TITLE
BUGFIX: Consistently use correct cr identifier across delegated cr:* commands

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -102,6 +102,6 @@ final class CrCommandController extends CommandController
         );
         $workspaceMaintenanceService->pruneAll();
 
-        $this->replayAllCommand();
+        $this->replayAllCommand($contentRepository);
     }
 }

--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -109,7 +109,7 @@ class CrCommandController extends CommandController
         }
 
         $this->outputLine('Replaying projections');
-        Scripts::executeCommand('neos.contentrepositoryregistry:cr:replayall', $this->flowSettings, false, ['contentRepositoryIdentifier' => $contentRepositoryId->value]);
+        Scripts::executeCommand('neos.contentrepositoryregistry:cr:replayall', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value]);
 
         $this->outputLine('<success>Done</success>');
     }


### PR DESCRIPTION
**The problem**

In Neos.ContentRepository, `./flow cr:prune` delegates internally to `cr:replayall`, but misses to pass its given `--content-repository` parameter to the subsequent command.

Likewise, in Neos.Neos, `./flow cr:import` delegates internally to `neos.contentrepositoryregistry:cr:replayall`, and also misses to pass its given `--content-repository` parameter to the subsequent command.

**The solution**

I fixed `cr:prune` by passing the missing parameter to the `$this->replayAllCommand(...)` call.

`cr:import` was actually attempting to pass the content repository identifier, but did so with a misspelled parameter name. I fixed it by correcting the name.
