### PR TITLE
TASK: Cleanup usage of `NodeTypeConstraintsWithSubNodeTypes`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
+use Neos\ContentRepository\Core\NodeType\ConstraintCheck;
 use Neos\ContentRepository\Core\SharedModel\Exception\RootNodeAggregateDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
 use Neos\ContentRepository\Core\SharedModel\Exception\DimensionSpacePointIsNotYetOccupied;
@@ -216,18 +217,15 @@ trait ConstraintChecks
         if (is_null($propertyDeclaration)) {
             throw ReferenceCannotBeSet::becauseTheNodeTypeDoesNotDeclareIt($referenceName, $nodeTypeName);
         }
-        if (isset($propertyDeclaration['constraints']['nodeTypes'])) {
-            $nodeTypeConstraints = NodeTypeConstraintsWithSubNodeTypes::createFromNodeTypeDeclaration(
-                $propertyDeclaration['constraints']['nodeTypes'],
-                $this->getNodeTypeManager()
+
+        $constraints = $propertyDeclaration['constraints']['nodeTypes'] ?? [];
+
+        if (!ConstraintCheck::create($constraints)->isNodeTypeAllowed($nodeType)) {
+            throw ReferenceCannotBeSet::becauseTheConstraintsAreNotMatched(
+                $referenceName,
+                $nodeTypeName,
+                $nodeTypeNameInQuestion
             );
-            if (!$nodeTypeConstraints->matches($nodeTypeNameInQuestion)) {
-                throw ReferenceCannotBeSet::becauseTheConstraintsAreNotMatched(
-                    $referenceName,
-                    $nodeTypeName,
-                    $nodeTypeNameInQuestion
-                );
-            }
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/NodeType/ConstraintCheck.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/ConstraintCheck.php
@@ -6,14 +6,22 @@ namespace Neos\ContentRepository\Core\NodeType;
  * Performs node type constraint checks against a given set of constraints
  * @internal
  */
-class ConstraintCheck
+final readonly class ConstraintCheck
 {
     /**
-     * @param array<string,mixed> $constraints
+     * @param array<string,bool> $constraints
      */
-    public function __construct(
-        private readonly array $constraints
+    private function __construct(
+        private array $constraints
     ) {
+    }
+
+    /**
+     * @param array<string,bool> $constraints
+     */
+    public static function create(array $constraints): self
+    {
+        return new self($constraints);
     }
 
     public function isNodeTypeAllowed(NodeType $nodeType): bool

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
@@ -479,7 +479,7 @@ class NodeType
     public function allowsChildNodeType(NodeType $nodeType): bool
     {
         $constraints = $this->getConfiguration('constraints.nodeTypes') ?: [];
-        return (new ConstraintCheck($constraints))->isNodeTypeAllowed($nodeType);
+        return ConstraintCheck::create($constraints)->isNodeTypeAllowed($nodeType);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
@@ -260,7 +260,7 @@ class NodeTypeManager
 
         $constraints = Arrays::arrayMergeRecursiveOverrule($constraints, $childNodeConstraintConfiguration);
 
-        return (new ConstraintCheck($constraints))->isNodeTypeAllowed($nodeType);
+        return ConstraintCheck::create($constraints)->isNodeTypeAllowed($nodeType);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraintsWithSubNodeTypes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTypeConstraintsWithSubNodeTypes.php
@@ -33,50 +33,6 @@ final class NodeTypeConstraintsWithSubNodeTypes
     ) {
     }
 
-    /**
-     * @param array<string,bool> $nodeTypeDeclaration
-     */
-    public static function createFromNodeTypeDeclaration(
-        array $nodeTypeDeclaration,
-        NodeTypeManager $nodeTypeManager
-    ): self {
-        $wildCardAllowed = false;
-        $explicitlyAllowedNodeTypeNames = [];
-        $explicitlyDisallowedNodeTypeNames = [];
-        foreach ($nodeTypeDeclaration as $constraintName => $allowed) {
-            if ($constraintName === '*') {
-                $wildCardAllowed = $allowed;
-            } else {
-                if ($allowed) {
-                    $explicitlyAllowedNodeTypeNames[] = $constraintName;
-                } else {
-                    $explicitlyDisallowedNodeTypeNames[] = $constraintName;
-                }
-            }
-        }
-
-        return new self(
-            $wildCardAllowed,
-            self::expandByIncludingSubNodeTypes(
-                NodeTypeNames::fromStringArray($explicitlyAllowedNodeTypeNames),
-                $nodeTypeManager
-            ),
-            self::expandByIncludingSubNodeTypes(
-                NodeTypeNames::fromStringArray($explicitlyDisallowedNodeTypeNames),
-                $nodeTypeManager
-            )
-        );
-    }
-
-    public static function allowAll(): self
-    {
-        return new self(
-            true,
-            NodeTypeNames::createEmpty(),
-            NodeTypeNames::createEmpty(),
-        );
-    }
-
     public static function create(NodeTypeConstraints $nodeTypeConstraints, NodeTypeManager $nodeTypeManager): self
     {
         // in case there are no filters, we fall back to allowing every node type.
@@ -136,23 +92,5 @@ final class NodeTypeConstraintsWithSubNodeTypes
 
         // otherwise, we return $wildcardAllowed.
         return $this->isWildCardAllowed;
-    }
-
-    public function toFilterString(): string
-    {
-        $parts = [];
-        if ($this->isWildCardAllowed) {
-            $parts[] = '*';
-        }
-
-        foreach ($this->explicitlyDisallowedNodeTypeNames as $nodeTypeName) {
-            $parts[] = '!' . $nodeTypeName->value;
-        }
-
-        foreach ($this->explicitlyAllowedNodeTypeNames as $nodeTypeName) {
-            $parts[] = $nodeTypeName->value;
-        }
-
-        return implode(',', $parts);
     }
 }


### PR DESCRIPTION
The `NodeTypeConstraintsWithSubNodeTypes` is internal and should not be used outside of the corresponding sub package. We also use the `ConstraintCheck` helper for childnodes instead of expanding the types.

see also https://github.com/neos/neos-development-collection/pull/4551#discussion_r1368849813



<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
