### PR TITLE
BUGFIX: `SiteDetectionMiddleware` should not crash without doctrine migrations

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionMiddleware.php
+++ b/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionMiddleware.php
@@ -47,18 +47,16 @@ final class SiteDetectionMiddleware implements MiddlewareInterface
         $requestUriHost = $request->getUri()->getHost();
         try {
             if (!empty($requestUriHost)) {
+                // try to get site by domain
                 $activeDomain = $this->domainRepository->findOneByHost($requestUriHost, true);
-                if ($activeDomain !== null) {
-                    $site = $activeDomain->getSite();
-                }
+                $site = $activeDomain?->getSite();
             }
             if ($site === null) {
+                // try to get any site
                 $site = $this->siteRepository->findFirstOnline();
             }
         } catch (DatabaseException) {
-            // doctrine might have not been migrated yet or not database exists.
-            // this doesn't have to be handled here, and we should allow other middlewares / routes to work
-            return $handler->handle($request);
+            // doctrine might have not been migrated yet or no database is connected.
         }
 
         if (!$site instanceof Site) {

--- a/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionMiddleware.php
+++ b/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\Neos\FrontendRouting\SiteDetection;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Doctrine\Exception\DatabaseException;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
@@ -42,19 +43,27 @@ final class SiteDetectionMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $requestUriHost = $request->getUri()->getHost();
         $site = null;
-        if (!empty($requestUriHost)) {
-            $activeDomain = $this->domainRepository->findOneByHost($requestUriHost, true);
-            if ($activeDomain !== null) {
-                $site = $activeDomain->getSite();
+        $requestUriHost = $request->getUri()->getHost();
+        try {
+            if (!empty($requestUriHost)) {
+                $activeDomain = $this->domainRepository->findOneByHost($requestUriHost, true);
+                if ($activeDomain !== null) {
+                    $site = $activeDomain->getSite();
+                }
             }
-        }
-        if ($site === null) {
-            $site = $this->siteRepository->findFirstOnline();
+            if ($site === null) {
+                $site = $this->siteRepository->findFirstOnline();
+            }
+        } catch (DatabaseException) {
+            // doctrine might have not been migrated yet or not database exists.
+            // this doesn't have to be handled here, and we should allow other middlewares / routes to work
+            return $handler->handle($request);
         }
 
         if (!$site instanceof Site) {
+            // no site has been created yet,
+            // but we allow other middlewares / routes to work
             return $handler->handle($request);
         }
 

--- a/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionResult.php
+++ b/Neos.Neos/Classes/FrontendRouting/SiteDetection/SiteDetectionResult.php
@@ -60,7 +60,7 @@ final class SiteDetectionResult
         if ($siteNodeName === null || $contentRepositoryId === null) {
             throw new \RuntimeException(
                 'Current site and content repository could not be extracted from the Request.'
-                    . ' SiteDetectionMiddleware must run before calling this method!'
+                    . ' The SiteDetectionMiddleware was not able to determine the site!'
             );
         }
         assert(is_string($siteNodeName));


### PR DESCRIPTION
The `SiteDetectionMiddleware` tries to match the current requested host to a site entity. For that our doctrine repositories are required. But in the case doctrine is not setup (migrated or no database exists) this middleware should not throw!

Especially non neos routes must still work as the site detection stuff is only mandatory for neos escr things.

Additional fix for https://github.com/neos/neos-development-collection/issues/4446

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
