### PR TITLE
BUGFIX: Allow dimension preset keys to be different from values for DimensionsMenu

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -105,7 +105,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
             }
 
             // determine metadata for target dimensions of node
-            array_walk($targetDimensions, function (&$dimensionValue, $dimensionName) use ($pinnedDimensionName, $presets) {
+            array_walk($targetDimensions, static function (&$dimensionValue, $dimensionName) use ($pinnedDimensionName, $presets) {
                 $dimensionValue = [
                     'value' => $dimensionValue,
                     'label' => $presets[$dimensionName]['label'],

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -77,7 +77,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
 
         foreach ($this->contentDimensionCombinator->getAllAllowedCombinations() as $allowedCombination) {
             $targetDimensions = $this->calculateTargetDimensionsForCombination($allowedCombination);
-
+            $presets = $this->configurationContentDimensionPresetSource->findPresetsByTargetValues($allowedCombination);
             if ($pinnedDimensionName !== null && is_array($pinnedDimensionValues)) {
                 if (!in_array($targetDimensions[$pinnedDimensionName], $pinnedDimensionValues)) {
                     continue;
@@ -105,13 +105,13 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
             }
 
             // determine metadata for target dimensions of node
-            array_walk($targetDimensions, static function (&$dimensionValue, $dimensionName, $allDimensionPresets) use ($pinnedDimensionName) {
+            array_walk($targetDimensions, function (&$dimensionValue, $dimensionName) use ($pinnedDimensionName, $presets) {
                 $dimensionValue = [
                     'value' => $dimensionValue,
-                    'label' => $allDimensionPresets[$dimensionName]['presets'][$dimensionValue]['label'],
+                    'label' => $presets[$dimensionName]['label'],
                     'isPinnedDimension' => $pinnedDimensionName === null || $dimensionName == $pinnedDimensionName
                 ];
-            }, $allDimensionPresets);
+            });
 
             $menuItems[] = [
                 'node' => $nodeInDimensions,


### PR DESCRIPTION
This removes the implicit convention that dimensionPresetKey must be the same as the dimensionValue. 

**Review instructions**
- Follow the manual to set up a bilingual site: https://docs.neos.io/guide/manual/content-repository/content-dimensions/multiple-languages#configuring-a-bilingual-site
- Open frontend with rendering of `Neos.Neos:DimensionsMenu`

Fixes https://github.com/neos/neos-development-collection/issues/4857
