### PR TITLE
BUGFIX: Fix and make `nodeTypes:show` command usable

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
@@ -27,8 +27,8 @@ class NodeTypesCommandController extends CommandController
      * Shows the merged configuration (including supertypes) of a NodeType
      *
      * @param string $nodeTypeName The name of the NodeType to show
-     * @param ?int $level Truncate the configuration at this depth and show '...' (Usefully for only seeing the keys of the properties)
-     * @param ?string $path Path of the NodeType-configuration which will be shown
+     * @param string $path Path of the NodeType-configuration which will be shown
+     * @param int $level Truncate the configuration at this depth and show '...' (Usefully for only seeing the keys of the properties)
      */
     public function showCommand(string $nodeTypeName, string $path = '', int $level = 0): void
     {

--- a/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
@@ -30,7 +30,7 @@ class NodeTypesCommandController extends CommandController
      * @param ?int $level Truncate the configuration at this depth and show '...' (Usefully for only seeing the keys of the properties)
      * @param ?string $path Path of the NodeType-configuration which will be shown
      */
-    public function showCommand(string $nodeTypeName, ?string $path = null, ?int $level = 0): void
+    public function showCommand(string $nodeTypeName, string $path = '', int $level = 0): void
     {
         if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
             $this->outputLine('<error>NodeType "%s" was not found!</error>', [$nodeTypeName]);

--- a/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
@@ -31,9 +31,15 @@ class NodeTypesCommandController extends CommandController
      */
     public function showCommand(string $nodeTypeName, ?string $path = null): void
     {
+        if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
+            $this->outputLine('<error>NodeType "%s" was not found!</error>', [$nodeTypeName]);
+            $this->quit();
+        }
+
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
-        if (!$nodeType) {
-            $this->outputLine('<b>NodeType "%s" was not found!</b>', [$nodeTypeName]);
+
+        if ($path && !$nodeType->hasConfiguration($path)) {
+            $this->outputLine('<b>NodeType "%s" does not have configuration "%s".</b>', [$nodeTypeName, $path]);
             $this->quit();
         }
         $yaml = Yaml::dump(

--- a/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
@@ -27,9 +27,10 @@ class NodeTypesCommandController extends CommandController
      * Shows the merged configuration (including supertypes) of a NodeType
      *
      * @param string $nodeTypeName The name of the NodeType to show
+     * @param ?int $level Truncate the configuration at this depth and show '...' (Usefully for only seeing the keys of the properties)
      * @param ?string $path Path of the NodeType-configuration which will be shown
      */
-    public function showCommand(string $nodeTypeName, ?string $path = null): void
+    public function showCommand(string $nodeTypeName, ?string $path = null, ?int $level = 0): void
     {
         if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
             $this->outputLine('<error>NodeType "%s" was not found!</error>', [$nodeTypeName]);
@@ -42,13 +43,14 @@ class NodeTypesCommandController extends CommandController
             $this->outputLine('<b>NodeType "%s" does not have configuration "%s".</b>', [$nodeTypeName, $path]);
             $this->quit();
         }
-        $yaml = Yaml::dump(
-            $path
-                ? $nodeType->getConfiguration($path)
-                : [$nodeTypeName => $nodeType->getFullConfiguration()],
-            99
-        );
-        $this->outputLine('<b>NodeType Configuration "%s":</b>', [$nodeTypeName . ($path ? ("." . $path) : "")]);
+
+        $configuration = $path
+            ? self::truncateArrayAtLevel($nodeType->getConfiguration($path), $level)
+            : [$nodeTypeName => self::truncateArrayAtLevel($nodeType->getFullConfiguration(), $level)];
+
+        $yaml = Yaml::dump($configuration, 99);
+
+        $this->outputLine('<b>NodeType configuration "%s":</b>', [$nodeTypeName . ($path ? ("." . $path) : "")]);
         $this->outputLine();
         $this->outputLine($yaml);
         $this->outputLine();
@@ -83,5 +85,29 @@ class NodeTypesCommandController extends CommandController
                 $this->output->outputFormatted($nodeTypeName, [], 2);
             }
         }
+    }
+
+    /**
+     * @param int $truncateLevel 0 for no truncation and 1 to only show the first keys of the array
+     * @param int $currentLevel 1 for the start and will be incremented recursively
+     */
+    private static function truncateArrayAtLevel(array $array, int $truncateLevel, int $currentLevel = 1): array
+    {
+        if ($truncateLevel <= 0) {
+            return $array;
+        }
+        $truncatedArray = [];
+        foreach ($array as $key => $value) {
+            if ($currentLevel >= $truncateLevel) {
+                $truncatedArray[$key] = '...'; // truncated
+                continue;
+            }
+            if (!is_array($value)) {
+                $truncatedArray[$key] = $value;
+                continue;
+            }
+            $truncatedArray[$key] = self::truncateArrayAtLevel($value, $truncateLevel, $currentLevel + 1);
+        }
+        return $truncatedArray;
     }
 }


### PR DESCRIPTION
Fixes handling of invalid nodetype or invalid path.

And introduces new option `level` to clamp the input (previously this command was useless for bigger nodetypes):

```
flow nodeTypes:show Neos.Demo:Document.Homepage --path properties --level 1
NodeType configuration "Neos.Demo:Document.Homepage.properties":

_removed: ...
_creationDateTime: ...
_lastModificationDateTime: ...
_lastPublicationDateTime: ...
_path: ...
_name: ...
_nodeType: ...
_hidden: ...
_hiddenBeforeDateTime: ...
_hiddenAfterDateTime: ...
titleOverride: ...
metaDescription: ...
...
```

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
