### PR TITLE
BUGFIX: `DateTime` node property with `defaultValue`

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -18,7 +18,7 @@ Feature: Create a node aggregate with complex default values
           type: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek
           defaultValue: 'https://schema.org/Wednesday'
         now:
-          type: DateTimeImmutable
+          type: DateTime
           defaultValue: 'now'
         date:
           type: DateTimeImmutable
@@ -66,6 +66,18 @@ Feature: Create a node aggregate with complex default values
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
     And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+
+    And I expect this node to have the following serialized property types:
+      | Key           | Type                                                                   |
+      | array         | array                                                                  |
+      | dayOfWeek     | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek          |
+      | postalAddress | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress      |
+      # DateTime must always be treated as immutable see DateTimeImmutable
+      | now           | DateTimeImmutable                                                      |
+      | date          | DateTimeImmutable                                                      |
+      | uri           | GuzzleHttp\Psr7\Uri                                                    |
+      | price         | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification |
+
     And I expect this node to have the following properties:
       | Key           | Value                                           |
       | array         | {"givenName":"Nody", "familyName":"McNodeface"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -72,16 +72,18 @@ Feature: Create a node aggregate with complex default values
     And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
 
-    And I expect this node to have the following serialized property types:
-      | Key           | Type                                                                   |
-      | array         | array                                                                  |
-      | dayOfWeek     | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek          |
-      | postalAddress | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress      |
-      # DateTime must always be treated as immutable see DateTimeImmutable
-      | now           | DateTimeImmutable                                                      |
-      | date          | DateTimeImmutable                                                      |
-      | uri           | GuzzleHttp\Psr7\Uri                                                    |
-      | price         | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification |
+    And I expect this node to have the following serialized properties:
+      | Key           | Type                                                                   | Value                                                              |
+      | array         | array                                                                  | {"givenName":"Nody","familyName":"McNodeface"}                     |
+      | dayOfWeek     | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek          | "https://schema.org/Wednesday"                                     |
+      | postalAddress | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress      | {"streetAddress":"28 31st of February Street","postalCode":12345,"addressLocality":"City","addressCountry":"Country"} |
+      # DateTime must always be treated as immutable see DateTimeImmutable.
+      # And the default value "now" must not be serialized as string "now" but as its actual value of the time of the command:
+      | now           | DateTimeImmutable                                                      | NOT:"now"                                                          |
+      | date          | DateTimeImmutable                                                      | "2020-08-20T18:56:15+00:00"                                        |
+      | uri           | GuzzleHttp\Psr7\Uri                                                    | "https://neos.io"                                                  |
+      # Defaults while deserializing value objects will be manifested at the time of the command: (valueAddedTaxIncluded was not explicitly declared above)
+      | price         | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification | {"price":13.37,"priceCurrency":"EUR","valueAddedTaxIncluded":true} |
 
     And I expect this node to have the following properties:
       | Key           | Value                                           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -39,6 +39,11 @@ Feature: Create a node aggregate with complex default values
             price: 13.37
             priceCurrency: 'EUR'
 
+    'Neos.ContentRepository.Testing:FaultyDateNode':
+      properties:
+        date:
+          type: DateTimeImmutable
+          defaultValue: 'not a date'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -106,3 +111,11 @@ Feature: Create a node aggregate with complex default values
       | date          | Date:2021-03-13T17:33:17+00:00                  |
       | uri           | URI:https://www.neos.io                         |
       | price         | PriceSpecification:anotherDummy                 |
+
+  Scenario: Create a node aggregate with faulty date time defaultValue fails
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                   | Value                                           |
+      | nodeAggregateId       | "nody-mc-nodeface"                              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                        |
+    And the last command should have thrown an exception of type "RuntimeException" with code 1708416598

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodePeerVariantWasCreated;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
@@ -35,6 +36,8 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 trait TetheredNodeInternals
 {
     use NodeVariationInternals;
+
+    abstract protected function getPropertyConverter(): PropertyConverter;
 
     abstract protected function createEventsForVariations(
         ContentStreamId $contentStreamId,
@@ -100,7 +103,7 @@ trait TetheredNodeInternals
                             $this->getInterDimensionalVariationGraph()->getSpecializationSet($rootGeneralization),
                             $parentNodeAggregate->nodeAggregateId,
                             $tetheredNodeName,
-                            SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType),
+                            SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType, $this->getPropertyConverter()),
                             NodeAggregateClassification::CLASSIFICATION_TETHERED,
                         );
                         $creationOriginDimensionSpacePoint = $rootGeneralizationOrigin;
