### PR TITLE
BUGFIX: Remove unnecessary basemixins dependency for ContentReferences

### DIFF
--- a/Neos.NodeTypes.ContentReferences/composer.json
+++ b/Neos.NodeTypes.ContentReferences/composer.json
@@ -6,8 +6,7 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/neos": "self.version",
-        "neos/nodetypes-basemixins": "self.version"
+        "neos/neos": "self.version"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The package has no direct dependency to the basemixins and should be usable without the other basemixins.
