### PR TITLE
TASK: Add test for nodeType property unset behaviour

### DIFF
--- a/Neos.ContentRepository.Core/Tests/Unit/NodeType/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/NodeType/NodeTypeManagerTest.php
@@ -320,7 +320,6 @@ class NodeTypeManagerTest extends TestCase
         $this->expectException(NodeConfigurationException::class);
         $nodeTypesFixture = [
             'Neos.ContentRepository.Testing:Base' => [
-                'final' => true
             ],
             'Neos.ContentRepository.Testing:Sub' => [
                 'superTypes' => [0 => 'Neos.ContentRepository.Testing:Base']
@@ -342,6 +341,94 @@ class NodeTypeManagerTest extends TestCase
 
         $subNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject', false);
         self::assertArrayNotHasKey('Neos.ContentRepository.Testing:AbstractType', $subNodeTypes);
+    }
+
+    /**
+     * @test
+     */
+    public function anInheritedNodeTypePropertyCannotBeUnset(): void
+    {
+        $nodeTypesFixture = [
+            'Neos.ContentRepository.Testing:Base' => [
+                'properties' => [
+                    'foo' => [
+                        'type' => 'boolean',
+                    ]
+                ]
+            ],
+            'Neos.ContentRepository.Testing:Sub' => [
+                'superTypes' => ['Neos.ContentRepository.Testing:Base' => true],
+                'properties' => [
+                    'foo' => null
+                ]
+            ]
+        ];
+
+        $this->prepareNodeTypeManager($nodeTypesFixture);
+        $nodeType = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Sub');
+
+        self::assertSame(['foo' => ['type' => 'boolean']], $nodeType->getProperties());
+    }
+
+    /**
+     * @test
+     */
+    public function allInheritedNodeTypePropertiesCannotBeUnset(): void
+    {
+        $nodeTypesFixture = [
+            'Neos.ContentRepository.Testing:Base' => [
+                'properties' => [
+                    'foo' => [
+                        'type' => 'boolean',
+                    ]
+                ]
+            ],
+            'Neos.ContentRepository.Testing:Sub' => [
+                'superTypes' => ['Neos.ContentRepository.Testing:Base' => true],
+                'properties' => null
+            ]
+        ];
+
+        $this->prepareNodeTypeManager($nodeTypesFixture);
+        $nodeType = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Sub');
+
+        self::assertSame(['foo' => ['type' => 'boolean']], $nodeType->getProperties());
+    }
+
+    /**
+     * @test
+     */
+    public function anInheritedNodeTypePropertyCannotBeSetToEmptyArray(): void
+    {
+        $nodeTypesFixture = [
+            'Neos.ContentRepository.Testing:Base' => [
+                'properties' => [
+                    'foo' => [
+                        'type' => 'boolean',
+                        'ui' => [
+                            'inspector' => [
+                                'group' => 'things'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'Neos.ContentRepository.Testing:Sub' => [
+                'superTypes' => ['Neos.ContentRepository.Testing:Base' => true],
+                'properties' => [
+                    // Pseudo unset.
+                    // The property will still be existent but looses its type information (falls back to string).
+                    // Also, the property will not show up anymore in the ui as the inspector configuration is gone as well.
+                    'foo' => []
+                ]
+            ]
+        ];
+
+        $this->prepareNodeTypeManager($nodeTypesFixture);
+        $nodeType = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Sub');
+
+        self::assertSame(['foo' => []], $nodeType->getProperties());
+        self::assertSame('string', $nodeType->getPropertyType('foo'));
     }
 
     /**


### PR DESCRIPTION
just to document the current state (it has been like this since neos 7 and 8 too).

In https://github.com/neos/neos-development-collection/pull/4618 we discuss wether we like to keep it this way.