### PR TITLE
BUGFIX: Don’t query for abstract nodetypes in nodedata repository

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1133,7 +1133,7 @@ class NodeDataRepository extends Repository
             } else {
                 $negate = false;
             }
-            $nodeTypeFilterPartSubTypes = array_merge([$this->nodeTypeManager->getNodeType($nodeTypeFilterPart)], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart));
+            $nodeTypeFilterPartSubTypes = array_merge([$this->nodeTypeManager->getNodeType($nodeTypeFilterPart)], $this->nodeTypeManager->getSubNodeTypes($nodeTypeFilterPart, false));
 
             foreach ($nodeTypeFilterPartSubTypes as $nodeTypeFilterPartSubType) {
                 if ($negate === true) {

--- a/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
@@ -82,7 +82,7 @@ class NodeTypeManager
     }
 
     /**
-     * Return all non-abstract node types which have a certain $superType, without
+     * Return all node types which have a certain $superType, without
      * the $superType itself.
      *
      * @param string $superTypeName


### PR DESCRIPTION
As abstract nodetypes don't (shouldn't) appear in the database it makes no sense to query them.

This is a regression that was introduced a long time ago, when the default parameter to include abstract nodetypes was added to the `getSubNodeTypes` method in the `NodeTypeManager` without adjusting the call in the `NodeDataRepository->getNodeTypeFilterConstraintsForDql` which relied on the previous behaviour.

The call in the method `getNodeTypeFilterConstraints` was fixed some years ago, but that method seems unused.