### PR TITLE
WIP improve NodeAggregate scoped properties

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -152,7 +152,7 @@ final class NodeFactory
         $rawNodeName = '';
         $rawNodeAggregateClassification = '';
         $occupiedDimensionSpacePoints = [];
-        $nodesByOccupiedDimensionSpacePoints = [];
+        $nodesByOccupiedDimensionSpacePoint = [];
         $coveredDimensionSpacePoints = [];
         $nodesByCoveredDimensionSpacePoints = [];
         $coverageByOccupants = [];
@@ -164,9 +164,9 @@ final class NodeFactory
             $occupiedDimensionSpacePoint = OriginDimensionSpacePoint::fromJsonString(
                 $nodeRow['origindimensionspacepoint']
             );
-            if (!isset($nodesByOccupiedDimensionSpacePoints[$occupiedDimensionSpacePoint->hash])) {
+            if (!isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])) {
                 // ... so we handle occupation exactly once ...
-                $nodesByOccupiedDimensionSpacePoints[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
+                $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
                     $nodeRow,
                     $occupiedDimensionSpacePoint->toDimensionSpacePoint(),
                     $visibilityConstraints
@@ -187,7 +187,7 @@ final class NodeFactory
                 = $coveredDimensionSpacePoint;
             $occupationByCovering[$coveredDimensionSpacePoint->hash] = $occupiedDimensionSpacePoint;
             $nodesByCoveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash]
-                = $nodesByOccupiedDimensionSpacePoints[$occupiedDimensionSpacePoint->hash];
+                = $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash];
             // ... as we do for disabling
             if (isset($nodeRow['disableddimensionspacepointhash'])) {
                 $disabledDimensionSpacePoints[$coveredDimensionSpacePoint->hash] = $coveredDimensionSpacePoint;
@@ -198,7 +198,7 @@ final class NodeFactory
         ksort($disabledDimensionSpacePoints);
 
         /** @var Node $primaryNode  a nodeAggregate only exists if it at least contains one node. */
-        $primaryNode = current($nodesByOccupiedDimensionSpacePoints);
+        $primaryNode = current($nodesByOccupiedDimensionSpacePoint);
 
         return new NodeAggregate(
             $primaryNode->subgraphIdentity->contentStreamId,
@@ -207,7 +207,7 @@ final class NodeFactory
             NodeTypeName::fromString($rawNodeTypeName),
             $rawNodeName ? NodeName::fromString($rawNodeName) : null,
             new OriginDimensionSpacePointSet($occupiedDimensionSpacePoints),
-            $nodesByOccupiedDimensionSpacePoints,
+            $nodesByOccupiedDimensionSpacePoint,
             CoverageByOrigin::fromArray($coverageByOccupants),
             new DimensionSpacePointSet($coveredDimensionSpacePoints),
             $nodesByCoveredDimensionSpacePoints,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_PropertyScopes.feature
@@ -1,7 +1,7 @@
 @contentrepository @adapters=DoctrineDBAL,Postgres
-Feature: Set node properties with different scopes
+Feature: Create a node aggregate with initial properties in different scopes
 
-  As a user of the CR I want to modify node properties with different scopes.
+  As a user of the CR I want to create initial node properties with different scopes.
 
   Background:
     Given using the following content dimensions:
@@ -13,48 +13,49 @@ Feature: Set node properties with different scopes
       properties:
         unscopedProperty:
           type: string
-          defaultValue: 'My initial string'
+          defaultValue: 'My string'
         nodeScopedProperty:
           type: string
           scope: node
-          defaultValue: 'My initial string'
+          defaultValue: 'My string'
         specializationsScopedProperty:
           type: string
           scope: specializations
-          defaultValue: 'My initial string'
+          defaultValue: 'My string'
         nodeAggregateScopedProperty:
           type: string
           scope: nodeAggregate
-          defaultValue: 'My initial string'
+          defaultValue: 'My string'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
-      | Key                        | Value                |
-      | workspaceName              | "live"               |
-      | workspaceTitle             | "Live"               |
-      | workspaceDescription       | "The live workspace" |
-      | newContentStreamId | "cs-identifier"      |
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | workspaceTitle       | "Live"               |
+      | workspaceDescription | "The live workspace" |
+      | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
     And I am in content stream "cs-identifier" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
-      | Key                     | Value                         |
+      | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
-      | nodeTypeName            | "Neos.ContentRepository:Root" |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
-    # We have to add another node since root nodes have no dimension space points and thus cannot be varied
-    # Node /document
+
+  Scenario: Create node with initial scoped properties
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                   | Value                                 |
+      | contentStreamId       | "cs-identifier"                       |
       | nodeAggregateId       | "nody-mc-nodeface"                    |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
-      | initialPropertyValues | {"unscopedProperty":"My string","nodeScopedProperty":"My string","specializationsScopedProperty":"My string","nodeAggregateScopedProperty":"My string"} |
+      | initialPropertyValues | {"unscopedProperty":"My new string","nodeScopedProperty":"My new string","specializationsScopedProperty":"My new string","nodeAggregateScopedProperty":"My new string"} |
     And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
-      | nodeAggregateId | "nody-mc-nodeface" |
+      | nodeAggregateId         | "nody-mc-nodeface" |
       | sourceOrigin            | {"language":"mul"} |
       | targetOrigin            | {"language":"de"}  |
     And the graph projection is fully up to date
@@ -64,21 +65,12 @@ Feature: Set node properties with different scopes
       | sourceOrigin            | {"language":"mul"} |
       | targetOrigin            | {"language":"gsw"} |
     And the graph projection is fully up to date
-
-  Scenario: Set node properties
-    And the command SetNodeProperties is executed with payload:
-      | Key                       | Value                                                                                                                                                                      |
-      | contentStreamId   | "cs-identifier"                                                                                                                                                            |
-      | nodeAggregateId   | "nody-mc-nodeface"                                                                                                                                                         |
-      | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                         |
-      | propertyValues            | {"unscopedProperty":"My new string", "nodeScopedProperty":"My new string", "specializationsScopedProperty":"My new string", "nodeAggregateScopedProperty":"My new string"} |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
     And I expect this node to have the following properties:
       | Key                           | Value           |
-      | unscopedProperty              | "My string"     |
-      | nodeScopedProperty            | "My string"     |
-      | specializationsScopedProperty | "My string"     |
+      | unscopedProperty              | "My new string" |
+      | nodeScopedProperty            | "My new string" |
+      | specializationsScopedProperty | "My new string" |
       | nodeAggregateScopedProperty   | "My new string" |
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"de"} to exist in the content graph
     And I expect this node to have the following properties:
@@ -90,7 +82,7 @@ Feature: Set node properties with different scopes
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"gsw"} to exist in the content graph
     And I expect this node to have the following properties:
       | Key                           | Value           |
