### PR TITLE
BUGFIX: Guard that Fusion path cannot be empty

### DIFF
--- a/Neos.Fusion/Classes/Core/RuntimeConfiguration.php
+++ b/Neos.Fusion/Classes/Core/RuntimeConfiguration.php
@@ -64,6 +64,10 @@ final class RuntimeConfiguration
             return $this->pathCache[$fusionPath]['c'];
         }
 
+        if ($fusionPath === '') {
+            throw new Exception('Fusion path cannot be empty.', 1695308681);
+        }
+
         // Find longest prefix of path that already is in path cache
         $pathUntilNow = '';
         $fusionPathLength = strlen($fusionPath);


### PR DESCRIPTION
Previously in php 7.4 this `Neos\Fusion\Exception\MissingFusionObjectException` was thrown

> No Fusion object found in path ""

but with php 8 this `ValueError` is thrown which is unexpected

> strrpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)

This change takes care of throwing an explicit `Neos\Fusion\Exception` instead:

> Fusion path cannot be empty.


--------

This error was noticed in the out of band rendering, when there is no content element wrapping: https://discuss.neos.io/t/argument-3-offset-must-be-contained-in-argument-1-haystack/6416/4

<img width="593" alt="image" src="https://github.com/neos/neos-development-collection/assets/85400359/0ac8d025-3ab4-44e8-9034-eb883f0b1894">



<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
