### PR TITLE
TASK: remigrate all Neos.Neos fusion files and implementations

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -139,7 +139,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $unresolvedUris = [];
         $absolute = $this->fusionValue('absolute');
 
-        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $nodeAddress, &$unresolvedUris, $absolute) {
+        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($nodeAddress, &$unresolvedUris, $absolute) {
             $resolvedUri = null;
             switch ($matches[1]) {
                 case 'node':
@@ -174,10 +174,13 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
             return $resolvedUri;
         }, $text);
+        assert($processedContent !== null, 'preg_* error');
 
         if ($unresolvedUris !== []) {
             $processedContent = preg_replace('/<a(?:\s+[^>]*)?\s+href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
+            assert($processedContent !== null, 'preg_* error');
             $processedContent = preg_replace(self::PATTERN_SUPPORTED_URIS, '', $processedContent);
+            assert($processedContent !== null, 'preg_* error');
         }
 
         $processedContent = $this->replaceLinkTargets($processedContent);
@@ -228,6 +231,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
             },
             $processedContent
         );
+        assert($processedContent !== null, 'preg_* error');
         return $processedContent;
     }
 
@@ -249,7 +253,9 @@ class ConvertUrisImplementation extends AbstractFusionObject
                 return $content;
             }
             // Add the attribute to the list
-            return \preg_replace('/' . $attribute . '="(.*?)"/', sprintf('%s="$1 %s"', $attribute, $value), $content);
+            $result = \preg_replace('/' . $attribute . '="(.*?)"/', sprintf('%s="$1 %s"', $attribute, $value), $content);
+            assert($result !== null, 'preg_* error');
+            return $result;
         }
 
         // Add the missing attribute with the value

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -111,7 +111,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         if (!is_string($text)) {
             throw new NeosException(sprintf(
                 'Only strings can be processed by this Fusion object, given: "%s".',
-                gettype($text)
+                get_debug_type($text)
             ), 1382624080);
         }
 
@@ -120,7 +120,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         if (!$node instanceof Node) {
             throw new NeosException(sprintf(
                 'The current node must be an instance of Node, given: "%s".',
-                gettype($text)
+                get_debug_type($text)
             ), 1382624087);
         }
 
@@ -139,53 +139,45 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $unresolvedUris = [];
         $absolute = $this->fusionValue('absolute');
 
