### PR TITLE
BUGFIX: FusionExceptionView must use mocked controller context

### DIFF
--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -204,14 +204,14 @@ class FusionExceptionView extends AbstractView
             $fusionConfiguration = $this->fusionService->createFusionConfigurationFromSite($site);
 
             $fusionGlobals = FusionGlobals::fromArray([
-                'request' => $this->controllerContext->getRequest(),
+                'request' => $controllerContext->getRequest(),
                 'renderingModeName' => RenderingMode::FRONTEND
             ]);
             $this->fusionRuntime = $this->runtimeFactory->createFromConfiguration(
                 $fusionConfiguration,
                 $fusionGlobals
             );
-            $this->fusionRuntime->setControllerContext($this->controllerContext);
+            $this->fusionRuntime->setControllerContext($controllerContext);
 
             if (isset($this->options['enableContentCache']) && $this->options['enableContentCache'] !== null) {
                 $this->fusionRuntime->setEnableContentCache($this->options['enableContentCache']);

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -102,9 +102,12 @@ class FusionExceptionView extends AbstractView
     public function render()
     {
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
-        $httpRequest = $requestHandler instanceof HttpRequestHandler
-            ? $requestHandler->getHttpRequest()
-            : ServerRequest::fromGlobals();
+
+        if (!$requestHandler instanceof HttpRequestHandler) {
+            throw new \RuntimeException('The FusionExceptionView only works in web requests.', 1695975353);
+        }
+
+        $httpRequest = $requestHandler->getHttpRequest();
 
         $siteDetectionResult = SiteDetectionResult::fromRequest($httpRequest);
         $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);


### PR DESCRIPTION
0f24c721c8a303e39542c69b1eae0056acd16998 (#4425) introduced a regression where we accidentally used `$this->controllerContext` instead of `$controllerContext`.
    
For $some reason we have to use the mocked controller context, as otherwise the `${request.format}` will be empty "" in fusion. And this causes trouble in the `/root` matcher.
    
This fix uses the mocked controller context again.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
