### PR TITLE
!!! TASK: Change default value for `body` of `Neos.Neos:Page` from `Neos.Fusion:Template` to `Neos.Fusion:Join`

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -741,12 +741,10 @@ into rendering a page; responsible for rendering the ``<html>`` tag and everythi
 :head.titleTag: (:ref:`Neos_Fusion__Tag`) The ``<title>`` tag
 :head.javascripts: (:ref:`Neos_Fusion__Join`) Script includes in the head should go here
 :head.stylesheets: (:ref:`Neos_Fusion__Join`) Link tags for stylesheets in the head should go here
-:body.templatePath: (string) Path to a fluid template for the page body
 :bodyTag: (:ref:`Neos_Fusion__Tag`) The opening ``<body>`` tag
 :bodyTag.attributes: (:ref:`Neos_Fusion__DataStructure`) Attributes for the ``<body>`` tag
-:body: (:ref:`Neos_Fusion__Template`) HTML markup for the ``<body>`` tag
+:body: (:ref:`Neos_Fusion__Join`) HTML markup for the ``<body>`` tag.
 :body.javascripts: (:ref:`Neos_Fusion__Join`) Body footer JavaScript includes
-:body.[key]: (mixed) Body template variables
 
 Examples:
 ^^^^^^^^^

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Page.fusion
@@ -68,15 +68,12 @@ prototype(Neos.Neos:Page) < prototype(Neos.Fusion:Http.Message) {
   }
 
   # Content of the body tag. To be defined by the integrator.
-  body = Neos.Fusion:Template {
+  body = Neos.Fusion:Join {
     @position = 'after bodyTag'
-    node = ${node}
-    site = ${site}
 
-    # Script includes before the closing body tag should go here
+    # Scripts before the closing body tag
     javascripts = Neos.Fusion:Join
-    # This processor appends the rendered javascripts Array to the rendered template
-    @process.appendJavaScripts = ${value + this.javascripts}
+    javascripts.@position = 'end 100'
   }
 
   closingBodyTag = '</body>'


### PR DESCRIPTION
The `body` of `Neos.Neos:Page` was by default initialized as a Template with assigned default values. Those defaults caused issues when the body was redefined as a different component or a Join. The PR adjusts the body to a `Neos.Fusion:Join` similar to the `head` of the page.

**Upgrade instructions**

If you need the old behavior you can create a version with the old behavior yourself.

```neosfusion
prototype(Vendor.Site:Page) < prototype(Neos.Neos:Page) {
  body = Neos.Fusion:Template {
    node = ${node}
    site = ${site}

    # Script includes before the closing body tag should go here
    javascripts = Neos.Fusion:Join
    # This processor appends the rendered javascripts Array to the rendered 
    @process.appendJavaScripts = ${value + this.javascripts}
  }
}
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
