### PR TITLE
FEATURE: Better multi-site support for media module

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -206,6 +206,8 @@ class AssetController extends ActionController
             'assetSources' => $this->assetSources,
             'variantsTabFeatureEnabled' => $this->settings['features']['variantsTab']['enable'],
             'constraints' => $this->assetConstraints,
+            'showAllCollections' => $this->settings['features']['showAllCollections']['enable'],
+            'showMediaTags' => $this->settings['features']['showMediaTags']['enable'],
         ]);
     }
 

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -257,10 +257,20 @@ class AssetController extends ActionController
         $searchResultCount = 0;
         $untaggedCount = 0;
 
+        $collectionSeparator = $this->settings['features']['collectionTree']['separator'];
+
         try {
             foreach ($this->assetCollectionRepository->findAll()->toArray() as $retrievedAssetCollection) {
                 assert($retrievedAssetCollection instanceof AssetCollection);
-                $assetCollections[] = ['object' => $retrievedAssetCollection, 'count' => $this->assetRepository->countByAssetCollection($retrievedAssetCollection)];
+                $collectionDepth = 0;
+                $title = $retrievedAssetCollection->getTitle();
+                if (!empty($collectionSeparator)) {
+                    $titleParts = explode($collectionSeparator, $title);
+                    if (($collectionDepth = count($titleParts)) > 1) {
+                        $title = ($collectionDepth > 2 ? str_repeat('&nbsp;', $collectionDepth - 1) : '') . '&rdca; ' . $titleParts[$collectionDepth - 1];
+                    }
+                }
+                $assetCollections[] = ['object' => $retrievedAssetCollection, 'count' => $this->assetRepository->countByAssetCollection($retrievedAssetCollection), 'depth' => $collectionDepth, 'title' => $title];
             }
 
             foreach ($activeAssetCollection !== null ? $activeAssetCollection->getTags() : $this->tagRepository->findAll() as $retrievedTag) {
@@ -301,7 +311,8 @@ class AssetController extends ActionController
             'maximumFileUploadSize' => $this->getMaximumFileUploadSize(),
             'humanReadableMaximumFileUploadSize' => Files::bytesToSizeString($this->getMaximumFileUploadSize()),
             'activeAssetSource' => $activeAssetSource,
-            'activeAssetSourceSupportsSorting' => $assetProxyRepository instanceof SupportsSortingInterface
+            'activeAssetSourceSupportsSorting' => $assetProxyRepository instanceof SupportsSortingInterface,
+            'collectionSeparator' => $collectionSeparator,
         ]);
     }
 
@@ -767,6 +778,24 @@ class AssetController extends ActionController
      */
     public function deleteAssetCollectionAction(AssetCollection $assetCollection): void
     {
+        $collectionSeparator = $this->settings['features']['collectionTree']['separator'];
+        if (!empty($collectionSeparator)) {
+            // find all assets in $assetCollection and move to base assetCollection
+            $baseAssetCollection = null;
+            $baseTitle = explode($collectionSeparator, $assetCollection->getTitle())[0];
+            foreach ($this->assetCollectionRepository->findAll()->toArray() as $tempAssetCollection) {
+                /** @var $tempAssetCollection AssetCollection */
+                if ($tempAssetCollection->getTitle() === $baseTitle) {
+                    $baseAssetCollection = $tempAssetCollection;
+                    break;
+                }
+            }
+            if (!empty($baseAssetCollection)) {
+                foreach ($assetCollection->getAssets() as $asset) {
+                    $this->addAssetToCollectionAction($asset, $baseAssetCollection);
+                }
+            }
+        }
         $this->forwardWithConstraints('delete', 'AssetCollection', ['assetCollection' => $assetCollection]);
     }
 

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -33,6 +33,10 @@ Neos:
         # Show  media tags
         showMediaTags:
           enable: false
+        # collection hierarchical tree view / separation character
+        # set to '' (empty string) to disable
+        collectionTree:
+          separator: '/'
 
   Flow:
     security:

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -23,10 +23,16 @@ Neos:
       features:
          # By default, disable the beta feature "variants tab":
         variantsTab:
-          enable: false
+          enable: true
         # By default, enable the option to create redirects for replaced asset resources
         createAssetRedirectsOption:
           enable: true
+        # Show all media collections
+        showAllCollections:
+          enable: false
+        # Show  media tags
+        showMediaTags:
+          enable: false
 
   Flow:
     security:

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -23,7 +23,7 @@ Neos:
       features:
          # By default, disable the beta feature "variants tab":
         variantsTab:
-          enable: true
+          enable: false
         # By default, enable the option to create redirects for replaced asset resources
         createAssetRedirectsOption:
           enable: true

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -126,10 +126,6 @@
                         </f:link.action>
                     </li>
 									</f:then>
-									<f:else>
-										<f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
-										</f:security.ifAccess>
-									</f:else>
                 </f:if>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -1,5 +1,5 @@
 {namespace neos=Neos\Neos\ViewHelpers}
-<f:layout name="Default" />
+<f:layout name="Default"/>
 
 <f:section name="Title">Index view</f:section>
 
@@ -10,29 +10,34 @@
             <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: {0: searchTerm}, package: 'Neos.Media.Browser')}</f:if>
         </span>
         <f:if condition="!{activeAssetSource.readOnly}">
-        <f:link.action action="new" addQueryString="true"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
+            <f:link.action action="new" addQueryString="true"><i class="fas fa-upload"></i> {neos:backend.translate(id:
+                'upload', package: 'Neos.Media.Browser')}
+            </f:link.action>
         </f:if>
     </div>
     <div class="neos-view-options">
         <f:if condition="{filterOptions}">
             <div class="neos-dropdown" id="neos-filter-menu">
-                <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
-                    <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#" data-neos-toggle="dropdown" data-target="#neos-filter-menu">
+                <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}"
+                      data-neos-toggle="tooltip">
+                    <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#"
+                       data-neos-toggle="dropdown" data-target="#neos-filter-menu">
                         <i class="fas fa-filter"></i>
                     </a>
                 </span>
                 <ul class="neos-dropdown-menu neos-pull-right" role="menu">
                     <f:for each="{filterOptions}" as="filterValue">
                         <li>
-                            <f:render section="FilterLink.{filterValue}" />
+                            <f:render section="FilterLink.{filterValue}"/>
                         </li>
                     </f:for>
                 </ul>
             </div>
         </f:if>
         <f:if condition="{activeAssetSourceSupportsSorting}">
-        <div class="neos-dropdown" id="neos-sort-menu">
-            <span title="{neos:backend.translate(id: 'tooltip.sortOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
+            <div class="neos-dropdown" id="neos-sort-menu">
+            <span title="{neos:backend.translate(id: 'tooltip.sortOptions', package: 'Neos.Media.Browser')}"
+                  data-neos-toggle="tooltip">
                 <a class="dropdown-toggle" href="#" data-neos-toggle="dropdown" data-target="#neos-sort-menu">
                     <f:if condition="{sortDirection} === 'ASC'">
                         <f:then>
@@ -44,34 +49,68 @@
                     </f:if>
                 </a>
             </span>
-            <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
-                <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
-                <ul>
-                    <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
-                    </li>
-                    <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
-                    </li>
-                </ul>
-                <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
-                <ul>
-                    <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
-                    </li>
-                    <li>
-                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
-                    </li>
-                </ul>
+                <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
+                    <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
+                    <ul>
+                        <li>
+                            <f:link.action action="index"
+                                           title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}"
+                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
+                                           arguments="{sortBy: 'Modified'}" addQueryString="true"
+                                           class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}">
+                                <i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i>
+                                {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
+                            </f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index"
+                                           title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}"
+                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
+                                           arguments="{sortBy: 'Name'}" addQueryString="true"
+                                           class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i
+                                    class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i>
+                                {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
+                            </f:link.action>
+                        </li>
+                    </ul>
+                    <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
+                    <ul>
+                        <li>
+                            <f:link.action action="index"
+                                           title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}"
+                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
+                                           arguments="{sortDirection: 'ASC'}" addQueryString="true"
+                                           class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}">
+                                <i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i>
+                                {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}
+                            </f:link.action>
+                        </li>
+                        <li>
+                            <f:link.action action="index"
+                                           title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}"
+                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
+                                           arguments="{sortDirection: 'DESC'}" addQueryString="true"
+                                           class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}">
+                                <i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i>
+                                {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}
+                            </f:link.action>
+                        </li>
+                    </ul>
+                </div>
             </div>
-        </div>
         </f:if>
         <f:if condition="{view} === 'Thumbnail'">
             <f:then>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
+                <f:link.action action="index"
+                               title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}"
+                               arguments="{view: 'List'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i
+                        class="fas fa-th-list"></i></f:link.action>
             </f:then>
             <f:else>
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
+                <f:link.action action="index"
+                               title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}"
+                               arguments="{view: 'Thumbnail'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i
+                        class="fas fa-th"></i></f:link.action>
             </f:else>
         </f:if>
     </div>
@@ -79,194 +118,275 @@
 
 <f:section name="Sidebar">
     <f:form action="index" addQueryString="true" method="get" class="neos-search">
-        <button type="submit" class="neos-button" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
+        <button type="submit" class="neos-button"
+                title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}"
+                data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
         <div>
