### PR TITLE
TASK: NodeController::show drop support for showInvisible

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -198,7 +198,7 @@ class NodeController extends ActionController
      * with unsafe requests from widgets or plugins that are rendered on the node
      * - For those the CSRF token is validated on the sub-request, so it is safe to be skipped here
      */
-    public function showAction(string $node, bool $showInvisible = false): void
+    public function showAction(string $node): void
     {
         $siteDetectionResult = SiteDetectionResult::fromRequest($this->request->getHttpRequest());
         $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);
@@ -208,15 +208,10 @@ class NodeController extends ActionController
             throw new NodeNotFoundException('The requested node isn\'t accessible to the current user', 1430218623);
         }
 
-        $visibilityConstraints = VisibilityConstraints::frontend();
-        if ($showInvisible && $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {
-            $visibilityConstraints = VisibilityConstraints::withoutRestrictions();
-        }
-
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
             $nodeAddress->contentStreamId,
             $nodeAddress->dimensionSpacePoint,
-            $visibilityConstraints
+            VisibilityConstraints::frontend()
         );
 
         $site = $this->nodeSiteResolvingService->findSiteNodeForNodeAddress(
@@ -231,7 +226,7 @@ class NodeController extends ActionController
 
         $nodeInstance = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
 
-        if (is_null($nodeInstance)) {
+        if ($nodeInstance === null) {
             throw new NodeNotFoundException('The requested node does not exist', 1596191460);
         }
 


### PR DESCRIPTION
This was a hidden feature in previous versions of Neos but was broken in various ways since years.

First of all I think we prevented live workspace with show invisible in other parts of the code in the first place.
There is also no route for this so you would have to know to use this as a GET argument. Could work apart from two further issues:

The check for backend policy access won't work in any installation with the Flowpack.FrontendLogin package as that prevents backend roles on the frontend (show) route, this is the case eg. for the demo site.

Even IF that is not the case and the conditions are successfully met, the showInvisible will work but the Fusion cache doesn't know about it, as cache identifiers currently do not contain visibility constraints, therefore this feature is dangerous as a visit from an authenticated user might store a cache entry with information that should not be visible to to the public.
