### PR TITLE
TASK: Remove references to `UnsupportedRequestTypeException`

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -22,7 +22,6 @@ use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
 use Neos\Flow\Mvc\Exception\StopActionException;
-use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Package\PackageManager;
@@ -358,7 +357,6 @@ class AssetController extends ActionController
      * @param string $assetProxyIdentifier
      * @return void
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function showAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {
@@ -387,7 +385,6 @@ class AssetController extends ActionController
      * @param string $assetProxyIdentifier
      * @return void
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function editAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {
@@ -441,7 +438,6 @@ class AssetController extends ActionController
      * @param string $assetProxyIdentifier
      * @param string $overviewAction
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function variantsAction(string $assetSourceIdentifier, string $assetProxyIdentifier, string $overviewAction): void
     {
@@ -485,7 +481,6 @@ class AssetController extends ActionController
      * @param string $assetProxyIdentifier
      * @param string $overviewAction
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function createVariantsAction(string $assetSourceIdentifier, string $assetProxyIdentifier, string $overviewAction): void
     {

--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -64,7 +64,6 @@ class ImageController extends AssetController
      * @param AssetInterface $asset
      * @return void
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
     public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, AssetInterface $asset = null): void
     {

--- a/Neos.Media/Classes/Controller/ThumbnailController.php
+++ b/Neos.Media/Classes/Controller/ThumbnailController.php
@@ -14,7 +14,6 @@ namespace Neos\Media\Controller;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\StopActionException;
-use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Media\Domain\Model\Thumbnail;
 use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Media\Exception\ThumbnailServiceException;
@@ -38,7 +37,6 @@ class ThumbnailController extends ActionController
      * @param Thumbnail $thumbnail
      * @return void
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      * @throws ThumbnailServiceException
      */
     public function thumbnailAction(Thumbnail $thumbnail)

--- a/Neos.Neos/Classes/Controller/Backend/BackendController.php
+++ b/Neos.Neos/Classes/Controller/Backend/BackendController.php
@@ -21,7 +21,6 @@ use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\StopActionException;
-use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\Package\Exception\UnknownPackageException;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
@@ -76,7 +75,6 @@ class BackendController extends ActionController
      * @return void
      * @throws MissingActionNameException
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      * @throws \Neos\Flow\Http\Exception
      * @throws IllegalObjectTypeException
      */
@@ -97,7 +95,6 @@ class BackendController extends ActionController
      * @throws \Neos\Cache\Exception
      * @throws InvalidDataException
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      * @throws MissingActionNameException
      * @throws SessionNotStartedException
      * @throws \Neos\Neos\Exception

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -113,7 +113,6 @@ class NodeController extends ActionController
      * @param string $node Legacy name for backwards compatibility of route components
      * @throws NodeNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
      * @throws \Neos\Flow\Session\Exception\SessionNotStartedException
      * @throws \Neos\Neos\Exception
@@ -184,7 +183,6 @@ class NodeController extends ActionController
      * @param string $node Legacy name for backwards compatibility of route components
      * @throws NodeNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
      * @throws \Neos\Flow\Session\Exception\SessionNotStartedException
      * @throws \Neos\Neos\Exception
@@ -273,7 +271,6 @@ class NodeController extends ActionController
      * @param NodeAddress $nodeAddress
      * @throws NodeNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
     protected function handleShortcutNode(NodeAddress $nodeAddress, ContentRepository $contentRepository): void
     {

--- a/Neos.Neos/Classes/Controller/Service/AssetProxiesController.php
+++ b/Neos.Neos/Classes/Controller/Service/AssetProxiesController.php
@@ -17,7 +17,6 @@ namespace Neos\Neos\Controller\Service;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\StopActionException;
-use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\FluidAdaptor\View\TemplateView;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
@@ -143,7 +142,6 @@ class AssetProxiesController extends ActionController
      * @param string $assetProxyIdentifier
      * @return void
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function showAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {
@@ -168,7 +166,6 @@ class AssetProxiesController extends ActionController
      * @return void
      * @throws AssetSourceServiceException
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function importAction(string $assetSourceIdentifier, string $assetProxyIdentifier): void
     {

--- a/Neos.Neos/Classes/Controller/Service/AssetsController.php
+++ b/Neos.Neos/Classes/Controller/Service/AssetsController.php
@@ -17,7 +17,6 @@ namespace Neos\Neos\Controller\Service;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\StopActionException;
-use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\FluidAdaptor\View\TemplateView;
 use Neos\Media\Domain\Repository\AssetRepository;
@@ -100,7 +99,6 @@ class AssetsController extends ActionController
      *
      * @param string $identifier Specifies the asset to look up
      * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
      */
     public function showAction($identifier): void
     {


### PR DESCRIPTION
The flow exception is unused (never thrown) and will either be deprecated or removed.

See https://github.com/neos/flow-development-collection/pull/3232#discussion_r1466943444

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
