### PR TITLE
TASK: Remove internal `ContentGraph::findNodeByIdAndOriginDimensionSpacePoint`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -85,40 +85,6 @@ final class ContentGraph implements ContentGraphInterface
     }
 
     /**
-     * @throws DBALException
-     * @throws NodeTypeNotFoundException
-     */
-    public function findNodeByIdAndOriginDimensionSpacePoint(
-        ContentStreamId $contentStreamId,
-        NodeAggregateId $nodeAggregateId,
-        OriginDimensionSpacePoint $originDimensionSpacePoint
-    ): ?Node {
-        $connection = $this->client->getConnection();
-
-        // HINT: we check the ContentStreamId on the EDGE;
-        // as this is where we actually find out whether the node exists in the content stream
-        $nodeRow = $connection->executeQuery(
-            'SELECT n.*, h.contentstreamid, h.name FROM ' . $this->tableNamePrefix . '_node n
-                  INNER JOIN ' . $this->tableNamePrefix . '_hierarchyrelation h
-                      ON h.childnodeanchor = n.relationanchorpoint
-                  WHERE n.nodeaggregateid = :nodeAggregateId
-                  AND n.origindimensionspacepointhash = :originDimensionSpacePointHash
-                  AND h.contentstreamid = :contentStreamId',
-            [
-                'nodeAggregateId' => $nodeAggregateId->value,
-                'originDimensionSpacePointHash' => $originDimensionSpacePoint->hash,
-                'contentStreamId' => $contentStreamId->value
-            ]
-        )->fetchAssociative();
-
-        return $nodeRow ? $this->nodeFactory->mapNodeRowToNode(
-            $nodeRow,
-            $originDimensionSpacePoint->toDimensionSpacePoint(),
-            VisibilityConstraints::withoutRestrictions()
-        ) : null;
-    }
-
-    /**
      * @throws RootNodeAggregateDoesNotExist
      */
     public function findRootNodeAggregateByType(

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
@@ -87,24 +87,6 @@ final class ContentHypergraph implements ContentGraphInterface
         return $this->subhypergraphs[$index];
     }
 
-    public function findNodeByIdAndOriginDimensionSpacePoint(
-        ContentStreamId $contentStreamId,
-        NodeAggregateId $nodeAggregateId,
-        OriginDimensionSpacePoint $originDimensionSpacePoint
-    ): ?Node {
-        $query = HypergraphQuery::create($contentStreamId, $this->tableNamePrefix);
-        $query = $query->withOriginDimensionSpacePoint($originDimensionSpacePoint);
-        $query = $query->withNodeAggregateId($nodeAggregateId);
-
-        $nodeRow = $query->execute($this->getDatabaseConnection())->fetchAssociative();
-
-        return $nodeRow ? $this->nodeFactory->mapNodeRowToNode(
-            $nodeRow,
-            VisibilityConstraints::withoutRestrictions(),
-            $originDimensionSpacePoint->toDimensionSpacePoint()
-        ) : null;
-    }
-
     public function findRootNodeAggregateByType(
         ContentStreamId $contentStreamId,
         NodeTypeName $nodeTypeName

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
@@ -95,15 +95,6 @@ interface ContentGraphInterface extends ProjectionStateInterface
     public function findUsedNodeTypeNames(): iterable;
 
     /**
-     * @internal
-     */
-    public function findNodeByIdAndOriginDimensionSpacePoint(
-        ContentStreamId $contentStreamId,
-        NodeAggregateId $nodeAggregateId,
-        OriginDimensionSpacePoint $originDimensionSpacePoint
-    ): ?Node;
-
-    /**
      * @internal only for consumption inside the Command Handler
      */
     public function findParentNodeAggregateByChildOriginDimensionSpacePoint(

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -89,8 +89,10 @@ trait ProjectedNodeTrait
             $currentNode = $subgraph->findNodeById(
                 $nodeDiscriminator->nodeAggregateId,
             );
-            Assert::assertNotNull(
-                $currentNode,
+            $nodeOriginatesFromExpectedDimension = $currentNode !== null
+                && $currentNode->originDimensionSpacePoint->equals($nodeDiscriminator->originDimensionSpacePoint);
+            Assert::assertTrue(
+                $nodeOriginatesFromExpectedDimension,
                 'Node with aggregate id "' . $nodeDiscriminator->nodeAggregateId->value
                 . '" and originating in dimension space point "' . $nodeDiscriminator->originDimensionSpacePoint->toJson()
                 . '" was not found in content stream "' . $nodeDiscriminator->contentStreamId->value . '"'

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -81,24 +81,18 @@ trait ProjectedNodeTrait
     {
         $nodeDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
         $this->initializeCurrentNodeFromContentGraph(function (ContentGraphInterface $contentGraph) use ($nodeDiscriminator) {
-            $subgraph = $contentGraph->getSubgraph(
+            $currentNodeAggregate = $contentGraph->findNodeAggregateById(
                 $nodeDiscriminator->contentStreamId,
-                $nodeDiscriminator->originDimensionSpacePoint->toDimensionSpacePoint(),
-                VisibilityConstraints::withoutRestrictions()
+                $nodeDiscriminator->nodeAggregateId
             );
-            $currentNode = $subgraph->findNodeById(
-                $nodeDiscriminator->nodeAggregateId,
-            );
-            $nodeOriginatesFromExpectedDimension = $currentNode !== null
-                && $currentNode->originDimensionSpacePoint->equals($nodeDiscriminator->originDimensionSpacePoint);
             Assert::assertTrue(
-                $nodeOriginatesFromExpectedDimension,
+                $currentNodeAggregate?->occupiesDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint),
                 'Node with aggregate id "' . $nodeDiscriminator->nodeAggregateId->value
                 . '" and originating in dimension space point "' . $nodeDiscriminator->originDimensionSpacePoint->toJson()
                 . '" was not found in content stream "' . $nodeDiscriminator->contentStreamId->value . '"'
             );
 
-            return $currentNode;
+            return $currentNodeAggregate->getNodeByOccupiedDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint);
         });
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -23,6 +23,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReference
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -80,10 +81,13 @@ trait ProjectedNodeTrait
     {
         $nodeDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
         $this->initializeCurrentNodeFromContentGraph(function (ContentGraphInterface $contentGraph) use ($nodeDiscriminator) {
-            $currentNode = $contentGraph->findNodeByIdAndOriginDimensionSpacePoint(
+            $subgraph = $contentGraph->getSubgraph(
                 $nodeDiscriminator->contentStreamId,
+                $nodeDiscriminator->originDimensionSpacePoint->toDimensionSpacePoint(),
+                VisibilityConstraints::withoutRestrictions()
+            );
+            $currentNode = $subgraph->findNodeById(
                 $nodeDiscriminator->nodeAggregateId,
-                $nodeDiscriminator->originDimensionSpacePoint
             );
             Assert::assertNotNull(
                 $currentNode,


### PR DESCRIPTION
Was added via https://github.com/neos/neos-development-collection/commit/e35e85cdb1af045004bf33f10579ce756bcc4110 but never used really.

Slack discussion: https://neos-project.slack.com/archives/C3MCBK6S2/p1697530059157759

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
