### PR TITLE
FEATURE: Allow uriPathSuffix to be specified per site

### DIFF
--- a/Neos.Neos/Classes/Domain/Model/SiteConfiguration.php
+++ b/Neos.Neos/Classes/Domain/Model/SiteConfiguration.php
@@ -33,11 +33,14 @@ final class SiteConfiguration
 
         $defaultDimensionSpacePoint = DimensionSpacePoint::fromArray($configuration['contentDimensions']['defaultDimensionSpacePoint'] ?? []);
 
+        $uriPathSuffix = $configuration['uriPathSuffix'] ?? '';
+
         return new self(
             ContentRepositoryId::fromString($contentRepositoryId),
             $contentDimensionResolverFactoryClassName,
             $contentDimensionResolverOptions,
-            $defaultDimensionSpacePoint
+            $defaultDimensionSpacePoint,
+            $uriPathSuffix,
         );
     }
 
@@ -52,6 +55,7 @@ final class SiteConfiguration
         public readonly string $contentDimensionResolverFactoryClassName,
         public readonly array $contentDimensionResolverOptions,
         public readonly DimensionSpacePoint $defaultDimensionSpacePoint,
+        public readonly string $uriPathSuffix,
     ) {
     }
 }

--- a/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinker.php
+++ b/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinker.php
@@ -40,24 +40,11 @@ final class CrossSiteLinker implements CrossSiteLinkerInterface
     protected $siteRepository;
 
     public function applyCrossSiteUriConstraints(
-        DocumentNodeInfo $targetNode,
-        SiteDetectionResult $currentRequestSiteDetectionResult
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints {
-        $uriConstraints = UriConstraints::create();
-        if (!$targetNode->getSiteNodeName()->equals($currentRequestSiteDetectionResult->siteNodeName)) {
-            /** @var Site $site */
-            foreach ($this->siteRepository->findOnline() as $site) {
-                if ($site->getNodeName()->equals($targetNode->getSiteNodeName())) {
-                    return $this->applyDomainToUriConstraints($uriConstraints, $site->getPrimaryDomain());
-                }
-            }
-        }
+        $domain = $targetSite->getPrimaryDomain();
 
-        return $uriConstraints;
-    }
-
-    private function applyDomainToUriConstraints(UriConstraints $uriConstraints, ?Domain $domain): UriConstraints
-    {
         if ($domain === null) {
             return $uriConstraints;
         }

--- a/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
+++ b/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
@@ -18,6 +18,7 @@ use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
 use Neos\Neos\FrontendRouting\EventSourcedFrontendNodeRoutePartHandler;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * The {@see CrossSiteLinkerInterface} is responsible for adjusting a built URL in case it needs to
@@ -31,11 +32,12 @@ interface CrossSiteLinkerInterface
 {
     /**
      * @param DocumentNodeInfo $targetNode the target node where we want to generate the link to
-     * @param SiteDetectionResult $currentRequestSiteDetectionResult
+     * @param Site $targetSite
+     * @param UriConstraints $uriConstraints
      * @return UriConstraints
      */
     public function applyCrossSiteUriConstraints(
-        DocumentNodeInfo $targetNode,
-        SiteDetectionResult $currentRequestSiteDetectionResult
+        Site $targetSite,
+        UriConstraints $uriConstraints
     ): UriConstraints;
 }

--- a/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
+++ b/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
@@ -31,7 +31,6 @@ use Neos\Neos\Domain\Model\Site;
 interface CrossSiteLinkerInterface
 {
     /**
-     * @param DocumentNodeInfo $targetNode the target node where we want to generate the link to
      * @param Site $targetSite
      * @param UriConstraints $uriConstraints
      * @return UriConstraints

--- a/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
+++ b/Neos.Neos/Classes/FrontendRouting/CrossSiteLinking/CrossSiteLinkerInterface.php
@@ -38,6 +38,6 @@ interface CrossSiteLinkerInterface
      */
     public function applyCrossSiteUriConstraints(
         Site $targetSite,
-        UriConstraints $uriConstraints
+        UriConstraints $uriConstraints,
     ): UriConstraints;
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DelegatingResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DelegatingResolver.php
@@ -18,11 +18,11 @@ use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\FrontendRouting\EventSourcedFrontendNodeRoutePartHandler;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * Entry Point to the dimension resolution process - called from {@see EventSourcedFrontendNodeRoutePartHandler}.
@@ -66,13 +66,9 @@ final class DelegatingResolver implements DimensionResolverInterface
     public function fromDimensionSpacePointToUriConstraints(
         DimensionSpacePoint $filteredDimensionSpacePoint,
         DocumentNodeInfo $targetNodeInfo,
-        UriConstraints $uriConstraints
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints {
-        $targetSite = $this->siteRepository->findOneByNodeName($targetNodeInfo->getSiteNodeName());
-
-        if ($targetSite === null) {
-            throw new \RuntimeException('Did not find site object for identifier ' . $targetNodeInfo->getSiteNodeName()->value);
-        }
         $targetSiteConfiguration = $targetSite->getConfiguration();
 
         $factory = $this->objectManager->get(
@@ -86,7 +82,8 @@ final class DelegatingResolver implements DimensionResolverInterface
         )->fromDimensionSpacePointToUriConstraints(
             $filteredDimensionSpacePoint,
             $targetNodeInfo,
-            $uriConstraints
+            $targetSite,
+            $uriConstraints,
         );
     }
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DelegatingResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DelegatingResolver.php
@@ -37,7 +37,6 @@ final class DelegatingResolver implements DimensionResolverInterface
 {
     public function __construct(
         private readonly ObjectManagerInterface $objectManager,
-        private readonly SiteRepository $siteRepository,
     ) {
     }
 
@@ -45,13 +44,7 @@ final class DelegatingResolver implements DimensionResolverInterface
         RequestToDimensionSpacePointContext $context
     ): RequestToDimensionSpacePointContext {
         $siteDetectionResult = SiteDetectionResult::fromRouteParameters($context->routeParameters);
-        $site = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
-        if ($site === null) {
-            throw new \RuntimeException(
-                'Did not find site object for identifier ' . $siteDetectionResult->siteNodeName->value
-            );
-        }
-        $siteConfiguration = $site->getConfiguration();
+        $siteConfiguration = $context->resolvedSite->getConfiguration();
 
         $factory = $this->objectManager->get($siteConfiguration->contentDimensionResolverFactoryClassName);
         assert($factory instanceof DimensionResolverFactoryInterface);

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DimensionResolverInterface.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/DimensionResolverInterface.php
@@ -11,6 +11,7 @@ use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\CompositeResolver;
 use Neos\Neos\FrontendRouting\EventSourcedFrontendNodeRoutePartHandler;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * Common interface for content dimension resolvers which are hooked into the Frontend Routing.
@@ -115,6 +116,7 @@ interface DimensionResolverInterface
     public function fromDimensionSpacePointToUriConstraints(
         DimensionSpacePoint $filteredDimensionSpacePoint,
         DocumentNodeInfo $targetNodeInfo,
-        UriConstraints $uriConstraints
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints;
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/RequestToDimensionSpacePointContext.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/RequestToDimensionSpacePointContext.php
@@ -33,7 +33,7 @@ final class RequestToDimensionSpacePointContext
             $routeParameters,
             $initialUriPath,
             DimensionSpacePoint::fromArray([]),
-            $resolvedSite
+            $resolvedSite,
         );
     }
 

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/RequestToDimensionSpacePointContext.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/RequestToDimensionSpacePointContext.php
@@ -7,6 +7,7 @@ namespace Neos\Neos\FrontendRouting\DimensionResolution;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * See {@see DimensionResolverInterface} for documentation.
@@ -21,16 +22,18 @@ final class RequestToDimensionSpacePointContext
         public readonly RouteParameters $routeParameters,
         public readonly string $remainingUriPath,
         public readonly DimensionSpacePoint $resolvedDimensionSpacePoint,
+        public readonly Site $resolvedSite,
     ) {
     }
 
-    public static function fromUriPathAndRouteParameters(string $initialUriPath, RouteParameters $routeParameters): self
+    public static function fromUriPathAndRouteParametersAndResolvedSite(string $initialUriPath, RouteParameters $routeParameters, Site $resolvedSite): self
     {
         return new self(
             $initialUriPath,
             $routeParameters,
             $initialUriPath,
-            DimensionSpacePoint::fromArray([])
+            DimensionSpacePoint::fromArray([]),
+            $resolvedSite
         );
     }
 
@@ -45,7 +48,8 @@ final class RequestToDimensionSpacePointContext
             $this->initialUriPath,
             $this->routeParameters,
             $this->remainingUriPath,
-            DimensionSpacePoint::fromArray($coordinatesSoFar)
+            DimensionSpacePoint::fromArray($coordinatesSoFar),
+            $this->resolvedSite,
         );
     }
 
@@ -55,7 +59,8 @@ final class RequestToDimensionSpacePointContext
             $this->initialUriPath,
             $this->routeParameters,
             $remainingUriPath,
-            $this->resolvedDimensionSpacePoint
+            $this->resolvedDimensionSpacePoint,
+            $this->resolvedSite,
         );
     }
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/CompositeResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/CompositeResolver.php
@@ -67,7 +67,7 @@ final class CompositeResolver implements DimensionResolverInterface
                 $filteredDimensionSpacePoint,
                 $targetNodeInfo,
                 $targetSite,
