### PR TITLE
TASK: Declare `NodeSubjectProvider` as internal/wip testing utility with no guarantees

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -47,7 +47,10 @@ use Symfony\Component\Serializer\Serializer;
  * The general provider class for node subjects.
  * Capable of creating all kinds of nodes to be used in unit tests.
  *
- * @api
+ * @internal this WIP helper is purely experimental and only to be used internally
+ *           behaviour or api may change at any time.
+ *           Generally It's advised to prefer behat testing over unit tests for complex cases,
+ *           like when interacting with the NodeType or the Subgraph or other parts of the CR.
  */
 final class NodeSubjectProvider
 {

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -119,7 +119,7 @@ class NodeHelperTest extends AbstractFusionObjectTest
 
     protected function setUp(): void
     {
-        $this->markTestSkipped('Skipped until we find a better way to mock node read models (see https://github.com/neos/neos-development-collection/issues/4317)');
+        $this->markTestSkipped('Skipped. Either migrate to behat or find a better way to mock node read models. See https://github.com/neos/neos-development-collection/issues/4317');
         parent::setUp();
         $nodeSubjectProvider = new NodeSubjectProvider();
 


### PR DESCRIPTION
since we have been fetching the nodetypes via the cr it has become an almost pointless to use classical unit testing.

discussion which lead to basic introduction of this helper https://github.com/neos/neos-development-collection/issues/4317
improvement pr of this helper once we now what we want https://github.com/neos/neos-development-collection/pull/4741

We should probably just write behat tests instead.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
