### PR TITLE
FEATURE: Migrate hidden states and timeable node visibility

### DIFF
--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/NodeDataToEventsProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/NodeDataToEventsProcessor.php
@@ -287,7 +287,7 @@ final class NodeDataToEventsProcessor implements ProcessorInterface
             $this->exportEvent(new NodeAggregateWithNodeWasCreated($this->contentStreamId, $nodeAggregateId, $nodeTypeName, $originDimensionSpacePoint, $this->interDimensionalVariationGraph->getSpecializationSet($originDimensionSpacePoint->toDimensionSpacePoint()), $parentNodeAggregate->nodeAggregateId, $nodeName, $serializedPropertyValuesAndReferences->serializedPropertyValues, NodeAggregateClassification::CLASSIFICATION_REGULAR, null));
         }
         // nodes are hidden via NodeAggregateWasDisabled event
-        if ($nodeDataRow['hidden']) {
+        if ($this->isNodeHidden($nodeDataRow)) {
             $this->exportEvent(new NodeAggregateWasDisabled($this->contentStreamId, $nodeAggregateId, $this->interDimensionalVariationGraph->getSpecializationSet($originDimensionSpacePoint->toDimensionSpacePoint(), true, $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId)->toDimensionSpacePointSet())));
         }
         foreach ($serializedPropertyValuesAndReferences->references as $referencePropertyName => $destinationNodeAggregateIds) {
@@ -351,6 +351,21 @@ final class NodeDataToEventsProcessor implements ProcessorInterface
         // hiddenInIndex is stored as separate column in the nodedata table, but we need it as (internal) property
         if ($nodeDataRow['hiddeninindex']) {
             $properties['_hiddenInIndex'] = true;
+        }
+
+        if ($nodeType->isOfType(NodeTypeName::fromString('Neos.TimeableNodeVisibility:Timeable'))) {
+            // hiddenbeforedatetime is stored as separate column in the nodedata table, but we need it as property
+            if ($nodeDataRow['hiddenbeforedatetime']) {
+                $properties['enableAfterDateTime'] = $nodeDataRow['hiddenbeforedatetime'];
+            }
+            // hiddenafterdatetime is stored as separate column in the nodedata table, but we need it as property
+            if ($nodeDataRow['hiddenafterdatetime']) {
+                $properties['disableAfterDateTime'] = $nodeDataRow['hiddenafterdatetime'];
+            }
+        } else {
+            if ($nodeDataRow['hiddenbeforedatetime'] || $nodeDataRow['hiddenafterdatetime']) {
+                $this->dispatch(Severity::WARNING, 'Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them.');
+            }
         }
 
         return new SerializedPropertyValuesAndReferences($this->propertyConverter->serializePropertyValues(PropertyValuesToWrite::fromArray($properties), $nodeType), $references);
@@ -443,5 +458,48 @@ final class NodeDataToEventsProcessor implements ProcessorInterface
         foreach ($this->callbacks as $callback) {
             $callback($severity, $renderedMessage);
         }
+    }
+
+    /**
+     * Determines actual hidden state based on "hidden", "hiddenafterdatetime" and "hiddenbeforedatetime"
+     *
+     * @param array<string, mixed> $nodeDataRow
+     */
+    private function isNodeHidden(array $nodeDataRow): bool
+    {
+        // Already hidden
+        if ($nodeDataRow['hidden']) {
+            return true;
+        }
+
+        $now = new \DateTimeImmutable();
+        $hiddenAfterDateTime = $nodeDataRow['hiddenafterdatetime'] ? new \DateTimeImmutable($nodeDataRow['hiddenafterdatetime']) : null;
+        $hiddenBeforeDateTime = $nodeDataRow['hiddenbeforedatetime'] ? new \DateTimeImmutable($nodeDataRow['hiddenbeforedatetime']) : null;
+
+        // Hidden after a date time, without getting already re-enabled by hidden before date time - afterward
+        if ($hiddenAfterDateTime != null
+            && $hiddenAfterDateTime < $now
+            && (
+                $hiddenBeforeDateTime == null
+                || $hiddenBeforeDateTime > $now
+                || $hiddenBeforeDateTime<= $hiddenAfterDateTime
+            )
+        ) {
+            return true;
+        }
+
+        // Hidden before a date time, without getting enabled by hidden after date time - before
+        if ($hiddenBeforeDateTime != null
+            && $hiddenBeforeDateTime > $now
+            && (
+                $hiddenAfterDateTime == null
+                || $hiddenAfterDateTime > $hiddenBeforeDateTime
+            )
+        ) {
+            return true;
+        }
+
+        return false;
+
     }
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -108,6 +108,8 @@ class FeatureContext implements Context
                 'properties' => !empty($row['Properties']) ? $row['Properties'] : '{}',
                 'dimensionvalues' => !empty($row['Dimension Values']) ? $row['Dimension Values'] : '{}',
                 'hiddeninindex' => $row['Hidden in index'] ?? '0',