-            <input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}" value="{searchTerm}"{f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')} />
+            <input type="search"
+                   name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}"
+                   placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}"
+                   value="{searchTerm}" {f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')}
+            />
         </div>
     </f:form>
     <f:if condition="{assetSources -> f:count()} > 1">
-    <div class="neos-media-aside-group">
-        <h2>{neos:backend.translate(id: 'mediaSources', package: 'Neos.Media.Browser')}</h2>
-        <ul class="neos-media-aside-list">
-            <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
-                <li>
-                    <f:link.action action="index" title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier}" addQueryString="true">
-                      <f:if condition="{assetSource.iconUri}"><img class="neos-media-assetsource-icon" src="{assetSource.iconUri}" /></f:if>
-                      {assetSource.label}
-                    </f:link.action>
-                </li>
-            </f:for>
-        </ul>
-    </div>
+        <div class="neos-media-aside-group">
+            <h2>{neos:backend.translate(id: 'mediaSources', package: 'Neos.Media.Browser')}</h2>
+            <ul class="neos-media-aside-list">
+                <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
+                    <li>
+                        <f:link.action action="index"
+                                       title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}"
+                                       class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}"
+                                       arguments="{assetSourceIdentifier: assetSourceIdentifier}" addQueryString="true">
+                            <f:if condition="{assetSource.iconUri}"><img class="neos-media-assetsource-icon"
+                                                                         src="{assetSource.iconUri}"/></f:if>
+                            {assetSource.label}
+                        </f:link.action>
+                    </li>
+                </f:for>
+            </ul>
+        </div>
     </f:if>
     <div class="neos-media-aside-group">
         <f:if condition="!{activeAssetSource.readOnly}">
-        <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
-            <f:then>
-                <h2>
-                    {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
-                    <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
-                </h2>
-            </f:then>
-            <f:else>
-                <f:if condition="{assetCollections}">
-                    <h2>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</h2>
-                </f:if>
-            </f:else>
-        </f:security.ifAccess>
+            <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+                <f:then>
+                    <h2>
+                        {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
+                        <span class="neos-media-aside-list-edit-toggle neos-button"
+                              title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}"
+                              data-neos-toggle="tooltip"><i
+                                class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
+                    </h2>
+                </f:then>
+                <f:else>
+                    <f:if condition="{assetCollections}">
+                        <h2>{neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}</h2>
+                    </f:if>
+                </f:else>
+            </f:security.ifAccess>
         </f:if>
         <f:if condition="{assetCollections -> f:count()}">
             <ul class="neos-media-aside-list">
-                <li>
-                    <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}" addQueryString="true">
-                        {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
-                        <span class="count">{allCollectionsCount}</span>
-                    </f:link.action>
-                </li>
+                <f:if condition="{showAllCollections}">
+                    <li>
+                        <f:link.action action="index"
+                                       class="{f:if(condition: activeAssetCollection, else: ' neos-active')}"
+                                       title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}"
+                                       arguments="{view: view, collectionMode: 1}" addQueryString="true">
+                            {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
+                            <span class="count">{allCollectionsCount}</span>
+                        </f:link.action>
+                    </li>
+                </f:if>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
-                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{assetCollection.object.title}"
+                                       class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}"
+                                       arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}"
+                                       addQueryString="true"
+                                       data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
                             {assetCollection.object.title}
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <f:if condition="!{activeAssetSource.readOnly}">
-                        <div class="neos-sidelist-edit-actions">
-                            <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" addQueryString="true" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
-                            <button type="submit" class="neos-button neos-button-danger" data-toggle="modal" href="#delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
-                        </div>
+                            <div class="neos-sidelist-edit-actions">
+                                <f:link.action class="neos-button" action="editAssetCollection"
+                                               arguments="{assetCollection: assetCollection.object}"
+                                               addQueryString="true"
+                                               title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}"
+                                               data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i>
+                                </f:link.action>
+                                <button type="submit" class="neos-button neos-button-danger" data-toggle="modal"
+                                        href="#delete-assetcollection-modal"
+                                        data-object-identifier="{assetCollection.object -> f:format.identifier()}"
+                                        data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}"
+                                        title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}"
+                                        data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
+                            </div>
                         </f:if>
                     </li>
                 </f:for>
             </ul>
             <f:if condition="!{activeAssetSource.readOnly}">
-            <div class="neos-hide" id="delete-assetcollection-modal">
-                <div class="neos-modal-centered">
-                    <div class="neos-modal-content">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser')}</div>
-                            <div>
-                                <div class="neos-subheader">
-                                    <p>
-                                        {neos:backend.translate(id: 'message.willDeleteCollection', package: 'Neos.Media.Browser')}<br />
-                                        {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
-                                    </p>
+                <div class="neos-hide" id="delete-assetcollection-modal">
+                    <div class="neos-modal-centered">
+                        <div class="neos-modal-content">
+                            <div class="neos-modal-header">
+                                <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection',
+                                    package: 'Neos.Media.Browser')}
+                                </div>
+                                <div>
+                                    <div class="neos-subheader">
+                                        <p>
+                                            {neos:backend.translate(id: 'message.willDeleteCollection', package:
+                                            'Neos.Media.Browser')}<br/>
+                                            {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
+                                            'Neos.Media.Browser')}
+                                        </p>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
-                                <f:form.hidden name="assetCollection" id="modal-form-object" />
-                                <button type="submit" class="neos-button neos-button-danger">
-                                    {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
-                                </button>
-                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-                            </f:form>
+                            <div class="neos-modal-footer">
+                                <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
+                                    'cancel', package: 'Neos.Neos')}</a>
+                                <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
+                                    <f:form.hidden name="assetCollection" id="modal-form-object"/>
+                                    <button type="submit" class="neos-button neos-button-danger">
+                                        {neos:backend.translate(id: 'message.confirmDeleteCollection', package:
+                                        'Neos.Media.Browser')}
+                                    </button>
+                                    <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
+                                </f:form>
+                            </div>
                         </div>
                     </div>
+                    <div class="neos-modal-backdrop neos-in"></div>
                 </div>
-                <div class="neos-modal-backdrop neos-in"></div>
-            </div>
-          </f:if>
+            </f:if>
         </f:if>
         <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
             <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
-                <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
-                <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
-                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
+                <f:form.textfield name="title"
+                                  placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}"/>
+                <br/><br/>
+                <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id:
+                    'createCollection', package: 'Neos.Media.Browser')}
+                </button>
+                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
             </f:form>
         </f:security.ifAccess>
     </div>
 
-    <div class="neos-media-aside-group">
-        <h2>
-            {neos:backend.translate(id: 'tags', package: 'Neos.Media.Browser')}
-            <f:if condition="!{activeAssetSource.readOnly}">
-            <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: tags, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
-            </f:if>
-        </h2>
-        <ul class="neos-media-aside-list">
-            <li class="neos-media-list-all">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}" addQueryString="true">
-                    {neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
-                    <span class="count">{allCount}</span>
-                </f:link.action>
-            </li>
-            <li class="neos-media-list-untagged">
-                <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}" addQueryString="true">
-                    {neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
-                    <span class="count">{untaggedCount}</span>
-                </f:link.action>
-            </li>
-            <f:for each="{tags}" as="tag">
-                <li>
-                    <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object, tagMode: 0}" addQueryString="true" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
-                        {tag.object.label}
-                        <span class="count">{tag.count}</span>
+    <f:if condition="{showMediaTags}">
+        <div class="neos-media-aside-group">
+            <h2>
+                {neos:backend.translate(id: 'tags', package: 'Neos.Media.Browser')}
+                <f:if condition="!{activeAssetSource.readOnly}">
+                    <span class="neos-media-aside-list-edit-toggle neos-button"
+                          title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}"
+                          data-neos-toggle="tooltip"><i
+                            class="{f:if(condition: tags, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
+                </f:if>
+            </h2>
+            <ul class="neos-media-aside-list">
+                <li class="neos-media-list-all">
+                    <f:link.action action="index"
+                                   title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}"
+                                   class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}"
+                                   arguments="{tagMode: 1}" addQueryString="true">
+                        {neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
+                        <span class="count">{allCount}</span>
                     </f:link.action>
-                    <f:if condition="!{activeAssetSource.readOnly}">
-                    <div class="neos-sidelist-edit-actions">
-                        <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" addQueryString="true" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
-                        <button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip" data-toggle="modal" href="#delete-tag-modal" data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteTag', package: 'Neos.Media.Browser', arguments:'{0: tag.object.label}')}" data-object-identifier="{tag.object -> f:format.identifier()}"><i class="fas fa-trash"></i></button>
-                    </div>
-                    </f:if>
                 </li>
-            </f:for>
-            <f:if condition="!{activeAssetSource.readOnly}">
-            <div class="neos-hide" id="delete-tag-modal">
-                <div class="neos-modal-centered">
-                    <div class="neos-modal-content">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteTag', package: 'Neos.Media.Browser')}</div>
-                            <div>
-                                <div class="neos-subheader">
-                                    <p>
-                                        {neos:backend.translate(id: 'message.willDeleteTag', package: 'Neos.Media.Browser')}<br />
-                                        {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
-                                    </p>
+                <li class="neos-media-list-untagged">
+                    <f:link.action action="index"
+                                   title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}"
+                                   class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}"
+                                   arguments="{tagMode: 2}" addQueryString="true">
+                        {neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
+                        <span class="count">{untaggedCount}</span>
+                    </f:link.action>
+                </li>
+                <f:for each="{tags}" as="tag">
+                    <li>
+                        <f:link.action action="index" title="{tag.object.label}"
+                                       class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}"
+                                       arguments="{tag: tag.object, tagMode: 0}" addQueryString="true"
+                                       data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+                            {tag.object.label}
+                            <span class="count">{tag.count}</span>
+                        </f:link.action>
+                        <f:if condition="!{activeAssetSource.readOnly}">
+                            <div class="neos-sidelist-edit-actions">
+                                <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}"
+                                               addQueryString="true"
+                                               title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}"
+                                               data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i>
+                                </f:link.action>
+                                <button class="neos-button neos-button-danger"
+                                        title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}"
+                                        data-neos-toggle="tooltip" data-toggle="modal" href="#delete-tag-modal"
+                                        data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteTag', package: 'Neos.Media.Browser', arguments:'{0: tag.object.label}')}"
+                                        data-object-identifier="{tag.object -> f:format.identifier()}"><i
+                                        class="fas fa-trash"></i></button>
+                            </div>
+                        </f:if>
+                    </li>
+                </f:for>
+                <f:if condition="!{activeAssetSource.readOnly}">
+                    <div class="neos-hide" id="delete-tag-modal">
+                        <div class="neos-modal-centered">
+                            <div class="neos-modal-content">
+                                <div class="neos-modal-header">
+                                    <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteTag',
+                                        package: 'Neos.Media.Browser')}
+                                    </div>
+                                    <div>
+                                        <div class="neos-subheader">
+                                            <p>
+                                                {neos:backend.translate(id: 'message.willDeleteTag', package:
+                                                'Neos.Media.Browser')}<br/>
+                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
+                                                'Neos.Media.Browser')}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="neos-modal-footer">
+                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
+                                        'cancel', package: 'Neos.Neos')}</a>
+                                    <f:form action="deleteTag" addQueryString="true" class="neos-inline">
+                                        <f:form.hidden name="tag" id="modal-form-object"/>
+                                        <button type="submit" class="neos-button neos-button-danger">
+                                            {neos:backend.translate(id: 'message.confirmDeleteTag', package:
+                                            'Neos.Media.Browser')}
+                                        </button>
+                                        <f:render partial="ConstraintsHiddenFields"
+                                                  arguments="{constraints: constraints}"/>
+                                    </f:form>
                                 </div>
                             </div>
                         </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="deleteTag" addQueryString="true" class="neos-inline">
