### PR TITLE
BUGFIX: Show asset count for assets from readonly asset sources

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -71,6 +71,11 @@
                             </tr>
                         </tbody>
                     </table>
+                    <f:if condition="{assetProxy.asset.inUse}">
+                        <f:link.action action="relatedNodes" arguments="{asset:assetProxy.asset}" addQueryString="true" class="neos-button">
+                            {neos:backend.translate(id: 'relatedNodes', quantity: '{assetProxy.asset.usageCount}', arguments: {0: assetProxy.asset.usageCount}, package: 'Neos.Media.Browser')}
+                        </f:link.action>
+                    </f:if>
                 </fieldset>
             </div>
             <div class="neos-span6 neos-image-example">


### PR DESCRIPTION
For asset sources that have `isReadOnly()` set, instead of the  *edit* action, the *show* action is resolved by default. But the corresponding template is missing the "usages" button

Fixes: #3989