### PR TITLE
TASK: Followup #3804 remove deprecated fusion object methods

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -140,25 +140,6 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     }
 
     /**
-     * Sort the Fusion objects inside $this->properties depending on:
-     * - numerical ordering
-     * - position meta-property
-     *
-     * This will ignore all properties defined in "@ignoreProperties" in Fusion
-     *
-     * @return array an ordered list of key value pairs
-     * @throws FusionException if the positional string has an unsupported format
-     * @see PositionalArraySorter
-     *
-     * @deprecated
-     * @see preparePropertyKeys()
-     */
-    protected function sortNestedProperties(): array
-    {
-        return $this->preparePropertyKeys($this->properties, $this->ignoreProperties);
-    }
-
-    /**
      * @param array $properties
      * @param array $ignoredProperties
      * @return array<string> Fusion keys in this Array fusion object

--- a/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/DataStructureImplementation.php
@@ -31,22 +31,4 @@ class DataStructureImplementation extends AbstractArrayFusionObject
     {
         return $this->evaluateNestedProperties('Neos.Fusion:DataStructure');
     }
-
-    /**
-     * Sort the Fusion objects inside $this->properties depending on:
-     * - numerical ordering
-     * - position meta-property
-     *
-     * This will ignore all properties defined in "@ignoreProperties" in Fusion
-     *
-     * @return array an ordered list of key value pairs
-     * @throws FusionException if the positional string has an unsupported format
-     * @see PositionalArraySorter
-     *
-     * @deprecated since 8.0 can be removed with 9.0 use {@see \Neos\Fusion\FusionObjects\AbstractArrayFusionObject::preparePropertyKeys}
-     */
-    protected function sortNestedFusionKeys()
-    {
-        return $this->preparePropertyKeys($this->properties, $this->ignoreProperties);
-    }
 }


### PR DESCRIPTION
with Neos 8.0 #3645 and with Neos 8.1 #3804 two methods on the fusion objects were deprecated.
Those will now be removed.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

The following method calls should be migrated.

`AbstractArrayFusionObject::sortNestedProperties`

-> migrate to `$this->preparePropertyKeys($this->properties, $this->ignoreProperties);`

`DataStructureImplementation::sortNestedFusionKeys`

-> migrate to `$this->preparePropertyKeys($this->properties, $this->ignoreProperties);`

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
