### PR TITLE
TASK: Use role label in list users/new user view if available

### DIFF
--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
@@ -1,7 +1,7 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <f:for each="{roles}" as="role" iteration="iteration">
 	<span class="neos-label" title="{f:render(section: 'tooltip', arguments: {role: role})}" data-neos-toggle="tooltip" data-placement="right" data-html="true">
-		{role.name}
+		{f:if(condition: role.label, then: role.label, else: role.name)}
 	</span>
 </f:for>
 

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
@@ -50,7 +50,7 @@
 						<div class="neos-controls">
 							<label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.packageKey}" data-neos-toggle="tooltip" data-placement="right">
 								<f:form.checkbox name="roleIdentifiers" multiple="true" value="{role.identifier}" id="roles-{rolesIteration.cycle}" /><span></span>
-								{role.name}
+								{f:if(condition: role.label, then: role.label, else: role.name)}
 							</label>
 						</div>
 					</f:for>


### PR DESCRIPTION
In Neos 7 (and with https://github.com/neos/flow-development-collection/issues/2162), role labels were introduced. While we now have a nice table view in the "edit account" view, the role label is not displayed anywhere else.

I'm aware that Neos 7 and 8 are in maintenance-only mode, but I think we all agree that Neos 8 will be around for quite a while. I suggest the minimal change to use the role label in the user list and the "new user" view if there is one.

- [N/A] Code follows the PSR-2 coding style
- [N/A] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [N/A] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
