### PR TITLE
TASK: #4396 prefer renderingMode::isEdit over node::isLive

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -685,7 +685,7 @@ class UserService
      */
     public function currentUserCanPublishToWorkspace(Workspace $workspace): bool
     {
-        if ($workspace->workspaceName->isLive()) {
+        if ($workspace->isPublicWorkspace()) {
             return $this->securityContext->hasRole('Neos.Neos:LivePublisher');
         }
 
@@ -709,7 +709,7 @@ class UserService
      */
     public function currentUserCanReadWorkspace(Workspace $workspace): bool
     {
-        if ($workspace->workspaceName->isLive() || $workspace->workspaceOwner === null) {
+        if ($workspace->isPublicWorkspace()) {
             return true;
         }
 

--- a/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementEditableService;
 
 /**
@@ -56,17 +57,23 @@ class ContentElementEditableImplementation extends AbstractFusionObject
     {
         $content = $this->getValue();
 
+        /** @var RenderingMode $renderingMode */
+        $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        if (!$renderingMode->isEdit) {
+            return $content;
+        }
+
         $node = $this->fusionValue('node');
         if (!$node instanceof Node) {
             return $content;
         }
 
-        /** @var string $property */
-        $property = $this->fusionValue('property');
-
         if (!$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {
             return $content;
         }
+
+        /** @var string $property */
+        $property = $this->fusionValue('property');
 
         return $this->contentElementEditableService->wrapContentProperty($node, $property, $content);
     }

--- a/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementEditableImplementation.php
@@ -57,8 +57,8 @@ class ContentElementEditableImplementation extends AbstractFusionObject
     {
         $content = $this->getValue();
 
-        /** @var RenderingMode $renderingMode */
         $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        assert($renderingMode instanceof RenderingMode);
         if (!$renderingMode->isEdit) {
             return $content;
         }

--- a/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementWrappingService;
 
 /**
@@ -65,6 +66,12 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $content = $this->getValue();
+
+        /** @var RenderingMode $renderingMode */
+        $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        if (!$renderingMode->isEdit) {
+            return $content;
+        }
 
         $node = $this->fusionValue('node');
         if (!$node instanceof Node) {

--- a/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ContentElementWrappingImplementation.php
@@ -67,8 +67,8 @@ class ContentElementWrappingImplementation extends AbstractFusionObject
     {
         $content = $this->getValue();
 
-        /** @var RenderingMode $renderingMode */
         $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        assert($renderingMode instanceof RenderingMode);
         if (!$renderingMode->isEdit) {
             return $content;
         }

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -17,6 +17,7 @@ namespace Neos\Neos\Fusion;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
@@ -123,15 +124,17 @@ class ConvertUrisImplementation extends AbstractFusionObject
             ), 1382624087);
         }
 
+        /** @var RenderingMode $renderingMode */
+        $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        if ($renderingMode->isEdit && $this->fusionValue('forceConversion') !== true) {
+            return $text;
+        }
+
         $contentRepository = $this->contentRepositoryRegistry->get(
             $node->subgraphIdentity->contentRepositoryId
         );
 
         $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromNode($node);
-
-        if (!$nodeAddress->isInLiveWorkspace() && !($this->fusionValue('forceConversion'))) {
-            return $text;
-        }
 
         $unresolvedUris = [];
         $absolute = $this->fusionValue('absolute');

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -124,8 +124,8 @@ class ConvertUrisImplementation extends AbstractFusionObject
             ), 1382624087);
         }
 
-        /** @var RenderingMode $renderingMode */
         $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+        assert($renderingMode instanceof RenderingMode);
         if ($renderingMode->isEdit && $this->fusionValue('forceConversion') !== true) {
             return $text;
         }

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/NodeWrappingHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/NodeWrappingHandler.php
@@ -74,8 +74,8 @@ class NodeWrappingHandler extends AbstractRenderingExceptionHandler
             /** @var Node $node */
             $node = $currentContext['node'];
 
-            /** @var RenderingMode $renderingMode */
             $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+            assert($renderingMode instanceof RenderingMode);
             $applicationContext = $this->environment->getContext();
 
             if (!$renderingMode->isEdit) {

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/NodeWrappingHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/NodeWrappingHandler.php
@@ -21,6 +21,7 @@ use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Utility\Environment;
 use Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler;
 use Neos\Fusion\Core\ExceptionHandlers\ContextDependentHandler;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementWrappingService;
 
 /**
@@ -72,19 +73,20 @@ class NodeWrappingHandler extends AbstractRenderingExceptionHandler
         if (isset($currentContext['node'])) {
             /** @var Node $node */
             $node = $currentContext['node'];
-            $contentRepositoryId = $node->subgraphIdentity->contentRepositoryId;
-            $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-            $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
-                $node->subgraphIdentity->contentStreamId
-            );
+
+            /** @var RenderingMode $renderingMode */
+            $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
             $applicationContext = $this->environment->getContext();
 
-            if (
-                $applicationContext->isProduction()
-                && $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
-                && !is_null($workspace)
-                && !$workspace->workspaceName->isLive()
-            ) {
+            if (!$renderingMode->isEdit) {
+                return $output;
+            }
+
+            if (!$this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')) {
+                return $output;
+            }
+
+            if ($applicationContext->isProduction()) {
                 $output = '<div class="neos-rendering-exception">
     <div class="neos-rendering-exception-title">Failed to render element' . $output . '</div>
 </div>';

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
@@ -87,8 +87,8 @@ class PageHandler extends AbstractRenderingExceptionHandler
         }
 
         if (!is_null($documentNode)) {
-            /** @var RenderingMode $renderingMode */
             $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
+            assert($renderingMode instanceof RenderingMode);
             if (
                 $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
                 && $renderingMode->isEdit

--- a/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
+++ b/Neos.Neos/Classes/Fusion/ExceptionHandlers/PageHandler.php
@@ -24,6 +24,7 @@ use Neos\Flow\Utility\Environment;
 use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler;
 use Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementWrappingService;
 use Psr\Http\Message\ResponseInterface;
 
@@ -86,14 +87,11 @@ class PageHandler extends AbstractRenderingExceptionHandler
         }
 
         if (!is_null($documentNode)) {
-            $contentRepositoryId = $documentNode->subgraphIdentity->contentRepositoryId;
-            $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-            $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
-                $documentNode->subgraphIdentity->contentStreamId
-            );
+            /** @var RenderingMode $renderingMode */
+            $renderingMode = $this->runtime->fusionGlobals->get('renderingMode');
             if (
-                $workspace && !$workspace->workspaceName->isLive()
-                && $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
+                $this->privilegeManager->isPrivilegeTargetGranted('Neos.Neos:Backend.GeneralAccess')
+                && $renderingMode->isEdit
             ) {
                 $isBackend = true;
                 $fluidView->assign(

--- a/Neos.Neos/Classes/Service/ContentElementEditableService.php
+++ b/Neos.Neos/Classes/Service/ContentElementEditableService.php
@@ -14,14 +14,12 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Service;
 
-use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Fusion\Service\HtmlAugmenter as FusionHtmlAugmenter;
+use Neos\Neos\FrontendRouting\NodeAddressFactory;
 
 /**
  * The content element editable service adds the necessary markup around
@@ -56,15 +54,6 @@ class ContentElementEditableService
             $node->subgraphIdentity->contentRepositoryId
         );
 
-        if (
-            $this->isContentStreamOfLiveWorkspace(
-                $node->subgraphIdentity->contentStreamId,
-                $contentRepository
-            )
-        ) {
-            return $content;
-        }
-
         // TODO: permissions
         //if (!$this->nodeAuthorizationService->isGrantedToEditNode($node)) {
         //    return $content;
@@ -78,14 +67,5 @@ class ContentElementEditableService
         ];
 
         return $this->htmlAugmenter->addAttributes($content, $attributes, 'span');
-    }
-
-    private function isContentStreamOfLiveWorkspace(
-        ContentStreamId $contentStreamId,
-        ContentRepository $contentRepository
-    ): bool {
-        return $contentRepository->getWorkspaceFinder()
-            ->findOneByCurrentContentStreamId($contentStreamId)
-            ?->workspaceName->isLive() ?: false;
     }
 }

--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -14,15 +14,13 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Service;
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Fusion\Service\HtmlAugmenter as FusionHtmlAugmenter;
+use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
@@ -86,15 +84,6 @@ class ContentElementWrappingService
             $node->subgraphIdentity->contentRepositoryId
         );
 
-        if (
-            $this->isContentStreamOfLiveWorkspace(
-                $node->subgraphIdentity->contentStreamId,
-                $contentRepository
-            )
-        ) {
-            return $content;
-        }
-
         // TODO: reenable permissions
         //if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
         //    return $content;
@@ -134,12 +123,10 @@ class ContentElementWrappingService
         string $fusionPath,
         array $additionalAttributes = [],
     ): string {
-        $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
-        );
-        if ($this->needsMetadata($node, $contentRepository, true) === false) {
-            return $content;
-        }
+        // TODO: reenable permissions
+        //if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
+        //    return $content;
+        //}
 
         $attributes = $additionalAttributes;
         $attributes['data-__neos-fusion-path'] = $fusionPath;
@@ -167,27 +154,5 @@ class ContentElementWrappingService
         }
 
         return $attributes;
-    }
-
-    protected function needsMetadata(
-        Node $node,
-        ContentRepository $contentRepository,
-        bool $renderCurrentDocumentMetadata
-    ): bool {
-        return $this->isContentStreamOfLiveWorkspace(
-            $node->subgraphIdentity->contentStreamId,
-            $contentRepository
-        )
-             && ($renderCurrentDocumentMetadata === true
-                /* TODO: permissions || $this->nodeAuthorizationService->isGrantedToEditNode($node) === true */);
-    }
-
-    private function isContentStreamOfLiveWorkspace(
-        ContentStreamId $contentStreamId,
-        ContentRepository $contentRepository
-    ): bool {
-        return $contentRepository->getWorkspaceFinder()
-            ->findOneByCurrentContentStreamId($contentStreamId)
-            ?->workspaceName->isLive() ?: false;
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -20,6 +20,7 @@ use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Fusion\ViewHelpers\FusionContextTrait;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementEditableService;
 
 /**
@@ -114,7 +115,15 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
         }
         $this->tag->setContent($content);
 
-        return $this->contentElementEditableService->wrapContentProperty($node, $propertyName, (string)$this->tag->render());
+        $output = (string)$this->tag->render();
+
+        /** @var RenderingMode $renderingMode */
+        $renderingMode = $this->getContextVariable('renderingMode');
+        if (!$renderingMode->isEdit) {
+            return $output;
+        }
+
+        return $this->contentElementEditableService->wrapContentProperty($node, $propertyName, $output);
     }
 
     /**

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/EditableViewHelper.php
@@ -117,8 +117,8 @@ class EditableViewHelper extends AbstractTagBasedViewHelper
 
         $output = (string)$this->tag->render();
 
-        /** @var RenderingMode $renderingMode */
         $renderingMode = $this->getContextVariable('renderingMode');
+        assert($renderingMode instanceof RenderingMode);
         if (!$renderingMode->isEdit) {
             return $output;
         }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -87,8 +87,8 @@ class WrapViewHelper extends AbstractViewHelper
             );
         }
 
-        /** @var RenderingMode $renderingMode */
         $renderingMode = $fusionObject->getRuntime()->fusionGlobals->get('renderingMode');
+        assert($renderingMode instanceof RenderingMode);
         if (!$renderingMode->isEdit) {
             return (string)$this->renderChildren();
         }

--- a/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/ContentElement/WrapViewHelper.php
@@ -19,6 +19,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Fusion\FusionObjects\Helpers\FusionAwareViewInterface;
+use Neos\Neos\Domain\Model\RenderingMode;
 use Neos\Neos\Service\ContentElementWrappingService;
 
 /**
@@ -85,6 +86,13 @@ class WrapViewHelper extends AbstractViewHelper
                 1645650713
             );
         }
+
+        /** @var RenderingMode $renderingMode */
+        $renderingMode = $fusionObject->getRuntime()->fusionGlobals->get('renderingMode');
+        if (!$renderingMode->isEdit) {
+            return (string)$this->renderChildren();
+        }
+
         $currentContext = $fusionObject->getRuntime()->getCurrentContext();
 
         $node = $this->arguments['node'] ?? $currentContext['node'];

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\PyStringNode;
-use Behat\Gherkin\Node\TableNode;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
@@ -24,9 +23,9 @@ use Neos\Fusion\Core\FusionGlobals;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\RuntimeFactory;
-use Neos\Neos\Domain\Model\RenderingMode;
-use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Fusion\Exception\RuntimeException;
+use Neos\Neos\Domain\Service\NodeTypeNameFactory;
+use Neos\Neos\Domain\Service\RenderingModeService;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 
@@ -68,12 +67,12 @@ trait FusionTrait
     }
 
     /**
-     * @When I am in Fusion rendering mode:
+     * @When the Fusion renderingMode is :requestUri
      */
