### PR TITLE
TASK: Fix and improve `find` and `children` flowQuery operation

### DIFF
--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteria.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteria.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeAccess\Filter;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+
+readonly class NodeFilterCriteria
+{
+    public function __construct(
+        public ?NodeTypeCriteria $nodeTypeCriteria = null,
+        public ?PropertyValueCriteriaInterface $propertyValueCriteria = null) {
+    }
+}

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteria.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteria.php
@@ -7,6 +7,9 @@ namespace Neos\ContentRepository\NodeAccess\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 
+/**
+ * @internal
+ */
 readonly class NodeFilterCriteria
 {
     public function __construct(

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
@@ -7,6 +7,7 @@ namespace Neos\ContentRepository\NodeAccess\Filter;
 use Traversable;
 
 /**
+ * @internal
  * @implements \IteratorAggregate<int, NodeFilterCriteria>
  */
 readonly class NodeFilterCriteriaGroup implements \IteratorAggregate

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
@@ -14,7 +14,7 @@ readonly class NodeFilterCriteriaGroup implements \IteratorAggregate
     /**
      * @var array<int, NodeFilterCriteria>
      */
-    protected array $criteria;
+    private array $criteria;
 
     public function __construct(NodeFilterCriteria ...$criteria)
     {

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
@@ -26,7 +26,7 @@ readonly class NodeFilterCriteriaGroup implements \IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->criteria);
+        yield from $this->criteria;
     }
 
 }

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroup.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeAccess\Filter;
+
+use Traversable;
+
+/**
+ * @implements \IteratorAggregate<int, NodeFilterCriteria>
+ */
+readonly class NodeFilterCriteriaGroup implements \IteratorAggregate
+{
+    /**
+     * @var array<int, NodeFilterCriteria>
+     */
+    protected array $criteria;
+
+    public function __construct(NodeFilterCriteria ...$criteria)
+    {
+        $this->criteria = array_values($criteria);
+    }
+
+    /**
+     * @return Traversable<int, NodeFilterCriteria>
+     */
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator($this->criteria);
+    }
+
+}

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroupFactory.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroupFactory.php
@@ -23,6 +23,9 @@ use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\Eel\FlowQuery\FizzleParser;
 use Neos\Utility\Arrays;
 
