### PR TITLE
BUGFIX: add dimensionshash migration to postgres

### DIFF
--- a/Neos.Neos/Migrations/Postgresql/Version20230727164600.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20230727164600.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Neos\ContentRepository\Utility;
+
+final class Version20230727164600 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'add dimensions hash to node event model';
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE neos_neos_eventlog_domain_model_event ADD dimensionshash VARCHAR(32) DEFAULT NULL');
+        $this->addSql('CREATE INDEX dimensionshash ON neos_neos_eventlog_domain_model_event (dimensionshash)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP INDEX dimensionshash ON neos_neos_eventlog_domain_model_event');
+        $this->addSql('ALTER TABLE neos_neos_eventlog_domain_model_event DROP dimensionshash');
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function postUp(Schema $schema): void
+    {
+        $eventLogResult = $this->connection->executeQuery('SELECT dimension FROM neos_neos_eventlog_domain_model_event where dimensionshash IS NULL AND dimension IS NOT NULL LIMIT 1');
+
+        while ($eventLogInfo = $eventLogResult->fetchAssociative()) {
+            $dimensionsArray = unserialize($eventLogInfo['dimension'], ['allowed_classes' => false]);
+            $dimensionsHash = Utility::sortDimensionValueArrayAndReturnDimensionsHash($dimensionsArray);
+            $this->connection->executeStatement('UPDATE neos_neos_eventlog_domain_model_event SET dimensionshash = ? WHERE dimension = ?', [$dimensionsHash, $eventLogInfo['dimension']]);
+            $eventLogResult = $this->connection->executeQuery('SELECT dimension FROM neos_neos_eventlog_domain_model_event where dimensionshash IS NULL AND dimension IS NOT NULL LIMIT 1');
+        }
+    }
+}

--- a/Neos.Neos/Migrations/Postgresql/Version20230727164600.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20230727164600.php
@@ -20,7 +20,7 @@ final class Version20230727164600 extends AbstractMigration
      */
     public function up(Schema $schema) : void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
         $this->addSql('ALTER TABLE neos_neos_eventlog_domain_model_event ADD dimensionshash VARCHAR(32) DEFAULT NULL');
         $this->addSql('CREATE INDEX dimensionshash ON neos_neos_eventlog_domain_model_event (dimensionshash)');
@@ -32,9 +32,9 @@ final class Version20230727164600 extends AbstractMigration
      */
     public function down(Schema $schema) : void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on "postgresql".');
 
-        $this->addSql('DROP INDEX dimensionshash ON neos_neos_eventlog_domain_model_event');
+        $this->addSql('DROP INDEX dimensionshash');
         $this->addSql('ALTER TABLE neos_neos_eventlog_domain_model_event DROP dimensionshash');
     }
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Regression https://github.com/neos/neos-development-collection/pull/3279

We need to generate add dimensions hash to node event model in order to be able to save new nodes as we do in MySQL: Neos.Neos/Migrations/Mysql/Version20210125134503.php

**Upgrade instructions**

Run ./flow doctrine:migrate

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

You want to make sure that the dimensions table has valid values. If not you might want to add a custom migration like this one:

```php
<?php
declare(strict_types=1);

namespace Neos\Flow\Persistence\Doctrine\Migrations;

use Doctrine\Migrations\AbstractMigration;
use Doctrine\DBAL\Schema\Schema;

class Version20230727164559 extends AbstractMigration
{
    public function getDescription(): string
    {
        return 'Correct null entries in event log caused by automated import';
    }

    public function up(Schema $schema): void
    {
        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');

        $this->addSql('UPDATE neos_neos_eventlog_domain_model_event SET dimension = NULL WHERE dimension = :dimension AND dtype = :dtype;', ['dimension' => 'N;', 'dtype' => 'ttree_contentrepositoryimporter_event']);
    }

    public function down(Schema $schema): void
    {
        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');

        $this->addSql('UPDATE neos_neos_eventlog_domain_model_event SET dimension = :dimension WHERE dimension IS NULL AND dtype = :dtype;', ['dimension' => 'N;', 'dtype' => 'ttree_contentrepositoryimporter_event']);
    }
}
```


<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
