### PR TITLE
FEATURE: Add ``PropertyValueCriteriaMatcher``

### DIFF
--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\Projection\ContentGraph\PropertyValue;
+
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueContains;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEndsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaMatcher;
+use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Neos\ContentRepository\TestSuite\Unit\NodeSubjectProvider;
+use PHPUnit\Framework\TestCase;
+
+class PropertyValueCriteriaMatcherTest extends TestCase
+{
+    protected PropertyCollection $propertyCollection;
+
+    public function setUp(): void
+    {
+        $subjectProvider = new NodeSubjectProvider();
+        $this->propertyCollection = new PropertyCollection(
+            SerializedPropertyValues::fromArray([
+                'nullProperty' => new SerializedPropertyValue(null, 'null'),
+                'stringProperty' => new SerializedPropertyValue('foo', 'string'),
+                'integerProperty' => new SerializedPropertyValue(123, 'int')
+            ]),
+            $subjectProvider->propertyConverter
+        );
+    }
+
+    public function andCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo');
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other');
+
+        yield 'both criteria are true' => [$trueCriterium, $trueCriterium, true];
+        yield 'first criterium is true' => [$trueCriterium, $falseCriterium, false];
+        yield 'last criterium is true' => [$falseCriterium, $trueCriterium, false];
+        yield 'both criteria are false' => [$falseCriterium, $falseCriterium, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider andCriteriaDataProvider
+     */
+    public function andCriteria(PropertyValueCriteriaInterface $criteriaA, PropertyValueCriteriaInterface $criteriaB, $expectation)
+    {
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                AndCriteria::create($criteriaA, $criteriaB)
+            )
+        );
+    }
+
+    public function negateCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo');
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other');
+
+        yield 'criterium is true' => [$trueCriterium, false];
+        yield 'criterium is false' => [$falseCriterium, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider negateCriteriaDataProvider
+     */
+    public function negateCriteria(PropertyValueCriteriaInterface $criteriaA, $expectation)
+    {
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                NegateCriteria::create($criteriaA)
+            )
+        );
+    }
+
+    public function orCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo');
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other');
+
+        yield 'both criteria are true' => [$trueCriterium, $trueCriterium, true];
+        yield 'first criterium is true' => [$trueCriterium, $falseCriterium, true];
+        yield 'last criterium is true' => [$falseCriterium, $trueCriterium, true];
+        yield 'both criteria are false' => [$falseCriterium, $falseCriterium, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider orCriteriaDataProvider
+     */
+    public function orCriteria(PropertyValueCriteriaInterface $criteriaA, PropertyValueCriteriaInterface $criteriaB, $expectation)
+    {
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                OrCriteria::create($criteriaA, $criteriaB)
+            )
+        );
+    }
+
+    public function containsCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" contains "foo"' => ['stringProperty', 'foo', true];
+        yield 'existing "stringProperty" contains "fo"' => ['stringProperty', 'fo', true];
+        yield 'existing "stringProperty" contains "oo"' => ['stringProperty', 'oo', true];
+        yield 'existing "stringProperty" does not contain "bar"' => ['foo', 'bar', false];
+        yield 'existing "integerProperty" does not contain "foo"' => ['integerProperty', 'foo', false];
+        yield 'not existing "otherProperty" does not contain "foo"' => ['otherProperty', 'foo', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider containsCriteriaDataProvider
+     */
+    public function containsCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueContains::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function valueEndsWithCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" ends with "o"' => ['stringProperty', 'o', true];
+        yield 'existing "stringProperty" ends with "foo"' => ['stringProperty', 'foo', true];
+        yield 'existing "stringProperty" does not end with "ffoo"' => ['stringProperty', 'ffoo', false];
+        yield 'existing "stringProperty" does not end with "bar"' => ['stringProperty', 'bar', false];
+        yield 'existing "integerProperty" does not end with "foo"' => ['integerProperty', 'foo', false];
+        yield 'not existing "otherProperty" does not end with "foo"' => ['otherProperty', 'foo', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider valueEndsWithCriteriaDataProvider
+     */
+    public function valueEndsWithCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueEndsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function equalsCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" equals "foo"' => ['stringProperty', 'foo', true];
+        yield 'existing "integerProperty" does equal 123' => ['integerProperty', 123, true];
+        yield 'existing "stringProperty" does not equal "bar"' => ['stringProperty', 'bar', false];
+        yield 'existing "stringProperty" does not equal 123' => ['stringProperty', 123, false];
+        yield 'existing "nullProperty" does not equal 123' => ['nullProperty', 123, false];
+        yield 'existing "stringProperty" does not equal empty string' => ['stringProperty', '', false];
+        yield 'existing "integerProperty" does not equal 0' => ['integerProperty', 0, false];
+        yield 'non existing "otherProperty" bar does not equal "foo"' => ['otherProperty', 'foo', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider equalsCriteriaDataProvider
+     */
+    public function equalsCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueEquals::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function greaterThanCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, true];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, true];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, false];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, false];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider greaterThanCriteriaDataProvider
+     */
+    public function greaterThanCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueGreaterThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function greaterThanOrEqualCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, true];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, true];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, true];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, false];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider greaterThanOrEqualCriteriaDataProvider
+     */
+    public function greaterThanOrEquelCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueGreaterThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function lessThanCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, false];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, false];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, false];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, true];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider lessThanCriteriaDataProvider
+     */
+    public function lessThanCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueLessThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function lessThanOrEqualCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, false];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, false];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, true];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, true];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider lessThanOrEqualCriteriaDataProvider
+     */
+    public function lessThanOrEqualCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueLessThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function valueStartsWithCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" starts with "f"' => ['stringProperty', 'f', true];
+        yield 'existing "stringProperty" starts with "foo"' => ['stringProperty', 'foo', true];
+        yield 'existing "stringProperty" does not start with "fooo"' => ['stringProperty', 'ffoo', false];
+        yield 'existing "stringProperty" does not start with "bar"' => ['stringProperty', 'bar', false];
+        yield 'existing "integerProperty" does not start with "foo"' => ['integerProperty', 'foo', false];
+        yield 'not existing "otherProperty" does not start with "foo"' => ['otherProperty', 'foo', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider valueStartsWithCriteriaDataProvider
+     */
+    public function valueStartsWithCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueStartsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
The property value criteria matcher accepts a ``PropertyValueCriteriaInterface`` and provides static methods to check wether a ``Node`` or a ``PropertyCollection`` matches those criteria. This allows to apply the same criteria that are usually handled by the database adapters to a list of nodes that are already read into php memory.

**Review instructions**

I tried to write this using match but was not able to achieve a readable result for the cases where first a property has to be read.

This should be reviewed carefully to ensure that we apply the same rules as the database drivers especially when property types do not match exactly and are casted.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
