### PR TITLE
TASK: Fix paths for Neos.Media RTD rendering setup

### DIFF
--- a/Neos.Media/Documentation/.readthedocs.yaml
+++ b/Neos.Media/Documentation/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: conf.py
+  configuration: Neos.Media/Documentation/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
@@ -23,4 +23,4 @@ formats:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: Neos.Media/Documentation/requirements.txt


### PR DESCRIPTION
The paths need to be from the repo root, not relative to the `.readthedocs.yaml` file (it seems).

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
