### PR TITLE
4610 - save thered nodes from disallowedChildnodes structure adjustments

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
@@ -1,0 +1,49 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Remove disallowed Child Nodes and grandchild nodes
+
+  As a user of the CR I want to be able to keep tethered child nodes although their type is not allowed below their parent
+
+  Scenario: Direct constraints
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root':
+      constraints:
+        nodeTypes:
+          '*': false
+          'Neos.ContentRepository.Testing:Document': true
+    'Neos.ContentRepository.Testing:Document':
+      constraints:
+        nodeTypes:
+          '*': false
+      childNodes:
+        tethered:
+          type: 'Neos.ContentRepository.Testing:AnotherDocument'
+
+    'Neos.ContentRepository.Testing:AnotherDocument': []
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
+    And the graph projection is fully up to date
+    And I am in content stream "cs-identifier" and dimension space point {}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId  | parentNodeAggregateId  | nodeTypeName                            |
+      | nody-mc-nodeface | lady-eleonode-rootford | Neos.ContentRepository.Testing:Document |
+
+    ########################
+    # Actual Test
+    ########################
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:AnotherDocument"

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
@@ -67,7 +67,8 @@ class DisallowedChildNodeAdjustment
                 if ($parentNode !== null) {
                     if ($this->nodeTypeManager->hasNodeType($parentNode->nodeTypeName)) {
                         $parentNodeType = $this->nodeTypeManager->getNodeType($parentNode->nodeTypeName);
-                        $allowedByParent = $parentNodeType->allowsChildNodeType($nodeType);
+                        $allowedByParent = $parentNodeType->allowsChildNodeType($nodeType)
+                            || $nodeAggregate->nodeName && $parentNodeType->hasTetheredNode($nodeAggregate->nodeName);
                     }
                 }
 


### PR DESCRIPTION
resolves #4610

This flags tethered children as allowed even if their types are not

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