@@ -117,7 +120,7 @@ trait TetheredNodeInternals
                         $parentNodeAggregate->getCoverageByOccupant($originDimensionSpacePoint),
                         $parentNodeAggregate->nodeAggregateId,
                         $tetheredNodeName,
-                        SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType),
+                        SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType, $this->getPropertyConverter()),
                         NodeAggregateClassification::CLASSIFICATION_TETHERED,
                     )
                 );

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -224,7 +224,7 @@ trait NodeCreation
             );
         }
 
-        $defaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType);
+        $defaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->getPropertyConverter());
         $initialPropertyValues = $defaultPropertyValues->merge($command->initialPropertyValues);
 
         $events = [
@@ -294,7 +294,7 @@ trait NodeCreation
                 : NodePath::fromString($nodeName->value);
             $childNodeAggregateId = $nodeAggregateIds->getNodeAggregateId($childNodePath)
                 ?? NodeAggregateId::create();
-            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType);
+            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType, $this->getPropertyConverter());
 
             $this->requireContentStreamToExist($command->contentStreamId, $contentRepository);
             $events[] = $this->createTetheredWithNode(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -69,10 +69,6 @@ trait NodeCreation
         ContentRepository $contentRepository
     ): EventsToPublish {
         $this->requireNodeType($command->nodeTypeName);
-        $this->validateProperties(
-            $this->deserializeDefaultProperties($command->nodeTypeName),
-            $command->nodeTypeName
-        );
         $this->validateProperties($command->initialPropertyValues, $command->nodeTypeName);
 
         $lowLevelCommand = CreateNodeAggregateWithNodeAndSerializedProperties::create(
@@ -93,27 +89,6 @@ trait NodeCreation
         }
 
         return $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($lowLevelCommand, $contentRepository);
-    }
-
-    private function deserializeDefaultProperties(NodeTypeName $nodeTypeName): PropertyValuesToWrite
-    {
-        $nodeType = $this->nodeTypeManager->getNodeType($nodeTypeName);
-        $defaultValues = [];
-        foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
-            $propertyType = PropertyType::fromNodeTypeDeclaration(
-                $nodeType->getPropertyType($propertyName),
-                PropertyName::fromString($propertyName),
-                $nodeTypeName
-            );
-
-            $serializedPropertyValue = SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType());
-
-            $defaultValues[$propertyName] = $this->getPropertyConverter()->deserializePropertyValue(
-                $serializedPropertyValue
-            );
-        }
-
-        return PropertyValuesToWrite::fromArray($defaultValues);
     }
 
     private function validateProperties(?PropertyValuesToWrite $propertyValues, NodeTypeName $nodeTypeName): void

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -80,7 +80,12 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
             $deserializedDefaultValue = $propertyConverter->deserializePropertyValue(
                 SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType())
             );
-            $values[$propertyName] = $propertyConverter->serializePropertyValue(
+            // The $defaultValue and $properlySerializedDefaultValue will likely equal, but in some cases diverge.
+            // For example relative date time default values like "now" will herby be serialized to the current date.
+            // Also, custom value objects might serialize slightly different, but more "correct"
+            // (by for example adding default values for undeclared properties)
+            // Additionally due the double conversion, we guarantee that a valid property converted exists at this time.
+            $properlySerializedDefaultValue = $propertyConverter->serializePropertyValue(
                 PropertyType::fromNodeTypeDeclaration(
                     $nodeType->getPropertyType($propertyName),
                     PropertyName::fromString($propertyName),
@@ -88,6 +93,7 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
                 ),
                 $deserializedDefaultValue
             );
+            $values[$propertyName] = $properlySerializedDefaultValue;
         }
 
         return new self($values);

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -72,10 +72,6 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
     {
         $values = [];
         foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
-            if ($defaultValue instanceof \DateTimeInterface) {
-                $defaultValue = json_encode($defaultValue);
-            }
-
             $propertyType = PropertyType::fromNodeTypeDeclaration(
                 $nodeType->getPropertyType($propertyName),
                 PropertyName::fromString($propertyName),

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
@@ -200,7 +200,7 @@ trait RootNodeHandling
                 : NodePath::fromString($nodeName->value);
             $childNodeAggregateId = $nodeAggregateIdsByNodePath->getNodeAggregateId($childNodePath)
                 ?? NodeAggregateId::create();
-            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType);
+            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType, $this->getPropertyConverter());
 
             $this->requireContentStreamToExist($command->contentStreamId, $contentRepository);
             $events[] = $this->createTetheredWithNodeForRoot(

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyConverter.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyConverter.php
@@ -16,7 +16,6 @@ namespace Neos\ContentRepository\Core\Infrastructure\Property;
 
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\ContentRepository\Core\NodeType\NodeType;
-use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
@@ -45,9 +44,11 @@ final class PropertyConverter
 
         foreach ($propertyValuesToWrite->values as $propertyName => $propertyValue) {
             $serializedPropertyValues[$propertyName] = $this->serializePropertyValue(
-                $nodeType->getPropertyType($propertyName),
-                PropertyName::fromString($propertyName),
-                $nodeType->name,
+                PropertyType::fromNodeTypeDeclaration(
+                    $nodeType->getPropertyType($propertyName),
+                    PropertyName::fromString($propertyName),
+                    $nodeType->name
+                ),
                 $propertyValue
             );
         }
@@ -55,22 +56,14 @@ final class PropertyConverter
         return SerializedPropertyValues::fromArray($serializedPropertyValues);
     }
 
