### PR TITLE
TASK: Use `renderingMode.isEdit` in `NodeController`

### DIFF
--- a/Neos.Neos/Classes/Domain/Model/RenderingMode.php
+++ b/Neos.Neos/Classes/Domain/Model/RenderingMode.php
@@ -20,14 +20,14 @@ use Neos\Neos\Domain\Exception;
  * Describes the mode in which the Neos interface is rendering currently,
  * mainly distinguishing between edit and preview modes currently.
  */
-class RenderingMode
+final class RenderingMode
 {
     public const FRONTEND = 'frontend';
 
     /**
      * @param array<string,mixed> $options
      */
-    public function __construct(
+    private function __construct(
         public readonly string $name,
         public readonly bool $isEdit,
         public readonly bool $isPreview,
@@ -52,7 +52,7 @@ class RenderingMode
                 1694802951840
             );
         }
-        $mode = new RenderingMode(
+        return new self(
             $modeName,
             $configuration['isEditingMode'] ?? false,
             $configuration['isPreviewMode'] ?? false,
@@ -60,7 +60,6 @@ class RenderingMode
             $configuration['fusionRenderingPath'] ?? '',
             $configuration['options'] ?? [],
         );
-        return $mode;
     }
 
     /**
@@ -68,7 +67,7 @@ class RenderingMode
      */
     public static function createFrontend(): RenderingMode
     {
-        return new RenderingMode(
+        return new self(
             RenderingMode::FRONTEND,
             false,
             false,

--- a/Neos.Neos/Classes/FrontendRouting/NodeShortcutResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeShortcutResolver.php
@@ -64,6 +64,9 @@ class NodeShortcutResolver
      */
     public function resolveShortcutTarget(NodeAddress $nodeAddress, ContentRepository $contentRepository)
     {
+        if (!$nodeAddress->workspaceName->isLive()) {
+            throw new \RuntimeException(sprintf('Cannot resolve shortcut target for node-address %s in workspace %s because the DocumentUriPathProjection only handles the live workspace.', $nodeAddress->nodeAggregateId->value, $nodeAddress->workspaceName->value), 1707208650);
+        }
         $documentUriPathFinder = $contentRepository->projectionState(DocumentUriPathFinder::class);
         $documentNodeInfo = $documentUriPathFinder->getByIdAndDimensionSpacePointHash(
             $nodeAddress->nodeAggregateId,

--- a/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
@@ -31,22 +31,22 @@ final class NodeUriBuilder
 {
     private UriBuilder $uriBuilder;
 
-    protected function __construct(UriBuilder $uriBuilder)
+    private function __construct(UriBuilder $uriBuilder)
     {
         $this->uriBuilder = $uriBuilder;
     }
 
-    public static function fromRequest(ActionRequest $request): static
+    public static function fromRequest(ActionRequest $request): self
     {
         $uriBuilder = new UriBuilder();
         $uriBuilder->setRequest($request);
 
-        return new static($uriBuilder);
+        return new self($uriBuilder);
     }
 
-    public static function fromUriBuilder(UriBuilder $uriBuilder): static
+    public static function fromUriBuilder(UriBuilder $uriBuilder): self
     {
-        return new static($uriBuilder);
+        return new self($uriBuilder);
     }
 
     /**
@@ -54,7 +54,7 @@ final class NodeUriBuilder
      * If the node belongs to the live workspace, the public URL is generated
      * Otherwise a preview URI is rendered (@see previewUriFor())
      *
-     * Note: Shortcut nodes will are resolved in the RoutePartHandler thus the resulting URI will point
+     * Note: Shortcut nodes will be resolved in the RoutePartHandler thus the resulting URI will point
      * to the shortcut target (node, asset or external URI)
      *
      * @param NodeAddress $nodeAddress
@@ -63,10 +63,11 @@ final class NodeUriBuilder
      */
     public function uriFor(NodeAddress $nodeAddress): UriInterface
     {
-        if (!$nodeAddress->isInLiveWorkspace()) {
+        if (!$nodeAddress->workspaceName->isLive()) {
+            // we cannot build a human-readable uri using the showAction as
+            // the DocumentUriPathProjection only handles the live workspace
             return $this->previewUriFor($nodeAddress);
         }
-        /** @noinspection PhpUnhandledExceptionInspection */
         return new Uri($this->uriBuilder->uriFor('show', ['node' => $nodeAddress], 'Frontend\Node', 'Neos.Neos'));
     }
 


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Followup to https://github.com/neos/neos-development-collection/pull/4505
Followup to https://github.com/neos/neos-development-collection/pull/4733

Resolves partially https://github.com/neos/neos-development-collection/issues/4396
 
we want to avoid calling `$nodeAddress->isInLiveWorkspace()` and use the rendering mode instead as this reflects more accurate the users intention.

this change also documents clearly that shortcut nodes are only to be resolved for live workspaces.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
