### PR TITLE
TASK: Fusion Behat Test Make Sure To Throw Runtime Exceptions

### DIFF
--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -122,7 +122,14 @@ trait FusionTrait
         self::$bootstrap->setActiveRequestHandler($requestHandler);
         $this->throwExceptionIfLastRenderingLedToAnError();
         $this->renderingResult = null;
-        $fusionAst = (new Parser())->parseFromSource(FusionSourceCodeCollection::fromString($this->fusionCode . chr(10) . $fusionCode->getRaw()));
+        $fusionAst = (new Parser())->parseFromSource(FusionSourceCodeCollection::fromString($this->fusionCode . chr(10) . $fusionCode->getRaw())->union(
+            // make sure all exceptions are thrown. Not needed with Neos 9
+            FusionSourceCodeCollection::fromString(<<<FUSION
+            $path {
+                @exceptionHandler = 'Neos\\\\Fusion\\\\Core\\\\ExceptionHandlers\\\\ThrowingHandler'
+            }
+            FUSION)
+        ));
         $uriBuilder = new UriBuilder();
         $uriBuilder->setRequest($this->fusionRequest);
         $controllerContext = new ControllerContext($this->fusionRequest, new ActionResponse(), new Arguments(), $uriBuilder);

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
@@ -33,9 +33,7 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
     include: resource://Neos.Fusion/Private/Fusion/Root.fusion
     include: resource://Neos.Neos/Private/Fusion/Root.fusion
 
-    test = Neos.Neos:ContentCollection {
-      @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\ThrowingHandler'
-    }
+    test = Neos.Neos:ContentCollection
     """
     Then I expect the following Fusion rendering error:
     """
@@ -50,7 +48,6 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
 
     test = Neos.Neos:ContentCollection {
       nodePath = 'invalid'
-      @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\ThrowingHandler'
     }
     """
     Then I expect the following Fusion rendering error:


### PR DESCRIPTION
Additional fix for https://github.com/neos/neos-development-collection/pull/4686

Instead of manually declaring `@exceptionHandler` we set it automatically for the entry point ;) This will help us detect exceptions which would otherwise be absorbed.

Dont worry, this is only temporary and not at all needed with neos 9

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
