### PR TITLE
FEATURE: NodeType allow unsetting inherited properties

### DIFF
--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
@@ -152,6 +152,11 @@ class NodeType
         }
         $this->fullConfiguration = Arrays::arrayMergeRecursiveOverrule($mergedConfiguration, $this->localConfiguration);
 
+        // Remove unset properties
+        $this->fullConfiguration['properties'] = array_filter($this->fullConfiguration['properties'] ?? [], function ($propertyConfiguration) {
+            return $propertyConfiguration !== null;
+        });
+
         if (
             isset($this->fullConfiguration['childNodes'])
             && is_array($this->fullConfiguration['childNodes'])

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
@@ -220,20 +220,6 @@ class NodeTypeManager
             );
         }
 
-        // Remove unset properties
-        $properties = [];
-        if (isset($nodeTypeConfiguration['properties']) && is_array($nodeTypeConfiguration['properties'])) {
-            $properties = $nodeTypeConfiguration['properties'];
-        }
-
-        $nodeTypeConfiguration['properties'] = array_filter($properties, function ($propertyConfiguration) {
-            return $propertyConfiguration !== null;
-        });
-
-        if ($nodeTypeConfiguration['properties'] === []) {
-            unset($nodeTypeConfiguration['properties']);
-        }
-
         $nodeType = new NodeType(
             NodeTypeName::fromString($nodeTypeName),
             $superTypes,


### PR DESCRIPTION
This will make it possible to adjust https://github.com/neos/neos-development-collection/pull/4563#discussion_r1358029375. We want to unset the `uriPathSegment` of the Site:

```yaml
'Neos.Neos:Site':
  properties:
    uriPathSegment: ~
```



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
