### PR TITLE
BUGFIX: Add assetcollection privilege condition to asset edit view in Media.Browser

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -57,14 +57,16 @@
                                             </label>
                                         </f:for>
                                     </f:if>
-                                    <f:if condition="{assetCollections}">
-                                        <label>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</label>
-                                        <f:for each="{assetCollections}" as="assetCollection">
-                                            <label class="neos-checkbox neos-inline">
-                                                <m:form.checkbox property="assetCollections" multiple="TRUE" value="{assetCollection}" /><span></span> {assetCollection.title}
-                                            </label>
-                                        </f:for>
-                                    </f:if>
+                                    <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+                                        <f:if condition="{assetCollections}">
+                                            <label>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</label>
+                                            <f:for each="{assetCollections}" as="assetCollection">
+                                                <label class="neos-checkbox neos-inline">
+                                                    <m:form.checkbox property="assetCollections" multiple="TRUE" value="{assetCollection}" /><span></span> {assetCollection.title}
+                                                </label>
+                                            </f:for>
+                                        </f:if>
+                                    </f:security.ifAccess>
                                 </fieldset>
                                 <fieldset>
                                     <legend>{neos:backend.translate(id: 'metadata', package: 'Neos.Media.Browser')}</legend>


### PR DESCRIPTION
In the Media.Browser you can change the AssetCollections via checkboxes even when you don't have the privilege (Neos.Media.Browser:ManageAssetCollections) to do so.
With this PR the checkboxes are only rendered with the right privilege.
