### PR TITLE
90/edit preview mode support v3 review

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -115,7 +115,6 @@ class NodeController extends ActionController
 
     /**
      * @param string $node Legacy name for backwards compatibility of route components
-     * @param string $renderingModeName Name of the user interface mode to use
      * @throws NodeNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
@@ -126,13 +125,10 @@ class NodeController extends ActionController
      * with unsafe requests from widgets or plugins that are rendered on the node
      * - For those the CSRF token is validated on the sub-request, so it is safe to be skipped here
      */
-    public function previewAction(string $node, string $renderingModeName = null): void
+    public function previewAction(string $node): void
     {
-        if (is_null($renderingModeName)) {
-            $renderingMode = $this->renderingModeService->findByCurrentUser();
-        } else {
-            $renderingMode = $this->renderingModeService->findByName($renderingModeName);
-        }
+        // @todo add $renderingModeName as parameter and append it for successive links again as get parameter to node uris
+        $renderingMode = $this->renderingModeService->findByCurrentUser();
 
         $visibilityConstraints = VisibilityConstraints::frontend();
         if ($this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -35,6 +35,7 @@ use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Utility\Now;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Domain\Service\NodeSiteResolvingService;
 use Neos\Neos\Domain\Service\RenderingModeService;
 use Neos\Neos\FrontendRouting\Exception\InvalidShortcutException;
@@ -247,7 +248,7 @@ class NodeController extends ActionController
             $this->handleShortcutNode($nodeAddress, $contentRepository);
         }
 
-        $this->view->setOption('renderingModeName', 'frontend');
+        $this->view->setOption('renderingModeName', RenderingMode::FRONTEND);
 
         $this->view->assignMultiple([
             'value' => $nodeInstance,

--- a/Neos.Neos/Classes/Domain/Model/RenderingMode.php
+++ b/Neos.Neos/Classes/Domain/Model/RenderingMode.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Domain\Model;
 
-use Neos\Utility\ObjectAccess;
+use Neos\Neos\Domain\Exception;
 
 /**
  * Describes the mode in which the Neos interface is rendering currently,
@@ -22,6 +22,8 @@ use Neos\Utility\ObjectAccess;
  */
 class RenderingMode
 {
+    public const FRONTEND = 'frontend';
+
     /**
      * @param array<string,mixed> $options
      */
@@ -36,13 +38,20 @@ class RenderingMode
     }
 
     /**
-     * Creates an UserInterfaceMode object by configuration
+     * Creates a rendering mode from its configuration
      *
      * @param string $modeName
      * @param array<string,mixed> $configuration
      */
     public static function createFromConfiguration(string $modeName, array $configuration): RenderingMode
     {
+        if ($modeName === RenderingMode::FRONTEND) {
+            throw new Exception(
+                'Cannot instantiate system rendering mode "frontend" from configuration.'
+                . ' Please use RenderingMode::createFrontend().',
+                1694802951840
+            );
+        }
         $mode = new RenderingMode(
             $modeName,
             $configuration['isEditingMode'] ?? false,
@@ -55,12 +64,12 @@ class RenderingMode
     }
 
     /**
-     * Creates the live User interface mode
+     * Creates the system integrated rendering mode 'frontend'
      */
     public static function createFrontend(): RenderingMode
     {
         return new RenderingMode(
-            'frontend',
+            RenderingMode::FRONTEND,
             false,
             false,
             'Frontend',

--- a/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
+++ b/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
@@ -90,14 +90,20 @@ class RenderingModeService
      */
     public function findByName(string $modeName): RenderingMode
     {
-        return $this->instances[$modeName] ??= match (true) {
-            $modeName === RenderingMode::FRONTEND => RenderingMode::createFrontend(),
-            isset($this->editPreviewModes[$modeName]) => RenderingMode::createFromConfiguration($modeName, $this->editPreviewModes[$modeName]),
-            default => throw new Exception(
+        if ($instance = $this->instances[$modeName] ?? null) {
+            return $instance;
+        }
+        if ($modeName === RenderingMode::FRONTEND) {
+            $this->instances[$modeName] = RenderingMode::createFrontend();
+        } elseif (isset($this->editPreviewModes[$modeName])) {
+            $this->instances[$modeName] = RenderingMode::createFromConfiguration($modeName, $this->editPreviewModes[$modeName]);
+        } else {
+            throw new Exception(
                 'The requested rendering mode "' . $modeName . '" is not configured.'
                 . ' Please make sure it exists as key in the Settings path "Neos.Neos.Interface.editPreviewModes".',
                 1427715962
-            )
-        };
+            );
+        }
+        return $this->instances[$modeName];
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
+++ b/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
@@ -52,6 +52,11 @@ class RenderingModeService
     protected $defaultEditPreviewMode;
 
     /**
+     * @var array<string, RenderingMode>
+     */
+    private array $instances = [];
+
+    /**
      * Get the current rendering mode.
      * Will return a live mode when not in backend.
      */
@@ -85,16 +90,14 @@ class RenderingModeService
      */
     public function findByName(string $modeName): RenderingMode
     {
-        if ($modeName === RenderingMode::FRONTEND) {
-            return RenderingMode::createFrontend();
-        }
-        if (isset($this->editPreviewModes[$modeName])) {
-            return RenderingMode::createFromConfiguration($modeName, $this->editPreviewModes[$modeName]);
-        }
-        throw new Exception(
-            'The requested rendering mode "' . $modeName . '" is not configured.'
+        return $this->instances[$modeName] ??= match (true) {
+            $modeName === RenderingMode::FRONTEND => RenderingMode::createFrontend(),
+            isset($this->editPreviewModes[$modeName]) => RenderingMode::createFromConfiguration($modeName, $this->editPreviewModes[$modeName]),
+            default => throw new Exception(
+                'The requested rendering mode "' . $modeName . '" is not configured.'
                 . ' Please make sure it exists as key in the Settings path "Neos.Neos.Interface.editPreviewModes".',
-            1427715962
-        );
+                1427715962
+            )
+        };
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
+++ b/Neos.Neos/Classes/Domain/Service/RenderingModeService.php
@@ -85,14 +85,14 @@ class RenderingModeService
      */
     public function findByName(string $modeName): RenderingMode
     {
-        if ($modeName === 'frontend') {
+        if ($modeName === RenderingMode::FRONTEND) {
             return RenderingMode::createFrontend();
         }
         if (isset($this->editPreviewModes[$modeName])) {
             return RenderingMode::createFromConfiguration($modeName, $this->editPreviewModes[$modeName]);
         }
         throw new Exception(
-            'The requested interface render mode "' . $modeName . '" is not configured.'
+            'The requested rendering mode "' . $modeName . '" is not configured.'
                 . ' Please make sure it exists as key in the Settings path "Neos.Neos.Interface.editPreviewModes".',
             1427715962
         );

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -35,6 +35,7 @@ use Neos\Fusion\Core\FusionGlobals;
 use Neos\Fusion\Core\Runtime as FusionRuntime;
 use Neos\Fusion\Core\RuntimeFactory;
 use Neos\Fusion\Exception\RuntimeException;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\FusionService;
 use Neos\Neos\Domain\Service\SiteNodeUtility;
@@ -204,7 +205,7 @@ class FusionExceptionView extends AbstractView
 
             $fusionGlobals = FusionGlobals::fromArray([
                 'request' => $this->controllerContext->getRequest(),
-                'renderingModeName' => 'frontend'
+                'renderingModeName' => RenderingMode::FRONTEND
             ]);
             $this->fusionRuntime = $this->runtimeFactory->createFromConfiguration(
                 $fusionConfiguration,

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -24,6 +24,7 @@ use Neos\Fusion\Core\FusionGlobals;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\Core\RuntimeFactory;
 use Neos\Fusion\Exception\RuntimeException;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\FusionService;
 use Neos\Neos\Domain\Service\SiteNodeUtility;
@@ -102,7 +103,7 @@ class FusionView extends AbstractView
             'boolean'
         ],
         'renderingModeName' => [
-            'frontend',
+            RenderingMode::FRONTEND,
             'Name of the user interface mode to use',
             'string'
         ]

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -271,7 +271,8 @@ Neos:
 
       defaultEditPreviewMode: inPlace
       editPreviewModes:
-        # the "frontend" renderingMode is hardcoded internally and cannot be modified
+        # the system integrated rendering mode "frontend" cannot be configured
+        # frontend: {}
         inPlace:
           isEditingMode: true
           isPreviewMode: false


### PR DESCRIPTION
TASK: Remove half-baked solution of session independent preview's
Otherwise, this feature would only work for this one page, successive links will currently not have that query param added - the linking service still needs to learn this, but we delay this for another time.

TASK: RenderingModeService instances runtime cache

TASK: Introduce constant `RenderingMode::FRONTEND` for system integrated rendering mode
