### PR TITLE
FEATURE: Add ``PropertyValueCriteriaMatcher``

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueContains;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEndsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
+
+/**
+ * Performs property checks against a given set of constraints
+ *
+ * @internal
+ */
+final class PropertyValueCriteriaMatcher
+{
+    public static function matchesPropertyCollection(PropertyCollection $propertyCollection, PropertyValueCriteriaInterface $propertyValueCriteria): bool
+    {
+        switch (true) {
+            case $propertyValueCriteria instanceof AndCriteria:
+                return self::matchesPropertyCollection($propertyCollection, $propertyValueCriteria->criteria1) && self::matchesPropertyCollection($propertyCollection, $propertyValueCriteria->criteria2);
+            case $propertyValueCriteria instanceof OrCriteria:
+                return self::matchesPropertyCollection($propertyCollection, $propertyValueCriteria->criteria1) || self::matchesPropertyCollection($propertyCollection, $propertyValueCriteria->criteria2);
+            case $propertyValueCriteria instanceof NegateCriteria:
+                return !self::matchesPropertyCollection($propertyCollection, $propertyValueCriteria->criteria);
+            case $propertyValueCriteria instanceof PropertyValueContains:
+                $propertyValue = $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value;
+                if ($propertyValueCriteria->caseSensitive) {
+                    return is_string($propertyValue)
+                        ? str_contains($propertyValue, $propertyValueCriteria->value)
+                        : false;
+                } else {
+                    return is_string($propertyValue)
+                        ? str_contains(mb_strtolower($propertyValue), mb_strtolower($propertyValueCriteria->value))
+                        : false;
+                }
+            case $propertyValueCriteria instanceof PropertyValueEndsWith:
+                $propertyValue = $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value;
+                if ($propertyValueCriteria->caseSensitive) {
+                    return is_string($propertyValue)
+                        ? str_ends_with($propertyValue, $propertyValueCriteria->value)
+                        : false;
+                } else {
+                    return is_string($propertyValue)
+                        ? str_ends_with(mb_strtolower($propertyValue), mb_strtolower($propertyValueCriteria->value))
+                        : false;
+                }
+            case $propertyValueCriteria instanceof PropertyValueStartsWith:
+                $propertyValue = $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value;
+                if ($propertyValueCriteria->caseSensitive) {
+                    return is_string($propertyValue)
+                        ? str_starts_with($propertyValue, $propertyValueCriteria->value)
+                        : false;
+                } else {
+                    return is_string($propertyValue)
+                        ? str_starts_with(mb_strtolower($propertyValue), mb_strtolower($propertyValueCriteria->value))
+                        : false;
+                }
+            case $propertyValueCriteria instanceof PropertyValueEquals:
+                if (!$propertyCollection->serialized()->propertyExists($propertyValueCriteria->propertyName->value)) {
+                    return false;
+                }
+                $propertyValue = $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value;
+                if ($propertyValueCriteria->caseSensitive) {
+                    return $propertyValue == $propertyValueCriteria->value;
+                } else {
+                    return (is_string($propertyValue) ? mb_strtolower($propertyValue) : $propertyValue)
+                        == (is_string($propertyValueCriteria->value) ? mb_strtolower($propertyValueCriteria->value) : $propertyValueCriteria->value);
+                }
+            case $propertyValueCriteria instanceof PropertyValueGreaterThan:
+                return $propertyCollection->serialized()->propertyExists($propertyValueCriteria->propertyName->value)
+                    && $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value > $propertyValueCriteria->value;
+            case $propertyValueCriteria instanceof PropertyValueGreaterThanOrEqual:
+                return $propertyCollection->serialized()->propertyExists($propertyValueCriteria->propertyName->value)
+                    && $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value >= $propertyValueCriteria->value;
+            case $propertyValueCriteria instanceof PropertyValueLessThan:
+                return $propertyCollection->serialized()->propertyExists($propertyValueCriteria->propertyName->value)
+                    && $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value < $propertyValueCriteria->value;
+            case $propertyValueCriteria instanceof PropertyValueLessThanOrEqual:
+                return $propertyCollection->serialized()->propertyExists($propertyValueCriteria->propertyName->value)
+                    && $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value <= $propertyValueCriteria->value;
+            default:
+                throw new \InvalidArgumentException(sprintf('Invalid/unsupported property value criteria "%s"', get_debug_type($propertyValueCriteria)), 1679561073);
+        }
+    }
+
+    public static function matchesNode(Node $node, PropertyValueCriteriaInterface $propertyValueCriteria): bool
+    {
+        return static::matchesPropertyCollection($node->properties, $propertyValueCriteria);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
@@ -87,9 +87,9 @@ final class PropertyValueCriteriaMatcher
         }
         $propertyValue = $propertyCollection->serialized()->getProperty($propertyValueCriteria->propertyName->value)?->value;
         if ($propertyValueCriteria->caseSensitive) {
-            return $propertyValue == $propertyValueCriteria->value;
+            return $propertyValue === $propertyValueCriteria->value;
         }
-        return (is_string($propertyValue) ? mb_strtolower($propertyValue) : $propertyValue) == (is_string($propertyValueCriteria->value) ? mb_strtolower($propertyValueCriteria->value) : $propertyValueCriteria->value);
+        return (is_string($propertyValue) ? mb_strtolower($propertyValue) : $propertyValue) === (is_string($propertyValueCriteria->value) ? mb_strtolower($propertyValueCriteria->value) : $propertyValueCriteria->value);
     }
 
     public static function matchesNode(Node $node, PropertyValueCriteriaInterface $propertyValueCriteria): bool

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/PropertyValue/PropertyValueCriteriaMatcher.php
@@ -26,6 +26,11 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
  */
 final class PropertyValueCriteriaMatcher
 {
+    public static function matchesNode(Node $node, PropertyValueCriteriaInterface $propertyValueCriteria): bool
+    {
+        return static::matchesPropertyCollection($node->properties, $propertyValueCriteria);
+    }
+
     public static function matchesPropertyCollection(PropertyCollection $propertyCollection, PropertyValueCriteriaInterface $propertyValueCriteria): bool
     {
         return match ($propertyValueCriteria::class) {
@@ -90,10 +95,5 @@ final class PropertyValueCriteriaMatcher
             return $propertyValue === $propertyValueCriteria->value;
         }
         return (is_string($propertyValue) ? mb_strtolower($propertyValue) : $propertyValue) === (is_string($propertyValueCriteria->value) ? mb_strtolower($propertyValueCriteria->value) : $propertyValueCriteria->value);
-    }
-
-    public static function matchesNode(Node $node, PropertyValueCriteriaInterface $propertyValueCriteria): bool
-    {
-        return static::matchesPropertyCollection($node->properties, $propertyValueCriteria);
     }
 }

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -224,6 +224,8 @@ class PropertyValueCriteriaMatcherTest extends TestCase
         yield 'existing "stringProperty" does not equal empty string' => ['stringProperty', '', true, false];
         yield 'existing "integerProperty" does not equal 0' => ['integerProperty', 0, true, false];
         yield 'non existing "otherProperty" bar does not equal "foo"' => ['otherProperty', 'foo', true, false];
