### PR TITLE
TASK: 4305 Mark *Serialized* commands `@internal`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNode.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNode.php
@@ -25,10 +25,8 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * CreateNodeAggregateWithNode
+ * Creates a new node aggregate with a new node.
  *
- * Creates a new node aggregate with a new node in the given `contentStreamId`
- * with the given `nodeAggregateId` and `originDimensionSpacePoint`.
  * The node will be appended as child node of the given `parentNodeId` which must cover the given
  * `originDimensionSpacePoint`.
  *

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
@@ -30,7 +30,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  * The properties of {@see CreateNodeAggregateWithNode} are directly serialized; and then this command
  * is called and triggers the actual processing.
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail, use {@see CreateNodeAggregateWithNode} instead.
  */
 final class CreateNodeAggregateWithNodeAndSerializedProperties implements
     CommandInterface,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetSerializedNodeProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetSerializedNodeProperties.php
@@ -24,11 +24,11 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * Set property values for a given node (internal implementation).
+ * Set property values for a given node.
  *
  * The property values contain the serialized types already, and include type information.
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail, use {@see SetNodeProperties} instead.
  */
 final class SetSerializedNodeProperties implements
     CommandInterface,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetSerializedNodeReferences.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetSerializedNodeReferences.php
@@ -25,11 +25,11 @@ use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * Set property values for a given node (internal implementation).
+ * Set property values for a given node.
  *
  * The property values contain the serialized types already, and include type information.
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail, use {@see SetNodeReferences} instead.
  */
 final class SetSerializedNodeReferences implements
     CommandInterface,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/SerializedNodeReference.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/SerializedNodeReference.php
@@ -20,7 +20,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 /**
  * "Raw" / Serialized node reference as saved in the event log // in projections.
  *
- * @api used as part of commands/events
+ * @internal
  */
 final class SerializedNodeReference implements \JsonSerializable
 {

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/SerializedNodeReferences.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/SerializedNodeReferences.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
  * A collection of SerializedNodeReference objects, to be used when creating reference relations.
  *
  * @implements \IteratorAggregate<SerializedNodeReference>
- * @api used as part of commands/events
+ * @internal
  */
 final readonly class SerializedNodeReferences implements \IteratorAggregate, \Countable, \JsonSerializable
 {


### PR DESCRIPTION
Resolves: #4305

they should normally not be called from user land.

Especially because in some cases the command validation is not perfect for the Serialized commands and we only validate the "main" commands fully.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