-        $processedContent = preg_replace_callback(
-            self::PATTERN_SUPPORTED_URIS,
-            function (array $matches) use (&$unresolvedUris, $absolute, $nodeAddress) {
-                $resolvedUri = null;
-                switch ($matches[1]) {
-                    case 'node':
-                        $nodeAddress = $nodeAddress->withNodeAggregateId(
-                            NodeAggregateId::fromString($matches[2])
+        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($node, $nodeAddress, &$unresolvedUris, $absolute) {
+            $resolvedUri = null;
+            switch ($matches[1]) {
+                case 'node':
+                    $nodeAddress = $nodeAddress->withNodeAggregateId(
+                        NodeAggregateId::fromString($matches[2])
+                    );
+                    $uriBuilder = new UriBuilder();
+                    $uriBuilder->setRequest($this->runtime->getControllerContext()->getRequest());
+                    $uriBuilder->setCreateAbsoluteUri($absolute);
+                    try {
+                        $resolvedUri = (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
+                    } catch (NoMatchingRouteException) {
+                        $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri. Arguments: %s', $matches[0], json_encode($uriBuilder->getLastArguments())), LogEnvironment::fromMethodName(__METHOD__));
+                    }
+                    $this->runtime->addCacheTag('node', $matches[2]);
+                    break;
+                case 'asset':
+                    $asset = $this->assetRepository->findByIdentifier($matches[2]);
+                    if ($asset instanceof AssetInterface) {
+                        $resolvedUri = $this->resourceManager->getPublicPersistentResourceUri(
+                            $asset->getResource()
                         );
-                        $uriBuilder = new UriBuilder();
-                        $uriBuilder->setRequest($this->runtime->getControllerContext()->getRequest());
-                        $uriBuilder->setCreateAbsoluteUri($absolute);
-                        try {
-                            $resolvedUri = (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
-                        } catch (NoMatchingRouteException) {
-                            $this->systemLogger->info(sprintf('Could not resolve "%s" to a live node uri. The node was probably deleted.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
-                        }
-                        $this->runtime->addCacheTag('node', $matches[2]);
-                        break;
-                    case 'asset':
-                        $asset = $this->assetRepository->findByIdentifier($matches[2]);
-                        if ($asset instanceof AssetInterface) {
-                            $resolvedUri = $this->resourceManager->getPublicPersistentResourceUri(
-                                $asset->getResource()
-                            );
-                            $this->runtime->addCacheTag('asset', $matches[2]);
-                        }
-                        break;
-                }
+                        $this->runtime->addCacheTag('asset', $matches[2]);
+                    }
+                    break;
+            }
 
-                if ($resolvedUri === null) {
-                    $unresolvedUris[] = $matches[0];
-                    return $matches[0];
-                }
+            if ($resolvedUri === null) {
+                $unresolvedUris[] = $matches[0];
+                return $matches[0];
+            }
 
-                return $resolvedUri;
-            },
-            $text
-        ) ?: '';
+            return $resolvedUri;
+        }, $text);
 
         if ($unresolvedUris !== []) {
-            $processedContent = preg_replace(
-                '/<a[^>]* href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/',
-                '$2',
-                $processedContent
-            ) ?: '';
-            $processedContent = preg_replace(self::PATTERN_SUPPORTED_URIS, '', $processedContent) ?: '';
+            $processedContent = preg_replace('/<a(?:\s+[^>]*)?\s+href="(node|asset):\/\/[^"]+"[^>]*>(.*?)<\/a>/', '$2', $processedContent);
+            $processedContent = preg_replace(self::PATTERN_SUPPORTED_URIS, '', $processedContent);
         }
 
         $processedContent = $this->replaceLinkTargets($processedContent);
@@ -196,57 +188,71 @@ class ConvertUrisImplementation extends AbstractFusionObject
     /**
      * Replace the target attribute of link tags in processedContent with the target
      * specified by externalLinkTarget and resourceLinkTarget options.
-     * Additionally sets rel="noopener" for links with target="_blank",
-     * and rel="noopener external" for external links.
+     * Additionally set rel="noopener external" for external links.
+     *
+     * @param string $processedContent
+     * @return string
      */
-    protected function replaceLinkTargets(string $processedContent): string
+    protected function replaceLinkTargets($processedContent)
     {
         $setNoOpener = $this->fusionValue('setNoOpener');
         $setExternal = $this->fusionValue('setExternal');
-        $externalLinkTarget = trim($this->fusionValue('externalLinkTarget'));
-        $resourceLinkTarget = trim($this->fusionValue('resourceLinkTarget'));
-        if ($externalLinkTarget === '' && $resourceLinkTarget === '') {
-            return $processedContent;
-        }
+        $externalLinkTarget = \trim((string)$this->fusionValue('externalLinkTarget'));
+        $resourceLinkTarget = \trim((string)$this->fusionValue('resourceLinkTarget'));
         $controllerContext = $this->runtime->getControllerContext();
         $host = $controllerContext->getRequest()->getHttpRequest()->getUri()->getHost();
-        // todo optimize to only use one preg_replace_callback for uri converting
-        $processedContent = preg_replace_callback(
-            '~<a.*?href="(.*?)".*?>~i',
-            function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $setNoOpener, $setExternal) {
-                list($linkText, $linkHref) = $matches;
-                $uriHost = parse_url($linkHref, PHP_URL_HOST);
+        $processedContent = \preg_replace_callback(
+            '~<a\s+.*?href="(.*?)".*?>~i',
+            static function ($matches) use ($externalLinkTarget, $resourceLinkTarget, $host, $setNoOpener, $setExternal) {
+                [$linkText, $linkHref] = $matches;
+                $uriHost = \parse_url($linkHref, PHP_URL_HOST);
                 $target = null;
-                $isExternalLink = is_string($uriHost) && $uriHost !== $host;
-                if ($externalLinkTarget !== '' && $isExternalLink) {
+                $isExternalLink = \is_string($uriHost) && $uriHost !== $host;
+
+                if ($externalLinkTarget && $externalLinkTarget !== '' && $isExternalLink) {
                     $target = $externalLinkTarget;
                 }
-                if ($resourceLinkTarget !== '' && str_contains($linkHref, '_Resources')) {
+                if ($resourceLinkTarget && $resourceLinkTarget !== '' && str_contains($linkHref, '_Resources')) {
                     $target = $resourceLinkTarget;
                 }
-                if ($target === null) {
-                    return $linkText;
+                if ($isExternalLink && $setNoOpener) {
+                    $linkText = self::setAttribute('rel', 'noopener', $linkText);
                 }
-                // todo merge with "rel" attribute if already existent
-                $relValue = $isExternalLink && $setNoOpener ? 'noopener ' : '';
-                $relValue .= $isExternalLink && $setExternal ? 'external' : '';
-                $relValue = ltrim($relValue);
-                if (str_contains($linkText, 'target="')) {
-                    // todo shouldn't we merge the current target value
-                    return preg_replace(
-                        '/target="[^"]*"/',
-                        sprintf('target="%s"%s', $target, $relValue ? sprintf(' rel="%s"', $relValue) : $relValue),
-                        $linkText
-                    );
+                if ($isExternalLink && $setExternal) {
+                    $linkText = self::setAttribute('rel', 'external', $linkText);
                 }
-                return str_replace(
-                    '<a',
-                    sprintf('<a target="%s"%s', $target, $relValue ? sprintf(' rel="%s"', $relValue) : $relValue),
-                    $linkText
-                );
+                if (is_string($target) && $target !== '') {
+                    return self::setAttribute('target', $target, $linkText);
+                }
+                return $linkText;
             },
             $processedContent
-        ) ?: '';
+        );
         return $processedContent;
+    }
+
+
+    /**
+     * Set or add value to the a attribute
+     *
+     * @param string $attribute The attribute, ('target' or 'rel')
+     * @param string $value The value of the attribute to add
+     * @param string $content The content to parse
+     * @return string
+     */
+    private static function setAttribute(string $attribute, string $value, string $content): string
+    {
+        // The attribute is already set
+        if (\preg_match_all('~\s+' . $attribute . '="(.*?)~i', $content, $matches)) {
+            // If the attribute is target or the value is already set, leave the attribute as it is
+            if ($attribute === 'target' || \preg_match('~' . $attribute . '=".*?' . $value . '.*?"~i', $content)) {
+                return $content;
+            }
+            // Add the attribute to the list
+            return \preg_replace('/' . $attribute . '="(.*?)"/', sprintf('%s="$1 %s"', $attribute, $value), $content);
+        }
+
+        // Add the missing attribute with the value
+        return \str_replace('<a', sprintf('<a %s="%s"', $attribute, $value), $content);
     }
 }

--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -15,12 +15,15 @@ declare(strict_types=1);
 namespace Neos\Neos\Fusion;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\Neos\FrontendRouting\NodeUriBuilder;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\Utility\LogEnvironment;
+use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Neos\Neos\FrontendRouting\NodeAddressFactory;
+use Neos\Neos\FrontendRouting\NodeUriBuilder;
+use Psr\Log\LoggerInterface;
 
 /**
  * Create a link to a node
@@ -32,6 +35,12 @@ class NodeUriImplementation extends AbstractFusionObject
      * @var ContentRepositoryRegistry
      */
     protected $contentRepositoryRegistry;
+
+    /**
+     * @Flow\Inject
+     * @var LoggerInterface
+     */
+    protected $systemLogger;
 
     /**
      * A node object or a string node path or NULL to resolve the current document node
@@ -72,7 +81,7 @@ class NodeUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * Arguments to be removed from the URI. Only active if addQueryString = TRUE
+     * Arguments to be removed from the URI. Only active if addQueryString = true
      *
      * @return array<int,string>
      */
@@ -82,7 +91,7 @@ class NodeUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * If TRUE, the current query parameters will be kept in the URI
+     * If true, the current query parameters will be kept in the URI
      *
      * @return boolean
      */
@@ -92,7 +101,7 @@ class NodeUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * If TRUE, an absolute URI is rendered
+     * If true, an absolute URI is rendered
      *
      * @return boolean
      */
@@ -119,6 +128,14 @@ class NodeUriImplementation extends AbstractFusionObject
      */
     public function evaluate()
     {
+        $baseNode = null;
+        $baseNodeName = $this->getBaseNodeName() ?: 'documentNode';
+        $currentContext = $this->runtime->getCurrentContext();
+        if (isset($currentContext[$baseNodeName])) {
+            $baseNode = $currentContext[$baseNodeName];
+        } else {
+            throw new \RuntimeException(sprintf('Could not find a node instance in Fusion context with name "%s" and no node instance was given to the node argument. Set a node instance in the Fusion context or pass a node object to resolve the URI.', $baseNodeName), 1373100400);
+        }
         $node = $this->getNode();
         if ($node instanceof Node) {
             $contentRepository = $this->contentRepositoryRegistry->get(
@@ -127,7 +144,7 @@ class NodeUriImplementation extends AbstractFusionObject
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($node);
         } else {
-            return '';
+            throw new \RuntimeException(sprintf('Passing node as %s is not supported yet.', get_debug_type($node)));
         }
         /* TODO implement us see https://github.com/neos/neos-development-collection/issues/4524 {@see \Neos\Neos\ViewHelpers\Uri\NodeViewHelper::resolveNodeAddressFromString} for an example implementation
         elseif ($node === '~') {
@@ -144,13 +161,18 @@ class NodeUriImplementation extends AbstractFusionObject
         $uriBuilder = new UriBuilder();
         $uriBuilder->setRequest($this->runtime->getControllerContext()->getRequest());
         $uriBuilder
-            ->setAddQueryString($this->getAddQueryString())
-            ->setArguments($this->getAdditionalParams())
-            ->setArgumentsToBeExcludedFromQueryString($this->getArgumentsToBeExcludedFromQueryString())
-            ->setCreateAbsoluteUri($this->isAbsolute())
             ->setFormat($this->getFormat())
-            ->setSection($this->getSection());
+            ->setCreateAbsoluteUri($this->isAbsolute())
+            ->setArguments($this->getAdditionalParams())
+            ->setSection($this->getSection())
+            ->setAddQueryString($this->getAddQueryString())
+            ->setArgumentsToBeExcludedFromQueryString($this->getArgumentsToBeExcludedFromQueryString());
 
-        return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
+        try {
+            return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
+        } catch (NoMatchingRouteException) {
+            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri. Arguments: %s', $node->nodeAggregateId->value, json_encode($uriBuilder->getLastArguments())), LogEnvironment::fromMethodName(__METHOD__));
+        }
+        return '';
     }
 }

--- a/Neos.Neos/Classes/Fusion/PluginImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginImplementation.php
@@ -78,7 +78,7 @@ class PluginImplementation extends AbstractArrayFusionObject
     }
 
     /**
-     * @return ?string
+     * @return string|null
      */
     public function getArgumentNamespace()
     {

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
@@ -8,6 +8,7 @@
 prototype(Neos.Neos:Content) < prototype(Neos.Fusion:Template) {
   node = ${node}
 
+  // @todo simple array join in fusion
   attributes = Neos.Fusion:DataStructure
   attributes.class = ''
 

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ContentCase.fusion
@@ -6,6 +6,7 @@ prototype(Neos.Neos:ContentCase) < prototype(Neos.Fusion:Case) {
   default {
     @position = 'end'
     condition = true
+    # this eel helper also handles the Neos.Neos:FallbackNode node type mechanism
     type = ${Neos.Node.getNodeType(node).name.value}
   }
 }

--- a/Neos.Neos/Resources/Private/Fusion/Root.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Root.fusion
@@ -4,4 +4,3 @@ include: ErrorCase.fusion
 include: RootCase.fusion
 include: RawContentMode.fusion
 include: Override/*.fusion
-include: Error/Root.fusion


### PR DESCRIPTION
We noticed that Neos 9.0 had one missing feature in the Fusion implementations. To make sure there are no other faulty fusion implementations i checked and remigrated some fusion implementations.

Especially the ConvertUris implementation seems to have been affected. It seems as that it was now optimised for performance with a loss in features.


see https://github.com/neos/neos-development-collection/pull/4744

> it seems $someone tried to optimize the convert uris stuff from 8.3 while migrating the code to 9.0
> it should behave more performant with the cost of being less accurate and not covering all edgecases.
> 
> Maybe we should revert those performance optimization and introduce all those additional preg_match and replaces again for more accuracy. People might already have trouble enough with 9.0. Silent regressions like these will make things even harder.

@kitsunet wrote
> We can probably work on this at another point again, given that this is cached I don't see much problem in having this regex there, also I am sure this won't be in the top 5 of performance problems of rendering 🙈
>
> tl;dr; fine by me to go back to this.

Thats why i did checkout the 8.3 version of the `ConvertUrisImplementation` and remigrated its code to 9.0 without any additional performance in mind.

How i did it?

i reset the interesting fusion files, and checked what could possibly be wrong:

```
git checkout 8.3 -- Neos.Neos/Classes/Fusion/*Implementation.php
git checkout 8.3 -- Neos.Neos/Resources/Private/Fusion/
git checkout 8.3 -- Neos.Neos/Classes/Fusion/ExceptionHandlers/
git checkout 8.3 -- Neos.Neos/Classes/Fusion/Helper/
```
**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