+        yield 'existing "stringProperty" does not equal true' => ['stringProperty', true, true, false];
+        yield 'existing "stringProperty" does not equal true (case insensitive)' => ['stringProperty', true, false, false];
     }
 
     /**

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -6,6 +6,7 @@ namespace Neos\ContentRepository\Core\Tests\Unit\Projection\ContentGraph\Propert
 
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
@@ -21,8 +22,8 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Cri
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaMatcher;
 use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
-use Neos\ContentRepository\TestSuite\Unit\NodeSubjectProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Serializer;
 
 class PropertyValueCriteriaMatcherTest extends TestCase
 {
@@ -37,10 +38,9 @@ class PropertyValueCriteriaMatcherTest extends TestCase
             'integerProperty' => new SerializedPropertyValue(123, 'int')
         ]);
 
-        $subjectProvider = new NodeSubjectProvider();
         $this->propertyCollection = new PropertyCollection(
             $this->serializedPropertyValues,
-            $subjectProvider->propertyConverter
+            new PropertyConverter(new Serializer())
         );
     }
 

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -27,16 +27,19 @@ use PHPUnit\Framework\TestCase;
 class PropertyValueCriteriaMatcherTest extends TestCase
 {
     protected PropertyCollection $propertyCollection;
+    protected SerializedPropertyValues $serializedPropertyValues;
 
     public function setUp(): void
     {
+        $this->serializedPropertyValues = SerializedPropertyValues::fromArray([
+            'nullProperty' => new SerializedPropertyValue(null, 'null'),
+            'stringProperty' => new SerializedPropertyValue('foo', 'string'),
+            'integerProperty' => new SerializedPropertyValue(123, 'int')
+        ]);
+
         $subjectProvider = new NodeSubjectProvider();
         $this->propertyCollection = new PropertyCollection(
-            SerializedPropertyValues::fromArray([
-                'nullProperty' => new SerializedPropertyValue(null, 'null'),
-                'stringProperty' => new SerializedPropertyValue('foo', 'string'),
-                'integerProperty' => new SerializedPropertyValue(123, 'int')
-            ]),
+            $this->serializedPropertyValues,
             $subjectProvider->propertyConverter
         );
     }
@@ -66,6 +69,14 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 AndCriteria::create($criteriaA, $criteriaB)
             )
         );
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                AndCriteria::create($criteriaA, $criteriaB)
+            )
+        );
     }
 
     public function negateCriteriaDataProvider(): \Generator
@@ -90,6 +101,14 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 NegateCriteria::create($criteriaA)
             )
         );
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                NegateCriteria::create($criteriaA)
+            )
+        );
     }
 
     public function orCriteriaDataProvider(): \Generator
@@ -109,11 +128,17 @@ class PropertyValueCriteriaMatcherTest extends TestCase
      */
     public function orCriteria(PropertyValueCriteriaInterface $criteriaA, PropertyValueCriteriaInterface $criteriaB, $expectation)
     {
-
         $this->assertSame(
             $expectation,
             PropertyValueCriteriaMatcher::matchesPropertyCollection(
                 $this->propertyCollection,
+                OrCriteria::create($criteriaA, $criteriaB)
+            )
+        );
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
                 OrCriteria::create($criteriaA, $criteriaB)
             )
         );
