### PR TITLE
TASK: Add tests for FlowQuery `nextUntil`, `prevUntil`, `siblings` and `find`

### DIFF
--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -271,3 +271,44 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     noFilter: a1a5,a1a6,a1a7
     withFilter: a1a5,a1a6
     """
+
+  Scenario: NextUntil
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      criteria = ${q(node).nextUntil('[instanceof Neos.Neos:Test.DocumentType1]').get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    criteria: a1a5,a1a6
+    """
+
+  Scenario: PrevUntil
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      criteria = ${q(node).prevUntil('[instanceof Neos.Neos:Test.DocumentType1]').get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    criteria: a1a2,a1a3
+    """
+
+  Scenario: Siblings
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      noFilter = ${q(node).siblings().get()}
+      withFilter = ${q(node).siblings('[instanceof Neos.Neos:Test.DocumentType1]').get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    noFilter: a1a1,a1a2,a1a3,a1a5,a1a6,a1a7
+    withFilter: a1a1,a1a7
+    """

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -312,3 +312,19 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     noFilter: a1a1,a1a2,a1a3,a1a5,a1a6,a1a7
     withFilter: a1a1,a1a7
     """
+
+  Scenario: Find
+    When the Fusion context node is "a1"
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      typeFilter = ${q(node).find('[instanceof Neos.Neos:Test.DocumentType2]').get()}
+      combinedFilter = ${q(node).find('[instanceof Neos.Neos:Test.DocumentType2][uriPathSegment*="b1"]').get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    typeFilter: a1a,a1b1a,a1a2,a1b2,a1a3,a1a4,a1a5,a1a6
+    combinedFilter: a1b1a
+    """


### PR DESCRIPTION
The tests of `nextUntil`, `prevUntil`, `siblings` and `find` that were still missing.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
