### PR TITLE
BUGFIX: Reduce nodetype schema size

### DIFF
--- a/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
+++ b/Neos.Neos/Classes/Service/NodeTypeSchemaBuilder.php
@@ -75,14 +75,15 @@ class NodeTypeSchemaBuilder
         }
 
         foreach ($nodeTypes as $nodeTypeName => $nodeType) {
+            // Skip abstract nodetypes which might have been added by the Neos.UI `nodeTypeRoles` configuration
             if ($nodeType->isAbstract() === false) {
                 $configuration = $nodeType->getFullConfiguration();
                 $schema['nodeTypes'][$nodeTypeName] = $configuration;
                 $schema['nodeTypes'][$nodeTypeName]['label'] = $nodeType->getLabel();
-
-                // Remove the postprocessors, as they are not needed in the UI
-                unset($schema['nodeTypes'][$nodeTypeName]['postprocessors']);
             }
+
+            // Remove the postprocessors, as they are not needed in the UI
+            unset($schema['nodeTypes'][$nodeTypeName]['postprocessors']);
 
             $subTypes = [];
             foreach ($this->nodeTypeManager->getSubNodeTypes($nodeType->getName(), false) as $subNodeType) {

--- a/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
+++ b/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
@@ -80,11 +80,11 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
     {
         $subTypesDefinition = $this->schema['inheritanceMap']['subTypes'];
 
-        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Document', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Node']);
-        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Content', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Node']);
-        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Page', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Node']);
-        self::assertContains('Neos.Neos.BackendSchemaControllerTest:SubPage', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Node']);
-        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Text', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Node']);
+        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Page', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Document']);
+        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Folder', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Document']);
+        self::assertContains('Neos.Neos.BackendSchemaControllerTest:SubPage', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Page']);
+        self::assertContains('Neos.Neos.BackendSchemaControllerTest:Text', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Content']);
+        self::assertContains('Neos.Neos.BackendSchemaControllerTest:TwoColumn', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Content']);
     }
 
     /**


### PR DESCRIPTION
With this change the following optimisations are done to improve speed and reduce size of the schema generation:

* Abstract nodetypes are not queried anymore for constraints as they are already resolved by the nodetype manager.

* Entries in the inheritance map and constraints will be skipped if they don’t contain any data.

These optimisations reduce the size of the schema in the Neos.Demo from ~357KB to ~300KB and improve the response time by ~20% in my tests.

The more nodetypes a project has, the bigger the benefit is.

**Review instructions**

Everything should work the same, adding nodes, constraints, etc.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
