### PR TITLE
Update DataSourceController.php

### DIFF
--- a/Neos.Neos/Classes/Service/Controller/DataSourceController.php
+++ b/Neos.Neos/Classes/Service/Controller/DataSourceController.php
@@ -61,7 +61,6 @@ class DataSourceController extends AbstractServiceController
 
         $arguments = $this->request->getArguments();
         unset($arguments['dataSourceIdentifier']);
-        unset($arguments['node']);
 
         $values = $dataSource->getData($node, $arguments);
 


### PR DESCRIPTION
**Review instructions**

API of DataSourceInterface says
```
    /**
     * @param NodeInterface $node The node that is currently edited (optional)
     * @param array $arguments Additional arguments (key / value)
     * @return mixed JSON serializable data
     * @api
     */
    public function getData(NodeInterface $node = null, array $arguments = []);
```
Programming a new DataSource controller the paramameter `$node` allwas is `null`.
With this bugfix it's set from the GET request.

**Checklist**

- [X] Code follows the PSR-2 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
