### PR TITLE
BUGFIX: Filter for assets by asset collection without overriding existing WHERE conditions

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -268,8 +268,9 @@ class AssetRepository extends Repository
             return;
         }
 
-        $constraints = $query->getConstraint();
-        $query->matching($query->logicalAnd([$constraints, $query->contains('assetCollections', $assetCollection)]));
+        $query->getQueryBuilder()->andWhere(
+            $query->contains('assetCollections', $assetCollection)
+        );
     }
 
     /**

--- a/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
@@ -13,7 +13,6 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
-use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageVariant;

--- a/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
@@ -10,7 +10,14 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
+use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Model\Image;
+use Neos\Media\Domain\Model\ImageVariant;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Utility\Files;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Tag;
@@ -35,6 +42,11 @@ class AssetRepositoryTest extends AbstractTest
     protected $assetRepository;
 
     /**
+     * @var AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+    /**
      * @var TagRepository
      */
     protected $tagRepository;
@@ -52,6 +64,7 @@ class AssetRepositoryTest extends AbstractTest
         $this->prepareResourceManager();
 
         $this->assetRepository = $this->objectManager->get(AssetRepository::class);
+        $this->assetCollectionRepository = $this->objectManager->get(AssetCollectionRepository::class);
         $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
@@ -141,6 +154,93 @@ class AssetRepositoryTest extends AbstractTest
         self::assertCount(2, $this->assetRepository->findBySearchTermOrTags('home', [$tag]));
         self::assertCount(2, $this->assetRepository->findBySearchTermOrTags('homepage', [$tag]));
         self::assertCount(1, $this->assetRepository->findBySearchTermOrTags('baz', [$tag]));
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testAddAssetVariantFilterClauseWithoutAssetCollection()
+    {
+        $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
+        $resource2 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/640px-Goodworkteam.jpg');
+
+        $image1 = new Image($resource1);
+        $image1->setTitle('asset for homepage');
+        $this->assetRepository->add($image1);
+
+        $imageVariant1 = new ImageVariant($image1);
+        $image1->addVariant($imageVariant1);
+
+        $image2 = new Image($resource2);
+        $image2->setTitle('asset for homepage');
+        $this->assetRepository->add($image2);
+
+        $imageVariant2 = new ImageVariant($image2);
+        $image2->addVariant($imageVariant2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $assets = $this->assetRepository->findAll();
+
+        self::assertCount(2, $assets);
+        foreach ($assets as $asset) {
+            self::assertInstanceOf(Image::class, $asset);
+            self::assertNotInstanceOf(ImageVariant::class, $asset);
+        }
+
+        // This is necessary to initialize all resource instances before the tables are deleted
+        foreach ($this->assetRepository->findAll() as $asset) {
+            $asset->getResource()->getSha1();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testAddAssetVariantFilterClauseWithAssetCollection()
+    {
+        $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
+        $resource2 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/640px-Goodworkteam.jpg');
+
+        $assetCollection1 = new AssetCollection('test-1');
+        $this->assetCollectionRepository->add($assetCollection1);
+
+        $collections1 = new ArrayCollection();
+        $collections1->add($assetCollection1);
+
+        $image1 = new Image($resource1);
+        $image1->setTitle('asset for homepage');
+        $image1->setAssetCollections($collections1);
+        $assetCollection1->addAsset($image1);
+
+        $imageVariant1 = new ImageVariant($image1);
+        $image1->addVariant($imageVariant1);
+
+        $assetCollection2 = new AssetCollection('test-2');
+        $this->assetCollectionRepository->add($assetCollection2);
+
+        $collections2 = new ArrayCollection();
+        $collections2->add($assetCollection2);
+
+        $image2 = new Image($resource2);
+        $image2->setTitle('asset for homepage');
+        $image2->setAssetCollections($collections2);
+        $assetCollection2->addAsset($image2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $assets = $this->assetRepository->findAll($assetCollection1);
+        self::assertCount(1, $assets);
+        self::assertInstanceOf(Image::class, $assets->getFirst());
+        self::assertNotInstanceOf(ImageVariant::class, $assets->getFirst());
+        self::assertNotInstanceOf(ImageVariant::class, $assets->getFirst());
 
         // This is necessary to initialize all resource instances before the tables are deleted
         foreach ($this->assetRepository->findAll() as $asset) {


### PR DESCRIPTION
The query to fetch assets gets build in multiple steps. E.g in `findAll` it creates the query, adds the "variant filter clause" and afterwards the "asset collection filter clause".

```
    public function findAll(AssetCollection $assetCollection = null): QueryResultInterface
    {
        $query = $this->createQuery();
        $this->addAssetVariantFilterClause($query);
        $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
        return $query->execute();
    }
```
But adding the "asset collection filter clause" removes/overrides the existing "variant filter clause"

This fix replaces the way of setting "asset collection filter clause", so the existing where clauses are retained.

Fixes: #4723