+                'hiddenbeforedatetime' =>  !empty($row['Hidden before DateTime']) ? ($row['Hidden before DateTime']): null,
+                'hiddenafterdatetime' =>  !empty($row['Hidden after DateTime']) ? ($row['Hidden after DateTime']) : null,
                 'hidden' => $row['Hidden'] ?? '0',
             ];
         }, $nodeDataRows->getHash());

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
@@ -1,0 +1,166 @@
+@contentrepository
+Feature: Simple migrations without content dimensions for hidden state migration
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Site': {}
+    'Neos.TimeableNodeVisibility:Timeable':
+      properties:
+        'disableAfterDateTime':
+          type: DateTime
+        'enableAfterDateTime':
+          type: DateTime
+    'Some.Package:Homepage':
+      superTypes:
+        'Neos.Neos:Site': true
+        'Neos.TimeableNodeVisibility:Timeable': true
+      properties:
+        'text':
+          type: string
+          defaultValue: 'My default text'
+
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+
+  Scenario: A node with a "hidden" property true must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 1      |                       |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                      |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                   |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                              |
+
+  Scenario: A node with a "hidden" property false must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                      |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                   |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+
+  Scenario: A node with active "hidden after" property, after a "hidden before" property must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   | 1989-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "1989-01-01 10:10:10"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+  Scenario: A node with active "hidden before" property, after a "hidden after" property must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1989-01-01 10:10:10   | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "1989-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}}} |
+
+
+  Scenario: A node with a active "hidden before" property and a "hidden after" property in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}}} |
+
+  Scenario: A node with a active "hidden after" property and a "hidden before" property in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+  Scenario: A node with a "hidden after" property in future and a "hidden before" property later in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2098-01-01 10:10:10   | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "2098-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}}} |
+
+  Scenario: A node with a "hidden before" property in future and a "hidden after" property later in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   | 2098-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "2098-01-01 10:10:10"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+  Scenario: A node with a active "hidden before" property must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                            |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                         |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}}} |
+
+  Scenario: A node with a active "hidden after" property must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                          |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "1990-01-01 10:10:10"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                     |
+
+  Scenario: A node with a "hidden after" property in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                          |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "disableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}}} |
+
+  Scenario: A node with a "hidden before" property in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                            |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                         |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}, "enableAfterDateTime": {"type": "DateTimeImmutable", "value": "2099-01-01 10:10:10"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                    |
+

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
@@ -1,0 +1,177 @@
+@contentrepository
+Feature: Simple migrations without content dimensions for hidden state migration without installed Neos.TimeableNodeVisibility
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Site': {}
+    'Some.Package:Homepage':
+      superTypes:
+        'Neos.Neos:Site': true
+      properties:
+        'text':
+          type: string
+          defaultValue: 'My default text'
+
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+
+  Scenario: A node with a "hidden" property true must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 1      |                       |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                      |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                   |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                              |
+
+  Scenario: A node with a "hidden" property false must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                      |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                   |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+
+  Scenario: A node with active "hidden after" property, after a "hidden before" property must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   | 1989-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with active "hidden before" property, after a "hidden after" property must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1989-01-01 10:10:10   | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a active "hidden before" property and a "hidden after" property in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a active "hidden after" property and a "hidden before" property in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a "hidden after" property in future and a "hidden before" property later in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2098-01-01 10:10:10   | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a "hidden before" property in future and a "hidden after" property later in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   | 2098-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                                                                                                           |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a active "hidden before" property must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       | 1990-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                            |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                         |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a active "hidden after" property must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 1990-01-01 10:10:10   |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                          |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                                                                                                                                                                                     |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a "hidden after" property in future must not get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      | 2099-01-01 10:10:10   |                        |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                                                                                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                                                                                                                                                                                          |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |
+
+  Scenario: A node with a "hidden before" property in future must get disabled
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Properties      | Hidden | Hidden after DateTime | Hidden before DateTime |
+      | sites-node-id | /sites           | unstructured          |                 | 0      |                       |                        |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"text": "foo"} | 0      |                       | 2099-01-01 10:10:10    |
+    And I run the event migration for content stream "cs-id"
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                                 |
+      | RootNodeAggregateWithNodeWasCreated | {"contentStreamId": "cs-id", "nodeAggregateId": "sites-node-id", "nodeTypeName": "Neos.Neos:Sites", "nodeAggregateClassification": "root"}                                                                              |
+      | NodeAggregateWithNodeWasCreated     | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id", "nodeTypeName": "Some.Package:Homepage", "nodeName": "test-site", "parentNodeAggregateId": "sites-node-id", "nodeAggregateClassification": "regular", "initialPropertyValues": {"text": {"type": "string", "value": "foo"}}} |
+      | NodeAggregateWasDisabled            | {"contentStreamId": "cs-id", "nodeAggregateId": "site-node-id"}                                                                                                                                                         |
+    And I expect the following warnings to be logged
+      | Skipped the migration of your "hiddenBeforeDateTime" and "hiddenAfterDateTime" properties as your target NodeTypes do not inherit "Neos.TimeableNodeVisibility:Timeable". Please install neos/timeable-node-visibility, if you want to migrate them. |


### PR DESCRIPTION
Adds a migration for node properties "_hiddenBeforeDateTime" and "_hiddenAfterDateTime".

1) Calculation of the current hidden state on time of migration to prevent accidently showing nodes meant to be hidden.
2) Migrate "_hiddenBeforeDateTime" and "_hiddenAfterDateTime" into new properties "enableAfterDateTime" and "disableAfterDateTime" if the new Package "neos/timeable-node-visibility" is installed (or more explicit, the Nodetype `Neos.TimeableNodeVisibility:Timeable` is available on the target NodeType).

Depends on: #4817