### PR TITLE
TASK: Homepage should hide uriPathSegment

### DIFF
--- a/Neos.Neos/NodeTypes/Mixin/Site.yaml
+++ b/Neos.Neos/NodeTypes/Mixin/Site.yaml
@@ -8,3 +8,8 @@
   abstract: true
   superTypes:
     'Neos.Neos:Document': true
+  properties:
+    uriPathSegment:
+      ui:
+        inspector:
+          hidden: true

--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -52,7 +52,7 @@ additionalProperties:
                         additionalProperties: false
                         properties:
 
-                          'hidden': { type: ['string', 'null'], description: 'Option to hide a property.' }
+                          'hidden': { type: ['string', 'boolean', 'null'], description: 'Option to hide a property.' }
 
                           'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Resolves #4621

Neos Ui adjustments: https://github.com/neos/neos-ui/pull/3686

instead of martins suggested solution https://github.com/neos/neos-development-collection/issues/4621#issuecomment-1772415808 i decided for a simpler and less hacky way: we just hide the property from the inspector but the node technically still has this property: https://github.com/neos/neos-development-collection/pull/4563#discussion_r1359860395

<img width="321" alt="image" src="https://github.com/neos/neos-development-collection/assets/85400359/85a0b774-e0fc-43b5-9d01-2ca5835b2cbc">


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
