### PR TITLE
BUGFIX: Followup `nodeTypes:show` with `--path` to primitive value

### DIFF
--- a/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepository/Classes/Command/NodeTypesCommandController.php
@@ -44,9 +44,14 @@ class NodeTypesCommandController extends CommandController
             $this->quit();
         }
 
-        $configuration = $path
-            ? self::truncateArrayAtLevel($nodeType->getConfiguration($path), $level)
-            : [$nodeTypeName => self::truncateArrayAtLevel($nodeType->getFullConfiguration(), $level)];
+        if (empty($path)) {
+            $configuration = [$nodeTypeName => self::truncateArrayAtLevel($nodeType->getFullConfiguration(), $level)];
+        } else {
+            $configuration = $nodeType->getConfiguration($path);
+            if (is_array($configuration)) {
+                $configuration = self::truncateArrayAtLevel($configuration, $level);
+            }
+        }
 
         $yaml = Yaml::dump($configuration, 99);
 


### PR DESCRIPTION
Related: #4619

Primitive values cannot be shown currently:

```
flow nodetypes:show Neos.Neos:Document --path properties.title.ui.label
Neos\ContentRepository\Command\NodeTypesCommandController_Original::truncateArrayAtLevel(): Argument #1 ($array) must be of type array, string given
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