-                $uriConstraints
+                $uriConstraints,
             );
         }
         return $uriConstraints;

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/CompositeResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/CompositeResolver.php
@@ -20,6 +20,7 @@ use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\FrontendRouting\DimensionResolution\RequestToDimensionSpacePointContext;
 use Neos\Neos\FrontendRouting\DimensionResolution\DimensionResolverInterface;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * Helper class implementing a Resolver Chain.
@@ -57,13 +58,15 @@ final class CompositeResolver implements DimensionResolverInterface
     public function fromDimensionSpacePointToUriConstraints(
         DimensionSpacePoint $filteredDimensionSpacePoint,
         DocumentNodeInfo $targetNodeInfo,
-        UriConstraints $uriConstraints
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints {
         foreach (array_reverse($this->resolvers) as $resolver) {
             assert($resolver instanceof DimensionResolverInterface);
             $uriConstraints = $resolver->fromDimensionSpacePointToUriConstraints(
                 $filteredDimensionSpacePoint,
                 $targetNodeInfo,
+                $targetSite,
                 $uriConstraints
             );
         }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/NoopResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/NoopResolver.php
@@ -20,6 +20,7 @@ use Neos\Neos\Domain\Model\SiteNodeName;
 use Neos\Neos\FrontendRouting\DimensionResolution\RequestToDimensionSpacePointContext;
 use Neos\Neos\FrontendRouting\DimensionResolution\DimensionResolverInterface;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * Resolver which does not do anything.
@@ -39,7 +40,8 @@ final class NoopResolver implements DimensionResolverInterface
     public function fromDimensionSpacePointToUriConstraints(
         DimensionSpacePoint $filteredDimensionSpacePoint,
         DocumentNodeInfo $targetNodeInfo,
-        UriConstraints $uriConstraints
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints {
         return $uriConstraints;
     }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
@@ -26,6 +26,7 @@ use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\Segme
 use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\Separator;
 use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolver\UriPathResolverConfigurationException;
 use Neos\Neos\FrontendRouting\Projection\DocumentNodeInfo;
+use Neos\Neos\Domain\Model\Site;
 
 /**
  * URI path segment based dimension value resolver
@@ -64,7 +65,7 @@ final class UriPathResolver implements DimensionResolverInterface
         DimensionSpacePoint $defaultDimensionSpacePoint,
     ): self {
         self::validate($segments, $separator, $contentDimensionSource);
-        list($uriPathToDimensionSpacePoint, $dimensionSpacePointHashToUriPath) = self::calculateUriPaths(
+        [$uriPathToDimensionSpacePoint, $dimensionSpacePointHashToUriPath] = self::calculateUriPaths(
             $segments,
             $separator
         );
@@ -227,7 +228,8 @@ final class UriPathResolver implements DimensionResolverInterface
     public function fromDimensionSpacePointToUriConstraints(
         DimensionSpacePoint $dimensionSpacePoint,
         DocumentNodeInfo $targetNodeInfo,
-        UriConstraints $uriConstraints
+        Site $targetSite,
+        UriConstraints $uriConstraints,
     ): UriConstraints {
         $filteredDimensionSpacePoint = $this->reduceDimensionSpacePointToConfiguredDimensions($dimensionSpacePoint);
         unset($dimensionSpacePoint);

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver.php
@@ -65,7 +65,7 @@ final class UriPathResolver implements DimensionResolverInterface
         DimensionSpacePoint $defaultDimensionSpacePoint,
     ): self {
         self::validate($segments, $separator, $contentDimensionSource);
-        [$uriPathToDimensionSpacePoint, $dimensionSpacePointHashToUriPath] = self::calculateUriPaths(
+        list($uriPathToDimensionSpacePoint, $dimensionSpacePointHashToUriPath) = self::calculateUriPaths(
             $segments,
             $separator
         );

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -39,6 +39,7 @@ use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Psr\Http\Message\UriInterface;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\FrontendRouting\Exception\TargetSiteNotFoundException;
+use Neos\Neos\FrontendRouting\Exception\ResolvedSiteNotFoundException;
 
 /**
  * A route part handler for finding nodes in the website's frontend. Like every RoutePartHandler,
@@ -176,6 +177,10 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
 
         $siteDetectionResult = SiteDetectionResult::fromRouteParameters($parameters);
         $resolvedSite = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
+
+        if ($resolvedSite === null) {
+            throw new ResolvedSiteNotFoundException(sprintf('No site found for siteNodeName "%s"', $siteDetectionResult->siteNodeName->value));
+        }
 
         $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath, $resolvedSite->getConfiguration()->uriPathSuffix);
 

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -16,7 +16,6 @@ namespace Neos\Neos\FrontendRouting;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
-use Neos\Neos\FrontendRouting\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Mvc\Routing\RoutingMiddleware;
@@ -35,10 +34,11 @@ use Neos\Neos\FrontendRouting\CrossSiteLinking\CrossSiteLinkerInterface;
 use Neos\Neos\FrontendRouting\DimensionResolution\DelegatingResolver;
 use Neos\Neos\FrontendRouting\DimensionResolution\RequestToDimensionSpacePointContext;
 use Neos\Neos\FrontendRouting\DimensionResolution\DimensionResolverInterface;
-use Neos\Neos\FrontendRouting\Projection\DocumentUriPathProjection;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionMiddleware;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Psr\Http\Message\UriInterface;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\FrontendRouting\Exception\TargetSiteNotFoundException;
 
 /**
  * A route part handler for finding nodes in the website's frontend. Like every RoutePartHandler,
@@ -171,6 +171,12 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
     protected $crossSiteLinker;
 
     /**
+     * @Flow\Inject
+     * @var SiteRepository
+     */
+    protected $siteRepository;
+
+    /**
      * Incoming URLs
      *
      * @param mixed $requestPath
@@ -183,12 +189,16 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
             return false;
         }
 
-        $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath);
+        $siteDetectionResult = SiteDetectionResult::fromRouteParameters($parameters);
+        $resolvedSite = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
+
+        $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath, $resolvedSite->getConfiguration()->uriPathSuffix);
 
         $dimensionResolvingResult = $this->delegatingResolver->fromRequestToDimensionSpacePoint(
-            RequestToDimensionSpacePointContext::fromUriPathAndRouteParameters(
+            RequestToDimensionSpacePointContext::fromUriPathAndRouteParametersAndResolvedSite(
                 $requestPath,
-                $parameters
+                $parameters,
+                $resolvedSite,
             )
         );
         $dimensionSpacePoint = $dimensionResolvingResult->resolvedDimensionSpacePoint;
@@ -265,7 +275,7 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
 
         try {
             $resolveResult = $this->resolveNodeAddress($nodeAddress, $currentRequestSiteDetectionResult);
-        } catch (NodeNotFoundException | InvalidShortcutException $exception) {
+        } catch (NodeNotFoundException|InvalidShortcutException $exception) {
             // TODO log exception
             return false;
         }
@@ -308,27 +318,39 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
             }
         }
 
-        $uriConstraints = $this->crossSiteLinker->applyCrossSiteUriConstraints(
-            $nodeInfo,
-            $currentRequestSiteDetectionResult
-        );
+        $targetSite = $this->siteRepository->findOneByNodeName($nodeInfo->getSiteNodeName()->value);
+
+        if ($targetSite === null) {
+            throw new TargetSiteNotFoundException(sprintf('No site found for siteNodeName "%s"', $nodeInfo->getSiteNodeName()->value));
+        }
+
+        $uriConstraints = UriConstraints::create();
+        if (!$targetSite->getNodeName()->equals($currentRequestSiteDetectionResult->siteNodeName)) {
+            $uriConstraints = $this->crossSiteLinker->applyCrossSiteUriConstraints(
+                $targetSite,
+                $uriConstraints
+            );
+        }
+
         $uriConstraints = $this->delegatingResolver->fromDimensionSpacePointToUriConstraints(
             $nodeAddress->dimensionSpacePoint,
             $nodeInfo,
+            $targetSite,
             $uriConstraints
         );
 
-        if (!empty($this->options['uriPathSuffix']) && $nodeInfo->hasUriPath()) {
-            $uriConstraints = $uriConstraints->withPathSuffix($this->options['uriPathSuffix']);
+        if ($targetSite->getConfiguration()->uriPathSuffix !== '' && $nodeInfo->hasUriPath()) {
+            $uriConstraints = $uriConstraints->withPathSuffix($targetSite->getConfiguration()->uriPathSuffix);
         }
+
         return new ResolveResult($nodeInfo->getUriPath(), $uriConstraints, $nodeInfo->getRouteTags());
     }
 
 
-    private function truncateRequestPathAndReturnRemainder(string &$requestPath): string
+    private function truncateRequestPathAndReturnRemainder(string &$requestPath, string $uriPathSuffix): string
     {
-        if (!empty($this->options['uriPathSuffix'])) {
-            $suffixPosition = strpos($requestPath, $this->options['uriPathSuffix']);
+        if ($uriPathSuffix !== '') {
+            $suffixPosition = strpos($requestPath, $uriPathSuffix);
             if ($suffixPosition === false) {
                 return '';
             }

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -146,35 +146,20 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
 {
     private string $splitString = '';
 
-    /**
-     * @Flow\Inject
-     * @var ContentRepositoryRegistry
-     */
-    protected $contentRepositoryRegistry;
+    #[Flow\Inject]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    /**
-     * @Flow\Inject
-     * @var NodeShortcutResolver
-     */
-    protected $nodeShortcutResolver;
+    #[Flow\Inject]
+    protected NodeShortcutResolver $nodeShortcutResolver;
 
-    /**
-     * @Flow\Inject
-     * @var DelegatingResolver
-     */
-    protected $delegatingResolver;
+    #[Flow\Inject]
+    protected DelegatingResolver $delegatingResolver;
 
-    /**
-     * @Flow\Inject
-     * @var CrossSiteLinkerInterface
-     */
-    protected $crossSiteLinker;
+    #[Flow\Inject]
+    protected CrossSiteLinkerInterface $crossSiteLinker;
 
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
+    #[Flow\Inject]
+    protected SiteRepository $siteRepository;
 
     /**
      * Incoming URLs
@@ -275,7 +260,7 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
 
         try {
             $resolveResult = $this->resolveNodeAddress($nodeAddress, $currentRequestSiteDetectionResult);
-        } catch (NodeNotFoundException|InvalidShortcutException $exception) {
+        } catch (NodeNotFoundException | InvalidShortcutException $exception) {
             // TODO log exception
             return false;
         }

--- a/Neos.Neos/Classes/FrontendRouting/Exception/ResolvedSiteNotFoundException.php
+++ b/Neos.Neos/Classes/FrontendRouting/Exception/ResolvedSiteNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\FrontendRouting\Exception;
+
+use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
+
+final class ResolvedSiteNotFoundException extends NoMatchingRouteException
+{
+}

--- a/Neos.Neos/Classes/FrontendRouting/Exception/TargetSiteNotFoundException.php
+++ b/Neos.Neos/Classes/FrontendRouting/Exception/TargetSiteNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\FrontendRouting\Exception;
+
+use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
+
+final class TargetSiteNotFoundException extends NoMatchingRouteException
+{
+}

--- a/Neos.Neos/Configuration/Routes.Frontend.yaml
+++ b/Neos.Neos/Configuration/Routes.Frontend.yaml
@@ -15,6 +15,4 @@
   routeParts:
     'node':
       handler: 'Neos\Neos\FrontendRouting\FrontendNodeRoutePartHandlerInterface'
-      options:
-        uriPathSuffix: '<defaultUriSuffix>'
   appendExceedingArguments: true

--- a/Neos.Neos/Configuration/Routes.yaml
+++ b/Neos.Neos/Configuration/Routes.yaml
@@ -62,5 +62,3 @@
     'FrontendSubRoutes':
       package: 'Neos.Neos'
       suffix:  'Frontend'
-      variables:
-        'defaultUriSuffix': '<defaultUriSuffix>'

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -61,6 +61,7 @@ Neos:
 
     sites:
       '*':
+        uriPathSuffix: '.html'
         contentRepository: default
         contentDimensions:
           resolver:
@@ -439,10 +440,7 @@ Neos:
           middleware: 'Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionMiddleware'
     mvc:
       routes:
-        'Neos.Neos':
-          variables:
-            # Set this to an empty string if you prefer URLs without the ".html" suffix
-            'defaultUriSuffix': '.html'
+        'Neos.Neos': true
         # Move Neos.Media routes before default Neos routes so that they have priority
         'Neos.Media':
           position: 'before Neos.Neos'

--- a/Neos.Neos/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/Testing/NodeTypes.yaml
@@ -59,7 +59,7 @@
       ui:
         inlineEditable: true
 
-'Acme.Demo:Texti':
+'Acme.Demo:Text':
   superTypes:
     'Neos.Neos:Content': true
   ui:

--- a/Neos.Neos/Configuration/Testing/NodeTypes.yaml
+++ b/Neos.Neos/Configuration/Testing/NodeTypes.yaml
@@ -59,7 +59,7 @@
       ui:
         inlineEditable: true
 
-'Acme.Demo:Text':
+'Acme.Demo:Texti':
   superTypes:
     'Neos.Neos:Content': true
   ui:

--- a/Neos.Neos/Migrations/Code/Version20230801154834.php
+++ b/Neos.Neos/Migrations/Code/Version20230801154834.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Neos\Flow\Core\Migrations;
+
+
+/**
+ * Replace defaultUriSuffix configuration with uriPathSuffix in default site configuration
+ */
+class Version20230801154834 extends AbstractMigration
+{
+
+    public function getIdentifier(): string
+    {
+        return 'Neos.Neos-20230801154834';
+    }
+
+    public function up(): void
+    {
+        $this->moveSettingsPaths(['Neos', 'Flow', 'mvc', 'routes', 'Neos.Neos', 'variables', 'defaultUriSuffix'], ['Neos', 'Neos', 'sites', '*', 'uriPathSuffix']);
+    }
+}

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -341,10 +341,13 @@ trait RoutingTrait
         assert($dimensionResolverFactory instanceof DimensionResolverFactoryInterface);
         $dimensionResolver = $dimensionResolverFactory->create($siteConfiguration->contentRepositoryId, $siteConfiguration);
 
-        $siteDetectionResult = SiteDetectionResult::create(SiteNodeName::fromString("site-node"), $siteConfiguration->contentRepositoryId);
+        $siteNodeName = SiteNodeName::fromString("site-node");
+        $siteDetectionResult = SiteDetectionResult::create($siteNodeName, $siteConfiguration->contentRepositoryId);
         $routeParameters = $siteDetectionResult->storeInRouteParameters(RouteParameters::createEmpty());
 
-        $dimensionResolverContext = RequestToDimensionSpacePointContext::fromUriPathAndRouteParametersAndResolvedSite($this->requestUrl->getPath(), $routeParameters);
+        $site = new Site($siteNodeName->value);
+
+        $dimensionResolverContext = RequestToDimensionSpacePointContext::fromUriPathAndRouteParametersAndResolvedSite($this->requestUrl->getPath(), $routeParameters, $site);
         $dimensionResolverContext = $dimensionResolver->fromRequestToDimensionSpacePoint($dimensionResolverContext);
         $this->dimensionResolverContext = $dimensionResolverContext;
     }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -344,7 +344,7 @@ trait RoutingTrait
         $siteDetectionResult = SiteDetectionResult::create(SiteNodeName::fromString("site-node"), $siteConfiguration->contentRepositoryId);
         $routeParameters = $siteDetectionResult->storeInRouteParameters(RouteParameters::createEmpty());
 
-        $dimensionResolverContext = RequestToDimensionSpacePointContext::fromUriPathAndRouteParameters($this->requestUrl->getPath(), $routeParameters);
+        $dimensionResolverContext = RequestToDimensionSpacePointContext::fromUriPathAndRouteParametersAndResolvedSite($this->requestUrl->getPath(), $routeParameters);
         $dimensionResolverContext = $dimensionResolver->fromRequestToDimensionSpacePoint($dimensionResolverContext);
         $this->dimensionResolverContext = $dimensionResolverContext;
     }


### PR DESCRIPTION
This moves the configuration for `uriPathSuffix` into sites configuration. This allows to configure different `uriPathSuffix` per site in a multisite environment.

Also added a migration for the settings.

Old:
```
Neos:
  Flow:
    mvc:
      routes:
        'Neos.Neos':
          variables:
            'defaultUriSuffix': '.html'
```

New:
```
Neos:
  Neos:
    sites:
      '*':
        uriPathSuffix: .html
```

Fixes: https://github.com/neos/neos-development-collection/issues/4389
Depends on: https://github.com/neos/flow-development-collection/pull/3125