### PR TITLE
BUGFIX: Set correct siteNode in WorkspaceController

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -792,7 +792,7 @@ class WorkspacesController extends AbstractModuleController
                         }
                     }
                     if ($this->getNodeType($ancestor)->isOfType(NodeTypeNameFactory::NAME_SITE)) {
-                        $siteNode = $documentNode;
+                        $siteNode = $ancestor;
                     }
                 }
 


### PR DESCRIPTION
This fixes a merge error introduced with https://github.com/neos/neos-development-collection/pull/4588/commits/fa381195c11178825bf7f5fe746e5c6ef698fd63

We check `$ancestor` to be of nodeType `Neos.Neos:Site` so this is the correct value for `$siteNode`.

Relates: #4588

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
