### PR TITLE
TASK: Cleanup SVG Sanitzer workaround after 0.17.0 release

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -1032,15 +1032,11 @@ class AssetController extends ActionController
     private function checkForMaliciousContent(AssetProxyInterface $assetProxy): bool
     {
         if ($assetProxy->getMediaType() == 'image/svg+xml') {
-            // @todo: Simplify again when https://github.com/darylldoyle/svg-sanitizer/pull/90 is merged and released.
-            $previousXmlErrorHandling = libxml_use_internal_errors(true);
             $sanitizer = new Sanitizer();
 
             $resource = stream_get_contents($assetProxy->getImportStream());
 
             $sanitizer->sanitize($resource);
-            libxml_clear_errors();
-            libxml_use_internal_errors($previousXmlErrorHandling);
             $issues = $sanitizer->getXmlIssues();
             if ($issues && count($issues) > 0) {
                 return true;

--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -24,7 +24,7 @@
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/orm": "^2.6",
-        "enshrined/svg-sanitize": "^0.16.0"
+        "enshrined/svg-sanitize": "^0.17.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
SVG Sanitizer has merged and released the fix for restoring libxml error handler. So we can remove the workaround.

See: https://github.com/darylldoyle/svg-sanitizer/pull/90