### PR TITLE
!!! FEATURE: Improve escr cli commands

### DIFF
--- a/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
@@ -157,6 +157,7 @@ final class EventNormalizer
             );
         }
         assert(is_array($eventDataAsArray));
+        /** {@see EventInterface::fromArray()} */
         return $eventClassName::fromArray($eventDataAsArray);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryStatus.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryStatus.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\SharedModel\ContentRepository;
 
 use Neos\ContentRepository\Core\Projection\ProjectionStatuses;
+use Neos\ContentRepository\Core\Projection\ProjectionStatusType;
 use Neos\EventStore\Model\EventStore\Status as EventStoreStatus;
+use Neos\EventStore\Model\EventStore\StatusType as EventStoreStatusType;
 
 /**
  * @api
@@ -26,5 +28,18 @@ final readonly class ContentRepositoryStatus
         public EventStoreStatus $eventStoreStatus,
         public ProjectionStatuses $projectionStatuses,
     ) {
+    }
+
+    public function isOk(): bool
+    {
+        if ($this->eventStoreStatus->type !== EventStoreStatusType::OK) {
+            return false;
+        }
+        foreach ($this->projectionStatuses as $projectionStatus) {
+            if ($projectionStatus->type !== ProjectionStatusType::OK) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/CrCommandController.php
@@ -122,10 +122,9 @@ class CrCommandController extends CommandController
             $this->quit();
         }
         $this->connection->executeStatement('TRUNCATE ' . $connection->quoteIdentifier($eventTableName));
-        // we also need to reset the projections; in order to ensure the system runs deterministically. We
-        // do this by replaying the just-truncated event stream.
+        // we also need to reset the projections; in order to ensure the system runs deterministically
         $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionReplayServiceFactory);
-        $projectionService->replayAllProjections(CatchUpOptions::create());
+        $projectionService->resetAllProjections();
         $this->outputLine('Truncated events');
 
         $liveContentStreamId = ContentStreamId::create();

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -104,7 +104,7 @@ final class CrCommandController extends CommandController
      * @param bool $quiet If set only fatal errors are rendered to the output
      * @param int $until Until which sequence number should projections be replayed? useful for debugging
      */
-    public function replayCommand(string $projection, string $contentRepository = 'default', bool $quiet = false, int $until = 0): void
+    public function projectionReplayCommand(string $projection, string $contentRepository = 'default', bool $quiet = false, int $until = 0): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionServiceFactory);
@@ -133,7 +133,7 @@ final class CrCommandController extends CommandController
      * @param string $contentRepository Identifier of the Content Repository instance to operate on
      * @param bool $quiet If set only fatal errors are rendered to the output
      */
