### PR TITLE
BUGFIX: Load all thumbnails for an asset to skip further requests

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Thumbnail.php
+++ b/Neos.Media/Classes/Domain/Model/Thumbnail.php
@@ -224,4 +224,9 @@ class Thumbnail implements ImageInterface
     {
         $this->generatorStrategy->refresh($this);
     }
+
+    public function getConfigurationHash(): string
+    {
+        return $this->configurationHash;
+    }
 }


### PR DESCRIPTION
For the usecase of images with responsive variants this change prevents additional database requests for each additional variant of an image.

This can greatly reduce the number of queries on pages with many source tags or sources attributes for pictures and images.

**Review instructions**

As soon as an image is rendered in several sizes on a page the patch should skip additional db requests in the thumbnails repository.
Persistent resources and image entities are still queried as via the node property getter and to resolve the thumbnail.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