-    public function iAmInFusionRenderingMode(TableNode $renderingModeData): void
+    public function iAmInFusionRenderingMode(string $renderingModeName): void
     {
-        $data = $renderingModeData->getHash()[0];
-        $this->fusionGlobalContext['renderingMode'] = new RenderingMode($data['name'] ?? 'Testing', strtolower($data['isEdit'] ?? 'false') === 'true', strtolower($data['isPreview'] ?? 'false') === 'true', $data['title'] ?? 'Testing', $data['fusionPath'] ?? 'root', []);
+        $renderingMode = $this->getObject(RenderingModeService::class)->findByName($renderingModeName);
+        $this->fusionGlobalContext['renderingMode'] = $renderingMode;
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -55,7 +55,7 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     """
     And the Fusion context node is "a"
     And the Fusion context request URI is "http://localhost"
-
+    And the Fusion renderingMode is "frontend"
   Scenario: Default output
     When I execute the following Fusion code:
     """fusion
@@ -111,6 +111,22 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     Then I expect the following Fusion rendering result:
     """
     Some value with node URI: /a1.
+    """
+
+  Scenario: URI preserved in edit mode
+    Given the Fusion renderingMode is "inPlace"
+    When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      value = 'Some value with node URI: node://a1.'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    Some value with node URI: node://a1.
     """
 
   Scenario: Anchor tag without node or asset URI


### PR DESCRIPTION
Resolves partially #4396
Resolves: #2347

This refactors the `isBackend` checks in php land to use the defined [`renderingMode`](https://github.com/neos/neos-development-collection/pull/4505) in fusion. Currently the content element wrapping service would otherwise check if the workspace is live and otherwise assume we are in the backend which is wrong. This would cause the content element wrapping to be needlessly rendered in the preview mode (this causes also issues like https://github.com/neos/neos-ui/issues/3144)

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