-    public function replayAllCommand(string $contentRepository = 'default', bool $quiet = false): void
+    public function projectionReplayAllCommand(string $contentRepository = 'default', bool $quiet = false): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionServiceFactory);

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -40,7 +40,7 @@ final class CrCommandController extends CommandController
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
 
         if ($resetProjections) {
-            if (!$this->output->askConfirmation(sprintf('Advanced Mode. The flag --reset-projections will reset all projections in "%s", which leaves you with empty projections to be replayed. Are you sure to proceed? (y/n) ', $contentRepositoryId->value), false)) {
+            if (!$this->output->askConfirmation(sprintf('> Advanced Mode. The flag --reset-projections will reset all projections in "%s", which leaves you with empty projections to be replayed. Are you sure to proceed? (y/n) ', $contentRepositoryId->value), false)) {
                 $this->outputLine('<comment>Abort.</comment>');
                 return;
             }
@@ -124,7 +124,7 @@ final class CrCommandController extends CommandController
             $this->quit(1);
         }
 
-        if (!$force && !$this->output->askConfirmation(sprintf('This will replay the projection "%s" in "%s", which may take some time. Are you sure to proceed? (y/n) ', $projection, $contentRepository), false)) {
+        if (!$force && !$this->output->askConfirmation(sprintf('> This will replay the projection "%s" in "%s", which may take some time. Are you sure to proceed? (y/n) ', $projection, $contentRepository), false)) {
             $this->outputLine('<comment>Abort.</comment>');
             return;
         }
@@ -164,7 +164,7 @@ final class CrCommandController extends CommandController
             $this->quit(1);
         }
 
-        if (!$force && !$this->output->askConfirmation(sprintf('This will replay all projections in "%s", which may take some time. Are you sure to proceed? (y/n) ', $contentRepository), false)) {
+        if (!$force && !$this->output->askConfirmation(sprintf('> This will replay all projections in "%s", which may take some time. Are you sure to proceed? (y/n) ', $contentRepository), false)) {
             $this->outputLine('<comment>Abort.</comment>');
             return;
         }
@@ -173,11 +173,10 @@ final class CrCommandController extends CommandController
         $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionServiceFactory);
         if (!$quiet) {
             $this->outputLine('Replaying events for all projections of Content Repository "%s" ...', [$contentRepositoryId->value]);
-            // TODO start progress bar
         }
-        $projectionService->replayAllProjections(CatchUpOptions::create());
+        // TODO progress bar with all events? Like projectionReplayCommand?
+        $projectionService->replayAllProjections(CatchUpOptions::create(), fn (string $projectionAlias) => $this->outputLine(sprintf(' * replaying %s projection', $projectionAlias)));
         if (!$quiet) {
-            // TODO finish progress bar
             $this->outputLine('<success>Done.</success>');
         }
     }
@@ -191,7 +190,7 @@ final class CrCommandController extends CommandController
      */
     public function pruneCommand(string $contentRepository = 'default', bool $force = false): void
     {
-        if (!$force && !$this->output->askConfirmation(sprintf('This will prune your content repository "%s". Are you sure to proceed? (y/n) ', $contentRepository), false)) {
+        if (!$force && !$this->output->askConfirmation(sprintf('> This will prune your content repository "%s". Are you sure to proceed? (y/n) ', $contentRepository), false)) {
             $this->outputLine('<comment>Abort.</comment>');
             return;
         }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -149,6 +149,27 @@ final class CrCommandController extends CommandController
     }
 
     /**
+     * Resets all projections of the specified Content Repository
+     *
+     * @param string $contentRepository Identifier of the Content Repository instance to operate on
+     * @param bool $quiet If set only fatal errors are rendered to the output
+     */
+    public function resetAllCommand(string $contentRepository = 'default', bool $quiet = false): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionServiceFactory);
+        if (!$quiet) {
+            $this->outputLine('Resetting the state of all projections of Content Repository "%s".', [$contentRepositoryId->value]);
+            // TODO start progress bar
+        }
+        $projectionService->resetAllProjections();
+        if (!$quiet) {
+            // TODO finish progress bar
+            $this->outputLine('<success>Done.</success>');
+        }
+    }
+
+    /**
      * This will completely prune the data of the specified content repository.
      *
      * @param string $contentRepository name of the content repository where the data should be pruned from.

--- a/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayService.php
@@ -31,9 +31,12 @@ final class ProjectionReplayService implements ContentRepositoryServiceInterface
         $this->contentRepository->catchUpProjection($projectionClassName, $options);
     }
 
-    public function replayAllProjections(CatchUpOptions $options): void
+    public function replayAllProjections(CatchUpOptions $options, ?\Closure $progressCallback = null): void
     {
         foreach ($this->projectionClassNamesAndAliases() as $classNamesAndAlias) {
+            if ($progressCallback) {
+                $progressCallback($classNamesAndAlias['alias']);
+            }
             $this->contentRepository->resetProjectionState($classNamesAndAlias['className']);
             $this->contentRepository->catchUpProjection($classNamesAndAlias['className'], $options);
         }
@@ -87,6 +90,4 @@ final class ProjectionReplayService implements ContentRepositoryServiceInterface
         }
         return $alias;
     }
-
-
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayService.php
@@ -39,6 +39,13 @@ final class ProjectionReplayService implements ContentRepositoryServiceInterface
         }
     }
 
+    public function resetAllProjections(): void
+    {
+        foreach ($this->projectionClassNamesAndAliases() as $classNamesAndAlias) {
+            $this->contentRepository->resetProjectionState($classNamesAndAlias['className']);
+        }
+    }
+
     /**
      * @return class-string<ProjectionInterface<ProjectionStateInterface>>
      */

