### PR TITLE
TASK: Make the `ImageInterfaceArrayPresenter` required by the ui the …

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -167,7 +167,7 @@ Neos:
               placeholder: Choose
             defaultValue: {  }
           Neos\Media\Domain\Model\ImageInterface:
-            typeConverter: Neos\Media\TypeConverter\ImageInterfaceJsonSerializer
+            typeConverter: Neos\Media\TypeConverter\ImageInterfaceArrayPresenter
             editor: Neos.Neos/Inspector/Editors/ImageEditor
             editorOptions:
               # With this option you can limit the maximum file size to the specified number of bytes.


### PR DESCRIPTION
…default one

i happen to came across the `dataTypes` configuration in the neos ui, and noticed that we directly override the value set by Neos. I think this is a legacy part from the ember code base. And in the effort of having the configuration easier to read i think its needless to override it in the ui and thus i want to change the neos default here. 

see https://github.com/neos/neos-ui/blob/70ab40793e291784bb01d18223180855c96e52d3/Configuration/Settings.yaml#L23

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
