### PR TITLE
BUGFIX: Check SVG files for malicious code before providing original asset url links

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -421,7 +421,6 @@ class AssetController extends ActionController
                 }
             }
 
-
             $this->view->assignMultiple([
                 'tags' => $tags,
                 'assetProxy' => $assetProxy,

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -14,6 +14,7 @@ namespace Neos\Media\Browser\Controller;
 
 use Doctrine\Common\Persistence\Proxy as DoctrineProxy;
 use Doctrine\ORM\EntityNotFoundException;
+use enshrined\svgSanitize\Sanitizer;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
@@ -35,6 +36,7 @@ use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
+use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyRepositoryInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceConnectionExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
@@ -371,7 +373,8 @@ class AssetController extends ActionController
 
             $this->view->assignMultiple([
                 'assetProxy' => $assetProxy,
-                'assetCollections' => $this->assetCollectionRepository->findAll()
+                'assetCollections' => $this->assetCollectionRepository->findAll(),
+                'assetContainsMaliciousContent' => $this->checkForMaliciousContent($assetProxy)
             ]);
         } catch (AssetNotFoundExceptionInterface | AssetSourceConnectionExceptionInterface $e) {
             $this->view->assign('connectionError', $e);
@@ -418,12 +421,14 @@ class AssetController extends ActionController
                 }
             }
 
+
             $this->view->assignMultiple([
                 'tags' => $tags,
                 'assetProxy' => $assetProxy,
                 'assetCollections' => $this->assetCollectionRepository->findAll(),
                 'contentPreview' => $contentPreview,
                 'assetSource' => $assetSource,
+                'assetContainsMaliciousContent' => $this->checkForMaliciousContent($assetProxy),
                 'canShowVariants' => ($assetProxy instanceof NeosAssetProxy) && ($assetProxy->getAsset() instanceof VariantSupportInterface)
             ]);
         } catch (AssetNotFoundExceptionInterface | AssetSourceConnectionExceptionInterface $e) {
@@ -1022,5 +1027,26 @@ class AssetController extends ActionController
             $arguments['constraints'] = $this->request->getArgument('constraints');
         }
         $this->forward($actionName, $controllerName, null, $arguments);
