### PR TITLE
TASK: Deterministic projection schema with sensible defaults

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -122,7 +122,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
             throw new \RuntimeException('Failed to retrieve Schema Manager', 1625653914);
         }
 
-        $schema = (new DoctrineDbalContentGraphSchemaBuilder($this->tableNamePrefix))->buildSchema();
+        $schema = (new DoctrineDbalContentGraphSchemaBuilder($this->tableNamePrefix))->buildSchema($schemaManager);
 
         $schemaDiff = (new Comparator())->compare($schemaManager->createSchema(), $schema);
         foreach ($schemaDiff->toSaveSql($connection->getDatabasePlatform()) as $statement) {
@@ -807,7 +807,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
                         'nodeanchorpoint' => $nodeAnchorPoint?->value,
                         'destinationnodeaggregateid' => $reference->targetNodeAggregateId->value,
                         'properties' => $reference->properties
-                            ? \json_encode($reference->properties, JSON_THROW_ON_ERROR)
+                            ? \json_encode($reference->properties, JSON_THROW_ON_ERROR & JSON_FORCE_OBJECT)
                             : null
                     ]);
                     $position++;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -3,7 +3,11 @@
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Neos\ContentRepository\Core\Infrastructure\DbalSchemaFactory;
 
@@ -21,64 +25,49 @@ class DoctrineDbalContentGraphSchemaBuilder
 
     public function buildSchema(AbstractSchemaManager $schemaManager): Schema
     {
-        $schema = DbalSchemaFactory::createEmptySchema($schemaManager);
-
-        $this->createNodeTable($schema);
-        $this->createHierarchyRelationTable($schema);
-        $this->createReferenceRelationTable($schema);
-        $this->createRestrictionRelationTable($schema);
-
-        return $schema;
+        return DbalSchemaFactory::createSchemaWithTables($schemaManager, [
+            $this->createNodeTable(),
+            $this->createHierarchyRelationTable(),
+            $this->createReferenceRelationTable(),
+            $this->createRestrictionRelationTable()
+        ]);
     }
 
