### PR TITLE
TASK: Dont use NodeInfoHelper::renderNode

### DIFF
--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -97,7 +97,8 @@ class ContentElementWrappingService
 
         $this->userLocaleService->switchToUILocale();
 
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNode($node));
+        // TODO illegal dependency on ui
+        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node));
 
         $this->userLocaleService->switchToUILocale(true);
 


### PR DESCRIPTION
As that will be removed via https://github.com/neos/neos-ui/pull/3703

`renderNodeWithPropertiesAndChildrenInformation` behaves exactly the same because it was an alias:

https://github.com/neos/neos-ui/blob/65fbd3bfbca3323a0dc906254939afdd87111060/Classes/Fusion/Helper/NodeInfoHelper.php#L95

The dependency is obviously not cool. But nothing to fix now :D

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
