### PR TITLE
BUGFIX: Don’t include subnodetypes of subnodetypes in node search

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -23,7 +23,6 @@ use Neos\Neos\Domain\Service\SiteService;
 use Neos\Neos\View\Service\NodeJsonView;
 use Neos\Neos\Service\Mapping\NodePropertyConverterService;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 
@@ -93,22 +92,9 @@ class NodesController extends ActionController
      */
     public function indexAction($searchTerm = '', array $nodeIdentifiers = [], $workspaceName = 'live', array $dimensions = [], array $nodeTypes = ['Neos.Neos:Document'], NodeInterface $contextNode = null)
     {
-        $searchableNodeTypeNames = [];
-        foreach ($nodeTypes as $nodeTypeName) {
-            if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
-                $this->throwStatus(400, sprintf('Unknown node type "%s"', $nodeTypeName));
-            }
-
-            $searchableNodeTypeNames[$nodeTypeName] = $nodeTypeName;
-            /** @var NodeType $subNodeType */
-            foreach ($this->nodeTypeManager->getSubNodeTypes($nodeTypeName, false) as $subNodeTypeName => $subNodeType) {
-                $searchableNodeTypeNames[$subNodeTypeName] = $subNodeTypeName;
-            }
-        }
-
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
         if ($nodeIdentifiers === []) {
-            $nodes = $this->nodeSearchService->findByProperties($searchTerm, $searchableNodeTypeNames, $contentContext, $contextNode);
+            $nodes = $this->nodeSearchService->findByProperties($searchTerm, $nodeTypes, $contentContext, $contextNode);
         } else {
             $nodes = array_filter(
                 array_map(function ($identifier) use ($contentContext) {


### PR DESCRIPTION
The subnodetypes of the given filter are collected twice (once in the `NodesController` and once in the `NodeDataRepository`) leading to nodetypes being included which don't inherit from the given list of nodetypes as the second list of nodetypes is not checked against the nodetypefilter but against the subnodetypes of the nodetypefilter. See details in #4502.

Resolves: #4502