### PR TITLE
BUGFIX: Sites management new site throws directly when loading

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Controller\Module\Administration;
 
+use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\ContentRepository\Core\Feature\NodeRenaming\Command\ChangeNodeAggregateName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
@@ -22,6 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFoundException;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\ContentRepositoryRegistry\Exception\ContentRepositoryNotFoundException;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package;
@@ -246,13 +248,22 @@ class SitesController extends AbstractModuleController
     public function newSiteAction(Site $site = null)
     {
         // This is not 100% correct, but it is as good as we can get it to work right now
-        $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())
-            ->contentRepositoryId;
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        try {
+            $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())
+                ->contentRepositoryId;
+        } catch (\RuntimeException) {
+            $contentRepositoryId = ContentRepositoryId::fromString('default');
+        }
+
+        try {
+            $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+            $documentNodeTypes = $contentRepository->getNodeTypeManager()->getSubNodeTypes(NodeTypeNameFactory::forSite(), false);
+        } catch (ContentRepositoryNotFoundException) {
+            $documentNodeTypes = [];
+        }
 
 
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
-        $documentNodeTypes = $contentRepository->getNodeTypeManager()->getSubNodeTypes(NodeTypeNameFactory::forDocument(), false);
 
         $generatorServiceIsAvailable = $this->packageManager->isPackageAvailable('Neos.SiteKickstarter');
         $generatorServices = [];

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -40,7 +40,7 @@
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'nodeType', then: ' neos-error')}">
               <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType', source: 'Modules')}</label>
               <div class="neos-controls neos-select">
-                <f:form.select name="nodeType" options="{documentNodeTypes}" optionLabelField="name" optionValueField="name" id="node-type" class="neos-span12" />
+                <f:form.select name="nodeType" options="{documentNodeTypes}" optionLabelField="name.value" optionValueField="name.value" id="node-type" class="neos-span12" />
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">


### PR DESCRIPTION
Now it at least "looks" correct again without errors thrown.

<img width="1666" alt="image" src="https://github.com/neos/neos-development-collection/assets/85400359/9ed7c834-fc43-4555-b7a2-7f0613797809">

But didn't we want to solve this task via our new setup?
-> yes we might but we can also continue to have this screen for now _if_ it works and tell that its use is deprecated.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
