### PR TITLE
BUGFIX 4343 - Apply constraint checks to ChangeNodeAggregateName

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
@@ -21,27 +21,27 @@ Feature: Remove NodeAggregate
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
-      | Key                        | Value                |
-      | workspaceName              | "live"               |
-      | workspaceTitle             | "Live"               |
-      | workspaceDescription       | "The live workspace" |
-      | newContentStreamId | "cs-identifier"      |
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
     And I am in content stream "cs-identifier" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
-      | Key                     | Value                         |
+      | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
-      | nodeTypeName            | "Neos.ContentRepository:Root" |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName | tetheredDescendantNodeAggregateIds |
-      | sir-david-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | document | {"tethered":"nodewyn-tetherton"}           |
+      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document | {"tethered":"nodewyn-tetherton"}   |
 
   Scenario: Try to remove a node aggregate in a non-existing content stream
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                    |
-      | contentStreamId      | "i-do-not-exist"         |
-      | nodeAggregateId      | "sir-david-nodenborough" |
+      | contentStreamId              | "i-do-not-exist"         |
+      | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allVariants"            |
     Then the last command should have thrown an exception of type "ContentStreamDoesNotExistYet"
@@ -49,7 +49,7 @@ Feature: Remove NodeAggregate
   Scenario: Try to remove a non-existing node aggregate
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value             |
-      | nodeAggregateId      | "i-do-not-exist"  |
+      | nodeAggregateId              | "i-do-not-exist"  |
       | coveredDimensionSpacePoint   | {"language":"de"} |
       | nodeVariantSelectionStrategy | "allVariants"     |
     Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist"
@@ -57,7 +57,7 @@ Feature: Remove NodeAggregate
   Scenario: Try to remove a tethered node aggregate
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value               |
-      | nodeAggregateId      | "nodewyn-tetherton" |
+      | nodeAggregateId              | "nodewyn-tetherton" |
       | nodeVariantSelectionStrategy | "allVariants"       |
       | coveredDimensionSpacePoint   | {"language":"de"}   |
     Then the last command should have thrown an exception of type "TetheredNodeAggregateCannotBeRemoved"
@@ -65,23 +65,23 @@ Feature: Remove NodeAggregate
   Scenario: Try to remove a node aggregate in a non-existing dimension space point
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                       |
-      | nodeAggregateId      | "sir-david-nodenborough"    |
+      | nodeAggregateId              | "sir-david-nodenborough"    |
       | coveredDimensionSpacePoint   | {"undeclared": "undefined"} |
       | nodeVariantSelectionStrategy | "allVariants"               |
     Then the last command should have thrown an exception of type "DimensionSpacePointNotFound"
 
   Scenario: Try to remove a node aggregate in a dimension space point the node aggregate does not cover
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
-      | Key                          | Value                       |
-      | nodeAggregateId      | "sir-david-nodenborough"    |
-      | coveredDimensionSpacePoint   | {"language": "en"} |
-      | nodeVariantSelectionStrategy | "allVariants"               |
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"language": "en"}       |
+      | nodeVariantSelectionStrategy | "allVariants"            |
     Then the last command should have thrown an exception of type "NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint"
 
   Scenario: Try to remove a node aggregate using a non-existent removalAttachmentPoint
     When the command RemoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                    |
-      | nodeAggregateId      | "sir-david-nodenborough" |
+      | nodeAggregateId              | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"            |
       | coveredDimensionSpacePoint   | {"language":"de"}        |
       | removalAttachmentPoint       | "i-do-not-exist"         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/01_ChangeNodeAggregateName_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/01_ChangeNodeAggregateName_ConstraintChecks.feature
@@ -1,0 +1,73 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Change node name
+
+  As a user of the CR I want to change the name of a hierarchical relation between two nodes (e.g. in taxonomies)
+
+  These are the base test cases for the NodeAggregateCommandHandler to block invalid commands.
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content': []
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        tethered:
+          type: 'Neos.ContentRepository.Testing:Content'
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {}
+
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId        | nodeName | nodeTypeName                            | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds |
+      | sir-david-nodenborough | null     | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | {}                    | {"tethered": "nodewyn-tetherton"}  |
+      | nody-mc-nodeface       | occupied | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | {}                    | {}                                 |
+
+  Scenario: Try to rename a node aggregate in a non-existing content stream
+    When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
+      | Key             | Value                    |
+      | contentStreamId | "i-do-not-exist"         |
+      | nodeAggregateId | "sir-david-nodenborough" |
+      | newNodeName     | "new-name"               |
+    Then the last command should have thrown an exception of type "ContentStreamDoesNotExistYet"
+
+  Scenario: Try to rename a non-existing node aggregate
+    When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
+      | Key             | Value            |
+      | nodeAggregateId | "i-do-not-exist" |
+      | newNodeName     | "new-name"       |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist"
+
+  Scenario: Try to rename a root node aggregate
+    When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | newNodeName     | "new-name"               |
+    Then the last command should have thrown an exception of type "NodeAggregateIsRoot"
+
+  Scenario: Try to rename a tethered node aggregate
+    When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
+      | Key             | Value               |
+      | nodeAggregateId | "nodewyn-tetherton" |
+      | newNodeName     | "new-name"          |
+    Then the last command should have thrown an exception of type "NodeAggregateIsTethered"
+
+  Scenario: Try to rename a node aggregate using an already occupied name
+    When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
+      | Key             | Value              |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | newNodeName     | "tethered"         |
+    Then the last command should have thrown an exception of type "NodeNameIsAlreadyOccupied"

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/NodeRenaming.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/NodeRenaming.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\NodeRenaming;
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\Common\ConstraintChecks;


### PR DESCRIPTION
This resolves #4343

**Review instructions**

This adds constraint checks and the respective tests to ChangeNodeAggregateName command handling

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
