### PR TITLE
TASK: Content cache adjustments

### DIFF
--- a/Neos.Neos/Classes/Cache/ContentCacheFlusherInterface.php
+++ b/Neos.Neos/Classes/Cache/ContentCacheFlusherInterface.php
@@ -26,6 +26,7 @@ use Neos\Media\Domain\Model\AssetInterface;
  * {@see GraphProjectorCatchUpHookForCacheFlushing} which calls this method..
  *   This is the relevant case if publishing a workspace
  *   - where we f.e. need to flush the cache for Live.
+ * @internal this extension point is experimental 
  */
 interface ContentCacheFlusherInterface
 {

--- a/Neos.Neos/Classes/Cache/ContentCacheFlusherInterface.php
+++ b/Neos.Neos/Classes/Cache/ContentCacheFlusherInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Cache;
+
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\Media\Domain\Model\AssetInterface;
+
+/**
+ * The interface for services flushing content caches triggered by node changes.
+ *
+ * It is called when the projection changes: In this case, it is triggered by
+ * {@see GraphProjectorCatchUpHookForCacheFlushing} which calls this method..
+ *   This is the relevant case if publishing a workspace
+ *   - where we f.e. need to flush the cache for Live.
+ */
+interface ContentCacheFlusherInterface
+{
+    /**
+     * Main entry point to *directly* flush the caches of a given NodeAggregate
+     */
+    public function flushNodeAggregate(
+        ContentRepository $contentRepository,
+        ContentStreamId $contentStreamId,
+        NodeAggregateId $nodeAggregateId
+    ): void;
+
+    /**
+     * Fetches possible usages of the asset and registers nodes that use the asset as changed.
+     */
+    public function registerAssetChange(AssetInterface $asset): void;
+}

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -25,6 +25,7 @@ use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetVariantInterface;
+use Neos\Neos\Cache\ContentCacheFlusherInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -37,7 +38,7 @@ use Psr\Log\LoggerInterface;
  *
  * @Flow\Scope("singleton")
  */
-class ContentCacheFlusher
+class ContentCacheFlusher implements ContentCacheFlusherInterface
 {
     /**
      * @Flow\Inject

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -146,6 +146,11 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
                 $eventInstance->getNodeAggregateId()
             );
             if ($nodeAggregate) {
+                $this->scheduleCacheFlushJobForNodeAggregate(
+                    $this->contentRepository,
+                    $nodeAggregate->contentStreamId,
+                    $nodeAggregate->nodeAggregateId
+                );
                 $parentNodeAggregates = $this->contentRepository->getContentGraph()->findParentNodeAggregates(
                     $nodeAggregate->contentStreamId,
                     $nodeAggregate->nodeAggregateId

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -22,6 +22,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\EventStore\Model\EventEnvelope;
+use Neos\Neos\Cache\ContentCacheFlusherInterface;
 
 /**
  * Also contains a pragmatic performance booster for some "batch" operations, where the cache flushing
@@ -116,7 +117,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
 
     public function __construct(
         private readonly ContentRepository $contentRepository,
-        private readonly ContentCacheFlusher $contentCacheFlusher
+        private readonly ContentCacheFlusherInterface $contentCacheFlusher
     ) {
     }
 

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
@@ -14,11 +14,12 @@ namespace Neos\Neos\Fusion\Cache;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
+use Neos\Neos\Cache\ContentCacheFlusherInterface;
 
 class GraphProjectorCatchUpHookForCacheFlushingFactory implements CatchUpHookFactoryInterface
 {
     public function __construct(
-        private readonly ContentCacheFlusher $contentCacheFlusher
+        private readonly ContentCacheFlusherInterface $contentCacheFlusher
     ) {
     }
 

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\Neos;
 
-use Neos\EventStore\Model\EventEnvelope;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Monitor\FileMonitor;
@@ -26,7 +25,6 @@ use Neos\Media\Domain\Service\AssetService;
 use Neos\Neos\Controller\Backend\ContentController;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteService;
-use Neos\Neos\FrontendRouting\Projection\DocumentUriPathProjection;
 use Neos\Neos\Routing\Cache\RouteCacheFlusher;
 use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
 use Neos\Fusion\Core\Cache\ContentCache;

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -79,3 +79,6 @@ Neos\Neos\AssetUsage\GlobalAssetUsageService:
   arguments:
     3:
       setting: Neos.Neos.assetUsage.contentRepositories
+
+Neos\Neos\Cache\ContentCacheFlusherInterface:
+  className: Neos\Neos\Fusion\Cache\ContentCacheFlusher


### PR DESCRIPTION
This adds an interface for other content caches than Neos' Fusion content cache.

Also flushes caches for deleted nodes, not just their parents, in case they or their types were used in CacheTags elsewhere

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
