### PR TITLE
BUGFIX: Search assets in a case-insensitive way

### DIFF
--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -79,9 +79,9 @@ class AssetRepository extends Repository
         $query = $this->createQuery();
 
         $constraints = [
-            $query->like('title', '%' . $searchTerm . '%'),
-            $query->like('resource.filename', '%' . $searchTerm . '%'),
-            $query->like('caption', '%' . $searchTerm . '%')
+            $query->like('title', '%' . $searchTerm . '%', false),
+            $query->like('resource.filename', '%' . $searchTerm . '%', false),
+            $query->like('caption', '%' . $searchTerm . '%', false)
         ];
         foreach ($tags as $tag) {
             $constraints[] = $query->contains('tags', $tag);


### PR DESCRIPTION
This solves the problem that with Postgres the search was case-sensitive. Other database platforms didn’t have this issue as they ran case-insensitive comparisons by default.

Resolves: #3432