@@ -141,6 +166,17 @@ class PropertyValueCriteriaMatcherTest extends TestCase
             $expectedResult,
             PropertyValueCriteriaMatcher::matchesPropertyCollection(
                 $this->propertyCollection,
+                PropertyValueContains::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
                 PropertyValueContains::create(
                     PropertyName::fromString($propertyName),
                     $propertyValueToExpect,
@@ -179,6 +215,17 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 )
             )
         );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                PropertyValueStartsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
     }
 
     public function valueEndsWithCriteriaDataProvider(): \Generator
@@ -203,6 +250,17 @@ class PropertyValueCriteriaMatcherTest extends TestCase
             $expectedResult,
             PropertyValueCriteriaMatcher::matchesPropertyCollection(
                 $this->propertyCollection,
+                PropertyValueEndsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
                 PropertyValueEndsWith::create(
                     PropertyName::fromString($propertyName),
                     $propertyValueToExpect,
@@ -245,6 +303,17 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 )
             )
         );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                PropertyValueEquals::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
     }
 
     public function greaterThanCriteriaDataProvider(): \Generator
@@ -266,6 +335,16 @@ class PropertyValueCriteriaMatcherTest extends TestCase
             $expectedResult,
             PropertyValueCriteriaMatcher::matchesPropertyCollection(
                 $this->propertyCollection,
+                PropertyValueGreaterThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
                 PropertyValueGreaterThan::create(
                     PropertyName::fromString($propertyName),
                     $propertyValueToExpect
@@ -299,6 +378,16 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 )
             )
         );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                PropertyValueGreaterThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
     }
 
     public function lessThanCriteriaDataProvider(): \Generator
@@ -326,6 +415,16 @@ class PropertyValueCriteriaMatcherTest extends TestCase
                 )
             )
         );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
+                PropertyValueLessThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
     }
 
     public function lessThanOrEqualCriteriaDataProvider(): \Generator
