### PR TITLE
TASK: Extends exception message with NodeType name

### DIFF
--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
@@ -420,7 +420,7 @@ class NodeType
 
         if (!$this->hasProperty($propertyName)) {
             throw new \InvalidArgumentException(
-                sprintf('NodeType schema has no property "%s" configured. Cannot read its type.', $propertyName),
+                sprintf('NodeType schema has no property "%s" configured for the NodeType "%s". Cannot read its type.', $propertyName, $this->name->value),
                 1695062252040
             );
         }


### PR DESCRIPTION
When the NodeType property name is not available for the given NodeType we throw an exception. The exception method only mentions the property name, and that can be irritating when you have multiple NodeTypes with that property name or multiple errors. So this change extends the error message with the current NodeType name.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