-                                <f:form.hidden name="tag" id="modal-form-object" />
-                                <button type="submit" class="neos-button neos-button-danger">
-                                    {neos:backend.translate(id: 'message.confirmDeleteTag', package: 'Neos.Media.Browser')}
-                                </button>
-                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-                            </f:form>
-                        </div>
+                        <div class="neos-modal-backdrop neos-in"></div>
                     </div>
-                </div>
-                <div class="neos-modal-backdrop neos-in"></div>
-            </div>
+                </f:if>
+            </ul>
+            <f:if condition="!{activeAssetSource.readOnly}">
+                <f:form action="createTag" addQueryString="true" id="neos-tags-create-form">
+                    <f:form.textfield name="label"
+                                      placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}"/>
+                    <br/><br/>
+                    <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id:
+                        'createTag', package: 'Neos.Media.Browser')}
+                    </button>
+                    <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
+                </f:form>
             </f:if>
-        </ul>
-        <f:if condition="!{activeAssetSource.readOnly}">
-        <f:form action="createTag" addQueryString="true" id="neos-tags-create-form">
-            <f:form.textfield name="label" placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}" /><br /><br />
-            <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createTag', package: 'Neos.Media.Browser')}</button>
-            <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-        </f:form>
-        </f:if>
-    </div>
+        </div>
+    </f:if>
 </f:section>
 
 <f:section name="Content">
     <f:if condition="!{activeAssetSource.readOnly}">
-    <div id="dropzone" class="neos-upload-area">
-        <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
-        <f:form method="post" action="create" addQueryString="true" object="{asset}" objectName="asset" enctype="multipart/form-data">
-            <f:form.upload id="resource" property="resource" additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}" />
-            <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-        </f:form>
-    </div>
-    <div id="uploader">
-        <div id="filelist"></div>
-    </div>
+        <div id="dropzone" class="neos-upload-area">
+            <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}"
+                 data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i
+                    class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span>
+            </div>
+            <f:form method="post" action="create" addQueryString="true" object="{asset}" objectName="asset"
+                    enctype="multipart/form-data">
+                <f:form.upload id="resource" property="resource"
+                               additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}"/>
+                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
+            </f:form>
+        </div>
+        <div id="uploader">
+            <div id="filelist"></div>
+        </div>
     </f:if>
     <f:if condition="{connectionError}">
         <f:then>
@@ -275,46 +395,55 @@
         </f:then>
         <f:else>
             <f:if condition="{assetProxies -> f:count()}">
-        <f:then>
+                <f:then>
                     <f:if condition="!{activeAssetSource.readOnly}">
-            <div class="neos-media-content-help">
-                <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package: 'Neos.Media.Browser')}
-            </div>
+                        <div class="neos-media-content-help">
+                            <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package:
+                            'Neos.Media.Browser')}
+                        </div>
                     </f:if>
-                    <f:render partial="{view}View" arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}" />
+                    <f:render partial="{view}View"
+                              arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}"/>
 
-            <div class="neos-hide" id="delete-asset-modal">
-                <div class="neos-modal-centered">
-                    <div class="neos-modal-content">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset', package: 'Neos.Media.Browser')}</div>
-                            <div>
-                                <div class="neos-subheader">
-                                    <p>
-                                        {neos:backend.translate(id: 'message.willBeDeleted', package: 'Neos.Media.Browser')}<br />
-                                        {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
-                                    </p>
+                    <div class="neos-hide" id="delete-asset-modal">
+                        <div class="neos-modal-centered">
+                            <div class="neos-modal-content">
+                                <div class="neos-modal-header">
+                                    <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset',
+                                        package: 'Neos.Media.Browser')}
+                                    </div>
+                                    <div>
+                                        <div class="neos-subheader">
+                                            <p>
+                                                {neos:backend.translate(id: 'message.willBeDeleted', package:
+                                                'Neos.Media.Browser')}<br/>
+                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
+                                                'Neos.Media.Browser')}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="neos-modal-footer">
+                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
+                                        'cancel', package: 'Neos.Neos')}</a>
+                                    <f:form action="delete" addQueryString="true" method="post" class="neos-inline">
+                                        <f:form.hidden name="asset" id="modal-form-object"/>
+                                        <button type="submit" class="neos-button neos-button-mini neos-button-danger">
+                                            {neos:backend.translate(id: 'message.confirmDelete', package:
+                                            'Neos.Media.Browser')}
+                                        </button>
+                                        <f:render partial="ConstraintsHiddenFields"
+                                                  arguments="{constraints: constraints}"/>
+                                    </f:form>
                                 </div>
                             </div>
                         </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
-                            <f:form action="delete" addQueryString="true" method="post" class="neos-inline">
-                                <f:form.hidden name="asset" id="modal-form-object" />
-                                <button type="submit" class="neos-button neos-button-mini neos-button-danger">
-                                    {neos:backend.translate(id: 'message.confirmDelete', package: 'Neos.Media.Browser')}
-                                </button>
-                                <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}" />
-                            </f:form>
-                        </div>
+                        <div class="neos-modal-backdrop neos-in"></div>
                     </div>
-                </div>
-                <div class="neos-modal-backdrop neos-in"></div>
-            </div>
-        </f:then>
-        <f:else>
-            <p>{neos:backend.translate(id: 'noAssetsFound', package: 'Neos.Media.Browser')}</p>
+                </f:then>
+                <f:else>
+                    <p>{neos:backend.translate(id: 'noAssetsFound', package: 'Neos.Media.Browser')}</p>
                 </f:else>
             </f:if>
         </f:else>
@@ -322,34 +451,76 @@
 </f:section>
 
 <f:section name="Scripts">
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/jquery-ui/js/jquery-ui-1.10.3.custom.js')}"></script>
+    <script type="text/javascript"
+            src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/jquery-ui/js/jquery-ui-1.10.3.custom.js')}"></script>
     <f:if condition="!{activeAssetSource.readOnly}">
-    <script type="text/javascript">
-        var uploadUrl = "{f:uri.action(action: 'upload', addQueryString: true, additionalParams: {__csrfToken: '{f:security.csrfToken()}'}, absolute: true) -> f:format.raw()}";
-        var maximumFileUploadSize = {maximumFileUploadSize};
-<![CDATA[
-        if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail) {
-            window.parent.NeosMediaBrowserCallbacks.refreshThumbnail();
-        }
-]]>
-    </script>
-    <f:form action="tagAsset" addQueryString="true" id="tag-asset-form" format="json">
-        <f:form.hidden name="asset[__identity]" id="tag-asset-form-asset" />
-        <f:form.hidden name="tag[__identity]" id="tag-asset-form-tag" />
-    </f:form>
-    <f:form action="addAssetToCollection" addQueryString="true" id="link-asset-to-assetcollection-form" format="json">
-        <f:form.hidden name="asset[__identity]" id="link-asset-to-assetcollection-form-asset" />
-        <f:form.hidden name="assetCollection[__identity]" id="link-asset-to-assetcollection-form-assetcollection" />
-    </f:form>
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.min.js')}"></script>
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/upload.js')}"></script>
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/collections-and-tagging.js')}"></script>
+        <script type="text/javascript">
+            var uploadUrl = "{f:uri.action(action: 'upload', addQueryString: true, additionalParams: {__csrfToken: '{f:security.csrfToken()}'}, absolute: true) -> f:format.raw()}";
+            var maximumFileUploadSize = { maximumFileUploadSize };
+            <![CDATA[
+            if ( window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail )
+            {
+                window.parent.NeosMediaBrowserCallbacks.refreshThumbnail();
+            }
+            ]]>
+        </script>
+        <f:form action="tagAsset" addQueryString="true" id="tag-asset-form" format="json">
+            <f:form.hidden name="asset[__identity]" id="tag-asset-form-asset"/>
+            <f:form.hidden name="tag[__identity]" id="tag-asset-form-tag"/>
+        </f:form>
+        <f:form action="addAssetToCollection" addQueryString="true" id="link-asset-to-assetcollection-form"
+                format="json">
+            <f:form.hidden name="asset[__identity]" id="link-asset-to-assetcollection-form-asset"/>
+            <f:form.hidden name="assetCollection[__identity]" id="link-asset-to-assetcollection-form-assetcollection"/>
+        </f:form>
+        <script type="text/javascript"
+                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.min.js')}"></script>
+        <script type="text/javascript"
+                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/upload.js')}"></script>
+        <script type="text/javascript"
+                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/collections-and-tagging.js')}"></script>
     </f:if>
