### PR TITLE
BUGFIX: allow succeedingSiblingAnchorPoint without setting parent or child

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -242,7 +242,7 @@ class ProjectionContentGraph
         ContentStreamId $contentStreamId,
         DimensionSpacePoint $dimensionSpacePoint
     ): int {
-        if (!$parentAnchorPoint && !$childAnchorPoint) {
+        if (!$parentAnchorPoint && !$childAnchorPoint && !$succeedingSiblingAnchorPoint) {
             throw new \InvalidArgumentException(
                 'You must specify either parent or child node anchor to determine a hierarchy relation position',
                 1519847447


### PR DESCRIPTION
closes #4575 

for now, allowing to only use $succeedingSiblingAnchorPoint will fix the logic issue

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
