### PR TITLE
BUGFIX: PR 4425 `FusionGlobals` followup / fix

### DIFF
--- a/Neos.Fusion/Classes/Core/FusionGlobals.php
+++ b/Neos.Fusion/Classes/Core/FusionGlobals.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\Fusion\Core;
 
-use Neos\Utility\Arrays;
-
 /**
  * Fusion allows to add variable to the context either via
  * \@context.foo = "bar" or by leveraging the php api {@see Runtime::pushContext()}.
@@ -57,7 +55,7 @@ final readonly class FusionGlobals
     public function merge(FusionGlobals $other): self
     {
         return new self(
-            Arrays::arrayMergeRecursiveOverrule($this->value, $other->value)
+            [...$this->value, ...$other->value]
         );
     }
 }

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -174,7 +174,7 @@ class Runtime
         }
 
         if (!($request = $this->fusionGlobals->get('request')) instanceof ActionRequest) {
-            throw new \RuntimeException(sprintf('Expected Fusion variable "request" to be of type ActionRequest, got value of type "%s".', get_debug_type($request)), 1693558026485);
+            throw new Exception(sprintf('Expected Fusion variable "request" to be of type ActionRequest, got value of type "%s".', get_debug_type($request)), 1693558026485);
         }
 
         $uriBuilder = new UriBuilder();
@@ -251,7 +251,7 @@ class Runtime
     public function pushContext($key, $context)
     {
         if ($this->fusionGlobals->has($key)) {
-            throw new RuntimeException(sprintf('Overriding Fusion global variable "%s" via @context is not allowed.', $key), 1694284229044);
+            throw new Exception(sprintf('Overriding Fusion global variable "%s" via @context is not allowed.', $key), 1694284229044);
         }
         $newContext = $this->currentContext;
         $newContext[$key] = $context;
@@ -625,7 +625,7 @@ class Runtime
             $newContextArray ??= $this->currentContext;
             foreach ($fusionConfiguration['__meta']['context'] as $contextKey => $contextValue) {
                 if ($this->fusionGlobals->has($contextKey)) {
-                    throw new RuntimeException(sprintf('Overriding Fusion global variable "%s" via @context is not allowed.', $contextKey), 1694247627130);
+                    throw new Exception(sprintf('Overriding Fusion global variable "%s" via @context is not allowed.', $contextKey), 1694247627130);
                 }
                 $newContextArray[$contextKey] = $this->evaluate($fusionPath . '/__meta/context/' . $contextKey, $fusionObject, self::BEHAVIOR_EXCEPTION);
             }

--- a/Neos.Fusion/Classes/Exception/RuntimeException.php
+++ b/Neos.Fusion/Classes/Exception/RuntimeException.php
@@ -17,21 +17,11 @@ use Neos\Fusion\Exception;
  */
 class RuntimeException extends Exception
 {
-    /**
-     * @var string
-     */
-    protected $fusionPath;
+    private string $fusionPath;
 
-    /**
-     * @param string $message
-     * @param int $code
-     * @param \Exception $previous
-     * @param null $fusionPath
-     */
-    public function __construct($message = '', $code = 0, \Exception $previous = null, $fusionPath = null)
+    public function __construct(string $message, int $code, \Exception $previous, string $fusionPath)
     {
         parent::__construct($message, $code, $previous);
-
         $this->fusionPath = $fusionPath;
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
@@ -33,7 +33,7 @@ class RuntimeTest extends UnitTestCase
      */
     public function renderHandlesExceptionDuringRendering()
     {
-        $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'));
+        $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'), 'root');
         $runtime = $this->getMockBuilder(Runtime::class)->onlyMethods(['evaluate', 'handleRenderingException'])->disableOriginalConstructor()->getMock();
         $runtime->expects(self::any())->method('evaluate')->will(self::throwException($runtimeException));
         $runtime->expects(self::once())->method('handleRenderingException')->with('/foo/bar', $runtimeException)->will(self::returnValue('Exception Message'));
@@ -54,7 +54,7 @@ class RuntimeTest extends UnitTestCase
     {
         $this->expectException(Exception::class);
         $objectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->setMethods(['isRegistered', 'get'])->getMock();
-        $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'));
+        $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'), 'root');
         $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::empty());
         $this->inject($runtime, 'objectManager', $objectManager);
         $exceptionHandlerSetting = 'settings';
@@ -177,7 +177,7 @@ class RuntimeTest extends UnitTestCase
      */
     public function fusionContextIsNotAllowedToOverrideFusionGlobals()
     {
-        $this->expectException(\Neos\Fusion\Exception\RuntimeException::class);
+        $this->expectException(\Neos\Fusion\Exception::class);
         $this->expectExceptionMessage('Overriding Fusion global variable "request" via @context is not allowed.');
         $runtime = new Runtime(FusionConfiguration::fromArray([
             'foo' => [
@@ -190,6 +190,7 @@ class RuntimeTest extends UnitTestCase
                 ]
             ]
         ]), FusionGlobals::fromArray(['request' => 'fixed']));
+        $runtime->overrideExceptionHandler(new ThrowingHandler());
 
         $runtime->evaluate('foo');
     }
@@ -199,7 +200,7 @@ class RuntimeTest extends UnitTestCase
      */
     public function pushContextIsNotAllowedToOverrideFusionGlobals()
     {
-        $this->expectException(\Neos\Fusion\Exception\RuntimeException::class);
+        $this->expectException(\Neos\Fusion\Exception::class);
         $this->expectExceptionMessage('Overriding Fusion global variable "request" via @context is not allowed.');
         $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::fromArray(['request' => 'fixed']));
 


### PR DESCRIPTION
This is a little followup to https://github.com/neos/neos-development-collection/pull/4425

This fixes a bug with the error handling when overriding a fusion global variable.

### Also we add a possibility to override the exception handler in the Runtime.

It configures this runtime to override the default exception handler configured in the settings
or via Fusion's `@exceptionHandler`.

In combination with the throwing handler (`ThrowingHandler`) this can be used to rethrow all exceptions.
This is helpfully for renderings in CLI context or testing.

```php
$runtime->overrideExceptionHandler(new ThrowingHandler());
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

Best reviewed commit by commit ;)

In case one overrides a fusion global an error should occur. Currently there is an error in the error handling:

> Fatal error: Uncaught TypeError:
> Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler::exceptionDisablesCache(): Argument # 2 ($exception) must be of type Exception, null given, called in /Neos/Neos.Fusion/Classes/Core/ExceptionHandlers/AbstractRenderingExceptionHandler.php on line 69.

This was caused by using the RuntimeException wrongly


<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
