### PR TITLE
BUGFIX: Fix projection database schema

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -42,7 +42,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             DbalSchemaFactory::columnForDimensionSpacePointHash('origindimensionspacepointhash')->setNotnull(false),
             DbalSchemaFactory::columnForNodeTypeName('nodetypename'),
             (new Column('properties', Type::getType(Types::TEXT)))->setNotnull(true)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
-            (new Column('classification', Type::getType(Types::STRING)))->setLength(20)->setNotnull(true)->setCustomSchemaOption('charset', 'binary'),
+            (new Column('classification', Type::getType(Types::BINARY)))->setLength(20)->setNotnull(true),
             (new Column('created', Type::getType(Types::DATETIME_IMMUTABLE)))->setDefault('CURRENT_TIMESTAMP')->setNotnull(true),
             (new Column('originalcreated', Type::getType(Types::DATETIME_IMMUTABLE)))->setDefault('CURRENT_TIMESTAMP')->setNotnull(true),
             (new Column('lastmodified', Type::getType(Types::DATETIME_IMMUTABLE)))->setNotnull(false)->setDefault(null),

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalSchemaFactory.php
@@ -23,6 +23,11 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  */
 final class DbalSchemaFactory
 {
+    // This class only contains static members and should not be constructed
+    private function __construct()
+    {
+    }
+
     /**
      * The NodeAggregateId is limited to 64 ascii characters and therefore we should do the same in the database.
      *
@@ -48,9 +53,8 @@ final class DbalSchemaFactory
      */
     public static function columnForContentStreamId(string $columnName): Column
     {
-        return (new Column($columnName, Type::getType(Types::STRING)))
-            ->setLength(36)
-            ->setCustomSchemaOption('charset', 'binary');
+        return (new Column($columnName, Type::getType(Types::BINARY)))
+            ->setLength(36);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
@@ -93,7 +93,7 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
             (new Column('workspacedescription', Type::getType(Types::STRING)))->setLength(255)->setNotnull(true)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
             (new Column('workspaceowner', Type::getType(Types::STRING)))->setLength(255)->setNotnull(false)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
             DbalSchemaFactory::columnForContentStreamId('currentcontentstreamid')->setNotNull(true),
-            (new Column('status', Type::getType(Types::STRING)))->setLength(20)->setNotnull(false)->setCustomSchemaOption('charset', 'binary')
+            (new Column('status', Type::getType(Types::BINARY)))->setLength(20)->setNotnull(false)
         ]);
         $workspaceTable->setPrimaryKey(['workspacename']);
 

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -63,7 +63,7 @@ final class AssetUsageRepository
             DbalSchemaFactory::columnForContentStreamId('contentstreamid')->setNotNull(true),
             DbalSchemaFactory::columnForNodeAggregateId('nodeaggregateid')->setNotNull(true),
             DbalSchemaFactory::columnForDimensionSpacePoint('origindimensionspacepoint')->setNotNull(false),
-            DbalSchemaFactory::columnForDimensionSpacePoint('origindimensionspacepointhash')->setNotNull(true),
+            DbalSchemaFactory::columnForDimensionSpacePointHash('origindimensionspacepointhash')->setNotNull(true),
             (new Column('propertyname', Type::getType(Types::STRING)))->setLength(255)->setNotnull(true)->setDefault('')
         ]);
 

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -73,7 +73,7 @@ final class AssetUsageRepository
             ->addIndex(['originalassetid'])
             ->addIndex(['contentstreamid'])
             ->addIndex(['nodeaggregateid'])
-            ->addIndex(['origindimensionspacepointhash'], options: ['lengths' => [768]]);
+            ->addIndex(['origindimensionspacepointhash']);
 
         return DbalSchemaFactory::createSchemaWithTables($schemaManager, [$table]);
     }

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -70,7 +70,8 @@ final class AssetUsageRepository
             ->addIndex(['originalassetid'])
             ->addIndex(['contentstreamid'])
             ->addIndex(['nodeaggregateid'])
-            ->addIndex(['origindimensionspacepointhash']);
+            // NOTE: index for column of type TEXT has to be limited in size
+            ->addIndex(['origindimensionspacepointhash'], options: ['lengths' => [768]]);
     }
 
     public function findUsages(AssetUsageFilter $filter): AssetUsages


### PR DESCRIPTION
This is a follow-up to #4730 fixing the database schema for binary columns.

Without this fix, calling `ProjectionInterface::setUp()` will drop and re-add a lot of columns!

Furthermore, this fixes the `origindimensionspacepointhash` column of the `AssetUsageRepository` to correctly use the `DbalSchemaFactory::columnForDimensionSpacePointHash`. Previously it used `TEXT` without a length wich lead to the index from being recreated every setup.