### PR TITLE
WIP: TASK: Refactor and cleanup Neos.Neos FusionView

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -104,6 +104,16 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
         return null;
     }
 
+    public function last(): ?Node
+    {
+        if (count($this->nodes) > 0) {
+            $array = $this->nodes;
+            return end($array);
+        }
+
+        return null;
+    }
+
     public function merge(self $other): self
     {
         $nodes = array_merge($this->nodes, $other->getIterator()->getArrayCopy());

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -383,11 +383,9 @@ class Runtime
      * Determine if the given Fusion path is renderable, which means it exists
      * and has an implementation.
      *
-     * @param string $fusionPath
-     * @return boolean
-     * @throws Exception
+     * @throws Exception if the requested $fusionPath is not well-formed for example
      */
-    public function canRender($fusionPath)
+    public function canRender(string $fusionPath): bool
     {
         $fusionConfiguration = $this->runtimeConfiguration->forPath($fusionPath);
 

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -138,14 +138,6 @@ class NodeController extends ActionController
             $visibilityConstraints
         );
 
-        $site = $this->nodeSiteResolvingService->findSiteNodeForNodeAddress(
-            $nodeAddress,
-            $siteDetectionResult->contentRepositoryId
-        );
-        if ($site === null) {
-            throw new NodeNotFoundException("TODO: SITE NOT FOUND; should not happen (for address " . $nodeAddress);
-        }
-
         $this->fillCacheWithContentNodes($nodeAddress->nodeAggregateId, $subgraph);
 
         $nodeInstance = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
@@ -161,10 +153,7 @@ class NodeController extends ActionController
             $this->handleShortcutNode($nodeAddress, $contentRepository);
         }
 
-        $this->view->assignMultiple([
-            'value' => $nodeInstance,
-            'site' => $site,
-        ]);
+        $this->view->assign('value', $nodeInstance);
 
         if (!$nodeAddress->isInLiveWorkspace()) {
             $this->overrideViewVariablesFromInternalArguments();

--- a/Neos.Neos/Classes/Domain/Model/FusionRenderingStuff.php
+++ b/Neos.Neos/Classes/Domain/Model/FusionRenderingStuff.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Model;
+
+use Neos\Fusion\Core\FusionGlobals;
+
+final readonly class FusionRenderingStuff
+{
+    public function __construct(
+        public Site $site,
+        public RenderingContext $fusionContext,
+        public FusionGlobals $fusionGlobals
+    ) {
+    }
+
+    public function withMergedFusionGlobals(FusionGlobals $otherFusionGlobals): self
+    {
+        return new self(
+            $this->site,
+            $this->fusionContext,
+            $this->fusionGlobals->merge($otherFusionGlobals)
+        );
+    }
+}

--- a/Neos.Neos/Classes/Domain/Model/RenderingContext.php
+++ b/Neos.Neos/Classes/Domain/Model/RenderingContext.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Model;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+
+final readonly class RenderingContext
+{
+    public function __construct(
+        public Node $node,
+        public Node $documentNode,
+        public Node $siteNode
+    ) {
+    }
+
+    public function toContextArray(): array
+    {
+        return [
+            'node' => $this->node,
+            'documentNode' => $this->documentNode,
+            'site' => $this->siteNode
+        ];
+    }
+}

--- a/Neos.Neos/Classes/Domain/Service/RenderingUtility.php
+++ b/Neos.Neos/Classes/Domain/Service/RenderingUtility.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Service;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Fusion\Core\FusionGlobals;
+use Neos\Neos\Domain\Model\FusionRenderingStuff;
+use Neos\Neos\Domain\Model\RenderingContext;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Scope('singleton')]
+class RenderingUtility
+{
+    public function __construct(
+        private readonly ContentRepositoryRegistry $contentRepositoryRegistry,
+        private readonly SiteRepository $siteRepository
+    ) {
+    }
+
+    public function createRenderingContextForEntryNode(Node $entryNode): RenderingContext
+    {
+        $contentRepository = $this->contentRepositoryRegistry->get($entryNode->subgraphIdentity->contentRepositoryId);
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($entryNode);
+
+        $documentNodeAncestors = $subgraph->findAncestorNodes(
+            $entryNode->nodeAggregateId,
+            FindAncestorNodesFilter::create(nodeTypeConstraints: NodeTypeNameFactory::NAME_DOCUMENT)
+        );
+
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($entryNode->nodeTypeName);
+
+        $nodeIsDocument = $nodeType->isOfType(NodeTypeNameFactory::NAME_DOCUMENT);
+
+        return new RenderingContext(
+            $entryNode,
+            $nodeIsDocument ? $entryNode : $documentNodeAncestors->first(),
+            $documentNodeAncestors->last() ?? $entryNode
+        );
+    }
+
+    public function createFusionRenderingStuff(Node $node, ActionRequest $request): FusionRenderingStuff
+    {
+        $renderingContext = $this->createRenderingContextForEntryNode($node);
+
+        $site = $this->siteRepository->findSiteBySiteNode($renderingContext->siteNode);
+
+        $fusionGlobals = FusionGlobals::fromArray([
+            'request' => $request
+        ]);
+
+        return new FusionRenderingStuff(
+            $site,
+            $renderingContext,
+            $fusionGlobals
+        );
+    }
+}

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -16,10 +16,7 @@ namespace Neos\Neos\View;
 
 use GuzzleHttp\Psr7\Message;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\View\AbstractView;
-use Neos\Flow\Security\Context;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\Core\RuntimeFactory;
 use Neos\Fusion\Exception\RuntimeException;
@@ -47,27 +44,21 @@ class FusionView extends AbstractView
         ]
     ];
 
-    #[Flow\Inject]
-    protected RuntimeFactory $runtimeFactory;
-
-    #[Flow\Inject]
-    protected RenderingUtility $renderingUtility;
-
-    #[Flow\Inject]
-    protected FusionService $fusionService;
-
-    #[Flow\Inject]
-    protected Context $securityContext;
-
-    #[Flow\Inject]
-    protected ContentRepositoryRegistry $contentRepositoryRegistry;
-
     protected Runtime $fusionRuntime;
 
     /** The Fusion path to use for rendering the node given in "value", defaults to "root". */
     protected string $fusionPath = 'root';
 
     protected FusionRenderingStuff $fusionRenderingStuff;
+
+    public function __construct(
+        array $options,
+        private readonly RuntimeFactory $runtimeFactory,
+        private readonly RenderingUtility $renderingUtility,
+        private readonly FusionService $fusionService,
+    ) {
+        parent::__construct($options);
+    }
 
     /** Set the Fusion path to use for rendering the node given in "value" */
     public function setFusionPath(string $fusionPath): void

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -79,3 +79,9 @@ Neos\Neos\AssetUsage\GlobalAssetUsageService:
   arguments:
     3:
       setting: Neos.Neos.assetUsage.contentRepositories
+
+Neos\Neos\View\FusionView:
+  arguments:
+    1:
+      # this way once can instantiate the view without arguments
+      value: []


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

Related https://neos-project.slack.com/archives/C3MCBK6S2/p1694339628529459?thread_ts=1694269188.257739&channel=C3MCBK6S2&message_ts=1694339628.529459

Im just currently looking into wether i could fetch documentNode and siteNode with one query via

```
$ancestors = $subgraph->findAncestorNodes($node->nodeAggregateId, FindAncestorNodesFilter::create(nodeTypeConstraints: 'Neos.Neos:Document');

$documentNode = $ancestors->first();

$siteNode = $ancestors->last();
```

but i dont know if its a criteria for the homepage node to be of type Neos.Neos:Document?

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