+/**
+ * @internal
+ */
 readonly class NodeFilterCriteriaGroupFactory
 {
     public static function createFromFizzleExpressionString (string $fizzleExpression): ?NodeFilterCriteriaGroup

--- a/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroupFactory.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/Filter/NodeFilterCriteriaGroupFactory.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeAccess\Filter;
+
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
+use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueContains;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEndsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Neos\Eel\FlowQuery\FizzleParser;
+use Neos\Utility\Arrays;
+
+readonly class NodeFilterCriteriaGroupFactory
+{
+    public static function createFromFizzleExpressionString (string $fizzleExpression): ?NodeFilterCriteriaGroup
+    {
+        // ensure absolute node pathes are ignored as the fizzle parser cannot handle those yet
+        // @todo remove once the parser can handle those
+        $parts = Arrays::trimExplode(',', $fizzleExpression);
+        foreach ($parts as $part) {
+            if (AbsoluteNodePath::patternIsMatchedByString($part)) {
+                return null;
+            }
+        }
+        $parsedFilter = FizzleParser::parseFilterGroup($fizzleExpression);
+        return self::createFromParsedFizzleExpression($parsedFilter);
+    }
+
+    /**
+     * @param mixed[] $parsedFizzleExpression
+     */
+    private static function createFromParsedFizzleExpression (array $parsedFizzleExpression): ?NodeFilterCriteriaGroup
+    {
+        $filterCriteria = [];
+        if (is_array($parsedFizzleExpression)
+            && array_key_exists('name', $parsedFizzleExpression) && $parsedFizzleExpression['name'] === 'FilterGroup'
+            && array_key_exists('Filters', $parsedFizzleExpression) && is_array($parsedFizzleExpression['Filters'])
+        ) {
+            foreach ($parsedFizzleExpression['Filters'] as $filter) {
+                // anything but AttributeFilters yield a null result
+                if (array_key_exists('PathFilter', $filter)
+                    || array_key_exists('PropertyNameFilter', $filter)
+                    || array_key_exists('IdentifierFilter', $filter)
+                ) {
+                    return null;
+                }
+                if (array_key_exists('AttributeFilters', $filter) && is_array ($filter['AttributeFilters'])) {
+
+                    $allowedNodeTypeNames = NodeTypeNames::createEmpty();
+                    $disallowedNodeTypeNames = NodeTypeNames::createEmpty();
+
+                    /**
+                     * @var PropertyValueCriteriaInterface[]
+                     */
+                    $propertyCriteria = [];
+                    foreach ($filter['AttributeFilters'] as $attributeFilter) {
+                        $propertyPath = $attributeFilter['PropertyPath'] ?? null;
+                        $operator = $attributeFilter['Operator'] ?? null;
+                        $operand = $attributeFilter['Operand'] ?? null;
+                        switch ($operator) {
+                            case 'instanceof':
+                                $allowedNodeTypeNames = $allowedNodeTypeNames->withAdditionalNodeTypeName(NodeTypeName::fromString($operand));
+                                break;
+                            case '!instanceof':
+                                $disallowedNodeTypeNames = $disallowedNodeTypeNames->withAdditionalNodeTypeName(NodeTypeName::fromString($operand));
+                                break;
+                            case '=':
+                                $propertyCriteria[] = PropertyValueEquals::create(PropertyName::fromString($propertyPath), $operand, true);
+                                break;
+                            case '!=':
+                                $propertyCriteria[] = NegateCriteria::create(PropertyValueEquals::create(PropertyName::fromString($propertyPath), $operand, true));
+                                break;
+                            case '^=':
+                                $propertyCriteria[] = PropertyValueStartsWith::create(PropertyName::fromString($propertyPath), $operand, true);
+                                break;
+                            case '$=':
+                                $propertyCriteria[] = PropertyValueEndsWith::create(PropertyName::fromString($propertyPath), $operand, true);
+                                break;
+                            case '*=':
+                                $propertyCriteria[] = PropertyValueContains::create(PropertyName::fromString($propertyPath), $operand, true);
+                                break;
+                            case '=~':
+                                $propertyCriteria[] = PropertyValueEquals::create(PropertyName::fromString($propertyPath), $operand, false);
+                                break;
+                            case '!=~':
+                                $propertyCriteria[] = NegateCriteria::create(PropertyValueEquals::create(PropertyName::fromString($propertyPath), $operand, false));
+                                break;
+                            case '^=~':
+                                $propertyCriteria[] = PropertyValueStartsWith::create(PropertyName::fromString($propertyPath), $operand, false);
+                                break;
+                            case '$=~':
+                                $propertyCriteria[] = PropertyValueEndsWith::create(PropertyName::fromString($propertyPath), $operand, false);
+                                break;
+                            case '*=~':
+                                $propertyCriteria[] = PropertyValueContains::create(PropertyName::fromString($propertyPath), $operand, false);
+                                break;
+                            case '>':
+                                $propertyCriteria[] = PropertyValueGreaterThan::create(PropertyName::fromString($propertyPath), $operand);
+                                break;
+                            case '>=':
+                                $propertyCriteria[] = PropertyValueGreaterThanOrEqual::create(PropertyName::fromString($propertyPath), $operand);
+                                break;
+                            case '<':
+                                $propertyCriteria[] = PropertyValueLessThan::create(PropertyName::fromString($propertyPath), $operand);
+                                break;
+                            case '<=':
+                                $propertyCriteria[] = PropertyValueLessThanOrEqual::create(PropertyName::fromString($propertyPath), $operand);
+                                break;
+                            default:
+                                return null;
+                        }
+                    }
+
+                    if (count($propertyCriteria) > 1) {
+                        $propertyCriteriaCombined = array_shift($propertyCriteria);
+                        while ($other = array_shift($propertyCriteria)) {
+                            $propertyCriteriaCombined = AndCriteria::create($propertyCriteriaCombined, $other);
+                        }
+                    } elseif (count($propertyCriteria) == 1) {
+                        $propertyCriteriaCombined = $propertyCriteria[0];
+                    } else {
+                        $propertyCriteriaCombined = null;
+                    }
+
+                    $filterCriteria[] = new NodeFilterCriteria(
+                        ($allowedNodeTypeNames->isEmpty() && $disallowedNodeTypeNames->isEmpty()) ? null : NodeTypeCriteria::create($allowedNodeTypeNames, $disallowedNodeTypeNames),
+                        $propertyCriteriaCombined
+                    );
+                } else {
+                    return null;
+                }
+            }
+            return new NodeFilterCriteriaGroup(...$filterCriteria);
+        }
+        return null;
+    }
+}

--- a/Neos.ContentRepository.NodeAccess/Tests/Unit/Filter/NodeFilterCriteriaGroupFactoryTest.php
+++ b/Neos.ContentRepository.NodeAccess/Tests/Unit/Filter/NodeFilterCriteriaGroupFactoryTest.php
@@ -1,0 +1,147 @@
+<?php
+namespace Neos\ContentRepository\NodeAccess\Tests\Unit\Filter;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\AndCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\NegateCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueContains;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEndsWith;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Neos\ContentRepository\NodeAccess\Filter\NodeFilterCriteria;
+use Neos\ContentRepository\NodeAccess\Filter\NodeFilterCriteriaGroup;
+use Neos\ContentRepository\NodeAccess\Filter\NodeFilterCriteriaGroupFactory;
+use Neos\Eel\FlowQuery\FizzleParser;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Abstract base class for the Query Operation tests
+ */
+class NodeFilterCriteriaGroupFactoryTest extends UnitTestCase
+{
+
+    public function nodeFilterCriteriaGroupFactoryDataProvider(): \Generator
+    {
+        yield 'single InstanceOf' => ['[instanceof Foo:Bar]', [["types" => "Foo:Bar", "properties" => ""]]];
+        yield 'single NotInstanceOf' => ['[!instanceof Foo:Bar]', [["types" => "!Foo:Bar", "properties" => ""]]];
+        yield 'instanceOf OR combination' => ['[instanceof Foo:Bar],[instanceof Foo:Baz]', [["types" => "Foo:Bar", "properties" => ""], ["types" => "Foo:Baz", "properties" => ""]]];
+        yield 'instanceOf AND combination' => ['[instanceof Foo:Bar][instanceof Foo:Baz]', [["types" => "Foo:Bar,Foo:Baz", "properties" => ""]]];
+        yield 'notInstanceOf OR combination' => ['[instanceof Foo:Bar],[!instanceof Foo:Baz]', [["types" => "Foo:Bar", "properties" => ""], ["types" => "!Foo:Baz", "properties" => ""]]];
+        yield 'notInstanceOf AND combination' => ['[instanceof Foo:Bar][!instanceof Foo:Baz]', [["types" => "Foo:Bar,!Foo:Baz", "properties" => ""]]];
+
+        yield 'single PropertyEquals filter (case sensitive)' => ['[foo="bar"]', [["types" => "", "properties" => "foo=bar"]]];
+        yield 'single PropertyEquals filter (case insensitive)' => ['[foo=~"bar"]', [["types" => "", "properties" => "foo=~bar"]]];
+        yield 'single PropertyNotEquals filter (case sensitive)' => ['[foo!="bar"]', [["types" => "", "properties" => "!(foo=bar)"]]];
+        yield 'single PropertyNotEquals filter (case insensitive)' => ['[foo!=~"bar"]', [["types" => "", "properties" => "!(foo=~bar)"]]];
+        yield 'single PropertyContains filter (case sensitive)' => ['[foo*="bar"]', [["types" => "", "properties" => "foo*=bar"]]];
+        yield 'single PropertyContains filter (case insensitive)' => ['[foo*=~"bar"]', [["types" => "", "properties" => "foo*=~bar"]]];
+        yield 'single PropertyStartsWith filter (case sensitive)' => ['[foo^="bar"]', [["types" => "", "properties" => "foo^=bar"]]];
+        yield 'single PropertyStartsWith filter (case insensitive)' => ['[foo^=~"bar"]', [["types" => "", "properties" => "foo^=~bar"]]];
+        yield 'single PropertyEndsWith filter (case sensitive)' => ['[foo$="bar"]', [["types" => "", "properties" => "foo$=bar"]]];
+        yield 'single PropertyEndsWith filter (case insensitive)' => ['[foo$=~"bar"]', [["types" => "", "properties" => "foo$=~bar"]]];
+
+        yield 'single PropertyGreaterThan filter' => ['[foo > 123]', [["types" => "", "properties" => "foo>123"]]];
+        yield 'single PropertyGreaterThanOrEqual filter' => ['[foo >= 123]', [["types" => "", "properties" => "foo>=123"]]];
+        yield 'single PropertyLessThan filter ' => ['[foo < 123]', [["types" => "", "properties" => "foo<123"]]];
+        yield 'single PropertyLessThanOrEqual filter' => ['[foo <= 123]', [["types" => "", "properties" => "foo<=123"]]];
+
+        yield 'multiple Property AND filter' => ['[foo="bar"][bar="baz"]', [["types" => "", "properties" => "(foo=bar&&bar=baz)"]]];
+        yield 'multiple Property OR filter' => ['[foo="bar"],[bar="baz"]', [["types" => "", "properties" => "foo=bar"], ["types" => "", "properties" => "bar=baz"]]];
+
+        yield 'combination of Property AND NodeTypeFilter' => ['[instanceof Foo:Bar][bar="baz"]', [["types" => "Foo:Bar", "properties" => "bar=baz"]]];
+        yield 'combination of Property OR NodeTypeFilter' => ['[instanceof Foo:Bar],[bar="baz"]', [["types" => "Foo:Bar", "properties" => ""], ["types" => "", "properties" => "bar=baz"]]];
+    }
+
+    /**
+     * @dataProvider nodeFilterCriteriaGroupFactoryDataProvider
+     */
+    public function testNodeFilterCriteriaGroupFactory(string $fizzleExpresssion, array $expectation): void
+    {
+        $nodeFilterCriteria = NodeFilterCriteriaGroupFactory::createFromFizzleExpressionString($fizzleExpresssion);
+        $this->assertInstanceOf(NodeFilterCriteriaGroup::class, $nodeFilterCriteria);
+        $this->assertSame($expectation, self::nodeFilterCriteriaGroupToArray($nodeFilterCriteria));
+    }
+
+    public function nodeFilterCriteriaGroupIsNotCreatedForUnknownFiltersDataProvider(): \Generator
+    {
+        yield 'absolute node path' => ['/<Neos.Neos:Sites>/foo/bar'];
+        yield 'relative node path' => ['foo/bar/baz'];
+        yield 'node id' => ['#4d39e8b8-cd05-49ca-bd64-5efc4ea176e9'];
+
+        yield 'mixture of valid and invalid parts' => ['[instanceof Foo:Bar],/<Neos.Neos:Sites>/foo/baz'];
+        yield 'multiple pathes' => ['foo/bar/baz, bar/baz/bam'];
+        yield 'multiple ids' => ['#4d39e8b8-cd05-49ca-bd64-5efc4ea176e9,#4d39e8b8-cd05-49ca-bd64-5efc4ea17619'];
+    }
+
+    /**
+     * @dataProvider nodeFilterCriteriaGroupIsNotCreatedForUnknownFiltersDataProvider
+     */
+    public function testNodeFilterCriteriaGroupIsNotCreatedForUnknownFilters(string $fizzleExpresssion): void
+    {
+        $nodeFilterCriteria = NodeFilterCriteriaGroupFactory::createFromFizzleExpressionString($fizzleExpresssion);
+        $this->assertNull( $nodeFilterCriteria);
+    }
+
+    private static function nodeFilterCriteriaGroupToArray(NodeFilterCriteriaGroup $criteriaGroup): array
+    {
+        return array_map(
+            fn(NodeFilterCriteria $criteria) => self::nodeFilterCriteriaToArray($criteria),
+            iterator_to_array($criteriaGroup->getIterator())
+        );
+    }
+
+    private static function nodeFilterCriteriaToArray(NodeFilterCriteria $criteria): array
+    {
+        return [
+            'types' => $criteria->nodeTypeCriteria ? self::nodeTypeCriteriaToString( $criteria->nodeTypeCriteria) : '',
+            'properties' => $criteria->propertyValueCriteria ? self::propertyValueCriteriaToString($criteria->propertyValueCriteria): ''
+        ];
+    }
+
+    private static function nodeTypeCriteriaToString(NodeTypeCriteria $criteria): string
+    {
+        $resultParts = [];
+        foreach($criteria->explicitlyAllowedNodeTypeNames as $allowedNodeTypeName) {
+            $resultParts[] = $allowedNodeTypeName->value;
+        }
+        foreach($criteria->explicitlyDisallowedNodeTypeNames as $disallowedNodeTypeName) {
+            $resultParts[] = '!' . $disallowedNodeTypeName->value;
+        }
+        return implode(',', $resultParts);
+    }
+
+    private static function propertyValueCriteriaToString(PropertyValueCriteriaInterface $criteria): string
+    {
+        return match ($criteria::class) {
+            AndCriteria::class => '(' . self::propertyValueCriteriaToString($criteria->criteria1)  . '&&' .  self::propertyValueCriteriaToString($criteria->criteria2) . ')',
+            OrCriteria::class => '(' . self::propertyValueCriteriaToString($criteria->criteria1)  . '||' .  self::propertyValueCriteriaToString($criteria->criteria2) . ')',
+            NegateCriteria::class => '!(' . self::propertyValueCriteriaToString($criteria->criteria) . ')',
+            PropertyValueStartsWith::class => $criteria->propertyName->value . '^=' . ($criteria->caseSensitive ? '' : '~') . $criteria->value,
+            PropertyValueEndsWith::class => $criteria->propertyName->value . '$=' . ($criteria->caseSensitive ? '' : '~') . $criteria->value,
+            PropertyValueContains::class => $criteria->propertyName->value . '*=' . ($criteria->caseSensitive ? '' : '~') . $criteria->value,
+            PropertyValueEquals::class => $criteria->propertyName->value . '=' . ($criteria->caseSensitive ? '' : '~') . $criteria->value,
+            PropertyValueGreaterThan::class => $criteria->propertyName->value . '>' . $criteria->value,
+            PropertyValueLessThan::class => $criteria->propertyName->value . '<' . $criteria->value,
+            PropertyValueGreaterThanOrEqual::class => $criteria->propertyName->value . '>=' . $criteria->value,
+            PropertyValueLessThanOrEqual::class => $criteria->propertyName->value . '<=' . $criteria->value,
+            default => throw new \InvalidArgumentException('type ' . $criteria::class . ' was not hancled'())
+        };
+    }
+}

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -352,6 +352,7 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     """fusion
     test = Neos.Fusion:DataStructure {
       typeFilter = ${q(node).find('[instanceof Neos.Neos:Test.DocumentType2]').get()}
+      propertyFilter = ${q(node).find('[uriPathSegment*="1b"]').get()}
       combinedFilter = ${q(node).find('[instanceof Neos.Neos:Test.DocumentType2][uriPathSegment*="b1"]').get()}
       identifier = ${q(node).find('#a1b1a').get()}
       name = ${q(node).find('a1b').get()}
@@ -363,6 +364,7 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     Then I expect the following Fusion rendering result:
     """
     typeFilter: a1a,a1a2,a1b2,a1a3,a1a4,a1a5,a1a6,a1b1a
+    propertyFilter: a1b,a1b1,a1b2,a1b3,a1b1a,a1b1b
     combinedFilter: a1b1a
     identifier: a1b1a
     name: a1b


### PR DESCRIPTION
The flowQuery operations `find` and `children` are fixed & optimized for the new cr.  They now use a combined query with nodetype and property criteria when possible. The number of performed db-queries is the number of contextNodes times the number of filterGroups (comma separated parts)

In addition the `find` operation now can also handle single property criteria and does not rely on having an instanceof filter first.

The solution adds a `NodeFilterCriteria` class that encapsulates `nodeTypeCriteria` and `PropertyConstraints`. The collection object `NodeFilterCriteriaGroup` combines multiple of those. The `NodeFilterCriteriaGroupFactory` allows to take a fizzle-expression and create a `NodeFilterCriteriaGroup` once only Attribute filters (instanceof and property) are used.


**Upgrade instructions**

**Review instructions**

This based on #4699 and should be merged afterwards.
Also we should discuss how to proceed regarding the case insensitive operators feature https://github.com/neos/flow-development-collection/pull/2600 currently those are handled by the legacy code as fallback.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions