### PR TITLE
TASK: Static Node constructor

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -67,7 +67,7 @@ final class NodeFactory
             ? $this->nodeTypeManager->getNodeType($nodeRow['nodetypename'])
             : null;
 
-        return new Node(
+        return Node::create(
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
                 ContentStreamId::fromString($nodeRow['contentstreamid']),

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -75,7 +75,7 @@ final class NodeFactory
             ? $this->nodeTypeManager->getNodeType($nodeRow['nodetypename'])
             : null;
 
-        return new Node(
+        return Node::create(
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
                 $contentStreamId ?: ContentStreamId::fromString($nodeRow['contentstreamid']),

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -37,48 +37,35 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 final readonly class Node
 {
     /**
-     * @internal
+     * @param ContentSubgraphIdentity $subgraphIdentity This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}
+     * @param NodeAggregateId $nodeAggregateId NodeAggregateId (identifier) of this node. This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}
+     * @param OriginDimensionSpacePoint $originDimensionSpacePoint The DimensionSpacePoint the node originates in. Usually needed to address a Node in a NodeAggregate in order to update it.
+     * @param NodeAggregateClassification $classification The classification (regular, root, tethered) of this node
+     * @param NodeTypeName $nodeTypeName The node's node type name; always set, even if unknown to the NodeTypeManager
+     * @param NodeType|null $nodeType The node's node type, null if unknown to the NodeTypeManager - @deprecated Don't rely on this too much, as the capabilities of the NodeType here will probably change a lot; Ask the {@see NodeTypeManager} instead
+     * @param PropertyCollection $properties All properties of this node. References are NOT part of this API; To access references, {@see ContentSubgraphInterface::findReferences()} can be used; To read the serialized properties, call properties->serialized().
+     * @param NodeName|null $nodeName The optional name of this node {@see ContentSubgraphInterface::findChildNodeConnectedThroughEdgeName()}
+     * @param Timestamps $timestamps Creation and modification timestamps of this node
      */
-    public function __construct(
+    private function __construct(
         public ContentSubgraphIdentity $subgraphIdentity,
-        /**
-         * NodeAggregateId (identifier) of this node
-         * This is part of the node's "Read Model" identity, whis is defined by:
-         * - {@see getSubgraphIdentitity}
-         * - {@see getNodeAggregateId} (this method)
-         *
-         * With the above information, you can fetch a Subgraph using {@see ContentGraphInterface::getSubgraph()}.
-         * or {@see \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry::subgraphForNode()}
-         */
         public NodeAggregateId $nodeAggregateId,
-        /**
-         * returns the DimensionSpacePoint the node is at home in. Usually needed to address a Node in a NodeAggregate
-         * in order to update it.
-         */
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
         public NodeAggregateClassification $classification,
-        /**
-         * The node's node type name; always set, even if unknown to the NodeTypeManager
-         */
         public NodeTypeName $nodeTypeName,
-        /**
-         * The node's node type, null if unknown to the NodeTypeManager
-         * @deprecated Don't rely on this too much, as the capabilities of the NodeType here will probably change a lot;
-         * Ask the {@see NodeTypeManager} instead
-         */
         public ?NodeType $nodeType,
-        /**
-         * Returns all properties of this node. References are NOT part of this API;
-         * there you need to check getReference() and getReferences().
-         *
-         * To read the serialized properties, call properties->serialized().
-         *
-         * @param PropertyCollection $properties Property values, indexed by their name
-         */
         public PropertyCollection $properties,
         public ?NodeName $nodeName,
         public Timestamps $timestamps,
     ) {
+    }
+
+    /**
+     * @internal The signature of this method can change in the future!
+     */
+    public static function create(ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, Timestamps $timestamps): self
+    {
+        return new self($subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $timestamps);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -90,7 +90,7 @@ final class NodeSubjectProvider
             );
         }
         $serializedDefaultPropertyValues = SerializedPropertyValues::fromArray($defaultPropertyValues);
-        return new Node(
+        return Node::create(
             ContentSubgraphIdentity::create(
                 ContentRepositoryId::fromString('default'),
                 ContentStreamId::fromString('cs-id'),

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -156,7 +156,7 @@ class NodeHelperTest extends AbstractFusionObjectTest
 
         $now = new \DateTimeImmutable();
 
-        $this->textNode = new Node(
+        $this->textNode = Node::create(
             ContentSubgraphIdentity::create(
                 $contentRepositoryId,
                 ContentStreamId::fromString("cs"),


### PR DESCRIPTION
This is a follow-up to #4318 that makes the constructor of the `Node` read model private in favor of a new static `create` constructor.

Background:

Adding the `@internal` annotation to the constructor marked all promoted properties internal, too.
Additionally, a named constructor gives us more options to adjust this class without breaking changes