-    <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/select.js')}"></script>
+    <script type="text/javascript"
+            src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/select.js')}"></script>
 </f:section>
 
-<f:section name="FilterLink.All"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="true" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i> {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action></f:section>
-<f:section name="FilterLink.Image"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action></f:section>
-<f:section name="FilterLink.Document"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}</f:link.action></f:section>
-<f:section name="FilterLink.Video"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}</f:link.action></f:section>
-<f:section name="FilterLink.Audio"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.All">
+    <f:link.action action="index"
+                   title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}"
+                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="true"
+                   class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i>
+        {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
+    </f:link.action>
+</f:section>
+<f:section name="FilterLink.Image">
+    <f:link.action action="index"
+                   title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}"
+                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}"
+                   addQueryString="true" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i
+            class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}
+    </f:link.action>
+</f:section>
+<f:section name="FilterLink.Document">
+    <f:link.action action="index"
+                   title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}"
+                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}"
+                   addQueryString="true" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i
+            class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}
+    </f:link.action>
+</f:section>
+<f:section name="FilterLink.Video">
+    <f:link.action action="index"
+                   title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}"
+                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}"
+                   addQueryString="true" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i
+            class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}
+    </f:link.action>
+</f:section>
+<f:section name="FilterLink.Audio">
+    <f:link.action action="index"
+                   title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}"
+                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}"
+                   addQueryString="true" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i
+            class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}
+    </f:link.action>
+</f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -1,5 +1,5 @@
 {namespace neos=Neos\Neos\ViewHelpers}
-<f:layout name="Default"/>
+<f:layout name="Default" />
 
 <f:section name="Title">Index view</f:section>
 
@@ -10,34 +10,29 @@
             <f:if condition="{searchTerm}"> {neos:backend.translate(id: 'search.foundMatches', arguments: {0: searchTerm}, package: 'Neos.Media.Browser')}</f:if>
         </span>
         <f:if condition="!{activeAssetSource.readOnly}">
-            <f:link.action action="new" addQueryString="true"><i class="fas fa-upload"></i> {neos:backend.translate(id:
-                'upload', package: 'Neos.Media.Browser')}
-            </f:link.action>
+        <f:link.action action="new" addQueryString="true"><i class="fas fa-upload"></i> {neos:backend.translate(id: 'upload', package: 'Neos.Media.Browser')}</f:link.action>
         </f:if>
     </div>
     <div class="neos-view-options">
         <f:if condition="{filterOptions}">
             <div class="neos-dropdown" id="neos-filter-menu">
-                <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}"
-                      data-neos-toggle="tooltip">
-                    <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#"
-                       data-neos-toggle="dropdown" data-target="#neos-filter-menu">
+                <span title="{neos:backend.translate(id: 'filterOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
+                    <a class="dropdown-toggle{f:if(condition: '{filter} != \'All\'', then: ' neos-active')}" href="#" data-neos-toggle="dropdown" data-target="#neos-filter-menu">
                         <i class="fas fa-filter"></i>
                     </a>
                 </span>
                 <ul class="neos-dropdown-menu neos-pull-right" role="menu">
                     <f:for each="{filterOptions}" as="filterValue">
                         <li>
-                            <f:render section="FilterLink.{filterValue}"/>
+                            <f:render section="FilterLink.{filterValue}" />
                         </li>
                     </f:for>
                 </ul>
             </div>
         </f:if>
         <f:if condition="{activeAssetSourceSupportsSorting}">
-            <div class="neos-dropdown" id="neos-sort-menu">
-            <span title="{neos:backend.translate(id: 'tooltip.sortOptions', package: 'Neos.Media.Browser')}"
-                  data-neos-toggle="tooltip">
+        <div class="neos-dropdown" id="neos-sort-menu">
+            <span title="{neos:backend.translate(id: 'tooltip.sortOptions', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip">
                 <a class="dropdown-toggle" href="#" data-neos-toggle="dropdown" data-target="#neos-sort-menu">
                     <f:if condition="{sortDirection} === 'ASC'">
                         <f:then>
@@ -49,68 +44,34 @@
                     </f:if>
                 </a>
             </span>
-                <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
-                    <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
-                    <ul>
-                        <li>
-                            <f:link.action action="index"
-                                           title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}"
-                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
-                                           arguments="{sortBy: 'Modified'}" addQueryString="true"
-                                           class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}">
-                                <i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i>
-                                {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}
-                            </f:link.action>
-                        </li>
-                        <li>
-                            <f:link.action action="index"
-                                           title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}"
-                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
-                                           arguments="{sortBy: 'Name'}" addQueryString="true"
-                                           class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i
-                                    class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i>
-                                {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}
-                            </f:link.action>
-                        </li>
-                    </ul>
-                    <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
-                    <ul>
-                        <li>
-                            <f:link.action action="index"
-                                           title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}"
-                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
-                                           arguments="{sortDirection: 'ASC'}" addQueryString="true"
-                                           class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}">
-                                <i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i>
-                                {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}
-                            </f:link.action>
-                        </li>
-                        <li>
-                            <f:link.action action="index"
-                                           title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}"
-                                           data="{neos-toggle: 'tooltip', placement: 'left'}"
-                                           arguments="{sortDirection: 'DESC'}" addQueryString="true"
-                                           class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}">
-                                <i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i>
-                                {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}
-                            </f:link.action>
-                        </li>
-                    </ul>
-                </div>
+            <div class="neos-dropdown-menu-list neos-pull-right" role="menu">
+                <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortby', package: 'Neos.Media.Browser')}</span>
+                <ul>
+                    <li>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByLastModified', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Modified'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Modified\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-amount-up', else: 'fa-sort-amount-down')}"></i> {neos:backend.translate(id: 'field.lastModified', package: 'Neos.Media.Browser')}</f:link.action>
+                    </li>
+                    <li>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortByName', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortBy: 'Name'}" addQueryString="true" class="{f:if(condition: '{sortBy} === \'Name\'', then: 'neos-active')}"><i class="fas {f:if(condition: '{sortDirection} === \'ASC\'', then: 'fa-sort-alpha-up', else: 'fa-sort-alpha-down')}"></i> {neos:backend.translate(id: 'field.name', package: 'Neos.Media.Browser')}</f:link.action>
+                    </li>
+                </ul>
+                <span class="neos-dropdown-menu-list-title">{neos:backend.translate(id: 'sortDirection', package: 'Neos.Media.Browser')}</span>
+                <ul>
+                    <li>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.asc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'ASC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'ASC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-up', else: 'sort-amount-up')}"></i> {neos:backend.translate(id: 'sortDirection.asc', package: 'Neos.Media.Browser')}</f:link.action>
+                    </li>
+                    <li>
+                        <f:link.action action="index" title="{neos:backend.translate(id: 'sortDirection.desc.tooltip', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{sortDirection: 'DESC'}" addQueryString="true" class="{f:if(condition: '{sortDirection} === \'DESC\'', then: 'neos-active')}"><i class="fas fa-{f:if(condition: '{sortBy} === \'Name\'', then: 'sort-alpha-down', else: 'sort-amount-down')}"></i> {neos:backend.translate(id: 'sortDirection.desc', package: 'Neos.Media.Browser')}</f:link.action>
+                    </li>
+                </ul>
             </div>
+        </div>
         </f:if>
         <f:if condition="{view} === 'Thumbnail'">
             <f:then>
-                <f:link.action action="index"
-                               title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}"
-                               arguments="{view: 'List'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i
-                        class="fas fa-th-list"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.listView', package: 'Neos.Media.Browser')}" arguments="{view: 'List'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th-list"></i></f:link.action>
             </f:then>
             <f:else>
-                <f:link.action action="index"
-                               title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}"
-                               arguments="{view: 'Thumbnail'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i
-                        class="fas fa-th"></i></f:link.action>
+                <f:link.action action="index" title="{neos:backend.translate(id: 'tooltip.thumbnailView', package: 'Neos.Media.Browser')}" arguments="{view: 'Thumbnail'}" addQueryString="true" data="{neos-toggle: 'tooltip'}"><i class="fas fa-th"></i></f:link.action>
             </f:else>
         </f:if>
     </div>
@@ -118,35 +79,25 @@
 
 <f:section name="Sidebar">
     <f:form action="index" addQueryString="true" method="get" class="neos-search">
