### PR TITLE
BUGFIX: Make ChangeProjection independent from WorkspaceFinder

### DIFF
--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
@@ -37,7 +37,6 @@ use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeSpecializationVa
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
 use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
-use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\CatchUp\CatchUp;
@@ -46,7 +45,6 @@ use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
-use function in_array;
 
 /**
  * TODO: this class needs testing and probably a major refactoring!

--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeProjectionFactory.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeProjectionFactory.php
@@ -17,12 +17,8 @@ namespace Neos\Neos\PendingChangesProjection;
 use Neos\ContentRepository\Core\Factory\ProjectionFactoryDependencies;
 use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
-use Neos\Neos\PendingChangesProjection\ChangeProjection;
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
 use Neos\ContentRepository\Core\Projection\Projections;
-use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceFinder;
-use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceProjection;
-use Neos\Neos\FrontendRouting\Projection\DocumentUriPathProjection;
 
 /**
  * @implements ProjectionFactoryInterface<ChangeProjection>
@@ -40,21 +36,12 @@ class ChangeProjectionFactory implements ProjectionFactoryInterface
         CatchUpHookFactoryInterface $catchUpHookFactory,
         Projections $projectionsSoFar
     ): ChangeProjection {
-        $workspaceFinder = $projectionsSoFar->get(WorkspaceProjection::class)->getState();
-        assert($workspaceFinder instanceof WorkspaceFinder);
-        $projectionShortName = strtolower(str_replace(
-            'Projection',
-            '',
-            (new \ReflectionClass(ChangeProjection::class))->getShortName()
-        ));
         return new ChangeProjection(
             $projectionFactoryDependencies->eventNormalizer,
             $this->dbalClient,
-            $workspaceFinder,
             sprintf(
-                'cr_%s_p_neos_%s',
+                'cr_%s_p_neos_change',
                 $projectionFactoryDependencies->contentRepositoryId->value,
-                $projectionShortName
             ),
         );
     }


### PR DESCRIPTION
Adjusts the `ChangeProjection` such that it is aware of live content streams and won't require the `WorkspaceFinder` to determine them.

*NOTE:* This requires `./flow cr:setup` command to be executed for all active Content Repository instances in order to create missing tables!

Fixes: #4402