### PR TITLE
FEATURE: Add additional factory methods `createWithAllowedNodeTypeNames` and `createWithDisallowedNodeTypeNames` to the nodeTypeConstraints.

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraints.php
@@ -56,18 +56,24 @@ final class NodeTypeConstraints
     ) {
     }
 
+    /**
+     * We recommended to call this method with named arguments to better
+     * understand the distinction between allowed and disallowed NodeTypeNames
+     */
     public static function create(
-        NodeTypeNames $explicitlyAllowedNodeTypeNames,
-        NodeTypeNames $explicitlyDisallowedNodeTypeNames
+        NodeTypeNames $allowed,
+        NodeTypeNames $disallowed
     ): self {
-        return new self($explicitlyAllowedNodeTypeNames, $explicitlyDisallowedNodeTypeNames);
+        return new self($allowed, $disallowed);
     }
 
-    public static function createWithAllowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self {
+    public static function createWithAllowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self
+    {
         return new self($nodeTypeNames, NodeTypeNames::createEmpty());
     }
 
-    public static function createWithDisallowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self {
+    public static function createWithDisallowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self
+    {
         return new self(NodeTypeNames::createEmpty(), $nodeTypeNames);
     }
 

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraints.php
@@ -63,6 +63,14 @@ final class NodeTypeConstraints
         return new self($explicitlyAllowedNodeTypeNames, $explicitlyDisallowedNodeTypeNames);
     }
 
+    public static function createWithAllowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self {
+        return new self($nodeTypeNames, NodeTypeNames::createEmpty());
+    }
+
+    public static function createWithDisallowedNodeTypeNames(NodeTypeNames $nodeTypeNames): self {
+        return new self(NodeTypeNames::createEmpty(), $nodeTypeNames);
+    }
+
     public static function fromFilterString(string $serializedFilters): self
     {
         $explicitlyAllowedNodeTypeNames = [];

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -71,8 +71,7 @@ class ParentsOperation extends AbstractOperation
     {
         $parents = Nodes::createEmpty();
         $findAncestorNodesFilter = FindAncestorNodesFilter::create(
-            NodeTypeConstraints::create(
-                NodeTypeNames::createEmpty(),
+            NodeTypeConstraints::createWithDisallowedNodeTypeNames(
                 NodeTypeNames::fromArray(
                     [NodeTypeName::fromString('Neos.ContentRepository:Root')]
                 )

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -72,7 +72,7 @@ class ParentsOperation extends AbstractOperation
         $parents = Nodes::createEmpty();
         $findAncestorNodesFilter = FindAncestorNodesFilter::create(
             NodeTypeConstraints::createWithDisallowedNodeTypeNames(
-                NodeTypeNames::fromStringArray(['Neos.ContentRepository:Root')])
+                NodeTypeNames::fromStringArray(['Neos.ContentRepository:Root'])
             )
         );
 

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -72,9 +72,7 @@ class ParentsOperation extends AbstractOperation
         $parents = Nodes::createEmpty();
         $findAncestorNodesFilter = FindAncestorNodesFilter::create(
             NodeTypeConstraints::createWithDisallowedNodeTypeNames(
-                NodeTypeNames::fromArray(
-                    [NodeTypeName::fromString('Neos.ContentRepository:Root')]
-                )
+                NodeTypeNames::fromStringArray(['Neos.ContentRepository:Root')])
             )
         );
 


### PR DESCRIPTION
This makes defining constraints easier forward as one does not have to specify empty constraints unused conditions.

In addition the arguments names of `nodeTypeConstraints::create` were shortened and the use via named arguments is recommended. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
