### PR TITLE
TASK: Correct `DoctrineProxy` import in AssetController

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -12,7 +12,7 @@ namespace Neos\Media\Browser\Controller;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Proxy as DoctrineProxy;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Doctrine\ORM\EntityNotFoundException;
 use enshrined\svgSanitize\Sanitizer;
 use Neos\Error\Messages\Error;


### PR DESCRIPTION
The old import was deprecated with `doctrine/persistence:1.3` and one should use Doctrine\Persistence\Proxy instead:
https://github.com/greg0ire/persistence/blob/da3b167cde5c029d7941941c635879524d6e1484/lib/Doctrine/Common/Persistence/Proxy.php#L26


slack -> https://neos-project.slack.com/archives/C04PYL8H3/p1705607919309889