@@ -347,6 +446,16 @@ class PropertyValueCriteriaMatcherTest extends TestCase
             $expectedResult,
             PropertyValueCriteriaMatcher::matchesPropertyCollection(
                 $this->propertyCollection,
+                PropertyValueLessThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesSerializedPropertyValues(
+                $this->serializedPropertyValues,
                 PropertyValueLessThanOrEqual::create(
                     PropertyName::fromString($propertyName),
                     $propertyValueToExpect

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\Projection\ContentGraph\PropertyValue;
+
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueContains;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEndsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaMatcher;
+use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Neos\ContentRepository\TestSuite\Unit\NodeSubjectProvider;
+use PHPUnit\Framework\TestCase;
+
+class PropertyValueCriteriaMatcherTest extends TestCase
+{
+    protected PropertyCollection $propertyCollection;
+
+    public function setUp(): void
+    {
+        $subjectProvider = new NodeSubjectProvider();
+        $this->propertyCollection = new PropertyCollection(
+            SerializedPropertyValues::fromArray([
+                'nullProperty' => new SerializedPropertyValue(null, 'null'),
+                'stringProperty' => new SerializedPropertyValue('foo', 'string'),
+                'integerProperty' => new SerializedPropertyValue(123, 'int')
+            ]),
+            $subjectProvider->propertyConverter
+        );
+    }
+
+    public function andCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo', true);
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other', true);
+
+        yield 'both criteria are true' => [$trueCriterium, $trueCriterium, true];
+        yield 'first criterium is true' => [$trueCriterium, $falseCriterium, false];
+        yield 'last criterium is true' => [$falseCriterium, $trueCriterium, false];
+        yield 'both criteria are false' => [$falseCriterium, $falseCriterium, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider andCriteriaDataProvider
+     */
+    public function andCriteria(PropertyValueCriteriaInterface $criteriaA, PropertyValueCriteriaInterface $criteriaB, $expectation)
+    {
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                AndCriteria::create($criteriaA, $criteriaB)
+            )
+        );
+    }
+
+    public function negateCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo',true);
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other', true);
+
+        yield 'criterium is true' => [$trueCriterium, false];
+        yield 'criterium is false' => [$falseCriterium, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider negateCriteriaDataProvider
+     */
+    public function negateCriteria(PropertyValueCriteriaInterface $criteriaA, $expectation)
+    {
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                NegateCriteria::create($criteriaA)
+            )
+        );
+    }
+
+    public function orCriteriaDataProvider(): \Generator
+    {
+        $trueCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'foo', true);
+        $falseCriterium = PropertyValueEquals::create(PropertyName::fromString('stringProperty'), 'other', true);
+
+        yield 'both criteria are true' => [$trueCriterium, $trueCriterium, true];
+        yield 'first criterium is true' => [$trueCriterium, $falseCriterium, true];
+        yield 'last criterium is true' => [$falseCriterium, $trueCriterium, true];
+        yield 'both criteria are false' => [$falseCriterium, $falseCriterium, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider orCriteriaDataProvider
+     */
+    public function orCriteria(PropertyValueCriteriaInterface $criteriaA, PropertyValueCriteriaInterface $criteriaB, $expectation)
+    {
+
+        $this->assertSame(
+            $expectation,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                OrCriteria::create($criteriaA, $criteriaB)
+            )
+        );
+    }
+
+    public function containsCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" contains "foo"' => ['stringProperty', 'foo', true, true];
+        yield 'existing "stringProperty" contains "Foo" (non case sensitive)' => ['stringProperty', 'Foo', false, true];
+        yield 'existing "stringProperty" contains "Foo" (case sensitive)' => ['stringProperty', 'Foo', true, false];
+        yield 'existing "stringProperty" contains "fo"' => ['stringProperty', 'fo', true, true];
+        yield 'existing "stringProperty" contains "oo"' => ['stringProperty', 'oo', true, true];
+        yield 'existing "stringProperty" does not contain "bar"' => ['foo', 'bar', true, false];
+        yield 'existing "integerProperty" does not contain "foo"' => ['integerProperty', 'foo', true, false];
+        yield 'not existing "otherProperty" does not contain "foo"' => ['otherProperty', 'foo', true, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider containsCriteriaDataProvider
+     */
+    public function containsCriteria(string $propertyName, mixed $propertyValueToExpect, bool $caseSensitive, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueContains::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+    }
+
+    public function valueStartsWithCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" starts with "f"' => ['stringProperty', 'f', true, true];
+        yield 'existing "stringProperty" starts with "foo"' => ['stringProperty', 'foo', true, true];
+        yield 'existing "stringProperty" starts with "Foo" (case insensitive)' => ['stringProperty', 'Foo', false, true];
+        yield 'existing "stringProperty" does not start with "Foo" (case sensitive)' => ['stringProperty', 'Foo', true, false];
+        yield 'existing "stringProperty" does not start with "fooo"' => ['stringProperty', 'ffoo', true, false];
+        yield 'existing "stringProperty" does not start with "bar"' => ['stringProperty', 'bar', true, false];
+        yield 'existing "integerProperty" does not start with "foo"' => ['integerProperty', 'foo', true, false];
+        yield 'not existing "otherProperty" does not start with "foo"' => ['otherProperty', 'foo', true, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider valueStartsWithCriteriaDataProvider
+     */
+    public function valueStartsWithCriteria(string $propertyName, mixed $propertyValueToExpect, bool $caseSensitive, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueStartsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+    }
+
+    public function valueEndsWithCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" ends with "o"' => ['stringProperty', 'o', true, true];
+        yield 'existing "stringProperty" ends with "foo"' => ['stringProperty', 'foo', true, true];
+        yield 'existing "stringProperty" ends with "Foo" (case insensitive)' => ['stringProperty', 'Foo', false, true];
+        yield 'existing "stringProperty" does not end with "Foo" (case sensitive)' => ['stringProperty', 'Foo', true, false];
+        yield 'existing "stringProperty" does not end with "ffoo"' => ['stringProperty', 'ffoo', true, false];
+        yield 'existing "stringProperty" does not end with "bar"' => ['stringProperty', 'bar', true, false];
+        yield 'existing "integerProperty" does not end with "foo"' => ['integerProperty', 'foo', true, false];
+        yield 'not existing "otherProperty" does not end with "foo"' => ['otherProperty', 'foo', true, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider valueEndsWithCriteriaDataProvider
+     */
+    public function valueEndsWithCriteria(string $propertyName, mixed $propertyValueToExpect, bool $caseSensitive, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueEndsWith::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+    }
+
+    public function equalsCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "stringProperty" equals "foo"' => ['stringProperty', 'foo', true, true];
+        yield 'existing "stringProperty" equals "Foo" (case insensitive)' => ['stringProperty', 'Foo', false, true];
+        yield 'existing "stringProperty" does not equal "Foo" (case sensitive)' => ['stringProperty', 'Foo', true, false];
+        yield 'existing "integerProperty" does equal 123' => ['integerProperty', 123, true, true];
+        yield 'existing "stringProperty" does not equal "bar"' => ['stringProperty', 'bar', true, false];
+        yield 'existing "stringProperty" does not equal 123' => ['stringProperty', 123, true, false];
+        yield 'existing "nullProperty" does not equal 123' => ['nullProperty', 123, true, false];
+        yield 'existing "stringProperty" does not equal empty string' => ['stringProperty', '', true, false];
+        yield 'existing "integerProperty" does not equal 0' => ['integerProperty', 0, true, false];
+        yield 'non existing "otherProperty" bar does not equal "foo"' => ['otherProperty', 'foo', true, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider equalsCriteriaDataProvider
+     */
+    public function equalsCriteria(string $propertyName, mixed $propertyValueToExpect, bool $caseSensitive, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueEquals::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect,
+                    $caseSensitive
+                )
+            )
+        );
+    }
+
+    public function greaterThanCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, true];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, true];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, false];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, false];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider greaterThanCriteriaDataProvider
+     */
+    public function greaterThanCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueGreaterThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function greaterThanOrEqualCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, true];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, true];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, true];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, false];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, false];
+    }
+
+    /**
+     * @test
+     * @dataProvider greaterThanOrEqualCriteriaDataProvider
+     */
+    public function greaterThanOrEquelCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueGreaterThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function lessThanCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, false];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, false];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, false];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, true];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider lessThanCriteriaDataProvider
+     */
+    public function lessThanCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueLessThan::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+
+    public function lessThanOrEqualCriteriaDataProvider(): \Generator
+    {
+        yield 'existing "integerProperty" is greater than 0' => ['integerProperty', 0, false];
+        yield 'existing "integerProperty" is greater than 122' => ['integerProperty', 122, false];
+        yield 'existing "integerProperty" is not greater than 123' => ['integerProperty', 123, true];
+        yield 'existing "integerProperty" is not greater than 124' => ['integerProperty', 124, true];
+        yield 'existing "integerProperty" is not greater than 999' => ['integerProperty', 999, true];
+    }
+
+    /**
+     * @test
+     * @dataProvider lessThanOrEqualCriteriaDataProvider
+     */
+    public function lessThanOrEqualCriteria(string $propertyName, mixed $propertyValueToExpect, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            PropertyValueCriteriaMatcher::matchesPropertyCollection(
+                $this->propertyCollection,
+                PropertyValueLessThanOrEqual::create(
+                    PropertyName::fromString($propertyName),
+                    $propertyValueToExpect
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
The property value criteria matcher accepts a ``PropertyValueCriteriaInterface`` and provides static methods to check wether a ``Node`` or a ``PropertyCollection`` matches those criteria. This allows to use PHP for filtering nodes that were already fetched using the cr-property criteria.

Notes:
- The ``PropertyValueCriteriaMatcher`` operates on the serialized values to be as close to the database operations as possible.
- The ``PropertyValueCriteriaMatcher`` is merked @internal for now as is the the `NodeType/ConstraintCheck` that does very similar things.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

The review should check carefully that the implementation is in line with the checks in the db-drivers. 

Also please note that i tried to write this as `match` statement but die not manage to get readable results for values that have to be read to a variable before checking.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
