### PR TITLE
TASK: Remove legacy directory support for node migrations

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/YamlConfiguration.php
@@ -45,7 +45,6 @@ class YamlConfiguration extends Configuration
     {
         $this->availableVersions = [];
         foreach ($this->packageManager->getAvailablePackages() as $package) {
-            $this->registerVersionInDirectory($package, 'TYPO3CR');
             $this->registerVersionInDirectory($package, 'ContentRepository');
         }
         ksort($this->availableVersions);


### PR DESCRIPTION
Removes the support of the `TYPO3CR` directory as source for node migrations.