### PR TITLE
BUGFIX: Private props obscure error

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/Helpers/LazyReference.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/LazyReference.php
@@ -42,8 +42,11 @@ final class LazyReference
         }
 
         $this->isLocked = true;
-        $this->value = ($this->calculateValueCallback)();
-        $this->hasBeenDereferenced = true;
+        try {
+            $this->value = ($this->calculateValueCallback)();
+        } finally {
+            $this->hasBeenDereferenced = true;
+        }
 
         return $this->value;
     }


### PR DESCRIPTION
…uated

instead of the original error that something went wrong

> Circular reference detected while evaluating prop: "private.thepath"

is shown.

That happens because the locking didnt anticipate this case.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

this code reproduces the problem ... yes i know :D

```
prototype(YourVendor:FusionPrototype) < prototype(Neos.Fusion:Component) {
  @private {
    lol = ${true}
    throwingPath = ${private.lol && NonExistingFunctionError()}
  }

  renderer = YourVendor:FusionPrototypeWithPrivate {
    content = ${private.throwingPath}
  }
}

prototype(YourVendor:FusionPrototypeWithPrivate) < prototype(Neos.Fusion:Component) {
  renderer = ${props.content}
}
```


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