-        <button type="submit" class="neos-button"
-                title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}"
-                data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
+        <button type="submit" class="neos-button" title="{neos:backend.translate(id: 'search.title', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-search"></i></button>
         <div>
-            <input type="search"
-                   name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}"
-                   placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}"
-                   value="{searchTerm}" {f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')}
-            />
+            <input type="search" name="{f:if(condition: argumentNamespace, then: '{argumentNamespace}[searchTerm]', else: 'searchTerm')}" placeholder="{neos:backend.translate(id: 'search.placeholder', package: 'Neos.Media.Browser')}" value="{searchTerm}" {f:if(condition: '{tags -> f:count()} <= 25', then: ' autofocus="autofocus"')} />
         </div>
     </f:form>
     <f:if condition="{assetSources -> f:count()} > 1">
-        <div class="neos-media-aside-group">
-            <h2>{neos:backend.translate(id: 'mediaSources', package: 'Neos.Media.Browser')}</h2>
-            <ul class="neos-media-aside-list">
-                <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
-                    <li>
-                        <f:link.action action="index"
-                                       title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}"
-                                       class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}"
-                                       arguments="{assetSourceIdentifier: assetSourceIdentifier}" addQueryString="true">
-                            <f:if condition="{assetSource.iconUri}"><img class="neos-media-assetsource-icon"
-                                                                         src="{assetSource.iconUri}"/></f:if>
-                            {assetSource.label}
-                        </f:link.action>
-                    </li>
-                </f:for>
-            </ul>
-        </div>
+    <div class="neos-media-aside-group">
+        <h2>{neos:backend.translate(id: 'mediaSources', package: 'Neos.Media.Browser')}</h2>
+        <ul class="neos-media-aside-list">
+					  <f:for each="{assetSources}" key="assetSourceIdentifier" as="assetSource">
+                <li>
+                    <f:link.action action="index" title="{f:if(condition:assetSource.description, then: assetSource.description, else: assetSource.label)}" class="{f:if(condition: '{assetSourceIdentifier} === {activeAssetSource.identifier}', then: ' neos-active')}" arguments="{assetSourceIdentifier: assetSourceIdentifier}" addQueryString="true">
+                      <f:if condition="{assetSource.iconUri}"><img class="neos-media-assetsource-icon" src="{assetSource.iconUri}"/></f:if>
+                      {assetSource.label}
+                    </f:link.action>
+                </li>
+            </f:for>
+        </ul>
+    </div>
     </f:if>
     <div class="neos-media-aside-group">
         <f:if condition="!{activeAssetSource.readOnly}">
@@ -154,10 +105,7 @@
                 <f:then>
                     <h2>
                         {neos:backend.translate(id: 'collections', package: 'Neos.Media.Browser')}
-                        <span class="neos-media-aside-list-edit-toggle neos-button"
-                              title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}"
-                              data-neos-toggle="tooltip"><i
-                                class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
+                        <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editCollections', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: assetCollections, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
                     </h2>
                 </f:then>
                 <f:else>
@@ -171,10 +119,7 @@
             <ul class="neos-media-aside-list">
                 <f:if condition="{showAllCollections}">
                     <li>
-                        <f:link.action action="index"
-                                       class="{f:if(condition: activeAssetCollection, else: ' neos-active')}"
-                                       title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}"
-                                       arguments="{view: view, collectionMode: 1}" addQueryString="true">
+                        <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}" addQueryString="true">
                             {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
                             <span class="count">{allCollectionsCount}</span>
                         </f:link.action>
@@ -182,28 +127,14 @@
                 </f:if>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
-                        <f:link.action action="index" title="{assetCollection.object.title}"
-                                       class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}"
-                                       arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}"
-                                       addQueryString="true"
-                                       data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
                             {assetCollection.object.title}
                             <span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <f:if condition="!{activeAssetSource.readOnly}">
                             <div class="neos-sidelist-edit-actions">
-                                <f:link.action class="neos-button" action="editAssetCollection"
-                                               arguments="{assetCollection: assetCollection.object}"
-                                               addQueryString="true"
-                                               title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}"
-                                               data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i>
-                                </f:link.action>
-                                <button type="submit" class="neos-button neos-button-danger" data-toggle="modal"
-                                        href="#delete-assetcollection-modal"
-                                        data-object-identifier="{assetCollection.object -> f:format.identifier()}"
-                                        data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}"
-                                        title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}"
-                                        data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
+                                <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" addQueryString="true" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                                <button type="submit" class="neos-button neos-button-danger" data-toggle="modal" href="#delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                             </div>
                         </f:if>
                     </li>
@@ -215,28 +146,22 @@
                         <div class="neos-modal-content">
                             <div class="neos-modal-header">
                                 <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                                <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection',
-                                    package: 'Neos.Media.Browser')}
-                                </div>
+                                <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser')}</div>
                                 <div>
                                     <div class="neos-subheader">
                                         <p>
-                                            {neos:backend.translate(id: 'message.willDeleteCollection', package:
-                                            'Neos.Media.Browser')}<br/>
-                                            {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
-                                            'Neos.Media.Browser')}
+                                            {neos:backend.translate(id: 'message.willDeleteCollection', package: 'Neos.Media.Browser')}<br/>
+                                            {neos:backend.translate(id: 'message.operationCannotBeUndone', package: 'Neos.Media.Browser')}
                                         </p>
                                     </div>
                                 </div>
                             </div>
                             <div class="neos-modal-footer">
-                                <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
-                                    'cancel', package: 'Neos.Neos')}</a>
+                                <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
                                 <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
                                     <f:form.hidden name="assetCollection" id="modal-form-object"/>
                                     <button type="submit" class="neos-button neos-button-danger">
-                                        {neos:backend.translate(id: 'message.confirmDeleteCollection', package:
-                                        'Neos.Media.Browser')}
+                                        {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                                     </button>
                                     <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
                                 </f:form>
@@ -249,12 +174,8 @@
         </f:if>
         <f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
             <f:form action="createAssetCollection" addQueryString="true" id="neos-assetcollections-create-form">
-                <f:form.textfield name="title"
-                                  placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}"/>
-                <br/><br/>
-                <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id:
-                    'createCollection', package: 'Neos.Media.Browser')}
-                </button>
+                <f:form.textfield name="title" placeholder="{neos:backend.translate(id: 'newCollection.placeholder', package: 'Neos.Media.Browser')}" /><br /><br />
+                <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id: 'createCollection', package: 'Neos.Media.Browser')}</button>
                 <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
             </f:form>
         </f:security.ifAccess>
@@ -265,53 +186,32 @@
             <h2>
                 {neos:backend.translate(id: 'tags', package: 'Neos.Media.Browser')}
                 <f:if condition="!{activeAssetSource.readOnly}">
-                    <span class="neos-media-aside-list-edit-toggle neos-button"
-                          title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}"
-                          data-neos-toggle="tooltip"><i
-                            class="{f:if(condition: tags, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
+                    <span class="neos-media-aside-list-edit-toggle neos-button" title="{neos:backend.translate(id: 'editTags', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="{f:if(condition: tags, then: 'fas fa-pencil-alt', else: 'fas fa-plus')}"></i></span>
                 </f:if>
             </h2>
             <ul class="neos-media-aside-list">
                 <li class="neos-media-list-all">
-                    <f:link.action action="index"
-                                   title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}"
-                                   class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}"
-                                   arguments="{tagMode: 1}" addQueryString="true">
+                    <f:link.action action="index" title="{neos:backend.translate(id: 'tags.title.all', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 1', then: 'neos-active')}" arguments="{tagMode: 1}" addQueryString="true">
                         {neos:backend.translate(id: 'tags.all', package: 'Neos.Media.Browser')}
                         <span class="count">{allCount}</span>
                     </f:link.action>
                 </li>
                 <li class="neos-media-list-untagged">
-                    <f:link.action action="index"
-                                   title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}"
-                                   class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}"
-                                   arguments="{tagMode: 2}" addQueryString="true">
+                    <f:link.action action="index" title="{neos:backend.translate(id: 'untaggedAssets', package: 'Neos.Media.Browser')}" class="{f:if(condition: '{tagMode} === 2', then: 'neos-active')}" arguments="{tagMode: 2}" addQueryString="true">
                         {neos:backend.translate(id: 'untagged', package: 'Neos.Media.Browser')}
                         <span class="count">{untaggedCount}</span>
                     </f:link.action>
                 </li>
                 <f:for each="{tags}" as="tag">
                     <li>
-                        <f:link.action action="index" title="{tag.object.label}"
-                                       class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}"
-                                       arguments="{tag: tag.object, tagMode: 0}" addQueryString="true"
-                                       data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
+                        <f:link.action action="index" title="{tag.object.label}" class="droppable-tag{f:if(condition: '{tag.object} === {activeTag}', then: ' neos-active')}" arguments="{tag: tag.object, tagMode: 0}" addQueryString="true" data="{tag-identifier: '{tag.object -> f:format.identifier()}'}">
                             {tag.object.label}
                             <span class="count">{tag.count}</span>
                         </f:link.action>
                         <f:if condition="!{activeAssetSource.readOnly}">
                             <div class="neos-sidelist-edit-actions">