--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -109,7 +109,9 @@ class CrCommandController extends CommandController
         }
 
         $this->outputLine('Replaying projections');
-        Scripts::executeCommand('neos.contentrepositoryregistry:cr:replayall', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value]);
+        /** {@see \Neos\ContentRepositoryRegistry\Command\CrCommandController::projectionReplayAllCommand()} */
+        // todo why not run in this process?
+        Scripts::executeCommand('neos.contentrepositoryregistry:cr:projectionReplayAll', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value]);
 
         $this->outputLine('<success>Done</success>');
     }

--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -7,19 +7,18 @@ namespace Neos\Neos\Command;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
-use Neos\ContentRepository\Core\Service\ContentRepositoryBootstrapper;
+use Neos\ContentRepository\Core\Projection\CatchUpOptions;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Export\ExportService;
 use Neos\ContentRepository\Export\ExportServiceFactory;
 use Neos\ContentRepository\Export\ImportService;
 use Neos\ContentRepository\Export\ImportServiceFactory;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\ContentRepositoryRegistry\Service\ProjectionReplayServiceFactory;
 use Neos\Neos\AssetUsage\Projection\AssetUsageFinder;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
-use Neos\Flow\Core\Booting\Scripts;
 use Neos\Media\Domain\Repository\AssetRepository;
-use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Utility\Files;
 use Neos\Flow\ResourceManagement\ResourceRepository;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -39,6 +38,7 @@ class CrCommandController extends CommandController
         private readonly ResourceManager $resourceManager,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly ContentRepositoryRegistry $contentRepositoryRegistry,
+        private readonly ProjectionReplayServiceFactory $projectionReplayServiceFactory,
     ) {
         parent::__construct();
     }
@@ -109,9 +109,9 @@ class CrCommandController extends CommandController
         }
 
         $this->outputLine('Replaying projections');
-        /** {@see \Neos\ContentRepositoryRegistry\Command\CrCommandController::projectionReplayAllCommand()} */
-        // todo why not run in this process?
-        Scripts::executeCommand('neos.contentrepositoryregistry:cr:projectionReplayAll', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value, 'force' => true]);
+
+        $projectionService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->projectionReplayServiceFactory);
+        $projectionService->replayAllProjections(CatchUpOptions::create());
 
         $this->outputLine('<success>Done</success>');
     }

--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -111,7 +111,7 @@ class CrCommandController extends CommandController
         $this->outputLine('Replaying projections');
         /** {@see \Neos\ContentRepositoryRegistry\Command\CrCommandController::projectionReplayAllCommand()} */
         // todo why not run in this process?
-        Scripts::executeCommand('neos.contentrepositoryregistry:cr:projectionReplayAll', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value]);
+        Scripts::executeCommand('neos.contentrepositoryregistry:cr:projectionReplayAll', $this->flowSettings, false, ['contentRepository' => $contentRepositoryId->value, 'force' => true]);
 
         $this->outputLine('<success>Done</success>');
     }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Resolves: #4772

As discussed in the last weekly the following changes were made.

- `cr:replayAll` was renamed to `cr:projectionReplayAll`
- `cr:replay` was renamed to `cr:projectionReplay`
- `cr:projectionReplay` and `cr:projectionReplayAll` now both warn before continue and have a `--force` flag.
- `cr:prune` has  a `--force` flag.
- `cr:setup` has a `--reset-projections` flag.

Additionally `cr:projectionReplayAll` has a simple progress indicator.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