+    }
+
+    private function checkForMaliciousContent(AssetProxyInterface $assetProxy): bool
+    {
+        if ($assetProxy->getMediaType() == 'image/svg+xml') {
+            // @todo: Simplify again when https://github.com/darylldoyle/svg-sanitizer/pull/90 is merged and released.
+            $previousXmlErrorHandling = libxml_use_internal_errors(true);
+            $sanitizer = new Sanitizer();
+
+            $resource = stream_get_contents($assetProxy->getImportStream());
+
+            $sanitizer->sanitize($resource);
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousXmlErrorHandling);
+            $issues = $sanitizer->getXmlIssues();
+            if ($issues && count($issues) > 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
+++ b/Neos.Media.Browser/Resources/Private/Partials/ContentDefaultPreview.html
@@ -1,7 +1,14 @@
 {namespace m=Neos\Media\ViewHelpers}
 {namespace neos=Neos\Neos\ViewHelpers}
 <div class="neos-preview-image" id="neos-preview-image">
-    <a href="{assetProxy.originalUri}" target="_blank">
-        <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
-    </a>
+    <f:if condition="{assetContainsMaliciousContent}">
+        <f:then>
+            <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+        </f:then>
+        <f:else>
+            <a href="{assetProxy.originalUri}" target="_blank">
+                <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+            </a>
+        </f:else>
+    </f:if>
 </div>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Edit.html
@@ -78,7 +78,19 @@
                                         </f:if>
                                         <tr>
                                             <th>{neos:backend.translate(id: 'metadata.filename', package: 'Neos.Media.Browser')}</th>
-                                            <td><a href="#" target="_blank">{assetProxy.filename}</a></td>
+                                            <td>
+                                                <f:if condition="{assetContainsMaliciousContent}">
+                                                    <f:then>
+                                                        {assetProxy.filename}
+                                                        <div class="neos-badge neos-badge-important">
+                                                            {neos:backend.translate(id: 'message.assetContainsMaliciousContent', package: 'Neos.Media.Browser')}
+                                                        </div>
+                                                    </f:then>
+                                                    <f:else>
+                                                        <a href="{assetProxy.originalUri}" target="_blank">{assetProxy.filename}</a>
+                                                    </f:else>
+                                                </f:if>
+                                            </td>
                                         </tr>
                                         <tr>
                                             <th>{neos:backend.translate(id: 'metadata.lastModified', package: 'Neos.Media.Browser')}</th>

--- a/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Asset/Show.html
@@ -39,7 +39,19 @@
                             </f:if>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.filename', package: 'Neos.Media.Browser')}</th>
-                                <td><a href="{assetProxy.originalUri}" target="_blank">{assetProxy.filename}</a></td>
+                                <td>
+                                    <f:if condition="{assetContainsMaliciousContent}">
+                                        <f:then>
+                                            {assetProxy.filename}
+                                            <div class="neos-badge neos-badge-important">
+                                                {neos:backend.translate(id: 'message.assetContainsMaliciousContent', package: 'Neos.Media.Browser')}
+                                            </div>
+                                        </f:then>
+                                        <f:else>
+                                            <a href="{assetProxy.originalUri}" target="_blank">{assetProxy.filename}</a>
+                                        </f:else>
+                                    </f:if>
+                                </td>
                             </tr>
                             <tr>
                                 <th>{neos:backend.translate(id: 'metadata.lastModified', package: 'Neos.Media.Browser')}</th>
@@ -85,9 +97,16 @@
 <f:section name="ContentImage">
     <label>{neos:backend.translate(id: 'preview', package: 'Neos.Media.Browser')}</label>
     <div class="neos-preview-image">
-        <a href="{assetProxy.originalUri}" target="_blank">
-            <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
-        </a>
+        <f:if condition="{assetContainsMaliciousContent}">
+            <f:then>
+                <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+            </f:then>
+            <f:else>
+                <a href="{assetProxy.originalUri}" target="_blank">
+                    <img src="{assetProxy.previewUri}" class="img-polaroid" alt="{assetProxy.label}"/>
+                </a>
+            </f:else>
+        </f:if>
     </div>
 </f:section>
 

--- a/Neos.Media.Browser/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Media.Browser/Resources/Private/Translations/en/Main.xlf
@@ -101,6 +101,9 @@
 			<trans-unit id="message.operationCannotBeUndone" xml:space="preserve">
 				<source>This operation cannot be undone.</source>
 			</trans-unit>
+			<trans-unit id="message.assetContainsMaliciousContent" xml:space="preserve">
+				<source>This asset might contain malicious content!</source>
+			</trans-unit>
 			<trans-unit id="cancel" xml:space="preserve">
 				<source>Cancel</source>
 			</trans-unit>

--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
+        "ext-libxml": "*",
         "neos/media": "self.version",
         "neos/content-repository": "self.version",
         "neos/neos": "self.version",
@@ -22,7 +23,8 @@
         "neos/utility-mediatypes": "*",
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
-        "doctrine/orm": "^2.6"
+        "doctrine/orm": "^2.6",
+        "enshrined/svg-sanitize": "^0.16.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "neos/party": "*",
         "neos/fusion-form": "^1.0 || ^2.0",
         "neos/form": "*",
-        "neos/kickstarter": "~7.3.0"
+        "neos/kickstarter": "~7.3.0",
+        "enshrined/svg-sanitize": "^0.16.0"
     },
     "replace": {
         "typo3/typo3cr": "self.version",


### PR DESCRIPTION
This adds a check in the preview of assets in the media module and checks for malicous content in svgs. If detected, the direct links to the original url get removed from the preview pages and a warning is shown.

![image](https://github.com/neos/neos-development-collection/assets/13046100/bb8a2b73-a251-499e-926a-1e6b866bbc87)

Fixes: 
- https://github.com/neos/neos-development-collection/issues/4833
- https://github.com/neos/flow-development-collection/issues/3248