### PR TITLE
BUGFIX: Filter for assets by asset collection by using constraints

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -287,7 +287,7 @@ class AssetRepository extends Repository
         }
 
         $constraints = $query->getConstraint();
-        $query->matching($query->logicalAnd([$constraints], $query->logicalAnd($variantsConstraints)));
+        $query->matching($query->logicalAnd([$constraints, $query->logicalAnd($variantsConstraints)]));
     }
 
     /**

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -87,7 +87,7 @@ class AssetRepository extends Repository
             $constraints[] = $query->contains('tags', $tag);
         }
         $query->matching($query->logicalOr($constraints));
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }
@@ -104,7 +104,7 @@ class AssetRepository extends Repository
     {
         $query = $this->createQuery();
         $query->matching($query->contains('tags', $tag));
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }
@@ -147,7 +147,7 @@ class AssetRepository extends Repository
     public function findAll(AssetCollection $assetCollection = null): QueryResultInterface
     {
         $query = $this->createQuery();
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }
@@ -188,7 +188,7 @@ class AssetRepository extends Repository
     {
         $query = $this->createQuery();
         $query->matching($query->isEmpty('tags'));
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }
@@ -229,7 +229,7 @@ class AssetRepository extends Repository
     public function findByAssetCollection(AssetCollection $assetCollection): QueryResultInterface
     {
         $query = $this->createQuery();
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
         $this->addAssetCollectionToQueryConstraints($query, $assetCollection);
         return $query->execute();
     }
@@ -268,9 +268,8 @@ class AssetRepository extends Repository
             return;
         }
 
-        $query->getQueryBuilder()->andWhere(
-            $query->contains('assetCollections', $assetCollection)
-        );
+        $constraints = $query->getConstraint();
+        $query->matching($query->logicalAnd([$constraints, $query->contains('assetCollections', $assetCollection)]));
     }
 
     /**
@@ -279,14 +278,16 @@ class AssetRepository extends Repository
      * @param Query $query
      * @return void
      */
-    protected function addAssetVariantFilterClause(Query $query): void
+    protected function addAssetVariantToQueryConstraints(QueryInterface $query): void
     {
-        $queryBuilder = $query->getQueryBuilder();
-
+        $variantsConstraints = [];
         $variantClassNames = $this->reflectionService->getAllImplementationClassNamesForInterface(AssetVariantInterface::class);
         foreach ($variantClassNames as $variantClassName) {
-            $queryBuilder->andWhere('e NOT INSTANCE OF ' . $variantClassName);
+            $variantsConstraints[] = 'e NOT INSTANCE OF ' . $variantClassName;
         }
+
+        $constraints = $query->getConstraint();
+        $query->matching($query->logicalAnd([$constraints, ...$variantsConstraints]));
     }
 
     /**
@@ -353,7 +354,7 @@ class AssetRepository extends Repository
     {
         /** @var Query $query */
         $query = $this->createQuery();
-        $this->addAssetVariantFilterClause($query);
+        $this->addAssetVariantToQueryConstraints($query);
 
         return $query->getQueryBuilder()->getQuery()->iterate();
     }

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -287,7 +287,7 @@ class AssetRepository extends Repository
         }
 
         $constraints = $query->getConstraint();
-        $query->matching($query->logicalAnd([$constraints, ...$variantsConstraints]));
+        $query->matching($query->logicalAnd([$constraints], $query->logicalAnd($variantsConstraints)));
     }
 
     /**


### PR DESCRIPTION
Fixes a bug, that was introduced with: https://github.com/neos/neos-development-collection/pull/4724

Because of using the QueryBuilder twice, the count of the paramter and for the query is not correct anymore.

Fixes #4801