### PR TITLE
TASK: Improve `flow cr:status`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/CheckpointStorageStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CheckpointStorageStatus.php
@@ -7,24 +7,47 @@ namespace Neos\ContentRepository\Core\Projection;
  */
 final readonly class CheckpointStorageStatus
 {
-    public function __construct(
+    /**
+     * @param non-empty-string $details
+     */
+    private function __construct(
         public CheckpointStorageStatusType $type,
         public string $details,
     ) {
     }
 
-    public static function ok(string $details = ''): self
+    public static function ok(): self
     {
-        return new self(CheckpointStorageStatusType::OK, $details);
+        /**
+         * @phpstan-ignore-next-line php-stan doesn't support currently assertions on properties
+         * https://github.com/phpstan/phpstan/issues/10463
+         * Once implemented, we might be able to declare that $details is only a non-empty-string
+         * if the CheckpointStorageStatusType is not OK
+         */
+        return new self(CheckpointStorageStatusType::OK, '');
     }
 
+    /**
+     * @param non-empty-string $details
+     */
     public static function error(string $details): self
     {
         return new self(CheckpointStorageStatusType::ERROR, $details);
     }
 
-    public static function setupRequired(string $details = ''): self
+    /**
+     * @param non-empty-string $details
+     */
+    public static function setupRequired(string $details): self
     {
         return new self(CheckpointStorageStatusType::SETUP_REQUIRED, $details);
+    }
+
+    /**
+     * @param non-empty-string $details
+     */
+    public function withDetails(string $details): self
+    {
+        return new self($this->type, $details);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatus.php
@@ -7,7 +7,7 @@ namespace Neos\ContentRepository\Core\Projection;
  */
 final readonly class ProjectionStatus
 {
-    public function __construct(
+    private function __construct(
         public ProjectionStatusType $type,
         public string $details,
     ) {
@@ -18,18 +18,35 @@ final readonly class ProjectionStatus
         return new self(ProjectionStatusType::OK, '');
     }
 
+    /**
+     * @param non-empty-string $details
+     */
     public static function error(string $details): self
     {
         return new self(ProjectionStatusType::ERROR, $details);
     }
 
-    public static function setupRequired(string $details = ''): self
+    /**
+     * @param non-empty-string $details
+     */
+    public static function setupRequired(string $details): self
     {
         return new self(ProjectionStatusType::SETUP_REQUIRED, $details);
     }
 
-    public static function replayRequired(string $details = ''): self
+    /**
+     * @param non-empty-string $details
+     */
+    public static function replayRequired(string $details): self
     {
         return new self(ProjectionStatusType::REPLAY_REQUIRED, $details);
+    }
+
+    /**
+     * @param non-empty-string $details
+     */
+    public function withDetails(string $details): self
+    {
+        return new self($this->type, $details);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -83,8 +83,12 @@ final class CrCommandController extends CommandController
             if ($projectionStatus->type !== ProjectionStatusType::OK) {
                 $hasErrorsOrWarnings = true;
             }
-            if ($verbose && $projectionStatus->details !== '') {
-                $this->outputFormatted($projectionStatus->details, [], 2);
+            if ($verbose && ($projectionStatus->type !== ProjectionStatusType::OK || $projectionStatus->details)) {
+                $lines = explode(chr(10), $projectionStatus->details ?: '<comment>No details available.</comment>');
+                foreach ($lines as $line) {
+                    $this->outputLine('  ' . $line);
+                }
+                $this->outputLine();
             }
         }
         if ($hasErrorsOrWarnings) {

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
@@ -249,7 +249,7 @@ final class AssetUsageProjection implements ProjectionInterface
         }
         try {
             $falseOrDetailsString = $this->repository->isSetupRequired();
-            if ($falseOrDetailsString !== false) {
+            if (is_string($falseOrDetailsString)) {
                 return ProjectionStatus::setupRequired($falseOrDetailsString);
             }
         } catch (\Throwable $e) {

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageProjection.php
@@ -248,12 +248,12 @@ final class AssetUsageProjection implements ProjectionInterface
             return ProjectionStatus::setupRequired($checkpointStorageStatus->details);
         }
         try {
-            $this->repository->findUsages(AssetUsageFilter::create());
+            $falseOrDetailsString = $this->repository->isSetupRequired();
+            if ($falseOrDetailsString !== false) {
+                return ProjectionStatus::setupRequired($falseOrDetailsString);
+            }
         } catch (\Throwable $e) {
-            return ProjectionStatus::error($e->getMessage());
-        }
-        if ($this->repository->isSetupRequired()) {
-            return ProjectionStatus::setupRequired();
+            return ProjectionStatus::error(sprintf('Failed to determine required SQL statements: %s', $e->getMessage()));
         }
         return ProjectionStatus::ok();
     }

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -46,6 +46,9 @@ final class AssetUsageRepository
         }
     }
 
+    /**
+     * @return false|non-empty-string false if everything is okay, otherwise the details string, why a setup is required
+     */
     public function isSetupRequired(): false|string
     {
         $requiredSqlStatements = DbalSchemaDiff::determineRequiredSqlStatements($this->dbal, $this->databaseSchema());

--- a/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Projection/AssetUsageRepository.php
@@ -46,9 +46,13 @@ final class AssetUsageRepository
         }
     }
 
-    public function isSetupRequired(): bool
+    public function isSetupRequired(): false|string
     {
-        return DbalSchemaDiff::determineRequiredSqlStatements($this->dbal, $this->databaseSchema()) !== [];
+        $requiredSqlStatements = DbalSchemaDiff::determineRequiredSqlStatements($this->dbal, $this->databaseSchema());
+        if ($requiredSqlStatements !== []) {
+            return sprintf('The following SQL statement%s required: %s', count($requiredSqlStatements) !== 1 ? 's are' : ' is', implode(chr(10), $requiredSqlStatements));
+        }
+        return false;
     }
 
     private function databaseSchema(): Schema


### PR DESCRIPTION
Followup to https://github.com/neos/neos-development-collection/pull/4846

- require a $details string for all non-ok status
- print "No details available." if verbose and non-ok and no details are available
- dont wortbreak details in verbose mode but print them with indentation of 2 full line per line
- print new line after printing details
- add details to AssetUsageProjection's setupRequired
