### PR TITLE
TASK: Remove generic `theEventWasPublishedToStreamWithPayload` in tests

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -39,7 +39,7 @@ Feature: ForkContentStream Without Dimensions
       | parentNodeAggregateId       | "lady-eleonode-rootford"                 |
       | nodeName                    | "child"                                  |
       | nodeAggregateClassification | "regular"                                |
-    And the Event "NodePropertiesWereSet" was published to stream "ContentStream:cs-identifier" with payload:
+    And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
       | contentStreamId              | "cs-identifier"                                         |
       | nodeAggregateId              | "nody-mc-nodeface"                                      |
@@ -62,7 +62,7 @@ Feature: ForkContentStream Without Dimensions
       | Key                   | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "cs-identifier"      |
-    And the Event "NodePropertiesWereSet" was published to stream "ContentStream:user-cs-identifier" with payload:
+    And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
       | contentStreamId              | "user-cs-identifier"                                    |
       | nodeAggregateId              | "nody-mc-nodeface"                                      |
@@ -91,7 +91,7 @@ Feature: ForkContentStream Without Dimensions
       | Key                   | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "cs-identifier"      |
-    And the Event "NodePropertiesWereSet" was published to stream "ContentStream:cs-identifier" with payload:
+    And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
       | contentStreamId              | "cs-identifier"                                         |
       | nodeAggregateId              | "nody-mc-nodeface"                                      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
@@ -119,7 +119,7 @@ Feature: Properties
           type: string
     """
 
-    And the Event "NodePropertiesWereSet" was published to stream "ContentStream:cs-identifier" with payload:
+    And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                                       |
       | contentStreamId              | "cs-identifier"                                                             |
       | nodeAggregateId              | "sir-david-nodenborough"                                                    |

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -117,16 +117,6 @@ trait GenericCommandExecutionAndEventPublication
     }
 
     /**
-     * @Given /^the Event "([^"]*)" was published to stream "([^"]*)" with payload:$/
-     * @throws \Exception
-     */
-    public function theEventWasPublishedToStreamWithPayload(string $eventType, string $streamName, TableNode $payloadTable): void
-    {
-        $eventPayload = $this->readPayloadTable($payloadTable);
-        $this->publishEvent($eventType, StreamName::fromString($streamName), $eventPayload);
-    }
-
-    /**
      * @throws \Exception
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */


### PR DESCRIPTION
Related: #4336

It makes the tests easier to read if they are all uniform and we dont need a generic escape hatch to publish custom/wrong events while testing.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
