### PR TITLE
!!! TASK: Cleanup deprecated code in FusionService

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -14,83 +14,23 @@ namespace Neos\Neos\Domain\Service;
  * source code.
  */
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Fusion\Core\FusionConfiguration;
 use Neos\Flow\Annotations as Flow;
-use Neos\Fusion\Core\FusionGlobals;
-use Neos\Fusion\Core\FusionSourceCode;
+use Neos\Fusion\Core\FusionConfiguration;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\Parser;
-use Neos\Fusion\Core\Runtime;
-use Neos\Fusion\Core\RuntimeFactory;
 use Neos\Neos\Domain\Model\Site;
-use Neos\Neos\Domain\Model\SiteNodeName;
-use Neos\Neos\Domain\Repository\SiteRepository;
 
 /**
- * @todo currently scope prototype will change with the removal of the internal state to singleton in Neos 9.0
- *
- * @Flow\Scope("prototype")
  * @api
  */
+#[Flow\Scope('singleton')]
 class FusionService
 {
-    /**
-     * Pattern used for determining the Fusion root file for a site
-     *
-     * @deprecated with Neos 8.3, will be immutable with 9.0
-     * @var string
-     */
-    protected $siteRootFusionPattern = 'resource://%s/Private/Fusion/Root.fusion';
-
-    /**
-     * Array of Fusion files to include before the site Fusion
-     *
-     * Example:
-     *
-     *     array(
-     *         'resources://MyVendor.MyPackageKey/Private/Fusion/Root.fusion',
-     *         'resources://SomeVendor.OtherPackage/Private/Fusion/Root.fusion'
-     *     )
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * @var array<mixed>
-     */
-    protected $prependFusionIncludes = [];
-
-    /**
-     * Array of Fusion files to include after the site Fusion
-     *
-     * Example:
-     *
-     *     array(
-     *         'resources://MyVendor.MyPackageKey/Private/Fusion/Root.fusion',
-     *         'resources://SomeVendor.OtherPackage/Private/Fusion/Root.fusion'
-     *     )
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * @var array<mixed>
-     */
-    protected $appendFusionIncludes = [];
-
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
-
     /**
      * @Flow\Inject
      * @var Parser
      */
     protected $fusionParser;
-
-    /**
-     * @Flow\Inject
-     * @var RuntimeFactory
-     */
-    protected $runtimeFactory;
 
     /**
      * @Flow\Inject
@@ -109,156 +49,21 @@ class FusionService
         return $this->fusionConfigurationCache->cacheFusionConfigurationBySite($site, function () use ($site) {
             $siteResourcesPackageKey = $site->getSiteResourcesPackageKey();
 
-            $siteRootFusionPathAndFilename = sprintf($this->siteRootFusionPattern, $siteResourcesPackageKey);
-
             return $this->fusionParser->parseFromSource(
                 $this->fusionSourceCodeFactory->createFromNodeTypeDefinitions($site->getConfiguration()->contentRepositoryId)
                     ->union(
                         $this->fusionSourceCodeFactory->createFromAutoIncludes()
                     )
                     ->union(
-                        $this->createSourceCodeFromLegacyFusionIncludes($this->prependFusionIncludes, $siteRootFusionPathAndFilename)
-                    )
-                    ->union(
-                        FusionSourceCodeCollection::tryFromFilePath($siteRootFusionPathAndFilename)
-                    )
-                    ->union(
-                        $this->createSourceCodeFromLegacyFusionIncludes($this->appendFusionIncludes, $siteRootFusionPathAndFilename)
+                        FusionSourceCodeCollection::tryFromPackageRootFusion($siteResourcesPackageKey)
                     )
             );
         });
     }
 
-    /**
-     * Returns a merged Fusion object tree in the context of the given nodes
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0 {@link createFusionConfigurationFromSite}
-     *
-     * @param Node $startNode Node marking the starting point (i.e. the "Site" node)
-     * @return array<mixed> The merged object tree as of the given node
-     */
-    public function getMergedFusionObjectTree(Node $startNode)
-    {
-        return $this->createFusionConfigurationFromSite($this->findSiteBySiteNode($startNode))->toArray();
-    }
-
-    /**
-     * Create a runtime for the given site node
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0 use {@link createFusionConfigurationFromSite} and {@link RuntimeFactory::createFromConfiguration} instead
-     *
-     * @return Runtime
-     */
-    public function createRuntime(
-        Node $currentSiteNode,
-        ControllerContext $controllerContext
-    ) {
-        $fusionGlobals = FusionGlobals::fromArray(
-            ['request' => $controllerContext->getRequest()]
-        );
-        $runtime = $this->runtimeFactory->createFromConfiguration(
-            $this->createFusionConfigurationFromSite($this->findSiteBySiteNode($currentSiteNode)),
-            $fusionGlobals
-        );
-        $runtime->setControllerContext($controllerContext);
-        return $runtime;
-    }
-
-    /**
-     * Set the pattern for including the site root Fusion
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * use {@link FusionSourceCodeFactory} in combination with {@link RuntimeFactory::createRuntimeFromSourceCode()} instead
-     *
-     * @param string $siteRootFusionPattern A string for the sprintf format that takes the site package key as a single placeholder
-     * @return void
-     */
-    public function setSiteRootFusionPattern($siteRootFusionPattern)
-    {
-        $this->siteRootFusionPattern = $siteRootFusionPattern;
-    }
-
-    /**
-     * Get the Fusion resources that are included before the site Fusion.
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * use {@link FusionSourceCodeFactory} in combination with {@link RuntimeFactory::createRuntimeFromSourceCode()} instead
-     *
-     * @return array<mixed>
-     */
-    public function getPrependFusionIncludes()
-    {
-        return $this->prependFusionIncludes;
-    }
-
-    /**
-     * Set Fusion resources that should be prepended before the site Fusion,
-     * it defaults to the Neos Root.fusion Fusion.
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * use {@link FusionSourceCodeFactory} in combination with {@link RuntimeFactory::createRuntimeFromSourceCode()} instead
-     *
-     * @param array<mixed> $prependFusionIncludes
-     * @return void
-     */
-    public function setPrependFusionIncludes(array $prependFusionIncludes)
-    {
-        $this->prependFusionIncludes = $prependFusionIncludes;
-    }
-
-
-    /**
-     * Get Fusion resources that will be appended after the site Fusion.
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * use {@link FusionSourceCodeFactory} in combination with {@link RuntimeFactory::createRuntimeFromSourceCode()} instead
-     *
-     * @return array<mixed>
-     */
-    public function getAppendFusionIncludes()
-    {
-        return $this->appendFusionIncludes;
-    }
-
-    /**
-     * Set Fusion resources that should be appended after the site Fusion,
-     * this defaults to an empty array.
-     *
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     * use {@link FusionSourceCodeFactory} in combination with {@link RuntimeFactory::createRuntimeFromSourceCode()} instead
-     *
-     * @param array<mixed> $appendFusionIncludes An array of Fusion resource URIs
-     * @return void
-     */
-    public function setAppendFusionIncludes(array $appendFusionIncludes)
-    {
-        $this->appendFusionIncludes = $appendFusionIncludes;
-    }
-
-    /**
-     * @param array<mixed> $fusionIncludes
-     * @deprecated with Neos 8.3, will be removed with 9.0
-     */
-    private function createSourceCodeFromLegacyFusionIncludes(array $fusionIncludes, string $filePathForRelativeResolves): FusionSourceCodeCollection
-    {
-        return new FusionSourceCodeCollection(...array_map(
-            function (string $fusionFile) use ($filePathForRelativeResolves) {
-                if (str_starts_with($fusionFile, "resource://") === false) {
-                    // legacy relative includes
-                    $fusionFile = dirname($filePathForRelativeResolves) . '/' . $fusionFile;
-                }
-                return FusionSourceCode::fromFilePath($fusionFile);
-            },
-            $fusionIncludes
-        ));
-    }
-
-    private function findSiteBySiteNode(Node $siteNode): Site
-    {
-        if ($siteNode->nodeName === null) {
-            throw new \Neos\Neos\Domain\Exception(sprintf('Site node "%s" is unnamed', $siteNode->nodeAggregateId->value), 1681286146);
-        }
-        return $this->siteRepository->findOneByNodeName(SiteNodeName::fromNodeName($siteNode->nodeName))
-            ?? throw new \Neos\Neos\Domain\Exception(sprintf('No site found for nodeNodeName "%s"', $siteNode->nodeName->value), 1677245517);
-    }
+    // @todo reintroduce with edit preview mode support
+    // /**
+    //  * Create a runtime for the given site
+    //  */
+    // public function createRuntime(Site $site): Runtime;
 }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

With https://github.com/neos/neos-development-collection/pull/3839 the FusionService was refactored and weird/hardly usable functionally removed. The legacy parts will be removed in this pr.

`FusionService:: getMergedFusionObjectTree` was removed in favour of `FusionService:: createFusionConfigurationFromSite`

In case you used any of the setter methods like `setAppendFusionIncludes` to add additional Fusion includes to the configuration, you should instead build an own service like Monocle did, leveraging the `FusionSourceCodeFactory`: https://github.com/sitegeist/Sitegeist.Monocle/blob/b20da738e2999d66b6e2d10c901d7b1d7b540fc0/Classes/Fusion/FusionService.php#L67

Resolves #4089

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

related to https://github.com/neos/neos-development-collection/pull/4495

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
