### PR TITLE
TASK: Speed up Behat tests

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Classes/TestSuite/Behavior/CRBehavioralTestsSubjectProvider.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/TestSuite/Behavior/CRBehavioralTestsSubjectProvider.php
@@ -36,7 +36,7 @@ trait CRBehavioralTestsSubjectProvider
      * A runtime cache of all content repositories already set up, represented by their ID
      * @var array<ContentRepositoryId>
      */
-    protected array $alreadySetUpContentRepositories = [];
+    protected static array $alreadySetUpContentRepositories = [];
 
     protected ?ContentRepository $currentContentRepository = null;
 
@@ -169,8 +169,9 @@ trait CRBehavioralTestsSubjectProvider
          * Catch Up process and the testcase reset.
          */
         $contentRepository = $this->createContentRepository($contentRepositoryId);
-        if (!in_array($contentRepository->id, $this->alreadySetUpContentRepositories)) {
+        if (!in_array($contentRepository->id, self::$alreadySetUpContentRepositories)) {
             $contentRepository->setUp();
+            self::$alreadySetUpContentRepositories[] = $contentRepository->id;
         }
         /** @var EventStoreInterface $eventStore */
         $eventStore = (new \ReflectionClass($contentRepository))->getProperty('eventStore')->getValue($contentRepository);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -80,14 +80,12 @@ trait CRTestSuiteTrait
     use WorkspaceDiscarding;
     use WorkspacePublishing;
 
-    protected function setupCRTestSuiteTrait(bool $alwaysRunCrSetup = false): void
+    protected function setupCRTestSuiteTrait(): void
     {
         if (getenv('CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION')) {
             CatchUpTriggerWithSynchronousOption::enableSynchronicityForSpeedingUpTesting();
         }
     }
-
-    private static bool $wasContentRepositorySetupCalled = false;
 
     /**
      * @BeforeScenario

--- a/Neos.ContentRepositoryRegistry.TestSuite/Classes/Behavior/CRRegistrySubjectProvider.php
+++ b/Neos.ContentRepositoryRegistry.TestSuite/Classes/Behavior/CRRegistrySubjectProvider.php
@@ -34,7 +34,7 @@ trait CRRegistrySubjectProvider
     /**
      * @var array<ContentRepositoryId>
      */
-    protected array $alreadySetUpContentRepositories = [];
+    protected static array $alreadySetUpContentRepositories = [];
 
     /**
      * @template T of object
@@ -62,8 +62,9 @@ trait CRRegistrySubjectProvider
         $eventTableName = sprintf('cr_%s_events', $contentRepositoryId);
         $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName);
 
-        if (!in_array($contentRepository->id, $this->alreadySetUpContentRepositories)) {
+        if (!in_array($contentRepository->id, self::$alreadySetUpContentRepositories)) {
             $contentRepository->setUp();
+            self::$alreadySetUpContentRepositories[] = $contentRepository->id;
         }
         $contentRepository->resetProjectionStates();
     }

--- a/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
@@ -1,5 +1,11 @@
 Neos:
   Flow:
+    persistence:
+      doctrine:
+        migrations:
+          ignoredTables:
+            'cr_.*': true
+
     # Improve debug output for node objects by ignoring large classes
     error:
       debugger:

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -11,7 +11,6 @@
  */
 
 use Behat\Behat\Context\Context as BehatContext;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Neos\Behat\FlowBootstrapTrait;
 use Neos\Behat\FlowEntitiesTrait;
 use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\CRBehavioralTestsSubjectProvider;
@@ -50,7 +49,7 @@ class FeatureContext implements BehatContext
         $this->environment = $this->getObject(Environment::class);
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
 
-        $this->setupCRTestSuiteTrait(true);
+        $this->setupCRTestSuiteTrait();
     }
 
     /*
@@ -63,7 +62,7 @@ class FeatureContext implements BehatContext
     /**
      * @BeforeScenario
      */
-    public function resetContentRepositoryComponents(BeforeScenarioScope $scope): void
+    public function resetContentRepositoryComponents(): void
     {
         GherkinTableNodeBasedContentDimensionSourceFactory::reset();
         GherkinPyStringNodeBasedNodeTypeManagerFactory::reset();

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -73,9 +73,6 @@ class FeatureContext implements BehatContext
      */
     public function resetPersistenceManagerAndFeedbackCollection()
     {
-        // FIXME: we have some strange race condition between the scenarios; my theory is that
-        // somehow projectors still run in the background when we start from scratch...
-        sleep(2);
         $this->getObject(\Neos\Flow\Persistence\PersistenceManagerInterface::class)->clearState();
         // FIXME: FeedbackCollection is a really ugly, hacky SINGLETON; so it needs to be RESET!
         $this->getObject(\Neos\Neos\Ui\Domain\Model\FeedbackCollection::class)->reset();


### PR DESCRIPTION
During the refactoring of our testsuite via https://github.com/neos/neos-development-collection/pull/4455 a performance optimization got lost.

Previously we only `setUp` a content repository once because the schema creation in the setup is super slow: https://github.com/neos/neos-development-collection/issues/4762

By preventing the projections to be resetup again, we gain a noticeable performance improvement (about 80%) of the whole e2e tests on the ci:

| Before | After |
|--------|--------|
| 18:32m |  3:52m | 

locally they run in like a minute.

To let tests in `Neos.Neos` profit from the same performance boost, we need to avoid the cr tables being dropped due to the `@flowEntities` tag (see https://github.com/neos/behat/pull/37#issuecomment-1810848636). This. is achieved via the adjustments in https://github.com/neos/behat/pull/37 which will respect the configured `ignoredTables` configuration.

----

Additionally a `sleep(2);` statement which was run for every scenario was hidden in the `Neos.Neos` tests.

This was an early hotfix for our previously async running tests. Currently we run tests only in sync mode `CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1` as the async mode is broken: https://github.com/neos/neos-development-collection/issues/4612

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

### Things and answers (collected from https://github.com/neos/behat/pull/37 and [slack](https://neos-project.slack.com/archives/C3MCBK6S2/p1699904934364399)):

Dont we have to truncate the tables every time so the projections are empty?
> we do that explicitly via $contentRepository->resetProjectionStates();. 

Can we safely empty the tables? Would that be the equivalent to `resetProjectionStates`?
> nope we need an initial entry in the checkpoint tables

Shouldnt we make `setUp` just faster by caching the `createSchema`?
> yes and no. With https://github.com/neos/neos-development-collection/issues/4762 we plan to optimize performance of the setup but without caching the schema see issue.


Related: #4388