-                                <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}"
-                                               addQueryString="true"
-                                               title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}"
-                                               data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i>
-                                </f:link.action>
-                                <button class="neos-button neos-button-danger"
-                                        title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}"
-                                        data-neos-toggle="tooltip" data-toggle="modal" href="#delete-tag-modal"
-                                        data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteTag', package: 'Neos.Media.Browser', arguments:'{0: tag.object.label}')}"
-                                        data-object-identifier="{tag.object -> f:format.identifier()}"><i
-                                        class="fas fa-trash"></i></button>
+                                <f:link.action class="neos-button" action="editTag" arguments="{tag: tag.object}" addQueryString="true" title="{neos:backend.translate(id: 'editTag', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
+                                <button class="neos-button neos-button-danger" title="{neos:backend.translate(id: 'deleteTag', package: 'Neos.Media.Browser')}"data-neos-toggle="tooltip" data-toggle="modal" href="#delete-tag-modal"data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteTag', package: 'Neos.Media.Browser', arguments:'{0: tag.object.label}')}"data-object-identifier="{tag.object -> f:format.identifier()}"><iclass="fas fa-trash"></i></button>
                             </div>
                         </f:if>
                     </li>
@@ -322,31 +222,24 @@
                             <div class="neos-modal-content">
                                 <div class="neos-modal-header">
                                     <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteTag',
-                                        package: 'Neos.Media.Browser')}
-                                    </div>
+                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteTag',package: 'Neos.Media.Browser')}</div>
                                     <div>
                                         <div class="neos-subheader">
                                             <p>
-                                                {neos:backend.translate(id: 'message.willDeleteTag', package:
-                                                'Neos.Media.Browser')}<br/>
-                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
-                                                'Neos.Media.Browser')}
+                                                {neos:backend.translate(id: 'message.willDeleteTag', package:'Neos.Media.Browser')}<br/>
+                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:'Neos.Media.Browser')}
                                             </p>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="neos-modal-footer">
-                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
-                                        'cancel', package: 'Neos.Neos')}</a>
+                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:'cancel', package: 'Neos.Neos')}</a>
                                     <f:form action="deleteTag" addQueryString="true" class="neos-inline">
                                         <f:form.hidden name="tag" id="modal-form-object"/>
                                         <button type="submit" class="neos-button neos-button-danger">
-                                            {neos:backend.translate(id: 'message.confirmDeleteTag', package:
-                                            'Neos.Media.Browser')}
+                                            {neos:backend.translate(id: 'message.confirmDeleteTag', package:'Neos.Media.Browser')}
                                         </button>
-                                        <f:render partial="ConstraintsHiddenFields"
-                                                  arguments="{constraints: constraints}"/>
+                                        <f:render partial="ConstraintsHiddenFields"arguments="{constraints: constraints}"/>
                                     </f:form>
                                 </div>
                             </div>
@@ -357,12 +250,8 @@
             </ul>
             <f:if condition="!{activeAssetSource.readOnly}">
                 <f:form action="createTag" addQueryString="true" id="neos-tags-create-form">
-                    <f:form.textfield name="label"
-                                      placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}"/>
-                    <br/><br/>
-                    <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id:
-                        'createTag', package: 'Neos.Media.Browser')}
-                    </button>
+                    <f:form.textfield name="label"placeholder="{neos:backend.translate(id: 'placeholder.createTag', package: 'Neos.Media.Browser')}"/><br/><br/>
+                    <button type="submit" class="neos-button neos-button-primary">{neos:backend.translate(id:'createTag', package: 'Neos.Media.Browser')}</button>
                     <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
                 </f:form>
             </f:if>
@@ -373,14 +262,9 @@
 <f:section name="Content">
     <f:if condition="!{activeAssetSource.readOnly}">
         <div id="dropzone" class="neos-upload-area">
-            <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}"
-                 data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<i
-                    class="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span>
-            </div>
-            <f:form method="post" action="create" addQueryString="true" object="{asset}" objectName="asset"
-                    enctype="multipart/form-data">
-                <f:form.upload id="resource" property="resource"
-                               additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}"/>
+            <div title="{neos:backend.translate(id: 'maxUploadSize', arguments: {0: humanReadableMaximumFileUploadSize}, package: 'Neos.Media.Browser')}"data-neos-toggle="tooltip">{neos:backend.translate(id: 'dropFiles', package: 'Neos.Media.Browser')}<iclass="fas fa-arrow-down"></i><span> {neos:backend.translate(id: 'clickToUpload', package: 'Neos.Media.Browser')}</span></div>
+            <f:form method="post" action="create" addQueryString="true" object="{asset}" objectName="asset"enctype="multipart/form-data">
+                <f:form.upload id="resource" property="resource"additionalAttributes="{required: 'required', accept: constraints.mediaTypeAcceptAttribute}"/>
                 <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>
             </f:form>
         </div>
@@ -398,43 +282,34 @@
                 <f:then>
                     <f:if condition="!{activeAssetSource.readOnly}">
                         <div class="neos-media-content-help">
-                            <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package:
-                            'Neos.Media.Browser')}
+                            <i class="fas fa-info-circle"></i> {neos:backend.translate(id: 'dragHelp', package: 'Neos.Media.Browser')}
                         </div>
                     </f:if>
-                    <f:render partial="{view}View"
-                              arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}"/>
+                    <f:render partial="{view}View"arguments="{assetProxies: assetProxies, activeAssetSource: activeAssetSource, activeAssetSourceSupportsSorting: activeAssetSourceSupportsSorting, sortBy: sortBy, sortDirection: sortDirection}"/>
 
                     <div class="neos-hide" id="delete-asset-modal">
                         <div class="neos-modal-centered">
                             <div class="neos-modal-content">
                                 <div class="neos-modal-header">
                                     <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset',
-                                        package: 'Neos.Media.Browser')}
-                                    </div>
+                                    <div class="neos-header">{neos:backend.translate(id: 'message.reallyDeleteAsset',package: 'Neos.Media.Browser')}</div>
                                     <div>
                                         <div class="neos-subheader">
                                             <p>
-                                                {neos:backend.translate(id: 'message.willBeDeleted', package:
-                                                'Neos.Media.Browser')}<br/>
-                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:
-                                                'Neos.Media.Browser')}
+                                                {neos:backend.translate(id: 'message.willBeDeleted', package:'Neos.Media.Browser')}<br/>
+                                                {neos:backend.translate(id: 'message.operationCannotBeUndone', package:'Neos.Media.Browser')}
                                             </p>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="neos-modal-footer">
-                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:
-                                        'cancel', package: 'Neos.Neos')}</a>
+                                    <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id:'cancel', package: 'Neos.Neos')}</a>
                                     <f:form action="delete" addQueryString="true" method="post" class="neos-inline">
                                         <f:form.hidden name="asset" id="modal-form-object"/>
                                         <button type="submit" class="neos-button neos-button-mini neos-button-danger">
-                                            {neos:backend.translate(id: 'message.confirmDelete', package:
-                                            'Neos.Media.Browser')}
+                                            {neos:backend.translate(id: 'message.confirmDelete', package:'Neos.Media.Browser')}
                                         </button>
-                                        <f:render partial="ConstraintsHiddenFields"
-                                                  arguments="{constraints: constraints}"/>
+                                        <f:render partial="ConstraintsHiddenFields"arguments="{constraints: constraints}"/>
                                     </f:form>
                                 </div>
                             </div>
@@ -451,15 +326,13 @@
 </f:section>
 
 <f:section name="Scripts">
-    <script type="text/javascript"
-            src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/jquery-ui/js/jquery-ui-1.10.3.custom.js')}"></script>
+    <script type="text/javascript"src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/jquery-ui/js/jquery-ui-1.10.3.custom.js')}"></script>
     <f:if condition="!{activeAssetSource.readOnly}">
         <script type="text/javascript">
             var uploadUrl = "{f:uri.action(action: 'upload', addQueryString: true, additionalParams: {__csrfToken: '{f:security.csrfToken()}'}, absolute: true) -> f:format.raw()}";
             var maximumFileUploadSize = { maximumFileUploadSize };
             <![CDATA[
-            if ( window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail )
-            {
+            if ( window.parent !== window && window.parent.NeosMediaBrowserCallbacks && window.parent.NeosMediaBrowserCallbacks.refreshThumbnail ) {
                 window.parent.NeosMediaBrowserCallbacks.refreshThumbnail();
             }
             ]]>
@@ -468,59 +341,19 @@
             <f:form.hidden name="asset[__identity]" id="tag-asset-form-asset"/>
             <f:form.hidden name="tag[__identity]" id="tag-asset-form-tag"/>
         </f:form>
-        <f:form action="addAssetToCollection" addQueryString="true" id="link-asset-to-assetcollection-form"
-                format="json">
+        <f:form action="addAssetToCollection" addQueryString="true" id="link-asset-to-assetcollection-form" format="json">
             <f:form.hidden name="asset[__identity]" id="link-asset-to-assetcollection-form-asset"/>
             <f:form.hidden name="assetCollection[__identity]" id="link-asset-to-assetcollection-form-assetcollection"/>
         </f:form>
-        <script type="text/javascript"
-                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.min.js')}"></script>
-        <script type="text/javascript"
-                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/upload.js')}"></script>
-        <script type="text/javascript"
-                src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/collections-and-tagging.js')}"></script>
+        <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'Libraries/plupload/plupload.full.min.js')}"></script>
+        <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/upload.js')}"></script>
+        <script type="text/javascript" src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/collections-and-tagging.js')}"></script>
     </f:if>
-    <script type="text/javascript"
-            src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/select.js')}"></script>
+    <script type="text/javascript"src="{f:uri.resource(package: 'Neos.Media.Browser', path: 'JavaScript/select.js')}"></script>
 </f:section>
 
