### PR TITLE
BUGFIX: Don't allow explicit ordering of projections

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -195,7 +195,7 @@ final class ContentRepositoryRegistry
     {
         (isset($contentRepositorySettings['projections']) && is_array($contentRepositorySettings['projections'])) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have projections configured, or the value is no array.', $contentRepositoryId->value);
         $projectionsFactory = new ProjectionsFactory();
-        foreach ((new PositionalArraySorter($contentRepositorySettings['projections']))->toArray() as $projectionName => $projectionOptions) {
+        foreach ($contentRepositorySettings['projections'] as $projectionName => $projectionOptions) {
             $projectionFactory = $this->objectManager->get($projectionOptions['factoryObjectName']);
             if (!$projectionFactory instanceof ProjectionFactoryInterface) {
                 throw InvalidConfigurationException::fromMessage('Projection factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s.', $projectionName, $contentRepositoryId->value, ProjectionFactoryInterface::class, get_debug_type($projectionFactory));


### PR DESCRIPTION
Previously projections where ordered using the `PositionalArraySorter`. This was required because we had projections that depended on the state of other projections.
With #4411 the last case of these interdependencies were removed from the core so we don't have that requirement any longer.

And since it is a very bad practice to introduce dependencies between projections, this change removes this functionality.

Fixes: #4437