### PR TITLE
TASK: Implement flowQuery `parents` operations via `findAncestors` instead of recursive do while

### DIFF
--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -11,6 +11,10 @@ namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
  * source code.
  */
 
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -65,26 +69,28 @@ class ParentsOperation extends AbstractOperation
      */
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
-        $parents = [];
+        $parents = Nodes::createEmpty();
+        $findAncestorNodesFilter = FindAncestorNodesFilter::create(
+            NodeTypeConstraints::create(
+                NodeTypeNames::createEmpty(),
+                NodeTypeNames::fromArray(
+                    [NodeTypeName::fromString('Neos.ContentRepository:Root')]
+                )
+            )
+        );
+
         /* @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
-            $node = $contextNode;
-            do {
-                $node = $this->contentRepositoryRegistry->subgraphForNode($node)
-                    ->findParentNode($node->nodeAggregateId);
-                if ($node === null) {
-                    // no parent found
-                    break;
-                }
-                // stop at sites
-                if ($node->nodeTypeName === NodeTypeName::fromString('Neos.Neos:Sites')) {
-                    break;
-                }
-                $parents[] = $node;
-            } while (true);
+            $ancestorNodes = $this->contentRepositoryRegistry
+                ->subgraphForNode($contextNode)
+                ->findAncestorNodes(
+                    $contextNode->nodeAggregateId,
+                    $findAncestorNodesFilter
+                );
+            $parents = $parents->merge($ancestorNodes);
         }
 
-        $flowQuery->setContext($parents);
+        $flowQuery->setContext(iterator_to_array($parents));
 
         if (isset($arguments[0]) && !empty($arguments[0])) {
             $flowQuery->pushOperation('filter', $arguments);


### PR DESCRIPTION
With this change the parents operation will be executed via single `findAncestors` instead of traversing up via each nodes parent.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
