### PR TITLE
TASK: Drop `provide` from template [skip ci]

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -13,7 +13,6 @@
   "suggest": {
   },
   "provide": {
-    "neos/contentrepositoryregistry-storageclient": "self.version"
   },
   "scripts": {
     "lint:phpcs-psr12": "../../bin/phpcs --colors --standard=PSR12 ./Neos.ContentGraph.DoctrineDbalAdapter/src ./Neos.ContentGraph.PostgreSQLAdapter/src ./Neos.ContentRepository.BehavioralTests/Classes ./Neos.ContentRepository.TestSuite/Classes ./Neos.ContentRepository.Core/Classes ./Neos.Neos/Classes",


### PR DESCRIPTION
… in favour of a change to the manifest merger (neos/BuildEssentials#70)

**Checklist**

- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
