### PR TITLE
FEATURE: Extensible followup after asset replacement

### DIFF
--- a/Neos.Media/Classes/Domain/Model/AdjustmentCapableInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AdjustmentCapableInterface.php
@@ -5,7 +5,8 @@ use Neos\Media\Domain\Model\Adjustment\ImageAdjustmentInterface;
 
 interface AdjustmentCapableInterface
 {
-    public function getAdjustments(): \IteratorAggregate;
+    /** @return iterable<ImageAdjustmentInterface> */
+    public function getAdjustments(): iterable;
 
     public function addAdjustment(ImageAdjustmentInterface $adjustment): void;
 

--- a/Neos.Media/Classes/Domain/Model/AdjustmentCapableInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AdjustmentCapableInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace Neos\Media\Domain\Model;
+
+use Neos\Media\Domain\Model\Adjustment\ImageAdjustmentInterface;
+
+interface AdjustmentCapableInterface
+{
+    public function getAdjustments(): \IteratorAggregate;
+
+    public function addAdjustment(ImageAdjustmentInterface $adjustment): void;
+
+    /**
+     * @param ImageAdjustmentInterface[] $adjustments
+     * @return void
+     */
+    public function addAdjustments(array $adjustments): void;
+}

--- a/Neos.Media/Classes/Domain/Model/Dto/AssetResourceReplaced.php
+++ b/Neos.Media/Classes/Domain/Model/Dto/AssetResourceReplaced.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neos\Media\Domain\Model\Dto;
+
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Media\Domain\Model\AssetInterface;
+
+/**
+ *
+ */
+final readonly class AssetResourceReplaced
+{
+    public function __construct(
+        public AssetInterface $asset,
+        public PersistentResource $previousResource,
+        public PersistentResource $newResource
+    )
+    {}
+}

--- a/Neos.Media/Classes/Domain/Model/Dto/AssetResourceReplaced.php
+++ b/Neos.Media/Classes/Domain/Model/Dto/AssetResourceReplaced.php
@@ -13,6 +13,6 @@ final readonly class AssetResourceReplaced
         public AssetInterface $asset,
         public PersistentResource $previousResource,
         public PersistentResource $newResource
-    )
-    {}
+    ) {
+    }
 }

--- a/Neos.Media/Classes/Domain/Model/ImageVariant.php
+++ b/Neos.Media/Classes/Domain/Model/ImageVariant.php
@@ -32,7 +32,7 @@ use Neos\Utility\TypeHandling;
  *
  * @Flow\Entity
  */
-class ImageVariant extends Asset implements AssetVariantInterface, ImageInterface
+class ImageVariant extends Asset implements AssetVariantInterface, ImageInterface, AdjustmentCapableInterface, PresetVariantInterface
 {
     use DimensionsTrait;
 

--- a/Neos.Media/Classes/Domain/Model/PresetVariantInterface.php
+++ b/Neos.Media/Classes/Domain/Model/PresetVariantInterface.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Media\Domain\Model;
+
+/**
+ * Methods to identify a variant to be based on a preset
+ */
+interface PresetVariantInterface
+{
+    /**
+     * Sets the identifier of the variant preset which created this variant (if any)
+     *
+     * @param string $presetIdentifier For example: 'Acme.Demo:Preset1'
+     */
+    public function setPresetIdentifier(string $presetIdentifier): void;
+
+    /**
+     * Returns the identifier of the variant preset which created this variant (if any)
+     *
+     * @return string|null
+     */
+    public function getPresetIdentifier(): ?string;
+
+    /**
+     * @param string $presetVariantName
+     */
+    public function setPresetVariantName(string $presetVariantName): void;
+
+    /**
+     * @return string|null
+     */
+    public function getPresetVariantName(): ?string;
+}

--- a/Neos.Media/Classes/Domain/Service/AssetResourceReplacementFollowUpInterface.php
+++ b/Neos.Media/Classes/Domain/Service/AssetResourceReplacementFollowUpInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Neos\Media\Domain\Service;
+
+use Neos\Media\Domain\Model\Dto\AssetResourceReplaced;
+
+/**
+ * Contract for handling any other
+ */
+interface AssetResourceReplacementFollowUpInterface
+{
+    public function handle(AssetResourceReplaced $assetResourceReplaced): void;
+}

--- a/Neos.Media/Classes/Domain/Service/AssetVariantGenerator.php
+++ b/Neos.Media/Classes/Domain/Service/AssetVariantGenerator.php
@@ -147,7 +147,7 @@ class AssetVariantGenerator
      * @param AssetInterface $asset
      * @param string $presetIdentifier
      * @param string $variantIdentifier
-     * @return AssetVariantInterface The created variant (if any)
+     * @return AssetVariantInterface|null The created variant (if any)
      * @throws AssetVariantGeneratorException
      */
     public function recreateVariant(AssetInterface $asset, string $presetIdentifier, string $variantIdentifier): ?AssetVariantInterface


### PR DESCRIPTION
Allows implementing custom handlers to be called after an asset resource was replaced. This allows decoupling redirects for the replaced asset from the media package.

Also handles some unchecked couplings to asset methods via new interfaces and cleans up a bit of code.

Fixes: #4815
