### PR TITLE
TASK: Tweak dependency on neos/twitter-bootstrap

### DIFF
--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -12,6 +12,7 @@
         "neos/neos": "self.version",
         "neos/flow": "*",
         "neos/fluid-adaptor": "*",
+        "neos/twitter-bootstrap": "^3.0.6",
         "neos/utility-files": "*",
         "neos/utility-mediatypes": "*",
         "neos/error-messages": "*",

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -11,7 +11,6 @@
         "neos/flow": "~7.3.0",
         "neos/media-browser": "self.version",
         "neos/party": "*",
-        "neos/twitter-bootstrap": "*",
         "neos/content-repository": "self.version",
         "neos/fusion": "self.version",
         "neos/fusion-afx": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "gedmo/doctrine-extensions": "^3.5",
         "behat/transliterator": "~1.0",
         "neos/utility-unicode": "*",
+        "neos/twitter-bootstrap": "^3.0.6",
         "neos/utility-mediatypes": "*",
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
@@ -27,7 +28,6 @@
         "imagine/imagine": "*",
         "doctrine/dbal": "^2.8",
         "neos/party": "*",
-        "neos/twitter-bootstrap": "*",
         "neos/fusion-form": "^1.0 || ^2.0",
         "neos/form": "*",
         "neos/kickstarter": "~7.3.0"


### PR DESCRIPTION
- move the dependency from `neos/neos` to `neos/media-browser`
- change from `*` to `^3.0.6` (the first version allowing Neos 7.x)

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
