### PR TITLE
TASK: Remove `Neos.Node.inBackend()` and `Neos.Node.isLive()` eel helper

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -97,18 +97,6 @@ class NodeHelper implements ProtectedContextAwareInterface
 
     /**
      * @param Node $node
-     * @return bool
-     * @deprecated Remove before Neos 9.0 !!! Use ${userInterfaceMode.isEdit || userInterfaceMode.isPreview} instead
-     */
-    public function inBackend(Node $node): bool
-    {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return !$nodeAddressFactory->createFromNode($node)->isInLiveWorkspace();
-    }
-
-    /**
-     * @param Node $node
      * @return int
      * @deprecated do not rely on this, as it is rather expensive to calculate
      */
@@ -130,13 +118,6 @@ class NodeHelper implements ProtectedContextAwareInterface
         )->reverse();
 
         return AbsoluteNodePath::fromLeafNodeAndAncestors($node, $ancestors)->serializeToString();
-    }
-
-    public function isLive(Node $node): bool
-    {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return $nodeAddressFactory->createFromNode($node)->isInLiveWorkspace();
     }
 
     /**


### PR DESCRIPTION
It was deprecated in https://github.com/neos/neos-development-collection/pull/4505 in favor of `${renderingMode.isEdit}`. Since the ui is adjusted in https://github.com/neos/neos-ui/pull/3618 it can now be removed.

Relates: #4086

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
