### PR TITLE
TASK: Deprecate legacy User Utility

### DIFF
--- a/Neos.Neos/Classes/Utility/User.php
+++ b/Neos.Neos/Classes/Utility/User.php
@@ -14,7 +14,7 @@ class User
     /**
      * Constructs a personal workspace name for the user with the given username.
      *
-     * @deprecated with Neos 9.0 please use {@see NeosWorkspaceName::fromAccountIdentifier} instead.
+     * @deprecated with Neos 9.0 please use {@see WorkspaceNameBuilder::fromAccountIdentifier} instead.
      * @param string $username
      * @return string
      */

--- a/Neos.Neos/Classes/Utility/User.php
+++ b/Neos.Neos/Classes/Utility/User.php
@@ -6,12 +6,15 @@ use Neos\Neos\Domain\Model\WorkspaceName;
 
 /**
  * Utility functions for dealing with users in the Content Repository.
+ *
+ * @deprecated with Neos 9.0 please use the respective replacements instead.
  */
 class User
 {
     /**
      * Constructs a personal workspace name for the user with the given username.
      *
+     * @deprecated with Neos 9.0 please use {@see NeosWorkspaceName::fromAccountIdentifier} instead.
      * @param string $username
      * @return string
      */
@@ -23,6 +26,7 @@ class User
     /**
      * Will reduce the username to ascii alphabet and numbers.
      *
+     * @deprecated with Neos 9.0 please implement your own slug genration. You might also want to look into transliteration with {@see \Behat\Transliterator\Transliterator}.
      * @param string $username
      * @return string
      */


### PR DESCRIPTION
Lets deprecate the legacy `User` utility. The helper contained minimal logic, which is now mostly moved to `NeosWorkspaceName`

Removing or renaming the `UserUtility` might be a little unwise, as its also used in the Neos.Demo!

resolves partially https://github.com/neos/neos-development-collection/issues/4341

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
