### PR TITLE
TASK: Removes neos/neos-setup

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -4,8 +4,7 @@
   "license": ["GPL-3.0-or-later"],
   "type": "neos-package-collection",
   "require": {
-    "neos/flow-development-collection": "8.0.x-dev",
-    "neos/neos-setup": "^1.0"
+    "neos/flow-development-collection": "8.0.x-dev"
   },
   "replace": {
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "type": "neos-package-collection",
     "require": {
         "neos/flow-development-collection": "8.0.x-dev",
-        "neos/neos-setup": "^1.0",
         "php": "^8.0",
         "neos/flow": "*",
         "neos/cache": "*",


### PR DESCRIPTION
**Summary:**
When attempting to install Neos version 8.3 using the command `composer create-project neos/neos-development-distribution neos-development 8.3.x-dev --keep-vcs`, the installation results in the neos-setup (version 1.x) being installed. The `neos/cli-setup` tool has been removed and the default command `./flow welcome` is still called. But the  command is no longer available due to the absence of the CLI setup tool. Consequently, the setup process is not possible as the recommended command is missing.

We remove the dependency from the development collection and adds the `neos/neos-setup` in the latest version to the [neos-development-distribution](https://github.com/neos/neos-development-distribution) 