### PR TITLE
TASK: #4736 Json serialize Subgraph correctly

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -454,15 +454,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
     }
 
-    /**
-     * @return array<string,mixed>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): ContentSubgraphIdentity
     {
-        return [
-            'contentStreamId' => $this->contentStreamId,
-            'dimensionSpacePoint' => $this->dimensionSpacePoint
-        ];
+        return $this->getIdentity();
     }
 
     /** ------------------------------------------- */

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
@@ -532,14 +532,8 @@ final readonly class ContentSubhypergraph implements ContentSubgraphInterface
         return $this->databaseClient->getConnection();
     }
 
-    /**
-     * @return array<string,mixed>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): ContentSubgraphIdentity
     {
-        return [
-            'contentStreamId' => $this->contentStreamId,
-            'dimensionSpacePoint' => $this->dimensionSpacePoint
-        ];
+        return $this->getIdentity();
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryId.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryId.php
@@ -19,7 +19,7 @@ namespace Neos\ContentRepository\Core\Factory;
  *
  * @api
  */
-final class ContentRepositoryId
+final class ContentRepositoryId implements \JsonSerializable
 {
     private function __construct(
         public readonly string $value
@@ -46,5 +46,10 @@ final class ContentRepositoryId
     public function equals(self $other): bool
     {
         return $this->value === $other->value;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->value;
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -262,7 +262,7 @@ final class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
         return array_filter(get_object_vars($filter), static fn ($value) => $value !== null) === [];
     }
 
-    public function jsonSerialize(): mixed
+    public function jsonSerialize(): ContentSubgraphIdentity
     {
         return $this->wrappedContentSubgraph->jsonSerialize();
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
@@ -33,7 +33,7 @@ use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
  *
  * @api
  */
-final class ContentSubgraphIdentity
+final class ContentSubgraphIdentity implements \JsonSerializable
 {
     private function __construct(
         public readonly ContentRepositoryId $contentRepositoryId,
@@ -89,5 +89,18 @@ final class ContentSubgraphIdentity
             $this->dimensionSpacePoint,
             $visibilityConstraints
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'contentRepositoryId' => $this->contentRepositoryId,
+            'contentStreamId' => $this->contentStreamId,
+            'dimensionSpacePoint' => $this->dimensionSpacePoint,
+            'visibilityConstraints' => $this->visibilityConstraints
+        ];
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
@@ -209,4 +209,6 @@ interface ContentSubgraphInterface extends \JsonSerializable
      * @internal this method might change without further notice.
      */
     public function countNodes(): int;
+
+    public function jsonSerialize(): ContentSubgraphIdentity;
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
@@ -21,7 +21,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph;
  *
  * @api
  */
-final class VisibilityConstraints
+final class VisibilityConstraints implements \JsonSerializable
 {
     protected bool $disabledContentShown = false;
 
@@ -48,5 +48,10 @@ final class VisibilityConstraints
     public static function frontend(): VisibilityConstraints
     {
         return new VisibilityConstraints(false);
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->getHash();
     }
 }


### PR DESCRIPTION
Resolves: #4736

The subgraph should also serialize its newly added cr id as well as the visibility constraints.

example output:

```
{"contentRepositoryId":"default","contentStreamId":"a6e86502-5867-4460-a855-4134489d6b1b","dimensionSpacePoint":{"language":"en_US"},"visibilityConstraints":"075ae3d2fc31640504f814f60e5ef713"}
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