-      | unscopedProperty              | "My string"     |
-      | nodeScopedProperty            | "My string"     |
+      | unscopedProperty              | "My new string" |
+      | nodeScopedProperty            | "My new string" |
       | specializationsScopedProperty | "My new string" |
       | nodeAggregateScopedProperty   | "My new string" |

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -133,12 +133,7 @@ trait TetheredNodeInternals
                 );
             }
 
-            $childNodeSource = null;
-            foreach ($childNodeAggregate->getNodes() as $node) {
-                $childNodeSource = $node;
-                break;
-            }
-            /** @var Node $childNodeSource Node aggregates are never empty */
+            $childNodeSource = $childNodeAggregate->getSingleNodeIndependentOfItsDimension();
             return $this->createEventsForVariations(
                 $parentNodeAggregate->contentStreamId,
                 $childNodeSource->originDimensionSpacePoint,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyScope.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyScope.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\NodeModification\Dto;
 
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
+use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
@@ -41,6 +42,16 @@ enum PropertyScope: string implements \JsonSerializable
      * The "nodeAggregate" scope, meaning that all variants, e.g. all nodes in the aggregate will be modified
      */
     case SCOPE_NODE_AGGREGATE = 'nodeAggregate';
+
+    public static function fromNodeTypeDeclaration(NodeType $nodeType, string $propertyName): self
+    {
+        $declaration = $nodeType->getProperties()[$propertyName]['scope'] ?? null;
+        if (is_string($declaration)) {
+            return PropertyScope::from($declaration);
+        } else {
+            return PropertyScope::SCOPE_NODE;
+        }
+    }
 
     public function resolveAffectedOrigins(
         OriginDimensionSpacePoint $origin,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -114,12 +114,7 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
     {
         $propertyValuesByScope = [];
         foreach ($this->values as $propertyName => $propertyValue) {
-            $declaration = $nodeType->getProperties()[$propertyName]['scope'] ?? null;
-            if (is_string($declaration)) {
-                $scope = PropertyScope::from($declaration);
-            } else {
-                $scope = PropertyScope::SCOPE_NODE;
-            }
+            $scope = PropertyScope::fromNodeTypeDeclaration($nodeType, $propertyName);
             $propertyValuesByScope[$scope->value][$propertyName] = $propertyValue;
         }
 

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/PropertyCollection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/PropertyCollection.php
@@ -88,6 +88,20 @@ final class PropertyCollection implements \ArrayAccess, \IteratorAggregate, \Cou
         }
     }
 
+    public function filter(\Closure $fn): self
+    {
+        $filtered = [];
+        foreach ($this->serializedPropertyValues as $propertyName => $propertyValue) {
+           if ($fn($propertyName)) {
+               $filtered[$propertyName] = $propertyValue;
+           }
+        }
+        return new self(
+            SerializedPropertyValues::fromArray($filtered),
+            $this->propertyConverter
+        );
+    }
+
     public function serialized(): SerializedPropertyValues
     {
         return $this->serializedPropertyValues;


### PR DESCRIPTION
wip

Hmm i was just wondering if the NodeAggregate should now its scoped properties ... and while reading some code i was wondering that we never actually save the scope status in the db but generate the events accordingly. ~i have the feeling that only set properties works correctly with scopes but not the initial properties of the create node aggregate with node~.

It seems that the node creation doesnt need special treatment for scoped properties. I tried to come up with a test but it looks strange and this behavior is actually already tested via the `defaultValue`.

About the NodeAggregate's properties, the logic could look like this:

```php
public function getAggregateScopedProperties(NodeType $nodeType): PropertyCollection
{
    $singleNode = $this->getSingleNodeIndependentOfItsDimension();
    return $singleNode->properties->filter(
        fn (string $propertyName)
            => PropertyScope::fromNodeTypeDeclaration($nodeType, $propertyName) === PropertyScope::SCOPE_NODE_AGGREGATE
    );
}
```

Odd is that we are depending on the currents node types schema and thus pass it in additionally (and trust it to be correct).

The main usecase is that the site node would have SCOPE_NODE_AGGREGATE properties, which should be accessible easily. And we can only narrow down by domain to a sitenodeaggregate and not the specific dimension
