### PR TITLE
BUGFIX: Fusion parser fix multi line comment

### DIFF
--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
@@ -37,10 +37,10 @@ class MessageLinePart
 
     public function char(int $index = 0): string
     {
-        if ($index < 0) {
-            return mb_substr($this->linePart, $index, 1);
+        if (mb_strlen($this->linePart) < abs($index)) {
+            return '';
         }
-        return mb_substr($this->linePart, $index, $index + 1);
+        return mb_substr($this->linePart, $index, 1);
     }
 
     public function charPrint(int $index = 0): string

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
@@ -37,7 +37,8 @@ class MessageLinePart
 
     public function char(int $index = 0): string
     {
-        if (mb_strlen($this->linePart) < abs($index)) {
+        if ($index < 0 && mb_strlen($this->linePart) < abs($index)) {
+            // prevent mb_substr returning first char if out of bounds
             return '';
         }
         return mb_substr($this->linePart, $index, 1);

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
@@ -47,7 +47,7 @@ class Lexer
           [^*]*             # consume until special case '*'
           \*+               # consume all '*'
           (?:
-            [^/*]           # break if its the end: '/'
+            [^/]            # break if its the end: '/'
             [^*]*           # unrolled loop following Jeffrey E.F. Friedl
             \*+
           )*

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
@@ -44,12 +44,14 @@ class Lexer
         Token::MULTILINE_COMMENT => <<<'REGEX'
         `^
           /\*               # start of a comment '/*'
-          [^*]*             # match everything until special case '*'
+          [^*]*             # consume until special case '*'
+          \*+               # consume all '*'
           (?:
-            \*[^/]          # if after the '*' there is a '/' break, else continue
-            [^*]*           # until the special case '*' is encountered - unrolled loop following Jeffrey Friedl
+            [^/*]           # break if its the end: '/'
+            [^*]*           # unrolled loop following Jeffrey E.F. Friedl
+            \*+
           )*
-          \*/               # the end of a comment.
+          /                 # the end of a comment.
         `x
         REGEX,
 

--- a/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionComments01.fusion
+++ b/Neos.Fusion/Tests/Unit/Core/Fixtures/ParserTestFusionComments01.fusion
@@ -57,7 +57,17 @@ comment with // ane more comment
  Here comes some comment with # and /* and // in it
 */
 
+/**
+ * php doc style comment
+ */
 
+/***
+comment with multiple stars uneven
+***/
 
-// another edge-case mentioned in NEOS-864
+/**
+comment with multiple stars even
+**/
+
+// another edge-case mentioned in NEOS-864 (no new line at the end)
 #include: Pages/**/*.fusion

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * source code.
  */
 
+use Neos\Fusion\Core\ObjectTreeParser\ExceptionMessage\MessageLinePart;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion\Core\ObjectTreeParser\Exception\ParserException;
@@ -195,6 +196,11 @@ class ParserExceptionTest extends UnitTestCase
             'Unclosed comment.'
         ];
 
+        yield 'unclosed multiline comment with multiple stars' => [
+            '/***',
+            'Unclosed comment.'
+        ];
+
         yield 'unclosed eel expression' => [
             'a = ${',
             'Unclosed eel expression.'
@@ -285,5 +291,27 @@ class ParserExceptionTest extends UnitTestCase
         } catch (ParserException $e) {
             self::assertSame($expectedMessage, $e->getHelperMessagePart());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function messageLinePartWorks()
+    {
+        $part = new MessageLinePart('abcd');
+
+        self::assertSame('', $part->char(-5));
+        self::assertSame('a', $part->char(-4));
+        self::assertSame('b', $part->char(-3));
+        self::assertSame('c', $part->char(-2));
+        self::assertSame('d', $part->char(-1));
+        self::assertSame('a', $part->char());
+        self::assertSame('a', $part->char(0));
+        self::assertSame('b', $part->char(1));
+        self::assertSame('c', $part->char(2));
+        self::assertSame('d', $part->char(3));
+        self::assertSame('', $part->char(4));
+        self::assertSame('abcd', $part->line());
+        self::assertSame('bcd', $part->line(1));
     }
 }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

This fixes a bug where the Fusion parser would not parse following c-style comments correctly:

```
/**
comment with multiple stars even
**/
```

This happed when the ending count of `*` was even. So ending a comment with `***/` worked previously.

Now we use the "correct" regex from Jeffrey E.F. Friedl's book "Mastering Regular Expressions" Page 272 "Unrolling C Comments"
We already use his regex for string matching and it is really fast due to the unrolled loop. Faster than using the lazy quantifier `~^/\*.*?\*/~s`.

I did a performance test with 1 million iteration on three different comment samples (with each sample having a dynamic part to clear possible caches):

| Unrolled (this pr) | Simple Lazy Quantifier  |
|--------|--------|
| 0.143725s | 0.160235s |
| 0.181047s | 0.203759s |
| 0.156254s | 0.170144s | 


Additionally the error message for comments starting with `/**` was improved. Previously $nextLine->char(1) would return `**` instead of just one `*` because wrongly implemented.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