-    private function serializePropertyValue(
-        string $declaredType,
-        PropertyName $propertyName,
-        NodeTypeName $nodeTypeName,
+    public function serializePropertyValue(
+        PropertyType $propertyType,
         mixed $propertyValue
     ): SerializedPropertyValue {
-        $propertyType = PropertyType::fromNodeTypeDeclaration(
-            $declaredType,
-            $propertyName,
-            $nodeTypeName
-        );
-
         if ($propertyValue === null) {
             // should not happen, as we must separate regular properties and unsets beforehand!
             throw new \RuntimeException(
-                sprintf('Property %s with value "null" cannot be serialized as unsets are treated differently.', $propertyName->value),
+                sprintf('Property type %s with value "null" cannot be serialized as unsets are treated differently.', $propertyType->value),
                 1707578784
             );
         }
@@ -80,7 +73,7 @@ final class PropertyConverter
         } catch (NotEncodableValueException | NotNormalizableValueException $e) {
             // todo add custom exception class
             throw new \RuntimeException(
-                sprintf('There was a problem serializing property %s with value "%s".', $propertyName->value, get_debug_type($propertyValue)),
+                sprintf('There was a problem serializing property type %s with value "%s".', $propertyType->value, get_debug_type($propertyValue)),
                 1594842314,
                 $e
             );
@@ -88,14 +81,14 @@ final class PropertyConverter
 
         if ($serializedPropertyValue === null) {
             throw new \RuntimeException(
-                sprintf('While serializing property %s with value "%s" the serializer returned not allowed value "null".', $propertyName->value, get_debug_type($propertyValue)),
+                sprintf('While serializing property type %s with value "%s" the serializer returned not allowed value "null".', $propertyType->value, get_debug_type($propertyValue)),
                 1707578784
             );
         }
 
         return SerializedPropertyValue::create(
             $serializedPropertyValue,
-            $propertyType->value
+            $propertyType->getSerializationType()
         );
     }
 
@@ -110,9 +103,11 @@ final class PropertyConverter
             $declaredType = $nodeType->getProperties()[$referenceName->value]['properties'][$propertyName]['type'];
 
             $serializedPropertyValues[$propertyName] = $this->serializePropertyValue(
-                $declaredType,
-                PropertyName::fromString($propertyName),
-                $nodeType->name,
+                PropertyType::fromNodeTypeDeclaration(
+                    $declaredType,
+                    PropertyName::fromString($propertyName),
+                    $nodeType->name,
+                ),
                 $propertyValue
             );
         }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyConverter.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyConverter.php
@@ -117,9 +117,17 @@ final class PropertyConverter
 
     public function deserializePropertyValue(SerializedPropertyValue $serializedPropertyValue): mixed
     {
-        return $this->serializer->denormalize(
-            $serializedPropertyValue->value,
-            $serializedPropertyValue->type
-        );
+        try {
+            return $this->serializer->denormalize(
+                $serializedPropertyValue->value,
+                $serializedPropertyValue->type
+            );
+        } catch (NotNormalizableValueException $e) {
+            throw new \RuntimeException(
+                sprintf('TODO: There was a problem deserializing %s', json_encode($serializedPropertyValue)),
+                1708416598,
+                $e
+            );
+        }
     }
 }

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeType.php
@@ -433,7 +433,7 @@ class NodeType
      *
      * The default value is configured for each property under the "default" key.
      *
