### PR TITLE
FEATURE: Introduce `NodeIdentity`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -7,6 +7,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Types;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\CurrentWorkspaceContentStreamId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeRemoval;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeVariation;
@@ -43,6 +44,15 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregate
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceWasRemoved;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyPublished;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPublished;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Infrastructure\DbalCheckpointStorage;
 use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\Infrastructure\DbalSchemaDiff;
@@ -72,7 +82,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
     use SubtreeTagging;
     use NodeRemoval;
     use NodeMove;
-
+    use CurrentWorkspaceContentStreamId;
 
     public const RELATION_DEFAULT_OFFSET = 128;
 
@@ -177,6 +187,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
         $connection->executeQuery('TRUNCATE table ' . $this->tableNamePrefix . '_hierarchyrelation');
         $connection->executeQuery('TRUNCATE table ' . $this->tableNamePrefix . '_referencerelation');
         $connection->executeQuery('TRUNCATE table ' . $this->tableNamePrefix . '_dimensionspacepoints');
+        $connection->executeQuery('TRUNCATE table ' . $this->tableNamePrefix . '_workspaces');
     }
 
     public function canHandle(EventInterface $event): bool
@@ -200,6 +211,21 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
             NodePeerVariantWasCreated::class,
             SubtreeWasTagged::class,
             SubtreeWasUntagged::class,
+
+            /**
+             * Workspace related commands, see {@see CurrentWorkspaceContentStreamId}
+             * We are not interested in the events WorkspaceWasRenamed, WorkspaceRebaseFailed and WorkspaceOwnerWasChanged
+             * As they do not change the current content stream id
+             */
+            WorkspaceWasCreated::class,
+            RootWorkspaceWasCreated::class,
+            WorkspaceWasDiscarded::class,
+            WorkspaceWasPartiallyDiscarded::class,
+            WorkspaceWasPartiallyPublished::class,
+            WorkspaceWasPublished::class,
+            WorkspaceWasRebased::class,
+            WorkspaceWasRemoved::class,
+            WorkspaceBaseWorkspaceWasChanged::class,
         ]);
     }
 
@@ -224,6 +250,15 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
             NodePeerVariantWasCreated::class => $this->whenNodePeerVariantWasCreated($event, $eventEnvelope),
             SubtreeWasTagged::class => $this->whenSubtreeWasTagged($event),
             SubtreeWasUntagged::class => $this->whenSubtreeWasUntagged($event),
+            WorkspaceWasCreated::class => $this->whenWorkspaceWasCreated($event),
+            RootWorkspaceWasCreated::class => $this->whenRootWorkspaceWasCreated($event),
+            WorkspaceWasDiscarded::class => $this->whenWorkspaceWasDiscarded($event),
+            WorkspaceWasPartiallyDiscarded::class => $this->whenWorkspaceWasPartiallyDiscarded($event),
+            WorkspaceWasPartiallyPublished::class => $this->whenWorkspaceWasPartiallyPublished($event),
+            WorkspaceWasPublished::class => $this->whenWorkspaceWasPublished($event),
+            WorkspaceWasRebased::class => $this->whenWorkspaceWasRebased($event),
+            WorkspaceWasRemoved::class => $this->whenWorkspaceWasRemoved($event),
+            WorkspaceBaseWorkspaceWasChanged::class => $this->whenWorkspaceBaseWorkspaceWasChanged($event),
             default => throw new \InvalidArgumentException(sprintf('Unsupported event %s', get_debug_type($event))),
         };
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -28,7 +28,8 @@ class DoctrineDbalContentGraphSchemaBuilder
             $this->createNodeTable(),
             $this->createHierarchyRelationTable(),
             $this->createReferenceRelationTable(),
-            $this->createDimensionSpacePointsTable()
+            $this->createDimensionSpacePointsTable(),
+            $this->createWorkspacesTable()
         ]);
     }
 
@@ -93,5 +94,15 @@ class DoctrineDbalContentGraphSchemaBuilder
 
         return $table
             ->setPrimaryKey(['name', 'position', 'nodeanchorpoint']);
