### PR TITLE
BUGFIX: `props` will be unset after an exception

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ComponentImplementation.php
@@ -80,8 +80,10 @@ class ComponentImplementation extends JoinImplementation
     protected function render(array $context)
     {
         $this->runtime->pushContextArray($context);
-        $result = $this->runtime->render($this->path . '/renderer');
-        $this->runtime->popContext();
-        return $result;
+        try {
+            return $this->runtime->render($this->path . '/renderer');
+        } finally {
+            $this->runtime->popContext();
+        }
     }
 }


### PR DESCRIPTION
Resolves: #4525

The rendering in a Neos.Fusion Component had a bug where the `props` might be undefined if an exception happened earlier in an eel expression.

This was caused by not correctly poping the runtimes context and thus causing a unexpected shift in the context stack.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
