### PR TITLE
BUGFIX: Fix `DocumentUriPathProjection` for newly created child nodes of disabled nodes

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -329,6 +329,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
                 'succeedingNodeAggregateId' => $event->succeedingNodeAggregateId?->value,
                 'shortcutTarget' => $shortcutTarget,
                 'nodeTypeName' => $event->nodeTypeName->value,
+                'disabled' => $parentNode->getDisableLevel(),
             ]);
         }
     }

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -32,10 +32,10 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the command CreateRootNodeAggregateWithNode is executed with payload:
-      | Key                         | Value                    |
-      | contentStreamId             | "cs-identifier"          |
-      | nodeAggregateId             | "lady-eleonode-rootford" |
-      | nodeTypeName                | "Neos.Neos:Sites"        |
+      | Key             | Value                    |
+      | contentStreamId | "cs-identifier"          |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
     And the graph projection is fully up to date
 
     # lady-eleonode-rootford
@@ -48,7 +48,7 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
     #
     And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                          | initialPropertyValues                    | nodeName |
+      | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues                    | nodeName |
       | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "ignore-me"}          | node1    |
       | sir-david-nodenborough | shernode-homes         | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "david-nodenborough"} | node2    |
       | duke-of-contentshire   | sir-david-nodenborough | Neos.Neos:Test.Routing.Content | {"uriPathSegment": "ignore-me"}          | node3    |
@@ -263,3 +263,24 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
     And The documenturipath projection is up to date
     Then No node should match URL "/nody/earl-document"
     And The node "leaf-mc-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/nody/earl-document/leaf"
+
+  Scenario: Add child node underneath disabled node and re-enable parent (see https://github.com/neos/neos-development-collection/issues/4639)
+    When the command "DisableNodeAggregate" is executed with payload:
+      | Key                          | Value              |
+      | contentStreamId              | "cs-identifier"    |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | coveredDimensionSpacePoint   | {}                 |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+    And the graph projection is fully up to date
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId        | parentNodeAggregateId | nodeTypeName                | initialPropertyValues            |
+      | nody-mc-nodeface-child | nody-mc-nodeface      | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "nody-child"} |
+    And The documenturipath projection is up to date
+    When the command "EnableNodeAggregate" is executed with payload:
+      | Key                          | Value              |
+      | contentStreamId              | "cs-identifier"    |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | coveredDimensionSpacePoint   | {}                 |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+    When I am on URL "/nody/nody-child"
+    Then the matched node should be "nody-mc-nodeface-child" in content stream "cs-identifier" and dimension "{}"


### PR DESCRIPTION
Fixes the `disabled` counter for newly created document nodes underneath disabled parents

## Background

Previously, new document nodes underneath disabled nodes did not inherit the "disabled level" of
the parent node leading to a `disabled` value of `0` in the database (even though it should be 1 or higher).

This led to an error when re-enabling the parent node:

```
 Numeric value out of range: 1690 BIGINT UNSIGNED value is out of range in '`neos_behat`.`cr_default_p_neos_documenturipath_uri`.`disabled` - 1
```

Fixes: #4639