### PR TITLE
BUGFIX: Neos Ui JSON serializable property values

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -947,6 +947,10 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
         }
 
         try {
+            /**
+             * In case the value is a value object it _will_ already be deserialized due to the feature in flow_json_array
+             * {@see \Neos\Flow\Persistence\Doctrine\DataTypes\JsonArrayType::deserializeValueObject}
+             */
             return $this->propertyMapper->convert($value, $expectedPropertyType);
         } catch (\Neos\Flow\Property\Exception $exception) {
             throw new NodeException(sprintf('Failed to convert property "%s" of node "%s" to the expected type of "%s": %s', $propertyName, $this->getIdentifier(), $expectedPropertyType, $exception->getMessage()), 1630675703, $exception);

--- a/Neos.Neos/Classes/Service/Mapping/NodePropertyConverterService.php
+++ b/Neos.Neos/Classes/Service/Mapping/NodePropertyConverterService.php
@@ -19,6 +19,7 @@ use Neos\Flow\Property\Exception as PropertyException;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\TypeHandling;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -155,15 +156,27 @@ class NodePropertyConverterService
     }
 
     /**
-     * Convert the given value to a simple type or an array of simple types.
+     * Convert the given value to a simple type or an array of simple types or to a \JsonSerializable.
      *
-     * @param mixed $propertyValue
-     * @param string $dataType
-     * @return mixed
+     * @param mixed $propertyValue the deserialized node property value
+     * @param string $dataType the property type from the node type schema
+     * @return \JsonSerializable|int|float|string|bool|null|array<mixed>
      * @throws PropertyException
      */
     protected function convertValue($propertyValue, $dataType)
     {
+        if ($propertyValue instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable($propertyValue::class)) {
+            /**
+             * Value object support, as they can be stored directly the node properties flow_json_array
+             *
+             * If the value is json-serializable and deserializeable via the {@see DenormalizingObjectConverter} (via e.g. fromArray)
+             * We return the json-serializable directly.
+             *
+             * {@see \Neos\Flow\Persistence\Doctrine\DataTypes\JsonArrayType::deserializeValueObject()}
+             */
+            return $propertyValue;
+        }
+
         $parsedType = TypeHandling::parseType($dataType);
 
         // This hardcoded handling is to circumvent rewriting PropertyMappers that convert objects. Usually they expect the source to be an object already and break if not.


### PR DESCRIPTION
This bugfix will make use of the `\JsonSerializable` interface instead directly when serializing properties for the neos ui.

With https://github.com/neos/flow-development-collection/pull/2762 native support for vo's in `flow_json_array` was introduced.

That also allows value object support for node properties, as they can be stored directly the node properties flow_json_array.

Unfortunately the property serialisation for the NeosUi does NOT use the expected `\JsonSerializable::jsonSerialize` but the property mapper and the `ArrayFromObjectConverter` for object types to get an array that will be json encoded.

This works mostly fine but in some cases it fails:
- when your `fromArray` fields and property names values dont match
- when a "object" subtypes the object mapper is no convertable like the `GuzzleHttp\Psr7\Uri`:

```
Too few arguments to function GuzzleHttp\Psr7\Uri::isAbsolute(), 0 passed in /core/neos-manufacture-highest/Packages/Framework/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php on line 151 and exactly 1 expected

72 GuzzleHttp\Psr7\Uri::isAbsolute()
71 Neos\Utility\ObjectAccess::getPropertyInternal(GuzzleHttp\Psr7\Uri, "absolute", false, true)
70 Neos\Utility\ObjectAccess::getGettableProperties(GuzzleHttp\Psr7\Uri)
69 Neos\Flow\Property\TypeConverter\ArrayFromObjectConverter_Original::getSourceChildPropertiesToBeConverted(GuzzleHttp\Psr7\Uri)
```

Current workarounds are aop:
https://github.com/sitegeist/Sitegeist.InspectorGadget/blob/78f5f4a206287b1c4bedf5cb88582ed51cb4a311/Classes/Infrastructure/NodeInfo/NodeInfoPostProcessingAspect.php#L17
Or to use a dumb property mapper:
https://github.com/sitegeist/Sitegeist.Archaeopteryx/blob/9322b9cb8e4824bcaf7aaa247c23b1244a2f1167/Classes/LinkToArrayForNeosUiConverter.php#L12C16-L12C78



<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