-<f:section name="FilterLink.All">
-    <f:link.action action="index"
-                   title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}"
-                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="true"
-                   class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i>
-        {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
-    </f:link.action>
-</f:section>
-<f:section name="FilterLink.Image">
-    <f:link.action action="index"
-                   title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}"
-                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}"
-                   addQueryString="true" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i
-            class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}
-    </f:link.action>
-</f:section>
-<f:section name="FilterLink.Document">
-    <f:link.action action="index"
-                   title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}"
-                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}"
-                   addQueryString="true" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i
-            class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')}
-    </f:link.action>
-</f:section>
-<f:section name="FilterLink.Video">
-    <f:link.action action="index"
-                   title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}"
-                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}"
-                   addQueryString="true" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i
-            class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')}
-    </f:link.action>
-</f:section>
-<f:section name="FilterLink.Audio">
-    <f:link.action action="index"
-                   title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}"
-                   data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}"
-                   addQueryString="true" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i
-            class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')}
-    </f:link.action>
-</f:section>
+<f:section name="FilterLink.All"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.all', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'All'}" addQueryString="true" class="{f:if(condition: '{filter} === \'All\'', then: 'neos-active')}"><i class="fas fa-filter"></i>{neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Image"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.images', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Image'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Image\'', then: 'neos-active')}"><i class="fas fa-image"></i> {neos:backend.translate(id: 'filter.images', package: 'Neos.Media.Browser')}</f:link.action></f:section>
+<f:section name="FilterLink.Document"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.documents', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Document'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Document\'', then: 'neos-active')}"><i class="fas fa-file-alt"></i> {neos:backend.translate(id: 'filter.documents', package: 'Neos.Media.Browser')} </f:link.action></f:section>
+<f:section name="FilterLink.Video"><f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.video', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Video'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Video\'', then: 'neos-active')}"><i class="fas fa-film"></i> {neos:backend.translate(id: 'filter.video', package: 'Neos.Media.Browser')} </f:link.action></f:section>
+<f:section name="FilterLink.Audio"> <f:link.action action="index" title="{neos:backend.translate(id: 'filter.title.audio', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip', placement: 'left'}" arguments="{filter: 'Audio'}" addQueryString="true" class="{f:if(condition: '{filter} === \'Audio\'', then: 'neos-active')}"><i class="fas fa-music"></i> {neos:backend.translate(id: 'filter.audio', package: 'Neos.Media.Browser')} </f:link.action></f:section>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Index.html
@@ -116,26 +116,41 @@
             </f:security.ifAccess>
         </f:if>
         <f:if condition="{assetCollections -> f:count()}">
-            <ul class="neos-media-aside-list">
+            <ul class="neos-media-aside-list {f:if(condition: collectionSeparator, then: ' tree-view')}">
                 <f:if condition="{showAllCollections}">
+									<f:then>
                     <li>
                         <f:link.action action="index" class="{f:if(condition: activeAssetCollection, else: ' neos-active')}" title="{neos:backend.translate(id: 'allCollections', package: 'Neos.Media.Browser')}" arguments="{view: view, collectionMode: 1}" addQueryString="true">
                             {neos:backend.translate(id: 'filter.all', package: 'Neos.Media.Browser')}
                             <span class="count">{allCollectionsCount}</span>
                         </f:link.action>
                     </li>
+									</f:then>
+									<f:else>
+										<f:security.ifAccess privilegeTarget="Neos.Media.Browser:ManageAssetCollections">
+										</f:security.ifAccess>
+									</f:else>
                 </f:if>
                 <f:for each="{assetCollections}" as="assetCollection">
                     <li>
                         <f:link.action action="index" title="{assetCollection.object.title}" class="droppable-assetcollection{f:if(condition: '{assetCollection.object} === {activeAssetCollection}', then: ' neos-active')}" arguments="{view: view, assetCollection: assetCollection.object, collectionMode: 0}" addQueryString="true" data="{assetcollection-identifier: '{assetCollection.object -> f:format.identifier()}'}">
-                            {assetCollection.object.title}
-                            <span class="count">{assetCollection.count}</span>
+														<f:if condition="{assetCollection.depth} > 0">
+															<f:then>
+																<f:format.raw>{assetCollection.title}</f:format.raw>
+															</f:then>
+															<f:else>
+																{assetCollection.object.title}
+															</f:else>
+														</f:if>
+													<span class="count">{assetCollection.count}</span>
                         </f:link.action>
                         <f:if condition="!{activeAssetSource.readOnly}">
+													<f:if condition="{assetCollection.depth} <= 0 || {assetCollection.depth} > 1">
                             <div class="neos-sidelist-edit-actions">
                                 <f:link.action class="neos-button" action="editAssetCollection" arguments="{assetCollection: assetCollection.object}" addQueryString="true" title="{neos:backend.translate(id: 'editCollection', package: 'Neos.Media.Browser')}" data="{neos-toggle: 'tooltip'}"><i class="fas fa-pencil-alt"></i></f:link.action>
-                                <button type="submit" class="neos-button neos-button-danger" data-toggle="modal" href="#delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
+															  <button type="submit" class="neos-button neos-button-danger" data-toggle="modal" href="#delete-assetcollection-modal" data-object-identifier="{assetCollection.object -> f:format.identifier()}" data-modal-header="{neos:backend.translate(id: 'message.reallyDeleteCollection', package: 'Neos.Media.Browser', arguments:'{0: assetCollection.object.title}')}" title="{neos:backend.translate(id: 'deleteCollection', package: 'Neos.Media.Browser')}" data-neos-toggle="tooltip"><i class="fas fa-trash"></i></button>
                             </div>
+													</f:if>
                         </f:if>
                     </li>
                 </f:for>
@@ -160,7 +175,7 @@
                                 <a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', package: 'Neos.Neos')}</a>
                                 <f:form action="deleteAssetCollection" addQueryString="true" class="neos-inline">
                                     <f:form.hidden name="assetCollection" id="modal-form-object"/>
-                                    <button type="submit" class="neos-button neos-button-danger">
+																		<button type="submit" class="neos-button neos-button-danger">
                                         {neos:backend.translate(id: 'message.confirmDeleteCollection', package: 'Neos.Media.Browser')}
                                     </button>
                                     <f:render partial="ConstraintsHiddenFields" arguments="{constraints: constraints}"/>

--- a/Neos.Media.Browser/Resources/Public/Styles/MediaBrowser.css
+++ b/Neos.Media.Browser/Resources/Public/Styles/MediaBrowser.css
@@ -489,6 +489,9 @@
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li + li {
   margin-top: 1px;
 }
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li + li {
+  margin-top: 0;
+}
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li > a {
   display: block;
   color: #fff;
@@ -498,6 +501,9 @@
   font-weight: 400;
   font-size: 14px;
   line-height: 1.5;
+}
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li > a {
+  padding: 2px 100px 3px 4px;
 }
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li > a > img {
   height: 16px;
@@ -548,6 +554,9 @@
   padding: 4px;
   line-height: 1;
 }
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li > a > span {
+  top: 2px;
+}
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li .neos-sidelist-edit-actions {
   display: none;
   position: absolute;
@@ -567,6 +576,21 @@
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li .neos-sidelist-edit-actions a:hover.neos-button-danger,
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li .neos-sidelist-edit-actions button:hover.neos-button-danger {
   background-color: #ff460d;
+}
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li .neos-sidelist-edit-actions a,
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li .neos-sidelist-edit-actions button {
+  position: relative;
+  top: 2px;
+  padding: 0 9px;
+  height: 22px;
+  line-height: 21px;
+}
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li .neos-sidelist-edit-actions button:visited {
+
+}
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li .neos-sidelist-edit-actions a:hover,
+.neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list.tree-view li .neos-sidelist-edit-actions button:hover {
+  z-index: 10;
 }
 .neos.media-browser aside.neos-media-aside .neos-media-aside-group .neos-media-aside-list li .neos-sidelist-edit-actions form {
   display: inline-block;

--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
@@ -57,7 +57,7 @@ class AssetCollectionConditionGenerator extends EntityConditionGenerator
 
         return $propertyConditionGenerator->equals($collectionIdentifier);
     }
-    
+
     /**
      * @param string $collectionTitle
      * @return PropertyConditionGenerator
@@ -90,5 +90,4 @@ class AssetCollectionConditionGenerator extends EntityConditionGenerator
 
         return $propertyConditionGenerator->like('%' . $collectionTitle . '%');
     }
-
 }

--- a/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
+++ b/Neos.Media/Classes/Security/Authorization/Privilege/Doctrine/AssetCollectionConditionGenerator.php
@@ -57,4 +57,38 @@ class AssetCollectionConditionGenerator extends EntityConditionGenerator
 
         return $propertyConditionGenerator->equals($collectionIdentifier);
     }
+    
+    /**
+     * @param string $collectionTitle
+     * @return PropertyConditionGenerator
+     */
+    public function titleStartsWith($collectionTitle)
+    {
+        $propertyConditionGenerator = new PropertyConditionGenerator('title');
+
+        return $propertyConditionGenerator->like($collectionTitle . '%');
+    }
+
+    /**
+     * @param string $collectionTitle
+     * @return PropertyConditionGenerator
+     */
+    public function titleEndsWith($collectionTitle)
+    {
+        $propertyConditionGenerator = new PropertyConditionGenerator('title');
+
+        return $propertyConditionGenerator->like('%' . $collectionTitle);
+    }
+
+    /**
+     * @param string $collectionTitle
+     * @return PropertyConditionGenerator
+     */
+    public function titleContains($collectionTitle)
+    {
+        $propertyConditionGenerator = new PropertyConditionGenerator('title');
+
+        return $propertyConditionGenerator->like('%' . $collectionTitle . '%');
+    }
+
 }