+    }
+
+    private function createWorkspacesTable(): Table
+    {
+        $workspaceTable = new Table($this->tableNamePrefix . '_workspaces', [
+            (new Column('workspacename', Type::getType(Types::STRING)))->setLength(255)->setNotnull(true)->setCustomSchemaOption('collation', self::DEFAULT_TEXT_COLLATION),
+            DbalSchemaFactory::columnForContentStreamId('currentcontentstreamid')->setNotNull(true),
+        ]);
+
+        return $workspaceTable->setPrimaryKey(['workspacename']);
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/CurrentWorkspaceContentStreamId.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/CurrentWorkspaceContentStreamId.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceWasRemoved;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyPublished;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPublished;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * The CurrentWorkspaceContentStreamId projection feature trait
+ *
+ * Duplicated from the projection {@see \Neos\ContentRepository\Core\Projection\Workspace\WorkspaceProjection}
+ * But we only require the workspace name to content stream id mapping.
+ *
+ * @internal
+ */
+trait CurrentWorkspaceContentStreamId
+{
+    abstract protected function getTableNamePrefix(): string;
+
+    abstract protected function getDatabaseConnection(): Connection;
+
+    private function whenWorkspaceWasCreated(WorkspaceWasCreated $event): void
+    {
+        $this->getDatabaseConnection()->insert($this->getTableNamePrefix() . '_workspaces', [
+            'workspaceName' => $event->workspaceName->value,
+            'currentContentStreamId' => $event->newContentStreamId->value
+        ]);
+    }
+
+    private function whenRootWorkspaceWasCreated(RootWorkspaceWasCreated $event): void
+    {
+        $this->getDatabaseConnection()->insert($this->getTableNamePrefix() . '_workspaces', [
+            'workspaceName' => $event->workspaceName->value,
+            'currentContentStreamId' => $event->newContentStreamId->value
+        ]);
+    }
+
+    private function whenWorkspaceWasDiscarded(WorkspaceWasDiscarded $event): void
+    {
+        $this->updateContentStreamId($event->newContentStreamId, $event->workspaceName);
+    }
+
+    private function whenWorkspaceWasPartiallyDiscarded(WorkspaceWasPartiallyDiscarded $event): void
+    {
+        $this->updateContentStreamId($event->newContentStreamId, $event->workspaceName);
+    }
+
+    private function whenWorkspaceWasPartiallyPublished(WorkspaceWasPartiallyPublished $event): void
+    {
+        $this->updateContentStreamId($event->newSourceContentStreamId, $event->sourceWorkspaceName);
+    }
+
+    private function whenWorkspaceWasPublished(WorkspaceWasPublished $event): void
+    {
+        $this->updateContentStreamId($event->newSourceContentStreamId, $event->sourceWorkspaceName);
+    }
+
+    private function whenWorkspaceWasRebased(WorkspaceWasRebased $event): void
+    {
+        $this->updateContentStreamId($event->newContentStreamId, $event->workspaceName);
+    }
+
+    private function whenWorkspaceWasRemoved(WorkspaceWasRemoved $event): void
+    {
+        $this->getDatabaseConnection()->delete(
+            $this->getTableNamePrefix() . '_workspaces',
+            ['workspaceName' => $event->workspaceName->value]
+        );
+    }
+
+    private function whenWorkspaceBaseWorkspaceWasChanged(WorkspaceBaseWorkspaceWasChanged $event): void
+    {
+        $this->updateContentStreamId($event->newContentStreamId, $event->workspaceName);
+    }
+
+    private function updateContentStreamId(
+        ContentStreamId $contentStreamId,
+        WorkspaceName $workspaceName,
+    ): void {
+        $this->getDatabaseConnection()->update($this->getTableNamePrefix() . '_workspaces', [
+            'currentContentStreamId' => $contentStreamId->value,
+        ], [
+            'workspaceName' => $workspaceName->value
+        ]);
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -40,6 +40,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * The Doctrine DBAL adapter content graph
@@ -88,6 +89,8 @@ final class ContentGraph implements ContentGraphInterface
             $this->subgraphs[$index] = new ContentSubgraphWithRuntimeCaches(
                 new ContentSubgraph(
                     $this->contentRepositoryId,
+                    // todo accept Workspace
+                    WorkspaceName::forLive(),
                     $contentStreamId,
                     $dimensionSpacePoint,
                     $visibilityConstraints,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -30,7 +30,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * The read only content graph for use by the {@see GraphProjector}. This is the class for low-level operations
+ * The read only content graph for use by the {@see DoctrineDbalContentGraphProjection}. This is the class for low-level operations
  * within the projector, where implementation details of the graph structure are known.
  *
  * This is NO PUBLIC API in any way.

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
@@ -35,6 +35,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\RootNodeAggregateDoesNotEx
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * The PostgreSQL adapter content hypergraph
@@ -50,6 +51,7 @@ final class ContentHypergraph implements ContentGraphInterface
     private NodeFactory $nodeFactory;
 
     /**
+     * @phpstan-ignore-next-line unused
      * @var array|ContentSubhypergraph[]
      */
     private array $subhypergraphs;
@@ -57,7 +59,9 @@ final class ContentHypergraph implements ContentGraphInterface
     public function __construct(
         PostgresDbalClientInterface $databaseClient,
         NodeFactory $nodeFactory,
+        /** @phpstan-ignore-next-line unused */
         private readonly ContentRepositoryId $contentRepositoryId,
+        /** @phpstan-ignore-next-line unused */
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly string $tableNamePrefix
     ) {
@@ -66,10 +70,13 @@ final class ContentHypergraph implements ContentGraphInterface
     }
 
     public function getSubgraph(
-        ContentStreamId $contentStreamId,
+        WorkspaceName $workspaceName,
         DimensionSpacePoint $dimensionSpacePoint,
         VisibilityConstraints $visibilityConstraints
     ): ContentSubgraphInterface {
+        throw new \BadMethodCallException('The postgres adapter is not functional.');
+
+        /*
         $index = $contentStreamId->value . '-' . $dimensionSpacePoint->hash . '-' . $visibilityConstraints->getHash();
         if (!isset($this->subhypergraphs[$index])) {
             $this->subhypergraphs[$index] = new ContentSubhypergraph(
@@ -85,6 +92,7 @@ final class ContentHypergraph implements ContentGraphInterface
         }
 
         return $this->subhypergraphs[$index];
+        */
     }
 
     public function findRootNodeAggregateByType(

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -39,9 +39,11 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeIdentity;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * The node factory for mapping database rows to nodes and node aggregates
@@ -77,13 +79,20 @@ final class NodeFactory
             : null;
 
         return Node::create(
+            NodeIdentity::create(
+                $this->contentRepositoryId,
+                // todo use actual workspace name
+                WorkspaceName::fromString('missing'),
+                $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
+                $nodeId = NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
+            ),
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
                 $contentStreamId ?: ContentStreamId::fromString($nodeRow['contentstreamid']),
                 $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
                 $visibilityConstraints
             ),
-            NodeAggregateId::fromString($nodeRow['nodeaggregateid']),
+            $nodeId,
             OriginDimensionSpacePoint::fromJsonString($nodeRow['origindimensionspacepoint']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),

--- a/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/DimensionSpaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/DimensionSpaceCommandHandler.php
@@ -71,6 +71,8 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
         $streamName = ContentStreamEventStreamName::fromContentStreamId($command->contentStreamId)
             ->getEventStreamName();
 
+        // todo use WorkspaceName here as well but the command doesnt expose it
+        // https://github.com/neos/neos-development-collection/issues/4942
         self::requireDimensionSpacePointToBeEmptyInContentStream(
             $command->target,
             $command->contentStreamId,
@@ -99,6 +101,8 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
         $streamName = ContentStreamEventStreamName::fromContentStreamId($command->contentStreamId)
             ->getEventStreamName();
 
+        // todo use WorkspaceName here as well but the command doesnt expose it
+        // https://github.com/neos/neos-development-collection/issues/4942
         self::requireDimensionSpacePointToBeEmptyInContentStream(
             $command->target,
             $command->contentStreamId,
@@ -134,18 +138,18 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
 
     private static function requireDimensionSpacePointToBeEmptyInContentStream(
         DimensionSpacePoint $dimensionSpacePoint,
-        ContentStreamId $contentStreamId,
+        WorkspaceName $workspaceName,
         ContentGraphInterface $contentGraph
     ): void {
         $subgraph = $contentGraph->getSubgraph(
-            $contentStreamId,
+            $workspaceName,
             $dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );
         if ($subgraph->countNodes() > 0) {
             throw new DimensionSpacePointAlreadyExists(sprintf(
-                'the content stream %s already contained nodes in dimension space point %s - this is not allowed.',
-                $contentStreamId->value,
+                'the workspace %s already contained nodes in dimension space point %s - this is not allowed.',
+                $workspaceName->value,
                 $dimensionSpacePoint->toJson(),
             ), 1612898126);
         }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -193,7 +193,7 @@ trait NodeTypeChange
                 $tetheredNodeName = NodeName::fromString($serializedTetheredNodeName);
 
                 $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-                    $node->subgraphIdentity->contentStreamId,
+                    $node->identity->workspaceName,
                     $node->originDimensionSpacePoint->toDimensionSpacePoint(),
                     VisibilityConstraints::withoutRestrictions()
                 );

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
@@ -24,6 +24,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\RootNodeAggregateDoesNotEx
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * This is the MAIN ENTRY POINT for the Content Repository. This class exists only
@@ -40,7 +41,7 @@ interface ContentGraphInterface extends ProjectionStateInterface
      * @api main API method of ContentGraph
      */
     public function getSubgraph(
-        ContentStreamId $contentStreamId,
+        WorkspaceName $workspaceName,
         DimensionSpacePoint $dimensionSpacePoint,
         VisibilityConstraints $visibilityConstraints
     ): ContentSubgraphInterface;

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeIdentity;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
 /**
@@ -33,6 +34,8 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
  * $subgraphIdentity {@see Node::$subgraphIdentity}. and then
  * call findChildNodes() {@see ContentSubgraphInterface::findChildNodes()}
  * on the subgraph.
+ *
+ * The identity of a node is summarized here {@see NodeIdentity}
  *
  * @api Note: The constructor is not part of the public API
  */
@@ -51,6 +54,8 @@ final readonly class Node
      * @param Timestamps $timestamps Creation and modification timestamps of this node
      */
     private function __construct(
+        public NodeIdentity $identity,
+        /** @deprecated will be removed before the final 9.0 release */
         public ContentSubgraphIdentity $subgraphIdentity,
         public NodeAggregateId $nodeAggregateId,
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
@@ -70,9 +75,9 @@ final readonly class Node
     /**
      * @internal The signature of this method can change in the future!
      */
-    public static function create(ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
+    public static function create(NodeIdentity $identity, ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
     {
-        return new self($subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
+        return new self($identity, $subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -65,6 +65,7 @@ final class NodeAggregate
      * @param OriginByCoverage $occupationByCovered
      * @param DimensionSpacePointsBySubtreeTags $dimensionSpacePointsBySubtreeTags dimension space points for every subtree tag this aggregate is *explicitly* tagged with (excluding inherited tags)
      */
+    // todo add workspace name and content repository id and remove cs id
     public function __construct(
         public readonly ContentStreamId $contentStreamId,
         public readonly NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeIdentity.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeIdentity.php
@@ -15,9 +15,8 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  * By using the content graph for the content repository
  * one can build a subgraph with the right perspective to find this node:
  *
- *      $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($identity->workspaceName);
  *      $subgraph = $contentGraph->getSubgraph(
- *          $workspace->currentContentStreamId,
+ *          $identity->workspaceName,
  *          $nodeIdentity->dimensionSpacePoint,
  *          // resolve also all disabled nodes
  *          VisibilityConstraints::withoutRestrictions()

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeIdentity.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeIdentity.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Node;
+
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * The content-repository-id content-stream-id dimension-space-point and the node-aggregate-id
+ * Are used in combination to distinctly identify a single node.
+ *
+ * By using the content graph for the content repository
+ * one can build a subgraph with the right perspective to find this node:
+ *
+ *      $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($identity->workspaceName);
+ *      $subgraph = $contentGraph->getSubgraph(
+ *          $workspace->currentContentStreamId,
+ *          $nodeIdentity->dimensionSpacePoint,
+ *          // resolve also all disabled nodes
+ *          VisibilityConstraints::withoutRestrictions()
+ *      );
+ *      $node = $subgraph->findNodeById($nodeIdentity->nodeAggregateId);
+ *
+ * @api
+ */
+final readonly class NodeIdentity implements \JsonSerializable
+{
+    private function __construct(
+        public ContentRepositoryId $contentRepositoryId,
+        public WorkspaceName $workspaceName,
+        public DimensionSpacePoint $dimensionSpacePoint,
+        public NodeAggregateId $nodeAggregateId,
+    ) {
+    }
+
+    public static function create(
+        ContentRepositoryId $contentRepositoryId,
+        WorkspaceName $workspaceName,
+        DimensionSpacePoint $dimensionSpacePoint,
+        NodeAggregateId $nodeAggregateId,
+    ): self {
+        return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $nodeAggregateId);
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            ContentRepositoryId::fromString($array['contentRepositoryId']),
+            WorkspaceName::fromString($array['workspaceName']),
+            DimensionSpacePoint::fromArray($array['dimensionSpacePoint']),
+            NodeAggregateId::fromString($array['nodeAggregateId'])
+        );
+    }
+
+    public static function fromJsonString(string $jsonString): self
+    {
+        return self::fromArray(\json_decode($jsonString, true, JSON_THROW_ON_ERROR));
+    }
+
+    public function withNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    {
+        return new self($this->contentRepositoryId, $this->workspaceName, $this->dimensionSpacePoint, $nodeAggregateId);
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->contentRepositoryId->equals($other->contentRepositoryId)
+            && $this->workspaceName->equals($other->workspaceName)
+            && $this->dimensionSpacePoint->equals($other->dimensionSpacePoint)
+            && $this->nodeAggregateId->equals($other->nodeAggregateId);
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this, JSON_THROW_ON_ERROR);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'contentRepositoryId' => $this->contentRepositoryId,
+            'workspaceName' => $this->workspaceName,
+            'dimensionSpacePoint' => $this->dimensionSpacePoint,
+            'nodeAggregateId' => $this->nodeAggregateId
+        ];
+    }
+}

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
 
 class DisallowedChildNodeAdjustment
@@ -52,7 +53,7 @@ class DisallowedChildNodeAdjustment
             // Then, we only want to remove the single edge.
             foreach ($nodeAggregate->coveredDimensionSpacePoints as $coveredDimensionSpacePoint) {
                 $subgraph = $this->contentRepository->getContentGraph()->getSubgraph(
-                    $nodeAggregate->contentStreamId,
+                    WorkspaceName::forLive(), // structure adjustments are only carried out live
                     $coveredDimensionSpacePoint,
                     VisibilityConstraints::withoutRestrictions()
                 );

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -27,6 +27,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
 
 class TetheredNodeAdjustments
@@ -70,7 +71,7 @@ class TetheredNodeAdjustments
                     $tetheredNodeName = NodeName::fromString($tetheredNodeName);
 
                     $subgraph = $this->contentRepository->getContentGraph()->getSubgraph(
-                        $nodeAggregate->contentStreamId,
+                        WorkspaceName::forLive(), // structure adjustments are only carried out live
                         $originDimensionSpacePoint->toDimensionSpacePoint(),
                         VisibilityConstraints::withoutRestrictions()
                     );
@@ -138,8 +139,7 @@ class TetheredNodeAdjustments
             if ($foundMissingOrDisallowedTetheredNodes === false) {
                 foreach ($originDimensionSpacePoints as $originDimensionSpacePoint) {
                     $subgraph = $this->contentRepository->getContentGraph()->getSubgraph(
-                        // todo add workspace to node aggregate
-                        $nodeAggregate->contentStreamId,
+                        WorkspaceName::forLive(), // structure adjustments are only carried out live
                         $originDimensionSpacePoint->toDimensionSpacePoint(),
                         VisibilityConstraints::withoutRestrictions()
                     );

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -138,6 +138,7 @@ class TetheredNodeAdjustments
             if ($foundMissingOrDisallowedTetheredNodes === false) {
                 foreach ($originDimensionSpacePoints as $originDimensionSpacePoint) {
                     $subgraph = $this->contentRepository->getContentGraph()->getSubgraph(
+                        // todo add workspace to node aggregate
                         $nodeAggregate->contentStreamId,
                         $originDimensionSpacePoint->toDimensionSpacePoint(),
                         VisibilityConstraints::withoutRestrictions()

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -161,7 +161,7 @@ trait CRTestSuiteRuntimeVariables
     public function getCurrentSubgraph(): ContentSubgraphInterface
     {
         return $this->currentContentRepository->getContentGraph()->getSubgraph(
-            $this->currentContentStreamId,
+            $this->currentWorkspaceName,
             $this->currentDimensionSpacePoint,
             $this->currentVisibilityConstraints
         );

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -37,8 +37,10 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeIdentity;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -87,13 +89,19 @@ final class NodeSubjectProvider
     ): Node {
         $serializedDefaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->propertyConverter);
         return Node::create(
+            NodeIdentity::create(
+                ContentRepositoryId::fromString('default'),
+                WorkspaceName::forLive(),
+                DimensionSpacePoint::createWithoutDimensions(),
+                $id = NodeAggregateId::create()
+            ),
             ContentSubgraphIdentity::create(
                 ContentRepositoryId::fromString('default'),
                 ContentStreamId::fromString('cs-id'),
                 DimensionSpacePoint::createWithoutDimensions(),
                 VisibilityConstraints::withoutRestrictions()
             ),
-            NodeAggregateId::create(),
+            $id,
             OriginDimensionSpacePoint::createWithoutDimensions(),
             NodeAggregateClassification::CLASSIFICATION_REGULAR,
             $nodeType->name,

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -92,10 +92,10 @@ final class ContentRepositoryRegistry
 
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
-        $contentRepository = $this->get($node->subgraphIdentity->contentRepositoryId);
+        $contentRepository = $this->get($node->identity->contentRepositoryId);
         return $contentRepository->getContentGraph()->getSubgraph(
-            $node->subgraphIdentity->contentStreamId,
-            $node->subgraphIdentity->dimensionSpacePoint,
+            $node->identity->workspaceName,
+            $node->identity->dimensionSpacePoint,
             $node->subgraphIdentity->visibilityConstraints
         );
     }

--- a/Neos.Neos/Classes/AssetUsage/Service/AssetUsageSyncService.php
+++ b/Neos.Neos/Classes/AssetUsage/Service/AssetUsageSyncService.php
@@ -56,6 +56,7 @@ class AssetUsageSyncService implements ContentRepositoryServiceInterface
         $dimensionSpacePoint = $usage->originDimensionSpacePoint->toDimensionSpacePoint();
 
         $subGraph = $this->contentGraph->getSubgraph(
+            // todo use workspace name instead!!!
             $usage->contentStreamId,
             $dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()

--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -154,7 +154,7 @@ class ContentController extends ActionController
 
         $node = $contentRepository->getContentGraph()
             ->getSubgraph(
-                $nodeAddress->contentStreamId,
+                $nodeAddress->workspaceName,
                 $nodeAddress->dimensionSpacePoint,
                 VisibilityConstraints::withoutRestrictions()
             )

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -133,7 +133,7 @@ class NodeController extends ActionController
         $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($node);
 
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-            $nodeAddress->contentStreamId,
+            $nodeAddress->workspaceName,
             $nodeAddress->dimensionSpacePoint,
             $visibilityConstraints
         );
@@ -202,7 +202,7 @@ class NodeController extends ActionController
         }
 
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-            $nodeAddress->contentStreamId,
+            $nodeAddress->workspaceName,
             $nodeAddress->dimensionSpacePoint,
             VisibilityConstraints::frontend()
         );

--- a/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
@@ -18,7 +18,7 @@ namespace Neos\Neos\Domain\Service;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Model\Site;
@@ -41,13 +41,9 @@ final class SiteNodeUtility
      * To find the site node for the live workspace in a 0 dimensional content repository use:
      *
      * ```php
-     * $contentRepository = $this->contentRepositoryRegistry->get($site->getConfiguration()->contentRepositoryId);
-     * $liveWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::forLive())
-     *   ?? throw new \RuntimeException('Expected live workspace to exist.');
-     *
      * $siteNode = $this->siteNodeUtility->findSiteNodeBySite(
      *     $site,
-     *     $liveWorkspace->currentContentStreamId,
+     *     WorkspaceName::forLive(),
      *     DimensionSpacePoint::createWithoutDimensions(),
      *     VisibilityConstraints::frontend()
      * );
@@ -57,20 +53,24 @@ final class SiteNodeUtility
      */
     public function findSiteNodeBySite(
         Site $site,
-        ContentStreamId $contentStreamId,
+        WorkspaceName $workspaceName,
         DimensionSpacePoint $dimensionSpacePoint,
         VisibilityConstraints $visibilityConstraints
     ): Node {
         $contentRepository = $this->contentRepositoryRegistry->get($site->getConfiguration()->contentRepositoryId);
 
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-            $contentStreamId,
+            $workspaceName,
             $dimensionSpacePoint,
             $visibilityConstraints,
         );
 
+        // todo also refactor the getContentGraph to operate on live workspaces
+        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($workspaceName);
+        assert($workspace !== null);
+
         $rootNodeAggregate = $contentRepository->getContentGraph()->findRootNodeAggregateByType(
-            $contentStreamId,
+            $workspace->currentContentStreamId,
             NodeTypeNameFactory::forSites()
         );
         $rootNode = $rootNodeAggregate->getNodeByCoveredDimensionSpacePoint($dimensionSpacePoint);

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
@@ -31,7 +31,9 @@ use Neos\Flow\Annotations as Flow;
  *
  * It is used in Neos Routing to build a URI to a node.
  *
- * @api
+ * @deprecated will be removed before Final 9.0
+ * The NodeAddress was added 6 years ago without the concept of multiple crs
+ * Its usages will be replaced by the node identity
  */
 #[Flow\Proxy(false)]
 final class NodeAddress

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * @api
+ * @deprecated will be removed before Final 9.0
  */
 class NodeAddressFactory
 {

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -66,7 +66,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                 } else {
                     $variant = $contentRepository->getContentGraph()
                         ->getSubgraph(
-                            $currentNode->subgraphIdentity->contentStreamId,
+                            $currentNode->identity->workspaceName,
                             $dimensionSpacePoint,
                             $currentNode->subgraphIdentity->visibilityConstraints,
                         )
@@ -159,7 +159,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
             ) {
                 $variant = $contentRepository->getContentGraph()
                     ->getSubgraph(
-                        $this->currentNode->subgraphIdentity->contentStreamId,
+                        $this->currentNode->identity->workspaceName,
                         $generalization,
                         $this->currentNode->subgraphIdentity->visibilityConstraints,
                     )

--- a/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
@@ -142,13 +142,13 @@ final class DimensionHelper implements ProtectedContextAwareInterface
     {
         $contentDimensionId = is_string($dimensionName) ? new ContentDimensionId($dimensionName) : $dimensionName;
         $contentDimensionValue = is_string($dimensionValue) ? new ContentDimensionValue($dimensionValue) : $dimensionValue;
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get($node->identity->contentRepositoryId);
 
         return $contentRepository
             ->getContentGraph()
             ->getSubgraph(
-                $node->subgraphIdentity->contentStreamId,
-                $node->subgraphIdentity->dimensionSpacePoint->vary($contentDimensionId, $contentDimensionValue->value),
+                $node->identity->workspaceName,
+                $node->identity->dimensionSpacePoint->vary($contentDimensionId, $contentDimensionValue->value),
                 $node->subgraphIdentity->visibilityConstraints
             )->findNodeById($node->nodeAggregateId);
     }

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -315,7 +315,7 @@ class LinkingService
                 $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($node);
                 $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($nodeAddress->workspaceName);
                 $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-                    $nodeAddress->contentStreamId,
+                    $nodeAddress->workspaceName,
                     $nodeAddress->dimensionSpacePoint,
                     $workspace && !$workspace->isPublicWorkspace()
                         ? VisibilityConstraints::withoutRestrictions()

--- a/Neos.Neos/Classes/TypeConverter/HackyNodeAddressToNodeConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/HackyNodeAddressToNodeConverter.php
@@ -82,7 +82,7 @@ class HackyNodeAddressToNodeConverter extends AbstractTypeConverter
 
         $subgraph = $contentRepository->getContentGraph()
             ->getSubgraph(
-                $nodeAddress->contentStreamId,
+                $nodeAddress->workspaceName,
                 $nodeAddress->dimensionSpacePoint,
                 $nodeAddress->isInLiveWorkspace()
                     ? VisibilityConstraints::frontend()

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -16,6 +16,7 @@ namespace Neos\Neos\View;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
@@ -114,27 +115,26 @@ class FusionExceptionView extends AbstractView
             return $this->renderErrorWelcomeScreen();
         }
 
-        $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);
         $fusionExceptionViewInternals = $this->contentRepositoryRegistry->buildService(
             $siteDetectionResult->contentRepositoryId,
             new FusionExceptionViewInternalsFactory()
         );
         $dimensionSpacePoint = $fusionExceptionViewInternals->getArbitraryDimensionSpacePoint();
 
-        $liveWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::forLive());
-
-        $currentSiteNode = null;
         $site = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
-        if ($liveWorkspace && $site) {
+
+        if (!$site) {
+            return $this->renderErrorWelcomeScreen();
+        }
+
+        try {
             $currentSiteNode = $this->siteNodeUtility->findSiteNodeBySite(
                 $site,
-                $liveWorkspace->currentContentStreamId,
+                WorkspaceName::forLive(),
                 $dimensionSpacePoint,
                 VisibilityConstraints::frontend()
             );
-        }
-
-        if (!$currentSiteNode) {
+        } catch (WorkspaceDoesNotExist|\RuntimeException $exception) {
             return $this->renderErrorWelcomeScreen();
         }
 

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -279,7 +279,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
 
         $subgraph = $contentRepository->getContentGraph()
             ->getSubgraph(
-                $nodeAddress->contentStreamId,
+                $nodeAddress->workspaceName,
                 $nodeAddress->dimensionSpacePoint,
                 $node->subgraphIdentity->visibilityConstraints
             );
@@ -371,7 +371,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             );
         }
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-            $documentNodeAddress->contentStreamId,
+            $documentNodeAddress->workspaceName,
             $documentNodeAddress->dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -274,7 +274,7 @@ class NodeViewHelper extends AbstractViewHelper
             );
         }
         $subgraph = $contentRepository->getContentGraph()->getSubgraph(
-            $documentNodeAddress->contentStreamId,
+            $documentNodeAddress->workspaceName,
             $documentNodeAddress->dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Resolves partially: https://github.com/neos/neos-development-collection/issues/4564
Required for a new `NodeUriBuilder` api https://github.com/neos/neos-development-collection/issues/4552 which in-turn "should" solve cross cr linking: https://github.com/neos/neos-development-collection/issues/4441

The `NodeIdentity` will contain `WorkspaceName` instead of the `ContentStreamId`

For most, if not all use cases, like caching a reference to a node in fusions @cache.context or serializing a node into the frontend and passing it around as query parameter, the workspace name should be used.
    
That guarantees that a node is still findable, when a workspace will be rebased (which _can_ happen anytime, and thus the csid would be changed

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**


- [ ] Userland should not need to operate on cs ids
- [ ] Events must operate on cs ids
- [ ] getSubgraph arguments
    - [ ] WorkspaceName  → internally resolved to cs id and will do lookup instantly (CACHE)
    - [ ] DimensionSpacePoint
    - [ ] VisibilityConstraints
- [ ] NodeFactory::mapNodeRowToNode  must accept WorkspaceName and ContentStreamId from outside.
    - [x] must accept ContentStreamId as parameter see https://github.com/neos/neos-development-collection/pull/4941
    - [ ] must accept WorkspaceName as parameter
- [ ] => Extend SubgraphIdentity
    - [ ] add workspaceName
    - [ ] add @internal annotation
       - [ ] and to its getters like `getIdentity` https://github.com/neos/neos-development-collection/pull/4678
- [ ] command handlers should still operate on cs ids via getSubgraphByIdentity - INTERNAL
    - [ ] by that both apis always pass the WorkspaceName
- [ ] Node should know its
    - [ ] ContentRepositoryId
    - [ ] WorkspaceName
        - [ ] NOT: ContentSubgraphIdentity.
        - [ ] NOT: ContentStreamId
    - [ ] DimensionSpacePoint it was fetched from
    - [ ] VisibilityConstraints
       - [ ] so it can be passed as single instance and eel helpers can fetch parents e.t.c in the same context 
    - [ ] OriginDimensionSpacePoint (as before)
- [ ] WorkspaceName::fromString() must be stricter without colons (so that we _could_ allow in the future for extension, e.g. WorkspaceName::detached(ContentStreamid $csId) (with an internal representation like “cs:<cs-id>”)


https://github.com/neos/neos-development-collection/pull/4943#discussion_r1548415771 but maybe manual `refresh` instead of implicit through handle.



<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**TODOs** as discussed with @mhsdesign and @kitsunet today:

- [ ] add workspaceName <-> contentStreamId table to content graph projection
- [ ] add workspaceName -> contentStreamId lookup to `ContentGraph::getSubgraph()` (with runtime cache in the `ContentGraph` – the same workspace will resolve to the same CS ID in one request, maybe reset runtime cache via `markStale()`)
- [ ] rewrite `ContentGraph::find*` queries to use workspaceName instead of contentStreamId (IMO it's totally fine to join the workspaceName <-> cs id table here for those queries. Alternatively we could add a dedicated lookup + runtime cache)
- [ ] remove SubgraphIdentity

Afterwards we have to find out whether there are places that need to be able to override the worspace name -> cs id mapping for tests or CR constraints. If so we could either:
* Add a separate, internal, `ContentGraph::getSubgraphInternal()` – but that would be dangerous because it is part of the public interface (even if marked internal)
* Introduce a `ContentsubgraphFactoryInterface` that can be used via CR service
* Provide a way to hook into the runtime cache, e.g. `$contentGraph->dangerousSetContentStreamIdForWorkspaceNameFooBar(...)`
* Extract workspaceName<->cs id mapping to external service that can be replaced/hooked into

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
