### PR TITLE
TASK: Rename Afx Parsing `Node` to `AfxNode`

### DIFF
--- a/Neos.Fusion.Afx/Classes/Parser/Expression/AfxNode.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/AfxNode.php
@@ -16,11 +16,7 @@ namespace Neos\Fusion\Afx\Parser\Expression;
 use Neos\Fusion\Afx\Parser\AfxParserException;
 use Neos\Fusion\Afx\Parser\Lexer;
 
-/**
- * Class Node
- * @package Neos\Fusion\Afx\Parser\Expression
- */
-class Node
+class AfxNode
 {
     /**
      * @param Lexer $lexer
@@ -85,7 +81,7 @@ class Node
                 throw new AfxParserException(sprintf('Tag "%s" did not end with closing bracket.', $identifier), 1557860573);
             }
 
-            $children = NodeList::parse($lexer);
+            $children = AfxNodeList::parse($lexer);
 
             if ($lexer->isOpeningBracket()) {
                 $lexer->consume();

--- a/Neos.Fusion.Afx/Classes/Parser/Expression/AfxNodeList.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/AfxNodeList.php
@@ -16,11 +16,7 @@ namespace Neos\Fusion\Afx\Parser\Expression;
 use Neos\Fusion\Afx\Parser\AfxParserException;
 use Neos\Fusion\Afx\Parser\Lexer;
 
-/**
- * Class NodeList
- * @package Neos\Fusion\Afx\Parser\Expression
- */
-class NodeList
+class AfxNodeList
 {
     /**
      * @param Lexer $lexer
@@ -56,7 +52,7 @@ class NodeList
                     $lexer->rewind();
                     $contents[] = [
                         'type' => 'node',
-                        'payload' => Node::parse($lexer)
+                        'payload' => AfxNode::parse($lexer)
                     ];
                     $currentText = '';
                     continue;

--- a/Neos.Fusion.Afx/Classes/Parser/Parser.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Parser.php
@@ -39,6 +39,6 @@ class Parser
      */
     public function parse(): array
     {
-        return Expression\NodeList::parse($this->lexer);
+        return Expression\AfxNodeList::parse($this->lexer);
     }
 }


### PR DESCRIPTION
This will make it easier to import the correct Neos CR Node - which you will want to use 100% of the time instead.

Resolves partially https://github.com/neos/neos-development-collection/issues/4341

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
