### PR TITLE
BUGFIX: Fix Postgres compatibility

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -426,7 +426,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
         // TODO: still unsure why we need an "INSERT IGNORE" here;
         // normal "INSERT" can trigger a duplicate key constraint exception
         $this->getDatabaseConnection()->executeUpdate('
-                INSERT IGNORE INTO ' . $this->tableNamePrefix . '_restrictionrelation (
+                INSERT INTO ' . $this->tableNamePrefix . '_restrictionrelation (
                   contentstreamid,
                   dimensionspacepointhash,
                   originnodeaggregateid,
@@ -436,13 +436,19 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
                   r.contentstreamid,
                   r.dimensionspacepointhash,
                   r.originnodeaggregateid,
-                  "' . $newlyCreatedNodeAggregateId->value . '" as affectednodeaggregateid
+                  \'' . $newlyCreatedNodeAggregateId->value . '\' as affectednodeaggregateid
                 FROM
                     ' . $this->tableNamePrefix . '_restrictionrelation r
                     WHERE
                         r.contentstreamid = :sourceContentStreamId
                         and r.dimensionspacepointhash IN (:visibleDimensionSpacePoints)
                         and r.affectednodeaggregateid = :parentNodeAggregateId
+                ON CONFLICT (
+                    contentstreamid,
+                    dimensionspacepointhash,
+                    originnodeaggregateid,
+                    affectednodeaggregateid
+                ) DO NOTHING
             ', [
             'sourceContentStreamId' => $contentStreamId->value,
             'visibleDimensionSpacePoints' => $dimensionSpacePointsInWhichNewlyCreatedNodeAggregateIsVisible

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeDisabling.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeDisabling.php
@@ -35,7 +35,7 @@ trait NodeDisabling
             $this->getDatabaseConnection()->executeStatement(
                 '
 -- GraphProjector::whenNodeAggregateWasDisabled
-insert ignore into ' . $this->getTableNamePrefix() . '_restrictionrelation
+insert into ' . $this->getTableNamePrefix() . '_restrictionrelation
     (contentstreamid, dimensionspacepointhash, originnodeaggregateid, affectednodeaggregateid)
 
     -- we build a recursive tree
@@ -81,7 +81,13 @@ insert ignore into ' . $this->getTableNamePrefix() . '_restrictionrelation
         "' . $event->nodeAggregateId->value . '" as originnodeaggregateid,
         nodeaggregateid as affectednodeaggregateid
     from tree
-            ',
+
+    on conflict (
+        contentstreamid,
+        dimensionspacepointhash,
+        originnodeaggregateid,
+        affectednodeaggregateid
+    ) do nothing',
                 [
                     'entryNodeAggregateId' => $event->nodeAggregateId->value,
                     'contentStreamId' => $event->contentStreamId->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -270,7 +270,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     {
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
-            ->select('n.*, h.name, h.contentstreamid, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
+            ->select('n.*, h.name, h.contentstreamid, CAST("root" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
             ->from($this->tableNamePrefix . '_node', 'n')
             ->innerJoin('n', $this->tableNamePrefix . '_hierarchyrelation', 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->where('h.contentstreamid = :contentStreamId')
@@ -279,7 +279,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         $this->addRestrictionRelationConstraints($queryBuilderInitial);
 
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('c.*, h.name, h.contentstreamid, p.nodeaggregateid AS parentNodeAggregateId, p.level + 1 AS level, h.position')
+            ->select('c.*, h.name, h.contentstreamid, CAST(p.nodeaggregateid AS CHAR(50)) AS parentNodeAggregateId, p.level + 1 AS level, h.position')
             ->from('tree', 'p')
             ->innerJoin('p', $this->tableNamePrefix . '_hierarchyrelation', 'h', 'h.parentnodeanchor = p.relationanchorpoint')
             ->innerJoin('p', $this->tableNamePrefix . '_node', 'c', 'c.relationanchorpoint = h.childnodeanchor')
@@ -312,7 +312,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
                 $this->visibilityConstraints
             );
             $subtree = new Subtree((int)$nodeData['level'], $node);
-            $subtreesByNodeId[$nodeData['parentNodeAggregateId']]->add($subtree);
+            $subtreesByNodeId[trim($nodeData['parentNodeAggregateId'])]->add($subtree);
             $subtreesByNodeId[$nodeData['nodeaggregateid']] = $subtree;
         }
         return $rootSubtrees->first();


### PR DESCRIPTION
- Use "ON CONFLICT" instead of "INSERT IGNORE" for PostgreSQL compatibility.
- Use single quotes for fixed select values for PostgreSQL compatibility
- Fix type cast in recursive query

Related: #4337

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
