### PR TITLE
BUGFIX: Prevent `DocumentUriPathProjection` replay to fail on unknown node types

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -713,7 +713,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
             return false;
         }
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
-        return $nodeType->isOfType(NodeTypeNameFactory::NAME_SITE);
+        return $nodeType->isOfType(NodeTypeNameFactory::forSite());
     }
 
     private function isDocumentNodeType(NodeTypeName $nodeTypeName): bool
@@ -724,7 +724,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
             return false;
         }
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
-        return $nodeType->isOfType(NodeTypeNameFactory::NAME_DOCUMENT);
+        return $nodeType->isOfType(NodeTypeNameFactory::forDocument());
     }
 
     private function isShortcutNodeType(NodeTypeName $nodeTypeName): bool
@@ -735,7 +735,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
             return false;
         }
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
-        return $nodeType->isOfType(NodeTypeNameFactory::NAME_SHORTCUT);
+        return $nodeType->isOfType(NodeTypeNameFactory::forShortcut());
     }
 
     private function tryGetNode(\Closure $closure): ?DocumentNodeInfo

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -537,8 +537,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
 
             if (
                 $node === null
-                || $this->nodeTypeManager->getNodeType($node->getNodeTypeName())
-                    ->isOfType(NodeTypeNameFactory::forSite())
+                || $this->isSiteNodeType($node->getNodeTypeName())
             ) {
                 // probably not a document node
                 continue;
@@ -706,10 +705,24 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
         return $node->getDisableLevel() - $parentDisabledLevel !== 0;
     }
 
+    private function isSiteNodeType(NodeTypeName $nodeTypeName): bool
+    {
+        // HACK: We consider the currently configured node type of the given node.
+        // This is a deliberate side effect of this projector!
+        if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
+            return false;
+        }
+        $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
+        return $nodeType->isOfType(NodeTypeNameFactory::NAME_SITE);
+    }
+
     private function isDocumentNodeType(NodeTypeName $nodeTypeName): bool
     {
         // HACK: We consider the currently configured node type of the given node.
         // This is a deliberate side effect of this projector!
+        if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
+            return false;
+        }
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
         return $nodeType->isOfType(NodeTypeNameFactory::NAME_DOCUMENT);
     }
@@ -718,6 +731,9 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
     {
         // HACK: We consider the currently configured node type of the given node.
         // This is a deliberate side effect of this projector!
+        if (!$this->nodeTypeManager->hasNodeType($nodeTypeName)) {
+            return false;
+        }
         $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
         return $nodeType->isOfType(NodeTypeNameFactory::NAME_SHORTCUT);
     }

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -1,0 +1,63 @@
+@flowEntities @contentrepository
+Feature: Basic routing functionality (match & resolve nodes with unknown types)
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Test.Routing.Page':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+
+    When the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                    |
+      | contentStreamId | "cs-identifier"          |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
+    And the graph projection is fully up to date
+
+  Scenario:
+    When the event NodeAggregateWithNodeWasCreated was published with payload:
+      | Key                         | Value                         |
+      | contentStreamId             | "cs-identifier"               |
+      | nodeAggregateId             | "shernode-homes"              |
+      | nodeTypeName                | "Neos.Neos:Test.Routing.Page" |
+      | parentNodeAggregateId       | "lady-eleonode-rootford"      |
+      | nodeAggregateClassification | "regular"                     |
+    And the event NodeAggregateWithNodeWasCreated was published with payload:
+      | Key                         | Value                                                                 |
+      | contentStreamId             | "cs-identifier"                                                       |
+      | nodeAggregateId             | "sir-david-nodenborough"                                              |
+      | nodeTypeName                | "Neos.Neos:Test.Routing.Page"                                         |
+      | parentNodeAggregateId       | "shernode-homes"                                                      |
+      | nodeAggregateClassification | "regular"                                                             |
+      | initialPropertyValues       | {"uriPathSegment": {"type": "string", "value": "david-nodenborough"}} |
+    And the event NodeAggregateWithNodeWasCreated was published with payload:
+      | Key                         | Value                                                           |
+      | contentStreamId             | "cs-identifier"                                                 |
+      | nodeAggregateId             | "unknown-nodetype"                                              |
+      | nodeTypeName                | "Neos.Neos:Test.Routing.NonExisting"                            |
+      | parentNodeAggregateId       | "shernode-homes"                                                |
+      | nodeAggregateClassification | "regular"                                                       |
+      | initialPropertyValues       | {"uriPathSegment": {"type": "string", "value": "non-existing"}} |
+    And The documenturipath projection is up to date
+    Then I expect the documenturipath table to contain exactly:
+      | uripath              | nodeaggregateidpath                                            | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
+      | ""                   | "lady-eleonode-rootford"                                       | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
+      | ""                   | "lady-eleonode-rootford/shernode-homes"                        | "shernode-homes"         | "lady-eleonode-rootford" | null                     | null                      | "Neos.Neos:Test.Routing.Page" |
+      | "david-nodenborough" | "lady-eleonode-rootford/shernode-homes/sir-david-nodenborough" | "sir-david-nodenborough" | "shernode-homes"         | null                     | null                      | "Neos.Neos:Test.Routing.Page" |


### PR DESCRIPTION
If a document node type was deleted, running `cr:replay` or `cr:replayall` would throw th error `The node type "Vendor.Site:Document.Deleted" is not available`.