### PR TITLE
FEATURE: Add nodemigrations command to list all available node migration

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -117,13 +117,10 @@ class NodeMigrationCommandController extends CommandController
     /**
      * List available migrations
      *
-     * @return void
      * @see neos.contentrepositoryregistry:nodemigration:list
      */
     public function listCommand(): void
     {
-        $this->outputLine();
-
         $availableMigrations = $this->migrationFactory->getAvailableVersions();
         if (count($availableMigrations) === 0) {
             $this->outputLine('No migrations available.');

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -115,6 +115,40 @@ class NodeMigrationCommandController extends CommandController
     }
 
     /**
+     * List available migrations
+     *
+     * @return void
+     * @see neos.contentrepositoryregistry:nodemigration:list
+     */
+    public function listCommand(): void
+    {
+        $this->outputLine();
+
+        $availableMigrations = $this->migrationFactory->getAvailableVersions();
+        if (count($availableMigrations) === 0) {
+            $this->outputLine('No migrations available.');
+            $this->quit();
+        }
+
+        $tableRows = [];
+        foreach ($availableMigrations as $version => $migration) {
+            $migrationUpConfigurationComments = $this->migrationFactory->getMigrationForVersion($version)->getComments();
+
+            $tableRows[] = [
+                $version,
+                $migration['formattedVersionNumber'],
+                $migration['package']->getPackageKey(),
+
+                wordwrap($migrationUpConfigurationComments, 60)
+            ];
+        }
+
+        $this->outputLine('<b>Available migrations</b>');
+        $this->outputLine();
+        $this->output->outputTable($tableRows, ['Version', 'Date', 'Package', 'Comments']);
+    }
+
+    /**
      * Helper to output comments and warnings for the given configuration.
      *
      * @param MigrationConfiguration $migrationConfiguration

--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Factory/MigrationFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Factory/MigrationFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\ContentRepositoryRegistry\Migration\Factory;
 
 /*
@@ -30,5 +31,10 @@ class MigrationFactory
     public function getMigrationForVersion($version): MigrationConfiguration
     {
         return new MigrationConfiguration($this->migrationConfiguration->getMigrationVersion($version));
+    }
+
+    public function getAvailableVersions(): array
+    {
+        return $this->migrationConfiguration->getAvailableVersions();
     }
 }


### PR DESCRIPTION
Adds a cli command to list all available node migrations.

`nodemigration:list`

This was in previous versions built-in in the `node:migrationstatus`, but as we will not have this command in 9.0, this shall at least provide an overview over available node migrations.

```
> ./flow nodemigration:list

Available migrations

+----------------+---------------------+-----------+-------------------------------+
| Version        | Date                | Package   | Comments                      |
+----------------+---------------------+-----------+-------------------------------+
| 20231013141245 | 13-10-2023 14:12:45 | Neos.Demo | This is a important migration |
+----------------+---------------------+-----------+-------------------------------+
```

Related to: #4571