### PR TITLE
BUGFIX: node:repair fails with could not be converted to string

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -833,7 +833,16 @@ HELPTEXT;
                             $convertedProperty->__load();
                         } /** @noinspection PhpRedundantCatchClauseInspection */ catch (EntityNotFoundException $e) {
                             $nodesWithBrokenEntityReferences[$nodeData->getIdentifier()][$propertyName] = $nodeData;
-                            $this->dispatch(self::EVENT_NOTICE, sprintf('Broken reference in "<i>%s</i>" (%s), property "<i>%s</i>" (<i>%s</i>) referring to <i>%s</i>.', $nodeData->getPath(), $nodeData->getIdentifier(), $propertyName, $propertyType, $propertyValue));
+                            $this->dispatch(self::EVENT_NOTICE, sprintf(
+                                'Broken reference in "<i>%s</i>" (%s), property "<i>%s</i>" (<i>%s</i>)%s.',
+                                $nodeData->getPath(),
+                                $nodeData->getIdentifier(),
+                                $propertyName,
+                                $propertyType,
+                                method_exists($propertyValue, '__toString') ?
+                                    ' referring to <i>' . $propertyValue->__toString() . '</i>' :
+                                    ''
+                            ));
                             $brokenReferencesCount ++;
                         }
                     }


### PR DESCRIPTION
Fixes the following crash during node:repair

```shell
./flow node:repair --dry-run --only removeBrokenEntityReferences
Dry run, not committing any changes.

Checking for broken entity references ...
Object of class Neos\Flow\Persistence\Doctrine\Proxies\__CG__\Neos\Media\Domain\Model\ImageVariant could not be converted to string

  Type: Error
  File: Data/Temporary/Development/SubContextWbWeb/Cache/Code/Flow_Object_Classes/Neos_ContentRepository_Command_NodeCommandControllerPlugin.php
  Line: 836
```

resolved #4794

**Upgrade instructions**

- [x] Code follows the PSR-2 coding style
- ~~Tests have been created, run and adjusted as needed~~
    - There are not tests in place and I added none.
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) -> 7.3
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
