### PR TITLE
BUGFIX: NodeTypeManager::overrideNodeTypes root NodeType is always present

### DIFF
--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeManager.php
@@ -183,6 +183,15 @@ class NodeTypeManager
     public function overrideNodeTypes(array $completeNodeTypeConfiguration): void
     {
         $this->cachedNodeTypes = [];
+
+        if ($completeNodeTypeConfiguration === []) {
+            // as cachedNodeTypes is now empty loadNodeTypes will reload the default nodeTypes
+            return;
+        }
+
+        // the root node type must always exist
+        $completeNodeTypeConfiguration[NodeTypeName::ROOT_NODE_TYPE_NAME] ??= [];
+
         foreach (array_keys($completeNodeTypeConfiguration) as $nodeTypeName) {
             /** @var string $nodeTypeName */
             $this->loadNodeType($nodeTypeName, $completeNodeTypeConfiguration);

--- a/Neos.ContentRepository.Core/Tests/Unit/NodeType/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/NodeType/NodeTypeManagerTest.php
@@ -454,4 +454,18 @@ class NodeTypeManagerTest extends TestCase
         self::assertTrue($nodeTypeManager->hasNodeType(NodeTypeName::ROOT_NODE_TYPE_NAME));
         self::assertInstanceOf(NodeType::class, $nodeTypeManager->getNodeType(NodeTypeName::ROOT_NODE_TYPE_NAME));
     }
+
+    /**
+     * @test
+     */
+    public function rootNodeTypeIsPresentAfterOverride()
+    {
+        $nodeTypeManager = new NodeTypeManager(
+            fn() => [],
+            new DefaultNodeLabelGeneratorFactory()
+        );
+        $nodeTypeManager->overrideNodeTypes(['Some:NewNodeType' => []]);
+        self::assertTrue($nodeTypeManager->hasNodeType(NodeTypeName::fromString('Some:NewNodeType')));
+        self::assertTrue($nodeTypeManager->hasNodeType(NodeTypeName::ROOT_NODE_TYPE_NAME));
+    }
 }


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/pull/4644 the Neos.ContentRepository:Root should be always present. But this method doesnt keep that guarantee
