### PR TITLE
!!! BUGFIX: Prevent not fully translated content from getting lost in move operations

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -237,13 +237,14 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
     protected function setPathInternal(string $destinationPath, bool $recursiveCall): array
     {
         $originalPath = $this->nodeData->getPath();
-
-        /** @var Node $childNode */
-        foreach ($this->getChildNodes() as $childNode) {
-            $childNode->setPath(NodePaths::addNodePathSegment($destinationPath, $childNode->getName()), false);
-        }
+        $childNodes = $this->getChildNodes();
 
         $this->moveNodeToDestinationPath($this, $destinationPath);
+
+        /** @var Node $childNode */
+        foreach ($childNodes as $childNode) {
+            $childNode->setPath(NodePaths::addNodePathSegment($destinationPath, $childNode->getName()), false);
+        }
 
         return [
             [$this, $originalPath, $this->getNodeData()->getPath(), $recursiveCall]

--- a/Neos.Neos/NodeTypes/Content/ContentCollection.yaml
+++ b/Neos.Neos/NodeTypes/Content/ContentCollection.yaml
@@ -1,6 +1,8 @@
 # A content collection is a collection of "Neos.Neos:Content" (and its subclasses),
 # i.e. contains variable number of children.
 'Neos.Neos:ContentCollection':
+  # The aggregate mode keeps child nodes from getting lost in other dimensions after move operations, when the collection itself only exists as fallback in those dimensions.
+  aggregate: true
   superTypes:
     'Neos.Neos:Node': true
   ui:


### PR DESCRIPTION
This resolves the issue that moving a collection with subnodes in dimension value A doesn’t update the parent path of nodes in dimension value B if the collection itself does not exist in language B. The result would be that the content in B is now disconnected from the tree and not reachable anymore.

This slightly changes the behavior in existing projects, but the change keeps content from getting lost and is therefore essential for every Neos project with dimensions and fallbacks.
The new behaviour is also more in line with the default behaviour of the new Content Repository in Neos 9.

Resolves: #3340

**Upgrade instructions**

The `aggregate` mode of the collection will now enforce that the content is moved in all dimensions at the same time to the same parent path. This is different than from the behaviour before. 

If the new behaviour is a problem in your project, you can revert the setting with the following yaml nodetype configuration:

```yaml
Neos.Neos:ContentCollection':
  aggregate: false
```