### PR TITLE
TASK: Avoid potential deprecation warnings

### DIFF
--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -58,11 +58,11 @@ class HtmlAugmenter
      * Detects a unique root tag in the given $html string and returns its DOMNode representation - or NULL if no unique root element could be found
      *
      * @param string $html
-     * @return \DOMNode
+     * @return \DOMNode|null
      */
     protected function getHtmlRootElement($html)
     {
-        $html = trim($html);
+        $html = trim((string)$html);
         if ($html === '') {
             return null;
         }

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -129,7 +129,7 @@ class LinkingService
             $uri = (string)$uri;
         }
 
-        return preg_match(self::PATTERN_SUPPORTED_URIS, $uri) === 1;
+        return $uri !== null && preg_match(self::PATTERN_SUPPORTED_URIS, $uri) === 1;
     }
 
     /**
@@ -142,7 +142,7 @@ class LinkingService
             return $uri->getScheme();
         }
 
-        if (preg_match(self::PATTERN_SUPPORTED_URIS, $uri, $matches) === 1) {
+        if ($uri !== null && preg_match(self::PATTERN_SUPPORTED_URIS, $uri, $matches) === 1) {
             return $matches[1];
         }
 


### PR DESCRIPTION
`trim()` and `preg_match()` expect strings, but Eel with it's loose typing might pass in different types.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] ~Reviewer - The first section explains the change briefly for change-logs~
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
