### PR TITLE
BUGFIX: 4824 FusionExceptionView doesnt set editPreviewMode correctly

### DIFF
--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -205,7 +205,7 @@ class FusionExceptionView extends AbstractView
 
             $fusionGlobals = FusionGlobals::fromArray([
                 'request' => $controllerContext->getRequest(),
-                'renderingModeName' => RenderingMode::FRONTEND
+                'renderingMode' => RenderingMode::createFrontend()
             ]);
             $this->fusionRuntime = $this->runtimeFactory->createFromConfiguration(
                 $fusionConfiguration,


### PR DESCRIPTION
Resolves #4824
Regression from https://github.com/neos/neos-development-collection/pull/4505

The variable is expected (by convention) to be `renderingMode` and hold a `RenderingMode` instance.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
