### PR TITLE
BUGFIX: Respect position when ordering nodes

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -406,7 +406,8 @@ final class ContentGraph implements ContentGraphInterface
                           AND r.dimensionspacepointhash = ph.dimensionspacepointhash
                       WHERE p.nodeaggregateid = :parentNodeAggregateId
                       AND ph.contentstreamid = :contentStreamId
-                      AND ch.contentstreamid = :contentStreamId';
+                      AND ch.contentstreamid = :contentStreamId
+                      ORDER BY ch.position';
     }
 
     /**

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -317,7 +317,7 @@ final class ContentGraph implements ContentGraphInterface
     ): iterable {
         $connection = $this->client->getConnection();
 
-        $query = $this->createChildNodeAggregateQuery();
+        $query = $this->createChildNodeAggregateQuery() . ' ORDER BY ch.position';
 
         $parameters = [
             'parentNodeAggregateId' => $parentNodeAggregateId->value,
@@ -344,7 +344,8 @@ final class ContentGraph implements ContentGraphInterface
         $connection = $this->client->getConnection();
 
         $query = $this->createChildNodeAggregateQuery() . '
-                      AND ch.name = :relationName';
+                      AND ch.name = :relationName
+                      ORDER BY ch.position';
 
         $parameters = [
             'contentStreamId' => $contentStreamId->value,
@@ -371,7 +372,8 @@ final class ContentGraph implements ContentGraphInterface
         $connection = $this->client->getConnection();
 
         $query = $this->createChildNodeAggregateQuery() . '
-                      AND c.classification = :tetheredClassification';
+                      AND c.classification = :tetheredClassification
+                      ORDER BY ch.position';
 
         $parameters = [
             'contentStreamId' => $contentStreamId->value,
@@ -406,8 +408,7 @@ final class ContentGraph implements ContentGraphInterface
                           AND r.dimensionspacepointhash = ph.dimensionspacepointhash
                       WHERE p.nodeaggregateid = :parentNodeAggregateId
                       AND ph.contentstreamid = :contentStreamId
-                      AND ch.contentstreamid = :contentStreamId
-                      ORDER BY ch.position';
+                      AND ch.contentstreamid = :contentStreamId';
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -220,7 +220,8 @@ trait GenericCommandExecutionAndEventPublication
             $key = $assertionTableRow['Key'];
             $actualValue = Arrays::getValueByPath($actualEventPayload, $key);
 
-            if ($key === 'affectedDimensionSpacePoints') {
+            // Note: For dimension space points we switch to an array comparison because the order is not deterministic (@see https://github.com/neos/neos-development-collection/issues/4769)
+            if ($key === 'affectedDimensionSpacePoints' || $key === 'affectedOccupiedDimensionSpacePoints') {
                 $expected = DimensionSpacePointSet::fromJsonString($assertionTableRow['Expected']);
                 $actual = DimensionSpacePointSet::fromArray($actualValue);
                 Assert::assertTrue($expected->equals($actual), 'Actual Dimension Space Point set "' . json_encode($actualValue) . '" does not match expected Dimension Space Point set "' . $assertionTableRow['Expected'] . '"');

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -263,8 +263,8 @@ trait NodeTraversalTrait
         $subgraph = $this->getCurrentSubgraph();
 
         $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findDescendantNodes($entryNodeAggregateId, $filter)));
-        // Note: In contrast to other similar checks, in this case we use assertEquals() instead of assertSame() because the order of descendant nodes is not completely deterministic (@see https://github.com/neos/neos-development-collection/issues/4769)
-        Assert::assertEquals($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
+        // Note: In contrast to other similar checks, in this case we use assertEqualsCanonicalizing() instead of assertSame() because the order of descendant nodes is not completely deterministic (@see https://github.com/neos/neos-development-collection/issues/4769)
+        Assert::assertEqualsCanonicalizing($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
         $actualCount = $subgraph->countDescendantNodes($entryNodeAggregateId, CountDescendantNodesFilter::fromFindDescendantNodesFilter($filter));
         Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countDescendantNodes returned an unexpected result');
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -263,7 +263,8 @@ trait NodeTraversalTrait
         $subgraph = $this->getCurrentSubgraph();
 
         $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findDescendantNodes($entryNodeAggregateId, $filter)));
-        Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
+        // Note: In contrast to other similar checks, in this case we use assertEquals() instead of assertSame() because the order of descendant nodes is not completely deterministic (@see https://github.com/neos/neos-development-collection/issues/4769)
+        Assert::assertEquals($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
         $actualCount = $subgraph->countDescendantNodes($entryNodeAggregateId, CountDescendantNodesFilter::fromFindDescendantNodesFilter($filter));
         Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countDescendantNodes returned an unexpected result');
     }


### PR DESCRIPTION
...and relax Behat tests where a deterministic ordering is not given

Related: #4769