### PR TITLE
TASK: Ensure `Neos.Neos:*Menu` prototypes behave according to tests in Neos 9

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -44,7 +44,9 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
     protected function buildItems(): array
     {
         $menuItems = [];
-        $contentRepositoryId = $this->currentNode->subgraphIdentity->contentRepositoryId;
+        $currentNode = $this->getCurrentNode();
+
+        $contentRepositoryId = $currentNode->subgraphIdentity->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get(
             $contentRepositoryId,
         );
@@ -56,28 +58,28 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         assert($dimensionMenuItemsImplementationInternals instanceof DimensionsMenuItemsImplementationInternals);
 
         $interDimensionalVariationGraph = $dimensionMenuItemsImplementationInternals->interDimensionalVariationGraph;
-        $currentDimensionSpacePoint = $this->currentNode->subgraphIdentity->dimensionSpacePoint;
+        $currentDimensionSpacePoint = $currentNode->subgraphIdentity->dimensionSpacePoint;
         $contentDimensionIdentifierToLimitTo = $this->getContentDimensionIdentifierToLimitTo();
         foreach ($interDimensionalVariationGraph->getDimensionSpacePoints() as $dimensionSpacePoint) {
             $variant = null;
             if ($this->isDimensionSpacePointRelevant($dimensionSpacePoint)) {
                 if ($dimensionSpacePoint->equals($currentDimensionSpacePoint)) {
-                    $variant = $this->currentNode;
+                    $variant = $currentNode;
                 } else {
                     $variant = $contentRepository->getContentGraph()
                         ->getSubgraph(
-                            $this->currentNode->subgraphIdentity->contentStreamId,
+                            $currentNode->subgraphIdentity->contentStreamId,
                             $dimensionSpacePoint,
-                            $this->currentNode->subgraphIdentity->visibilityConstraints,
+                            $currentNode->subgraphIdentity->visibilityConstraints,
                         )
-                        ->findNodeById($this->currentNode->nodeAggregateId);
+                        ->findNodeById($currentNode->nodeAggregateId);
                 }
 
                 if (!$variant && $this->includeGeneralizations() && $contentDimensionIdentifierToLimitTo) {
                     $variant = $this->findClosestGeneralizationMatchingDimensionValue(
                         $dimensionSpacePoint,
                         $contentDimensionIdentifierToLimitTo,
-                        $this->currentNode->nodeAggregateId,
+                        $currentNode->nodeAggregateId,
                         $dimensionMenuItemsImplementationInternals,
                         $contentRepository
                     );

--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -176,7 +176,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
 
         $maximumLevels = $this->getMaximumLevels();
         $lastLevels = $this->getLastLevel();
-        if ($lastLevels !== 0) {
+        if ($lastLevels !== null) {
             $depthOfEntryParentNodeAggregateId = $subgraph->countAncestorNodes(
                 $entryParentNodeAggregateId,
                 CountAncestorNodesFilter::create(

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1103,7 +1103,11 @@ Menu with absolute uris:
 Neos.Neos:BreadcrumbMenuItems
 -----------------------------
 
-Create a list of of menu-items for a breadcrumb (ancestor documents), based on :ref:`Neos_Neos__MenuItems`.
+Create a list of of menu-items for the breadcrumb (ancestor documents).
+
+:maximumLevels: (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
+:renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
+:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
 
 Example::
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1006,6 +1006,7 @@ Render a breadcrumb (ancestor documents).
 
 The following properties are passed over to :ref:`Neos_Neos__BreadcrumbMenuItems` internally:
 
+:node: (Node) The current node to render the menu for. Defaults to ``documentNode`` from the fusion context
 :maximumLevels: (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
 :renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
 :calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
@@ -1032,6 +1033,7 @@ Create links to other node variants (e.g. variants of the current node in other 
 
 The following fusion properties are passed over to :ref:`Neos_Neos__DimensionsMenuItems` internally:
 
+:node: (Node) The current node used to calculate the Menu. Defaults to ``documentNode`` from the fusion context
 :dimension: (optional, string): name of the dimension which this menu should be based on. Example: "language".
 :presets: (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
 :includeAllPresets: (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
@@ -1131,6 +1133,7 @@ Neos.Neos:BreadcrumbMenuItems
 
 Create a list of of menu-items for the breadcrumb (ancestor documents).
 
+:node: (Node) The current node to render the menu for. Defaults to ``documentNode`` from the fusion context
 :maximumLevels: (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
 :renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
 :calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
@@ -1160,7 +1163,7 @@ If no node variant exists for the preset combination, a ``NULL`` node will be in
 
 Each ``item`` has the following properties:
 
-:node: (Node) A node instance (with resolved shortcuts) that should be used to link to the item
+:node: (Node) The current node used to calculate the Menu. Defaults to ``documentNode`` from the fusion context
 :state: (string) Menu state of the item: ``normal``, ``current`` (the current node), ``absent``
 :label: (string) Label of the item (the dimension preset label)
 :menuLevel: (integer) Menu level the item is rendered on

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -969,7 +969,18 @@ Neos.Neos:Menu
 Render a menu with items for nodes.
 
 :attributes: (:ref:`Neos_Fusion__DataStructure`) attributes for the whole menu
-:[key]: (mixed) all other fusion properties are passed over to :ref:`Neos_Neos__MenuItems` internally to calculate the `items`
+
+The following properties are passed over to :ref:`Neos_Neos__MenuItems` internally:
+
+:node: (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
+:entryLevel: (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
+:lastLevel: (optional, integer) Restrict the depth of the menu relatively. Positive values specify this as n levels below root. Negative values specify this as n steps up from ``node``. Defaults to ``null``
+:maximumLevels: (integer) Restrict the maximum depth of items in the menu (relative to ``entryLevel``)
+:startingPoint: (optional, Node) The node where the menu hierarchy starts. If not specified explicitly the startingPoint is calculated from (``node`` and ``entryLevel``), defaults to ``null``
+:filter: (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``. The filter is only used for fetching subItems and is ignored for determining the ``startingPoint``
+:renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered, defaults to ``false``
+:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``.
+:itemCollection: (optional, array of Nodes) Explicitly set the Node items for the menu (taking precedence over ``startingPoints`` and ``entryLevel`` and ``lastLevel``). The children for each ``Node`` will be fetched taking the ``maximumLevels`` property into account.
 
 Example::
 
@@ -991,8 +1002,13 @@ Neos.Neos:BreadcrumbMenu
 
 Render a breadcrumb (ancestor documents).
 
-:attributes: (:ref:`Neos_Fusion__DataStructure`) attributes for the whole menu
-:[key]: (mixed) all other fusion properties are passed over to :ref:`Neos_Neos__BreadcrumbMenuItems` internally
+:attributes: (:ref:`Neos_Fusion__DataStructure`) html attributes for the rendered list
+
+The following properties are passed over to :ref:`Neos_Neos__BreadcrumbMenuItems` internally:
+
+:maximumLevels: (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
+:renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
+:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
 
 Example::
 
@@ -1013,7 +1029,14 @@ Neos.Neos:DimensionsMenu
 Create links to other node variants (e.g. variants of the current node in other dimensions).
 
 :attributes: (:ref:`Neos_Fusion__DataStructure`) attributes for the whole menu
-:[key]: (mixed) all other fusion properties are passed over to :ref:`Neos_Neos__DimensionsMenuItems` internally
+
+The following fusion properties are passed over to :ref:`Neos_Neos__DimensionsMenuItems` internally:
+
+:dimension: (optional, string): name of the dimension which this menu should be based on. Example: "language".
+:presets: (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
+:includeAllPresets: (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
+:renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
+:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
 
 .. note:: The ``items`` of the ``DimensionsMenu`` are internally calculated with the prototype :ref:`Neos_Neos__DimensionsMenuMenuItems` which
    you can use directly aswell.
@@ -1037,15 +1060,17 @@ Neos.Neos:MenuItems
 
 Create a list of menu-items items for nodes.
 
-:entryLevel: (integer) Start the menu at the given depth
+:node: (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
+:entryLevel: (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
+:lastLevel: (optional, integer) Restrict the depth of the menu relatively. Positive values specify this as n levels below root. Negative values specify this as n steps up from ``node``. Defaults to ``null``
 :maximumLevels: (integer) Restrict the maximum depth of items in the menu (relative to ``entryLevel``)
-:startingPoint: (Node) The parent node of the first menu level (defaults to ``node`` context variable)
-:lastLevel: (integer) Restrict the menu depth by node depth (relative to site node)
-:filter: (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``
+:startingPoint: (optional, Node) The node where the menu hierarchy starts. If not specified explicitly the startingPoint is calculated from (``node`` and ``entryLevel``), defaults to ``null``
+:filter: (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``. The filter is only used for fetching subItems and is ignored for determining the ``startingPoint``
 :renderHiddenInIndex: (boolean) Whether nodes with ``hiddenInIndex`` should be rendered, defaults to ``false``
-:itemCollection: (array) Explicitly set the Node items for the menu (alternative to ``startingPoints`` and levels)
-:itemUriRenderer: (:ref:`Neos_Neos__NodeUri`) prototype to use for rendering the URI of each item
-:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
+:calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``.
+:itemCollection: (optional, array of Nodes) Explicitly set the Node items for the menu (taking precedence over ``startingPoints`` and ``entryLevel`` and ``lastLevel``). The children for each ``Node`` will be fetched taking the ``maximumLevels`` property into account.
+
+Note::
 
 MenuItems item properties:
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1056,6 +1081,7 @@ MenuItems item properties:
 :label: (string) Full label of the node
 :menuLevel: (integer) Menu level the item is rendered on
 :uri: (string) Frontend URI of the node
+:children: (array) array of ``MenuItem`` instances
 
 Examples:
 ^^^^^^^^^
@@ -1130,7 +1156,6 @@ If no node variant exists for the preset combination, a ``NULL`` node will be in
 :presets: (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
 :includeAllPresets: (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
 :renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
-:itemUriRenderer: (:ref:`Neos_Neos__NodeUri`) prototype to use for rendering the URI of each item
 :calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
 
 Each ``item`` has the following properties:

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
@@ -2,11 +2,15 @@
 #
 prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Fusion:Component) {
   attributes = Neos.Fusion:DataStructure
+  maximumLevels = 0
+  renderHiddenInIndex = false
+  calculateItemStates = false
 
   @private {
     items = Neos.Neos:BreadcrumbMenuItems {
-      @ignoreProperties = ${['attributes']}
-      @apply.props = ${props}
+      maximumLevels = ${props.maximumLevels}
+      renderHiddenInIndex = ${props.renderHiddenInIndex}
+      calculateItemStates = ${props.calculateItemStates}
     }
   }
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
@@ -1,6 +1,10 @@
 # Neos.Neos:BreadcrumbMenu provides a breadcrumb navigation based on menu items.
 #
 prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Fusion:Component) {
+
+  # (Node) The current node to render the menu for. Defaults to ``documentNode`` from the fusion context
+  node = ${documentNode}
+
   # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
 
@@ -15,6 +19,7 @@ prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Fusion:Component) {
 
   @private {
     items = Neos.Neos:BreadcrumbMenuItems {
+      node = ${props.node}
       maximumLevels = ${props.maximumLevels}
       renderHiddenInIndex = ${props.renderHiddenInIndex}
       calculateItemStates = ${props.calculateItemStates}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenu.fusion
@@ -1,9 +1,16 @@
 # Neos.Neos:BreadcrumbMenu provides a breadcrumb navigation based on menu items.
 #
 prototype(Neos.Neos:BreadcrumbMenu) < prototype(Neos.Fusion:Component) {
+  # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
+
+  # (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
   maximumLevels = 0
-  renderHiddenInIndex = false
+
+  # (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
+  renderHiddenInIndex = true
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``
   calculateItemStates = false
 
   @private {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,4 +1,8 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Fusion:Component) {
+
+  # (Node) The current node to render the menu for. Defaults to ``documentNode`` from the fusion context
+  node = ${documentNode}
+
   # (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
   maximumLevels = 0
 
@@ -10,6 +14,7 @@ prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Fusion:Component) {
 
   renderer = Neos.Fusion:Value {
     parentItems = Neos.Neos:MenuItems {
+      node = ${props.node}
       calculateItemStates = ${props.calculateItemStates}
       renderHiddenInIndex = ${props.renderHiddenInIndex}
       maximumLevels = ${props.maximumLevels}
@@ -17,6 +22,7 @@ prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Fusion:Component) {
     }
 
     currentItem = Neos.Neos:MenuItems {
+      node = ${props.node}
       calculateItemStates = ${props.calculateItemStates}
       renderHiddenInIndex = true
       maximumLevels = ${props.maximumLevels}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,6 +1,11 @@
 prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Fusion:Component) {
+  # (integer) Restrict the maximum depth of items in the menu, defaults to ``0``
   maximumLevels = 0
+
+  # (boolean) Whether nodes with ``hiddenInIndex`` should be rendered (the current documentNode is always included), defaults to ``false``.
   renderHiddenInIndex = true
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``
   calculateItemStates = false
 
   renderer = Neos.Fusion:Value {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/BreadcrumbMenuItems.fusion
@@ -1,19 +1,23 @@
-prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Neos:MenuItems) {
-    itemCollection = ${q(documentNode).parents('[instanceof Neos.Neos:Document]').get()}
-    maximumLevels = 0
+prototype(Neos.Neos:BreadcrumbMenuItems) < prototype(Neos.Fusion:Component) {
+  maximumLevels = 0
+  renderHiddenInIndex = true
+  calculateItemStates = false
 
-    @process {
-        // Show always the current node, event when it is hidden in index
-        addCurrent = Neos.Fusion:Value {
-            currentItem = Neos.Neos:MenuItems {
-                calculateItemStates = ${props.calculateItemStates}
-                renderHiddenInIndex = true
-                maximumLevels = 0
-                itemCollection = ${[documentNode]}
-            }
-            value = ${Array.concat(this.currentItem, value)}
-        }
-
-        reverseOrder = ${Array.reverse(value)}
+  renderer = Neos.Fusion:Value {
+    parentItems = Neos.Neos:MenuItems {
+      calculateItemStates = ${props.calculateItemStates}
+      renderHiddenInIndex = ${props.renderHiddenInIndex}
+      maximumLevels = ${props.maximumLevels}
+      itemCollection = ${Array.reverse(q(documentNode).parents('[instanceof Neos.Neos:Document]').get())}
     }
+
+    currentItem = Neos.Neos:MenuItems {
+      calculateItemStates = ${props.calculateItemStates}
+      renderHiddenInIndex = true
+      maximumLevels = ${props.maximumLevels}
+      itemCollection = ${[documentNode]}
+    }
+
+    value = ${Array.concat(this.parentItems, this.currentItem)}
+  }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
@@ -1,11 +1,31 @@
 # Neos.Neos:DimensionsMenu provides dimension (e.g. language) menu rendering
 prototype(Neos.Neos:DimensionsMenu) < prototype(Neos.Fusion:Component) {
+  # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
+
+  # (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
+  renderHiddenInIndex = true
+
+  # (optional, string): name of the dimension which this menu should be based on. Example: "language".
+  dimension = null
+
+  # (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
+  presets = null
+
+  # (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
+  includeAllPresets = false
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``
+  calculateItemStates = false
+
 
   @private {
     items = Neos.Neos:DimensionsMenuItems {
-      @ignoreProperties = ${['attributes']}
-      @apply.props = ${props}
+      renderHiddenInIndex = ${props.renderHiddenInIndex}
+      dimension = ${props.dimension}
+      presets = ${props.presets}
+      includeAllPresets = ${props.includeAllPresets}
+      calculateItemStates = ${props.calculateItemStates}
     }
   }
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenu.fusion
@@ -1,5 +1,8 @@
 # Neos.Neos:DimensionsMenu provides dimension (e.g. language) menu rendering
 prototype(Neos.Neos:DimensionsMenu) < prototype(Neos.Fusion:Component) {
+  # (Node) The current node to render the menu for. Defaults to ``documentNode`` from the fusion context
+  node = ${documentNode}
+
   # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
 
@@ -18,9 +21,9 @@ prototype(Neos.Neos:DimensionsMenu) < prototype(Neos.Fusion:Component) {
   # (boolean) activate the *expensive* calculation of item states defaults to ``false``
   calculateItemStates = false
 
-
   @private {
     items = Neos.Neos:DimensionsMenuItems {
+      node = ${props.node}
       renderHiddenInIndex = ${props.renderHiddenInIndex}
       dimension = ${props.dimension}
       presets = ${props.presets}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenuItems.fusion
@@ -1,15 +1,24 @@
-prototype(Neos.Neos:DimensionsMenuItems) < prototype(Neos.Neos:MenuItems)  {
- @class = 'Neos\\Neos\\Fusion\\DimensionsMenuItemsImplementation'
+prototype(Neos.Neos:DimensionsMenuItems) {
+  @class = 'Neos\\Neos\\Fusion\\DimensionsMenuItemsImplementation'
 
-  # if documents which are hidden in index should be rendered or not
+  # (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
   renderHiddenInIndex = true
 
-  # name of the dimension to use (optional)
+  # (optional, string): name of the dimension which this menu should be based on. Example: "language".
   dimension = null
 
-  # list of presets, if the default order should be overridden, only used with "dimension" set
+  # (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
   presets = null
 
-  # if true, items for all presets will be included, ignoring dimension constraints
+  # (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
   includeAllPresets = false
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``
+  calculateItemStates = false
+
+  // This property is used internally by `MenuItemsImplementation` to render each items uri.
+  // It can be modified to change behaviour for all rendered uris.
+  itemUriRenderer = Neos.Neos:NodeUri {
+    node = ${itemNode}
+  }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/DimensionsMenuItems.fusion
@@ -1,6 +1,9 @@
 prototype(Neos.Neos:DimensionsMenuItems) {
   @class = 'Neos\\Neos\\Fusion\\DimensionsMenuItemsImplementation'
 
+  # (Node) The current node. Defaults to ``node`` from the fusion context
+  node = ${documentNode}
+
   # (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
   renderHiddenInIndex = true
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
@@ -1,12 +1,48 @@
 # Neos.Neos:Menu provides basic menu rendering
 #
 prototype(Neos.Neos:Menu) < prototype(Neos.Fusion:Component) {
+  # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
+
+  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
+  node = ${node}
+
+  # (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
+  entryLevel = ${this.startingPoint ? 0 : 1}
+
+  # (optional, integer) Restrict the depth of the menu relatively. Positive values specify this as n levels below root. Negative values specify this as n steps up from ``node``. Defaults to ``null``
+  lastLevel = null
+
+  # (integer) Restrict the maximum depth of items in the menu (relative to ``entryLevel``)
+  maximumLevels = 2
+
+  # (optional, Node) The node where the menu hierarchy starts. If not specified explicitly the startingPoint is calculated from (``node`` and ``entryLevel``), defaults to ``null``
+  startingPoint = null
+
+  # (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``. The filter is only used for fetching subItems and is ignored for determining the ``startingPoint``
+  filter = 'Neos.Neos:Document'
+
+  # (boolean) Whether nodes with ``hiddenInIndex`` should be rendered, defaults to ``false``
+  renderHiddenInIndex = false
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``.
+  calculateItemStates = false
+
+  # (optional, array of Nodes) Explicitly set the Node items for the menu (taking precedence over ``startingPoints`` and ``entryLevel`` and ``lastLevel``). The children for each ``Node`` will be fetched taking the ``maximumLevels`` property into account.
+  itemCollection = null
+
 
   @private {
     items = Neos.Neos:MenuItems {
-      @ignoreProperties = ${['attributes']}
-      @apply.props = ${props}
+      node = ${props.node}
+      entryLevel = ${props.entryLevel}
+      lastLevel = ${props.lastLevel}
+      maximumLevels = ${props.maximumLevels}
+      startingPoint = ${props.startingPoint}
+      filter = ${props.filter}
+      renderHiddenInIndex = ${props.renderHiddenInIndex}
+      calculateItemStates = ${props.calculateItemStates}
+      itemCollection = ${props.itemCollection}
     }
   }
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Menu.fusion
@@ -4,8 +4,8 @@ prototype(Neos.Neos:Menu) < prototype(Neos.Fusion:Component) {
   # html attributes for the rendered list
   attributes = Neos.Fusion:DataStructure
 
-  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
-  node = ${node}
+  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``documentNode`` from the fusion context
+  node = ${documentNode}
 
   # (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
   entryLevel = ${this.startingPoint ? 0 : 1}

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
@@ -1,15 +1,32 @@
 prototype(Neos.Neos:MenuItems) {
   @class = 'Neos\\Neos\\Fusion\\MenuItemsImplementation'
 
+  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
   node = ${node}
+
+  # (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
   entryLevel = ${this.startingPoint ? 0 : 1}
-  maximumLevels = 2
-  startingPoint = null
+
+  # (optional, integer) Restrict the depth of the menu relatively. Positive values specify this as n levels below root. Negative values specify this as n steps up from ``node``. Defaults to ``null``
   lastLevel = null
+
+  # (integer) Restrict the maximum depth of items in the menu (relative to ``entryLevel``)
+  maximumLevels = 2
+
+  # (optional, Node) The node where the menu hierarchy starts. If not specified explicitly the startingPoint is calculated from (``node`` and ``entryLevel``), defaults to ``null``
+  startingPoint = null
+
+  # (string) Filter items by node type (e.g. ``'!My.Site:News,Neos.Neos:Document'``), defaults to ``'Neos.Neos:Document'``. The filter is only used for fetching subItems and is ignored for determining the ``startingPoint``
   filter = 'Neos.Neos:Document'
+
+  # (boolean) Whether nodes with ``hiddenInIndex`` should be rendered, defaults to ``false``
   renderHiddenInIndex = false
-  itemCollection = null
+
+  # (boolean) activate the *expensive* calculation of item states defaults to ``false``.
   calculateItemStates = false
+
+  # (optional, array of Nodes) Explicitly set the Node items for the menu (taking precedence over ``startingPoints`` and ``entryLevel`` and ``lastLevel``). The children for each ``Node`` will be fetched taking the ``maximumLevels`` property into account.
+  itemCollection = null
 
   // This property is used internally by `MenuItemsImplementation` to render each items uri.
   // It can be modified to change behaviour for all rendered uris.

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/MenuItems.fusion
@@ -1,8 +1,8 @@
 prototype(Neos.Neos:MenuItems) {
   @class = 'Neos\\Neos\\Fusion\\MenuItemsImplementation'
 
-  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``node`` from the fusion context
-  node = ${node}
+  # (Node) The current node used to calculate the itemStates, and ``startingPoint`` (if not defined explicitly). Defaults to ``documentNode`` from the fusion context
+  node = ${documentNode}
 
   # (integer) Define the startingPoint of the menu relatively. Non negative values specify this as n levels below root. Negative values are n steps up from ``node`` or ``startingPoint`` if defined. Defaults to ``1`` if no ``startingPoint`` is set otherwise ``0``
   entryLevel = ${this.startingPoint ? 0 : 1}

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -130,6 +130,22 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
 
     """
 
+  Scenario: MenuItems (default on home page)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems
+    }
+    """
+    And the Fusion context node is "a"
+    Then I expect the following Fusion rendering result:
+    """
+    a1. (1)
+    a1a* (2)
+    a1b (2)
+
+    """
+
   Scenario: MenuItems (maximumLevels = 3)
     When I execute the following Fusion code:
     """fusion
@@ -150,23 +166,19 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
 
     """
 
-#  NOTE: This scenario currently breaks because the actual output is empty
-#  Scenario: MenuItems (entryLevel = -5)
-#    When I execute the following Fusion code:
-#    """fusion
-#    test = Neos.Neos:Test.Menu {
-#      items = Neos.Neos:MenuItems {
-#        entryLevel = -5
-#      }
-#    }
-#    """
-#    Then I expect the following Fusion rendering result:
-#    """
-#    a1. (1)
-#    a1a* (2)
-#    a1b (2)
-#
-#    """
+  Scenario: MenuItems (entryLevel = -5)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems {
+        entryLevel = -5
+      }
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+
+    """
 
 
   Scenario: MenuItems (entryLevel = -1)
@@ -235,21 +247,19 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
 
     """
 
-# NOTE: This scenario currently breaks because the actual output is "a1., a1a*, a1b"
-#  Scenario: MenuItems (lastLevel = -5)
-#    When I execute the following Fusion code:
-#    """fusion
-#    test = Neos.Neos:Test.Menu {
-#      items = Neos.Neos:MenuItems {
-#        lastLevel = -5
-#      }
-#    }
-#    """
-#    Then I expect the following Fusion rendering result:
-#    """
-#    a1. (1)
-#
-#    """
+  Scenario: MenuItems (lastLevel = -5)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems {
+        lastLevel = -5
+      }
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+
+    """
 
   Scenario: MenuItems (lastLevel = -1)
     When I execute the following Fusion code:
@@ -285,21 +295,20 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
 
     """
 
-#  NOTE: This scenario currently breaks because the actual output is "a1., a1a*, a1b"
-#  Scenario: MenuItems (lastLevel = 1)
-#    When I execute the following Fusion code:
-#    """fusion
-#    test = Neos.Neos:Test.Menu {
-#      items = Neos.Neos:MenuItems {
-#        lastLevel = 1
-#      }
-#    }
-#    """
-#    Then I expect the following Fusion rendering result:
-#    """
-#    a1. (1)
-#
-#    """
+  Scenario: MenuItems (lastLevel = 1)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems {
+        lastLevel = 1
+      }
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    a1. (1)
+
+    """
 
   Scenario: MenuItems (filter non existing node type)
     When I execute the following Fusion code:
@@ -314,22 +323,21 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
     """
     """
 
-#  NOTE: This scenario currently breaks because the actual output is empty
-#  Scenario: MenuItems (filter = DocumentType1)
-#    When I execute the following Fusion code:
-#    """fusion
-#    test = Neos.Neos:Test.Menu {
-#      items = Neos.Neos:MenuItems {
-#        filter = 'Neos.Neos:Test.DocumentType1'
-#      }
-#    }
-#    """
-#    Then I expect the following Fusion rendering result:
-#    """
-#    a1. (1)
-#    a1b (2)
-#
-#    """
+  Scenario: MenuItems (filter = DocumentType1)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems {
+        filter = 'Neos.Neos:Test.DocumentType1'
+      }
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    a1. (1)
+    a1b (2)
+
+    """
 
   Scenario: MenuItems (filter = DocumentType2)
     When I execute the following Fusion code:
@@ -376,22 +384,21 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
     """
     """
 
-#  NOTE: This scenario currently breaks because the actual output is "a., a1., a1a*, a1b"
-#  Scenario: MenuItems (itemCollection document nodes)
-#    When I execute the following Fusion code:
-#    """fusion
-#    test = Neos.Neos:Test.Menu {
-#      items = Neos.Neos:MenuItems {
-#        itemCollection = ${q(site).filter('[instanceof Neos.Neos:Document]').get()}
-#      }
-#    }
-#    """
-#    Then I expect the following Fusion rendering result:
-#    """
-#    a (1)
-#    a1. (2)
-#
-#    """
+  Scenario: MenuItems (itemCollection document nodes)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.Menu {
+      items = Neos.Neos:MenuItems {
+        itemCollection = ${q(site).filter('[instanceof Neos.Neos:Document]').get()}
+      }
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    a. (1)
+    a1. (2)
+
+    """
 
   Scenario: MenuItems (startingPoint a1b1)
     When I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -507,27 +507,28 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
     </ul>
     """
 
-#  NOTE: This scenario currently breaks because the "breadcrumb" class attribute is missing and the item states are different than expected "active" vs "normal" for homepage
-#  Scenario: BreadcrumbMenu
-#    When I execute the following Fusion code:
-#    """fusion
-#    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
-#    include: resource://Neos.Neos/Private/Fusion/Root.fusion
-#
-#    test = Neos.Neos:BreadcrumbMenu {
-#      # calculate menu item state to get Neos < 9 behavior
-#      calculateItemStates = true
-#    }
-#    """
-#    Then I expect the following Fusion rendering result as HTML:
-#    """html
-#    <ul class="breadcrumb">
-#      <li class="normal">
-#        <a href="/" title="Neos.Neos:Test.DocumentType1">Neos.Neos:Test.DocumentType1</a>
-#      </li>
-#      <li class="active">
-#        <a href="/a1" title="Neos.Neos:Test.DocumentType1">Neos.Neos:Test.DocumentType1 (a1)</a>
-#      </li>
-#      <li class="current">Neos.Neos:Test.DocumentType2a</li>
-#    </ul>
-#    """
+  Scenario: BreadcrumbMenu
+    When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:BreadcrumbMenu {
+      # calculate menu item state to get Neos < 9 behavior
+      calculateItemStates = true
+    }
+    """
+    Then I expect the following Fusion rendering result as HTML:
+    """html
+    <ul>
+      <li class="active">
+        <a href="/" title="Neos.Neos:Site">Neos.Neos:Site</a>
+      </li>
+      <li class="active">
+        <a href="/a1" title="Neos.Neos:Test.DocumentType1">Neos.Neos:Test.DocumentType1</a>
+      </li>
+      <li class="current">
+        <a href="/a1/a1a" title="Neos.Neos:Test.DocumentType2a">Neos.Neos:Test.DocumentType2a</a>
+      </li>
+    </ul>
+    """


### PR DESCRIPTION
The Menu prototypes now behave according to the upmerged tests. 


With the following exceptions change the behavior:

- `node` is intialized with ``${documentNode}`` for all menus inestead of ``node``. This should work better if used inside a content

### Neos.Neos:Menu
- negative `entryLevel` (up from ``node``) which is greater than the current depth will yield an empty menu
-  negative `lastLevel` (up from ``node``) which is greater than the current depth will yield an empty menu

### Neos.Neos:BreadCrumbMenu
- The root document has the state `active` when `calculateItemStates` is set instead of `normal`
- The current document will have an url in the MenuItem.
- Other properties of `Neos.Neos:Menu` are not supported anymore as we do not inherit from Menu anymore

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