### PR DESCRIPTION
Currently, the Neos Media module offers no easily feasible path for multi-site support.

Asset collection names can hold any characters (up to 255). With an agreement of
specific asset collection titles (see below **Working with specific asset collection titles**)
in interaction with privilege methods `titleStartsWith`, `titleEndsWith` and 
`titleContains` for asset collection titles it is possible to utilize the Neos Media 
module for multi-site installations

The privilege methods `titleStartsWith`, `titleEndsWith` and `titleContains`
are available for asset titles and do operate identical on asset collection titles
when copied to the corresponding php source.

Some other Media interface features screw up the separation of assets for different
sites:
- opportunity to select "All" collections
  - here you would see all assets of all sites
- Tags
  - it is hard to manage tags to differentiate assets for separate sites

The Neos Media module offers som feature configurations (see file
`Packages/Neos/Neos.Media.Browser/Configuration/Settings.yaml` of this PR)
which easily can be extended

```yaml
Neos:
  Media:
    # ...
    Browser:
      # ...
      features:
        # ...
        
        # Show "all" collections
        showCollectionsAll:
          enable: false
        # Show tags
        showTags:
          enable: false
```

With these feature entries the Neos Media module can be customized as required for multi-site support.

**Review instructions**

- start with a fresh NEOS development installation (see https://github.com/neos/neos-development-collection#contributing)
  - `tds` is my development domain
  - shell command (adapted from https://discuss.neos.io/t/development-setup/504)
```shell
$ composer create-project neos/neos-development-distribution neos-dev.tds @dev --keep-vcs
```

- setup test sites

```shell
for s in First Second Third
do
  echo "0" | ./flow kickstart:site $s.Site $s
  ./flow site:import --package-key $s.Site
  ./flow domain:add ${s,,}-site ${s,,}.tds --scheme https
done
```

Retrieve the node names
```shell
$ ./flow site:list

 Name                 Node name                 Resources package               Status
----------------------------------------------------------------------------------------
 First                first-site                First.Site                      online
 Second               second-site               Second.Site                     online
 Third                third-site                Third.Site                      online
```

- Setup `Policy.yaml` for all three sites. Example file is
  `DistributionPackages/First.Site/Configuration/Policy.yaml`

```yaml
privilegeTargets:
  'Neos\Neos\Security\Authorization\Privilege\NodeTreePrivilege':

    'First.Site:NodeTreePrivilege':
      label: 'Access to First pages'
      matcher: 'isDescendantNodeOf("/sites/first-site")'

  'Neos\Media\Security\Authorization\Privilege\ReadAssetCollectionPrivilege':

    'First.Site:FirstAssetCollection':
      label: 'First site asset collections access'
      matcher: 'titleStartsWith("first")'

  # copy from Packages/Application/Neos.Media.Browser/Configuration/Policy.yaml
  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
    'Neos.Media.Browser:ManageAssetCollections':
      label: Allowed to manage asset collections
      matcher: 'method(Neos\Media\Browser\Controller\(Asset|Image)Controller->(createAssetCollection|editAssetCollection|updateAssetCollection|deleteAssetCollection)Action()) || method(Neos\Media\Browser\Controller\AssetCollectionController->(create|edit|update|delete)Action())'

roles:

  'Neos.Neos:Administrator':
    privileges:
      -
        privilegeTarget: 'First.Site:NodeTreePrivilege'
        permission: GRANT
      -
        privilegeTarget: 'First.Site:FirstAssetCollection'
        permission: GRANT

  'First.Site:FirstEditor':
    label: 'First Editor'
    description: 'Edit and release of First pages'
    parentRoles: ['Neos.Neos:Editor']
    privileges:
      -
        privilegeTarget: 'First.Site:NodeTreePrivilege'
        permission: GRANT

  'First.Site:FirstAssets':
    label: 'First Asset access'
    description: 'Access to First assets'
    privileges:
      -
        privilegeTarget: 'First.Site:FirstAssetCollection'
        permission: GRANT
      -
        privilegeTarget: 'Neos.Media.Browser:ManageAssetCollections'
        permission: grant
```
Result (if `Policy.yaml` is set for all three sites)
```shell
$ ./flow security:listroles
+-----------------------------------------------+---------------------+
| Id                                            | Label               |
+-----------------------------------------------+---------------------+
| Neos.Neos:LivePublisher                       | Live publisher      |
| Neos.Neos:Administrator                       | Neos Administrator  |
| Neos.Neos:RestrictedEditor                    | Restricted Editor   |
| Neos.Neos:Editor                              | Editor              |
| Neos.Neos:UserManager                         | Neos User Manager   |
| Third.Site:ThirdEditor                        | Third Editor        |
| Third.Site:ThirdAssets                        | Third Asset access  |
| First.Site:FirstEditor                        | First Editor        |
| First.Site:FirstAssets                        | First Asset access  |
| Second.Site:SecondEditor                      | Second Editor       |
| Second.Site:SecondAssets                      | Second Asset access |
| Neos.Setup:SetupUser                          | SetupUser           |
| Flowpack.Neos.FrontendLogin:User              | User                |
| Flowpack.Neos.FrontendLogin:UserAdministrator | UserAdministrator   |
+-----------------------------------------------+---------------------+
```
- Add site users `first`, `second` and `third`. Passwords are set to user's names:

```shell
for s in First Second Third
do
  ./flow user:create --roles ${s}.Site:${s}Editor,${s}.Site:${s}Assets ${s,,} ${s,,} $s User
done
```

```shell
$ ./flow user:list
+---------------+-------+-------------------+-----------------------------------------------------------+--------+
| Name          | Email | Account(s)        | Role(s)                                                   | Active |
+---------------+-------+-------------------+-----------------------------------------------------------+--------+
| First User    |       | first             | First.Site:FirstEditor, First.Site:FirstAssets            | yes    |
| Second User   |       | second            | Second.Site:SecondEditor, Second.Site:SecondAssets        | yes    |
| Third User    |       | third             | Third.Site:ThirdEditor, Third.Site:ThirdAssets            | yes    |
| Administrator |       | admin@mydomain.de | Neos.Neos:Administrator                                   | yes    |
+---------------+-------+-------------------+-----------------------------------------------------------+--------+
```
- Log into NEOS as administrator and add some asset collections

![image](https://github.com/neos/neos-development-collection/assets/19776511/92017274-abe2-4f75-b9d1-59a4fe5f2c8d)

- Add some assets and assign each asset to exactly one of the collections

![image](https://github.com/neos/neos-development-collection/assets/19776511/0a3ccfd2-d8c4-4631-b18c-ee85d1bf7bb1)

- Set default asset collection at sites in Site Management

![image](https://github.com/neos/neos-development-collection/assets/19776511/b747c6e8-3729-46dc-a832-ae9ca872a92f)

Repeat this step for sites `Second` and `Third`.

- The domains of the sites created are
```shell
$ flow domain:list
+-------------+---------------------------+--------+
| Node name   | Domain (Scheme/Host/Port) | State  |
+-------------+---------------------------+--------+
| first-site  | https://first.tds         | active |
| third-site  | https://third.tds         | active |
| second-site | https://second.tds        | active |
+-------------+---------------------------+--------+
```
It is mandatory to utilize these domains to access the Neos backends for operation of the site specific default asset collections.

- Log into Neos backend at `https://first.tds/neos` as user `first` (password `first`) and go to Media

![image](https://github.com/neos/neos-development-collection/assets/19776511/82d38267-0357-44d5-ab8b-cf35aba44a64)

- Log into Neos backend at `https://second.tds/neos` as user `second` (password `second`) and go to Media

![image](https://github.com/neos/neos-development-collection/assets/19776511/b45642b6-a5a9-4f5a-9562-1602d77b14b3)

### Working with specific asset collection titles

To work with specific asset collection titles set the feature parameter `collectionTree.separator` to
a character used to separate the different parts of the asset collection title (slash `/` for example) 
in file `Packages/Neos/Neos.Media.Browser/Configuration/Settings.yaml` of this PR.
```yaml
Neos:
  Media:
    # ...
    Browser:
      # ...
      features:
        # ...
        
        # Show "all" collections
        showCollectionsAll:
          enable: false
        # Show tags
        showTags:
          enable: false
        # collection hierarchical tree view / separation character
        # set to '' (empty string) to disable
        collectionTree:
          separator: '/'
```
Log into Neos backend at `https://first.tds/neos` as user `first` (password `first`) and go to Media
and add two asset collections
- `first/one`
- `first/one/two`

results in a tree view (each asset collection has an asset assigned):

![image](https://github.com/neos/neos-development-collection/assets/19776511/ff3a8033-799b-4e61-b3b8-329bee36904e)

Clicking the "edit" pencil at the "Collections" shows that the "base" asset collection (**first**)
cannot be edited or deleted.

![image](https://github.com/neos/neos-development-collection/assets/19776511/e40c4c51-7260-41c5-9bd1-87d8052d900b)

Deleting one asset collection...

![image](https://github.com/neos/neos-development-collection/assets/19776511/0e5262ec-5734-4ba3-a49e-9ffaa38b9b52)

...moves the assets of the deleted asset collection to the "base" asset collection (**first**)

![image](https://github.com/neos/neos-development-collection/assets/19776511/dab94098-2771-46e1-8c3a-7802b020f36f)


**Checklist**

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] ~The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)~
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