-    private function createNodeTable(Schema $schema): void
+    private function createNodeTable(): Table
     {
-        $table = $schema->createTable($this->tableNamePrefix . '_node');
-        $table = DbalSchemaFactory::addColumnForNodeAnchorPoint($table, 'relationanchorpoint');
-        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'nodeaggregateid', false);
-        $table = DbalSchemaFactory::addColumnForDimensionSpacePoint($table, 'origindimensionspacepoint', false);
-        $table = DbalSchemaFactory::addColumnForDimensionSpacePointHash($table, 'origindimensionspacepointhash', false);
-        $table = DbalSchemaFactory::addColumnForNodeTypeName($table, 'nodetypename');
-        $table->addColumn('properties', Types::TEXT)
-            ->setNotnull(true)
-            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
-        $table->addColumn('classification', Types::STRING)
-            ->setLength(20)
-            ->setNotnull(true)
-            ->setCustomSchemaOption('charset', 'binary');
-        $table->addColumn('created', Types::DATETIME_IMMUTABLE)
-            ->setDefault('CURRENT_TIMESTAMP')
-            ->setNotnull(true);
-        $table->addColumn('originalcreated', Types::DATETIME_IMMUTABLE)
-            ->setDefault('CURRENT_TIMESTAMP')
-            ->setNotnull(true);
-        $table->addColumn('lastmodified', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(false)
-            ->setDefault(null);
-        $table->addColumn('originallastmodified', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(false)
-            ->setDefault(null);
-        $table
+        $table = new Table($this->tableNamePrefix . '_node', [
+            DbalSchemaFactory::columnForNodeAnchorPoint('relationanchorpoint'),
+            DbalSchemaFactory::columnForNodeAggregateId('nodeaggregateid')->setNotnull(false),
+            DbalSchemaFactory::columnForDimensionSpacePoint('origindimensionspacepoint')->setNotnull(false),
+            DbalSchemaFactory::columnForDimensionSpacePointHash('origindimensionspacepointhash')->setNotnull(false),
+            DbalSchemaFactory::columnForNodeTypeName('nodetypename'),
+            (new Column('properties', Type::getType(Types::TEXT)))->setNotnull(true)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
+            (new Column('classification', Type::getType(Types::STRING)))->setLength(20)->setNotnull(true)->setCustomSchemaOption('charset', 'binary'),
+            (new Column('created', Type::getType(Types::DATETIME_IMMUTABLE)))->setDefault('CURRENT_TIMESTAMP')->setNotnull(true),
+            (new Column('originalcreated', Type::getType(Types::DATETIME_IMMUTABLE)))->setDefault('CURRENT_TIMESTAMP')->setNotnull(true),
+            (new Column('lastmodified', Type::getType(Types::DATETIME_IMMUTABLE)))->setNotnull(false)->setDefault(null),
+            (new Column('originallastmodified', Type::getType(Types::DATETIME_IMMUTABLE)))->setNotnull(false)->setDefault(null)
+        ]);
+
+        return $table
             ->setPrimaryKey(['relationanchorpoint'])
             ->addIndex(['nodeaggregateid'])
             ->addIndex(['nodetypename']);
     }
 
-    private function createHierarchyRelationTable(Schema $schema): void
+    private function createHierarchyRelationTable(): Table
     {
-        $table = $schema->createTable($this->tableNamePrefix . '_hierarchyrelation');
-        $table->addColumn('name', Types::STRING)
-            ->setLength(255)
-            ->setNotnull(false)
-            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
-        $table->addColumn('position', Types::INTEGER)
-            ->setNotnull(true);
-        $table = DbalSchemaFactory::addColumnForContentStreamId($table, 'contentstreamid', true);
-        $table = DbalSchemaFactory::addColumnForDimensionSpacePoint($table, 'dimensionspacepoint', true);
-        $table = DbalSchemaFactory::addColumnForDimensionSpacePointHash($table, 'dimensionspacepointhash', true);
-        $table = DbalSchemaFactory::addColumnForNodeAnchorPoint($table, 'parentnodeanchor');
-        $table = DbalSchemaFactory::addColumnForNodeAnchorPoint($table, 'childnodeanchor');
-        $table
+        $table = new Table($this->tableNamePrefix . '_hierarchyrelation', [
+            (new Column('name', Type::getType(Types::STRING)))->setLength(255)->setNotnull(false)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
+            (new Column('position', Type::getType(Types::INTEGER)))->setNotnull(true),
+            DbalSchemaFactory::columnForContentStreamId('contentstreamid')->setNotnull(true),
+            DbalSchemaFactory::columnForDimensionSpacePoint('dimensionspacepoint')->setNotnull(true),
+            DbalSchemaFactory::columnForDimensionSpacePointHash('dimensionspacepointhash')->setNotnull(true),
+            DbalSchemaFactory::columnForNodeAnchorPoint('parentnodeanchor'),
+            DbalSchemaFactory::columnForNodeAnchorPoint('childnodeanchor')
+        ]);
+
+        return $table
             ->addIndex(['childnodeanchor'])
             ->addIndex(['contentstreamid'])
             ->addIndex(['parentnodeanchor'])
@@ -86,40 +75,34 @@ class DoctrineDbalContentGraphSchemaBuilder
             ->addIndex(['contentstreamid', 'dimensionspacepointhash']);
     }
 
-    private function createReferenceRelationTable(Schema $schema): void
+    private function createReferenceRelationTable(): Table
     {
-        $table = $schema->createTable($this->tableNamePrefix . '_referencerelation');
-        $table->addColumn('name', Types::STRING)
-            ->setLength(255)
-            ->setNotnull(true)
-            ->setCustomSchemaOption('charset', 'ascii')
-            ->setCustomSchemaOption('collation', 'ascii_general_ci');
-        $table->addColumn('position', Types::INTEGER)
-            ->setNotnull(true);
-        $table = DbalSchemaFactory::addColumnForNodeAnchorPoint($table, 'nodeanchorpoint');
-        $table->addColumn('properties', Types::TEXT)
-            ->setNotnull(false)
-            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
-        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'destinationnodeaggregateid', true);
+        $table = new Table($this->tableNamePrefix . '_referencerelation', [
+            (new Column('name', Type::getType(Types::STRING)))->setLength(255)->setNotnull(true)->setCustomSchemaOption('charset', 'ascii')->setCustomSchemaOption('collation', 'ascii_general_ci'),
+            (new Column('position', Type::getType(Types::INTEGER)))->setNotnull(true),
+            DbalSchemaFactory::columnForNodeAnchorPoint('nodeanchorpoint'),
+            (new Column('properties', Type::getType(Types::TEXT)))->setNotnull(false)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
+            DbalSchemaFactory::columnForNodeAggregateId('destinationnodeaggregateid')->setNotnull(true)
+        ]);
 
-        $table
+        return $table
             ->setPrimaryKey(['name', 'position', 'nodeanchorpoint']);
     }
 
