### PR TITLE
BUGFIX: Fusion avoid error on cache invalidation while developing

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ParserCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCache.php
@@ -58,7 +58,12 @@ class ParserCache
         if (str_contains($contextPathAndFilename, '://')) {
             $contextPathAndFilename = $this->getAbsolutePathForPackageRessourceUri($contextPathAndFilename);
         }
-        $identifier = $this->getCacheIdentifierForFile($contextPathAndFilename);
+        $fusionFileRealPath = realpath($contextPathAndFilename);
+        if ($fusionFileRealPath === false) {
+            // should not happen as the file would not been able to be read in the first place.
+            throw new \RuntimeException("Couldn't resolve realpath for: '$contextPathAndFilename'", 1705409467);
+        }
+        $identifier = $this->getCacheIdentifierForAbsoluteUnixStyleFilePathWithoutDirectoryTraversal($fusionFileRealPath);
         return $this->cacheForIdentifier($identifier, $generateValueToCache);
     }
 

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
@@ -50,7 +50,10 @@ class ParserCacheFlusher
 
         $identifiersToFlush = [];
         foreach ($changedFiles as $changedFile => $status) {
-            $identifiersToFlush[] = $this->getCacheIdentifierForFile($changedFile);
+            // flow already returns absolute file paths from the file monitor, so we don't have to call realpath.
+            // attempting to use realpath can even result in an error as the file might be removed and thus no realpath can be resolved via file system.
+            // https://github.com/neos/neos-development-collection/pull/4509
+            $identifiersToFlush[] = $this->getCacheIdentifierForAbsoluteUnixStyleFilePathWithoutDirectoryTraversal($changedFile);
         }
 
         if ($identifiersToFlush !== []) {

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
@@ -19,7 +19,7 @@ namespace Neos\Fusion\Core\Cache;
 trait ParserCacheIdentifierTrait
 {
     /**
-     * creates a comparable hash of the dsl type and content to be used as cache identifier
+     * Creates a comparable hash of the dsl type and content to be used as cache identifier
      */
     private function getCacheIdentifierForDslCode(string $identifier, string $code): string
     {
@@ -27,18 +27,24 @@ trait ParserCacheIdentifierTrait
     }
 
     /**
-     * creates a comparable hash of the absolute, resolved $fusionFileName
+     * Creates a comparable hash of the absolute-unix-style-file-path-without-directory-traversal
      *
-     * @throws \InvalidArgumentException
+     * something like
+     *  - /Users/marc/Code/neos-project/Packages/Neos
+     *
+     * its crucial that the path
+     *  - is absolute
+     *  - the path separator is in unix style: forward-slash /
+     *  - doesn't contain directory traversal /../ or /./
+     *
+     * to be absolutely sure the path matches the criteria, {@see realpath} can be used.
+     *
+     * if the path does not match the criteria, a different hash as expected will be generated and caching will break.
      */
-    private function getCacheIdentifierForFile(string $fusionFileName): string
-    {
-        $realPath = realpath($fusionFileName);
-        if ($realPath === false) {
-            throw new \InvalidArgumentException("Couldn't resolve realpath for: '$fusionFileName'");
-        }
-
-        $realFusionFilePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $realPath);
-        return 'file_' . md5($realFusionFilePathWithoutRoot);
+    private function getCacheIdentifierForAbsoluteUnixStyleFilePathWithoutDirectoryTraversal(
+        string $absoluteUnixStyleFilePathWithoutDirectoryTraversal
+    ): string {
+        $filePathWithoutRoot = str_replace(FLOW_PATH_ROOT, '', $absoluteUnixStyleFilePathWithoutDirectoryTraversal);
+        return 'file_' . md5($filePathWithoutRoot);
     }
 }


### PR DESCRIPTION
Replaces #4509
Resolves #4415

After deleting a fusion file like `BrandLogo.fusion` one will face the error after booting flow and thus triggering the file monitor and its listeners: (even like a simple `flow help`)

```
Couldn't resolve realpath for: '/absolutePath/Code/core/Neos.NeosIo/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/Content/BrandLogo/BrandLogo.fusion'
```

This is caused as `realpath` returns false if the file was deleted, and we were to eager validating this. But as flows file monitor already returns absolute paths we can skip the realpath calculation here and move it to the `ParserCache::cacheForFusionFile`. Initially the call to `realpath` was made in a single place to avoid making to many assumptions about the form flow returned file paths.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