-     * @return array<string,mixed>
+     * @return array<string,int|float|string|bool|array<int|string,mixed>>
      * @api
      */
     public function getDefaultValuesForProperties(): array

--- a/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PriceSpecification.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PriceSpecification.php
@@ -22,7 +22,8 @@ final readonly class PriceSpecification implements \Stringable
 {
     private function __construct(
         public float $price,
-        public string $priceCurrency
+        public string $priceCurrency,
+        public bool $valueAddedTaxIncluded
     ) {
     }
 
@@ -30,7 +31,8 @@ final readonly class PriceSpecification implements \Stringable
     {
         return new self(
             $array['price'],
-            $array['priceCurrency']
+            $array['priceCurrency'],
+            $array['valueAddedTaxIncluded'] ?? true, // default value
         );
     }
 
@@ -38,7 +40,8 @@ final readonly class PriceSpecification implements \Stringable
     {
         return new self(
             13.37,
-            'EUR'
+            'EUR',
+            true
         );
     }
 
@@ -46,7 +49,8 @@ final readonly class PriceSpecification implements \Stringable
     {
         return new self(
             84.72,
-            'EUR'
+            'EUR',
+            false
         );
     }
 

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
@@ -78,13 +78,6 @@ class PropertyAdjustment
 
                 // detect missing default values
                 foreach ($nodeType->getDefaultValuesForProperties() as $propertyKey => $defaultValue) {
-                    if ($defaultValue instanceof \DateTimeInterface) {
-                        $defaultValue = json_encode($defaultValue);
-                    }
-                    if ($defaultValue === null) {
-                        // we don't need to set null as default value if it doesn't exist
-                        continue;
-                    }
                     if (!array_key_exists($propertyKey, $propertyKeysInNode)) {
                         yield StructureAdjustment::createForNode(
                             $node,

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\NodeMove\Dto\CoverageNodeMoveMapping;
 use Neos\ContentRepository\Core\Feature\NodeMove\Dto\CoverageNodeMoveMappings;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
@@ -41,6 +42,7 @@ class TetheredNodeAdjustments
         private readonly ProjectedNodeIterator $projectedNodeIterator,
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
+        private readonly PropertyConverter $propertyConverter
     ) {
     }
 
@@ -209,6 +211,11 @@ class TetheredNodeAdjustments
     protected function getInterDimensionalVariationGraph(): DimensionSpace\InterDimensionalVariationGraph
     {
         return $this->interDimensionalVariationGraph;
+    }
+
+    protected function getPropertyConverter(): PropertyConverter
+    {
+        return $this->propertyConverter;
     }
 
     /**

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\EventStore\EventPersister;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\StructureAdjustment\Adjustment\DimensionAdjustment;
@@ -32,6 +33,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         private readonly EventPersister $eventPersister,
         NodeTypeManager $nodeTypeManager,
         InterDimensionalVariationGraph $interDimensionalVariationGraph,
+        PropertyConverter $propertyConverter
     ) {
         $projectedNodeIterator = new ProjectedNodeIterator(
             $contentRepository->getWorkspaceFinder(),
@@ -43,6 +45,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
             $projectedNodeIterator,
             $nodeTypeManager,
             $interDimensionalVariationGraph,
+            $propertyConverter
         );
 
         $this->unknownNodeTypeAdjustment = new UnknownNodeTypeAdjustment(

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
@@ -20,6 +20,7 @@ class StructureAdjustmentServiceFactory implements ContentRepositoryServiceFacto
             $serviceFactoryDependencies->eventPersister,
             $serviceFactoryDependencies->nodeTypeManager,
             $serviceFactoryDependencies->interDimensionalVariationGraph,
+            $serviceFactoryDependencies->propertyConverter
         );
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -283,6 +283,10 @@ trait ProjectedNodeTrait
                 $expectedPropertyValue = $this->resolvePropertyValue($row['Value']);
                 $actualPropertyValue = $properties->offsetGet($row['Key']);
                 if ($row['Value'] === 'Date:now') {
+                    // special case as It's hard to work with relative times. We only handle `now` right now (pun intended) but this or similar handling would also be required for `yesterday` or `after rep tv`
+                    // as It's hard to check otherwise, we have to verify that `now` was not actually saved as string `now` but as timestamp when it was created
+                    $serializedValue = $currentNode->properties->serialized()->getProperty($row['Key'])?->value;
+                    Assert::assertNotEquals('now', $serializedValue, 'Relative DateTime must be serialized as absolute time in the events/serialized-properties');
                     // we accept 10s offset for the projector to be fine
                     Assert::assertLessThan($actualPropertyValue, $expectedPropertyValue->sub(new \DateInterval('PT10S')), 'Node property ' . $row['Key'] . ' does not match. Expected: ' . json_encode($expectedPropertyValue) . '; Actual: ' . json_encode($actualPropertyValue));
                 } else {

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -256,6 +256,21 @@ trait ProjectedNodeTrait
     }
 
     /**
+     * @Then /^I expect this node to have the following serialized property types:$/
+     * @param TableNode $expectedPropertyTypes
+     */
+    public function iExpectThisNodeToHaveTheFollowingSerializedPropertyTypes(TableNode $expectedPropertyTypes): void
+    {
+        $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedPropertyTypes) {
+            $serialized = $currentNode->properties->serialized();
+            foreach ($expectedPropertyTypes->getHash() as $row) {
+                Assert::assertTrue($serialized->propertyExists($row['Key']), 'Property "' . $row['Key'] . '" not found');
+                Assert::assertEquals($row['Type'], $serialized->getProperty($row['Key'])->type, 'Serialized node property ' . $row['Key'] . ' does not match expected type.');
+            }
+        });
+    }
+
+    /**
      * @Then /^I expect this node to have the following properties:$/
      * @param TableNode $expectedProperties
      */

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -256,7 +256,7 @@ trait ProjectedNodeTrait
     }
 
     /**
-     * @Then /^I expect this node to have the following serialized property types:$/
+     * @Then /^I expect this node to have the following serialized properties:$/
      * @param TableNode $expectedPropertyTypes
      */
     public function iExpectThisNodeToHaveTheFollowingSerializedPropertyTypes(TableNode $expectedPropertyTypes): void