-    private function createRestrictionRelationTable(Schema $schema): void
+    private function createRestrictionRelationTable(): Table
     {
-        $table = $schema->createTable($this->tableNamePrefix . '_restrictionrelation');
-        $table = DbalSchemaFactory::addColumnForContentStreamId($table, 'contentstreamid', true);
-        $table = DbalSchemaFactory::addColumnForDimensionSpacePointHash($table, 'dimensionspacepointhash', true);
-        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'originnodeaggregateid', true);
-        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'affectednodeaggregateid', true);
+        $table = new Table($this->tableNamePrefix . '_restrictionrelation', [
+            DbalSchemaFactory::columnForContentStreamId('contentstreamid')->setNotnull(true),
+            DbalSchemaFactory::columnForDimensionSpacePointHash('dimensionspacepointhash')->setNotnull(true),
+            DbalSchemaFactory::columnForNodeAggregateId('originnodeaggregateid')->setNotnull(false),
+            DbalSchemaFactory::columnForNodeAggregateId('affectednodeaggregateid')->setNotnull(false),
+        ]);
 
-        $table
-            ->setPrimaryKey([
-                'contentstreamid',
-                'dimensionspacepointhash',
-                'originnodeaggregateid',
-                'affectednodeaggregateid'
-            ]);
+        return $table->setPrimaryKey([
+            'contentstreamid',
+            'dimensionspacepointhash',
+            'originnodeaggregateid',
+            'affectednodeaggregateid'
+        ]);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
@@ -5,6 +5,10 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * Provide doctrine DBAL column schema definitions for common types in the content repository to
@@ -14,6 +18,10 @@ use Doctrine\DBAL\Types\Types;
  */
 final class DbalSchemaFactory
 {
+    /**
+     * The NodeAggregateId is limited to 64 ascii characters and therefore we should do the same in the database.
+     * @see NodeAggregateId
+     */
     public static function addColumnForNodeAggregateId(Table $table, string $columnName, bool $notNull): Table
     {
         $table->addColumn($columnName, Types::STRING)
@@ -25,6 +33,16 @@ final class DbalSchemaFactory
         return $table;
     }
 
+    /**
+     * The ContentStreamId is generally a UUID, therefore not a real "string" but at the moment a strified identifier,
+     * we can safely store it as binary string as the charset doesn't matter
+     * for the characters we use (they are all asscii).
+     *
+     * We should however reduce the allowed size to 36 like suggested
+     * here in the schema and as further improvement store the UUID in a more DB friendly format.
+     *
+     * @see ContentStreamId
+     */
     public static function addColumnForContentStreamId(Table $table, string $columnName, bool $notNull): Table
     {
         $table->addColumn($columnName, Types::STRING)
@@ -35,6 +53,14 @@ final class DbalSchemaFactory
         return $table;
     }
 
+    /**
+     * An anchorpoint can be used in a given projection to link two nodes, it is a purely internal identifier and should
+     * be as performant as possible in queries, the current code uses UUIDs,
+     * so we will store the stringified UUID as binary for now.
+     *
+     * A simpler and faster format would be preferable though, int or a shorter binary format if possible. Fortunately
+     * this is a pure projection information and therefore could change by replay.
+     */
     public static function addColumnForNodeAnchorPoint(Table $table, string $columnName): Table
     {
         $table->addColumn($columnName, Types::BINARY)
@@ -44,6 +70,14 @@ final class DbalSchemaFactory
         return $table;
     }
 
+    /**
+     * DimensionSpacePoints are PHP objects that need to be serialized as JSON, therefore we store them as TEXT for now,
+     * with a sensible collation for case insensitive text search.
+     *
+     * Using a dedicated JSON column format should be considered for the future.
+     *
+     * @see DimensionSpacePoint
+     */
     public static function addColumnForDimensionSpacePoint(Table $table, string $columnName, bool $notNull): Table
     {
         $table->addColumn($columnName, Types::TEXT)
@@ -54,6 +88,14 @@ final class DbalSchemaFactory
         return $table;
     }
 
+    /**
+     * The hash for a given dimension space point for better query performance. As this is a hash, the size and type of
+     * content is deterministic, a binary type can be used as the actual content is not so important.
+     *
+     * We could imrpove by actually storing the hash in binary form and shortening and fixing the length.
+     *
+     * @see DimensionSpacePoint
+     */
     public static function addColumnForDimensionSpacePointHash(Table $table, string $columnName, bool $notNull): Table
     {
         $table->addColumn($columnName, Types::BINARY)
@@ -64,6 +106,11 @@ final class DbalSchemaFactory
         return $table;
     }
 
+    /**
+     * The NodeTypeName is an ascii string, we should be able to sort it properly, but we don't need unicode here.
+     *
+     * @see NodeTypeName
+     */
     public static function addColumnForNodeTypeName(Table $table, string $columnName): Table
     {
         $table->addColumn($columnName, Types::STRING)

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Infrastructure;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -20,6 +23,7 @@ final class DbalSchemaFactory
 {
     /**
      * The NodeAggregateId is limited to 64 ascii characters and therefore we should do the same in the database.
+     *
      * @see NodeAggregateId
      */
     public static function addColumnForNodeAggregateId(Table $table, string $columnName, bool $notNull): Table

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
@@ -1,0 +1,87 @@
+<?php
+namespace Neos\ContentRepository\Core\Infrastructure;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Provide doctrine DBAL column schema definitions for common types in the content repository to
+ * produce consistent columns across projections.
+ *
+ * @internal Because we might need to check for platform later on and generally change the input and output format of functions within.
+ */
+final class DbalSchemaFactory
+{
+    public static function addColumnForNodeAggregateId(Table $table, string $columnName, bool $notNull): Table
+    {
+        $table->addColumn($columnName, Types::STRING)
+                ->setLength(64)
+                ->setNotnull($notNull)
+                ->setCustomSchemaOption('charset', 'ascii')
+                ->setCustomSchemaOption('collation', 'ascii_general_ci');
+
+        return $table;
+    }
+
+    public static function addColumnForContentStreamId(Table $table, string $columnName, bool $notNull): Table
+    {
+        $table->addColumn($columnName, Types::STRING)
+            ->setLength(36)
+            ->setNotnull($notNull)
+            ->setCustomSchemaOption('charset', 'binary');
+
+        return $table;
+    }
+
+    public static function addColumnForNodeAnchorPoint(Table $table, string $columnName): Table
+    {
+        $table->addColumn($columnName, Types::BINARY)
+            ->setLength(36)
+            ->setNotnull(true);
+
+        return $table;
+    }
+
+    public static function addColumnForDimensionSpacePoint(Table $table, string $columnName, bool $notNull): Table
+    {
+        $table->addColumn($columnName, Types::TEXT)
+            ->setNotnull($notNull)
+            ->setDefault('{}')
+            ->setCustomSchemaOption('collation', 'utf8mb4_unicode_520_ci');
+
+        return $table;
+    }
+
+    public static function addColumnForDimensionSpacePointHash(Table $table, string $columnName, bool $notNull): Table
+    {
+        $table->addColumn($columnName, Types::BINARY)
+            ->setLength(32)
+            ->setDefault('')
+            ->setNotnull($notNull);
+
+        return $table;
+    }
+
+    public static function addColumnForNodeTypeName(Table $table, string $columnName): Table
+    {
+        $table->addColumn($columnName, Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true)
+            ->setCustomSchemaOption('charset', 'ascii')
+            ->setCustomSchemaOption('collation', 'ascii_general_ci');
+
+        return $table;
+    }
+
+    public static function createEmptySchema(AbstractSchemaManager $schemaManager): Schema
+    {
+        $schemaConfig = $schemaManager->createSchemaConfig();
+        $schemaConfig->setDefaultTableOptions([
+            'charset' => 'utf8mb4'
+        ]);
+
+        return new Schema([], [], $schemaConfig);
+    }
+}

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -86,8 +86,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
         if (!$schemaManager instanceof AbstractSchemaManager) {
             throw new \RuntimeException('Failed to retrieve Schema Manager', 1625653914);
         }
-
-        $schema = (new DocumentUriPathSchemaBuilder($this->tableNamePrefix))->buildSchema();
+        $schema = (new DocumentUriPathSchemaBuilder($this->tableNamePrefix))->buildSchema($schemaManager);
 
         $schemaDiff = (new Comparator())->compare($schemaManager->createSchema(), $schema);
         foreach ($schemaDiff->toSaveSql($connection->getDatabasePlatform()) as $statement) {

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
@@ -2,19 +2,24 @@
 
 namespace Neos\Neos\FrontendRouting\Projection;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Types\Types;
+use Neos\ContentRepository\Core\Infrastructure\DbalSchemaFactory;
 
 class DocumentUriPathSchemaBuilder
 {
+    private const DEFAULT_TEXT_COLLATION = 'utf8mb4_unicode_520_ci';
+
     public function __construct(
         private readonly string $tableNamePrefix,
     ) {
     }
 
-    public function buildSchema(): Schema
+    public function buildSchema(AbstractSchemaManager $schemaManager): Schema
     {
-        $schema = new Schema();
+        $schema = DbalSchemaFactory::createEmptySchema($schemaManager);
 
         $this->createUriTable($schema);
         $this->createLiveContentStreamsTable($schema);
@@ -26,18 +31,14 @@ class DocumentUriPathSchemaBuilder
     {
 
         $table = $schema->createTable($this->tableNamePrefix . '_uri');
-        $table->addColumn('nodeaggregateid', Types::STRING)
-            ->setLength(64)
-            ->setDefault('')
-            ->setNotnull(true);
+        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'nodeaggregateid', true);
+
         $table->addColumn('uripath', Types::STRING)
             ->setLength(4000)
             ->setDefault('')
-            ->setNotnull(true);
-        $table->addColumn('dimensionspacepointhash', Types::STRING)
-            ->setLength(255)
-            ->setDefault('')
-            ->setNotnull(true);
+            ->setNotnull(true)
+            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
+        $table = DbalSchemaFactory::addColumnForDimensionSpacePointHash($table, 'dimensionspacepointhash', true);
         $table->addColumn('disabled', Types::INTEGER)
             ->setLength(4)
             ->setUnsigned(true)
@@ -46,30 +47,22 @@ class DocumentUriPathSchemaBuilder
         $table->addColumn('nodeaggregateidpath', Types::STRING)
             ->setLength(4000)
             ->setDefault('')
-            ->setNotnull(true);
+            ->setNotnull(true)
+            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
         $table->addColumn('sitenodename', Types::STRING)
             ->setLength(255)
             ->setDefault('')
-            ->setNotnull(true);
-        $table->addColumn('origindimensionspacepointhash', Types::STRING)
-            ->setLength(255)
-            ->setDefault('')
-            ->setNotnull(true);
-        $table->addColumn('parentnodeaggregateid', Types::STRING)
-            ->setLength(64)
-            ->setNotnull(false);
-        $table->addColumn('precedingnodeaggregateid', Types::STRING)
-            ->setLength(64)
-            ->setNotnull(false);
-        $table->addColumn('succeedingnodeaggregateid', Types::STRING)
-            ->setLength(64)
-            ->setNotnull(false);
+            ->setNotnull(true)
+            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
+        $table = DbalSchemaFactory::addColumnForDimensionSpacePointHash($table, 'origindimensionspacepointhash', true);
+        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'parentnodeaggregateid', false);
+        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'precedingnodeaggregateid', false);
+        $table = DbalSchemaFactory::addColumnForNodeAggregateId($table, 'succeedingnodeaggregateid', false);
         $table->addColumn('shortcuttarget', Types::STRING)
             ->setLength(1000)
-            ->setNotnull(false);
-        $table->addColumn('nodetypename', Types::STRING)
-            ->setLength(255)
-            ->setNotnull(true);
+            ->setNotnull(false)
+            ->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION);
+        $table = DbalSchemaFactory::addColumnForNodeTypeName($table, 'nodetypename');
 
         $table
             ->addUniqueIndex(['nodeaggregateid', 'dimensionspacepointhash'], 'variant')
@@ -84,10 +77,7 @@ class DocumentUriPathSchemaBuilder
     private function createLiveContentStreamsTable(Schema $schema): void
     {
         $table = $schema->createTable($this->tableNamePrefix . '_livecontentstreams');
-        $table->addColumn('contentstreamid', Types::STRING)
-            ->setLength(40)
-            ->setDefault('')
-            ->setNotnull(true);
+        $table = DbalSchemaFactory::addColumnForContentStreamId($table, 'contentstreamid', true);
         $table->addColumn('workspacename', Types::STRING)
             ->setLength(255)
             ->setDefault('')


### PR DESCRIPTION
Projections should be created with deterministic charset and collation and columns containing the same data should behave the same to have similar conditions between installations, therefore the configured charset/collation should be applied when creating projection schemas.

This includes some additional optimizations for column definitions limiting the possible contents based on the currently existing limitations in the code.

Fixes: #4729