### PR TITLE
BUGFIX: Replace incorrect mention of itemRenderer to itemReducer

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -208,7 +208,7 @@ Render each item in ``items`` using ``itemRenderer`` and return the result as an
 Neos.Fusion:Reduce
 ------------------
 
-Reduce the given items to a single value by using ``itemRenderer``.
+Reduce the given items to a single value by using ``itemReducer``.
 
 :items: (array/Iterable, **required**) The array or iterable to iterate over (to calculate ``iterator.isLast`` items have to be ``countable``)
 :itemName: (string, defaults to ``item``) Context variable name for each item


### PR DESCRIPTION
I'm not sure if we should target the 7.0 branch and then apply this to all following versions?

Was introduced here:
https://github.com/neos/neos-development-collection/commit/a7bc229541baa91dde6a85fbe4853b88db511af5#diff-3ed794da2fb825c61dd55eee6535b77958799b33384df7c47ac2a22242608969R207-R210