@@ -266,6 +266,14 @@ trait ProjectedNodeTrait
             foreach ($expectedPropertyTypes->getHash() as $row) {
                 Assert::assertTrue($serialized->propertyExists($row['Key']), 'Property "' . $row['Key'] . '" not found');
                 Assert::assertEquals($row['Type'], $serialized->getProperty($row['Key'])->type, 'Serialized node property ' . $row['Key'] . ' does not match expected type.');
+                if (str_starts_with($row['Value'], 'NOT:')) {
+                    // special case. assert NOT equals:
+                    $value = json_decode(mb_substr($row['Value'], 4), true, 512, JSON_THROW_ON_ERROR);
+                    Assert::assertNotEquals($value, $serialized->getProperty($row['Key'])->value, 'Serialized node property ' . $row['Key'] . ' does match value it should not.');
+                } else {
+                    $value = json_decode($row['Value'], true, 512, JSON_THROW_ON_ERROR);
+                    Assert::assertEquals($value, $serialized->getProperty($row['Key'])->value, 'Serialized node property ' . $row['Key'] . ' does not match expected value.');
+                }
             }
         });
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -17,7 +17,6 @@ namespace Neos\ContentRepository\TestSuite\Unit;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Infrastructure\Property\Normalizer\ArrayNormalizer;
 use Neos\ContentRepository\Core\Infrastructure\Property\Normalizer\CollectionTypeDenormalizer;
@@ -85,14 +84,7 @@ final class NodeSubjectProvider
         SerializedPropertyValues $propertyValues = null,
         ?NodeName $nodeName = null
     ): Node {
-        $defaultPropertyValues = [];
-        foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $propertyValue) {
-            $defaultPropertyValues[$propertyName] = SerializedPropertyValue::create(
-                $propertyValue,
-                $nodeType->getPropertyType($propertyName)
-            );
-        }
-        $serializedDefaultPropertyValues = SerializedPropertyValues::fromArray($defaultPropertyValues);
+        $serializedDefaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->propertyConverter);
         return Node::create(
             ContentSubgraphIdentity::create(
                 ContentRepositoryId::fromString('default'),


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Resolves: https://github.com/neos/neos-development-collection/issues/4901

**Upgrade instructions**

In case you already used `defaultValue` with a relative string like `now`, you have to manually migrate the events by hand.
Not doing so is not critical as the node property will still work, just a little unexpected as `now` will always be _now_.
If there is much demand for it, we can provide an optional migration to handle `DateTime` in `initialProperties` correctly.
But it is to be suspected that this feature was not yet used as its a niche thing.

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
