### PR TITLE
TASK: Allow to disable `projection` or `catchUpHook` in config

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -211,12 +211,18 @@ final class ContentRepositoryRegistry
         (isset($contentRepositorySettings['projections']) && is_array($contentRepositorySettings['projections'])) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have projections configured, or the value is no array.', $contentRepositoryId->value);
         $projectionsFactory = new ProjectionsAndCatchUpHooksFactory();
         foreach ($contentRepositorySettings['projections'] as $projectionName => $projectionOptions) {
+            if ($projectionOptions === null) {
+                continue;
+            }
             $projectionFactory = $this->objectManager->get($projectionOptions['factoryObjectName']);
             if (!$projectionFactory instanceof ProjectionFactoryInterface) {
                 throw InvalidConfigurationException::fromMessage('Projection factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s.', $projectionName, $contentRepositoryId->value, ProjectionFactoryInterface::class, get_debug_type($projectionFactory));
             }
             $projectionsFactory->registerFactory($projectionFactory, $projectionOptions['options'] ?? []);
             foreach (($projectionOptions['catchUpHooks'] ?? []) as $catchUpHookOptions) {
+                if ($catchUpHookOptions === null) {
+                    continue;
+                }
                 $catchUpHookFactory = $this->objectManager->get($catchUpHookOptions['factoryObjectName']);
                 if (!$catchUpHookFactory instanceof CatchUpHookFactoryInterface) {
                     throw InvalidConfigurationException::fromMessage('CatchUpHook factory object name for projection "%s" (content repository "%s") is not an instance of %s but %s', $projectionName, $contentRepositoryId->value, CatchUpHookFactoryInterface::class, get_debug_type($catchUpHookFactory));

--- a/Neos.ContentRepositoryRegistry/Classes/Exception/InvalidConfigurationException.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Exception/InvalidConfigurationException.php
@@ -1,13 +1,10 @@
 <?php
 namespace Neos\ContentRepositoryRegistry\Exception;
 
-use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 
-#[Flow\Proxy(false)]
 final class InvalidConfigurationException extends \RuntimeException
 {
-
     public static function missingPreset(ContentRepositoryId $contentRepositoryId, string $presetName): self
     {
         return new self(sprintf('The preset "%s" referred to in content repository "%s" does not exist', $presetName, $contentRepositoryId->value), 1650557150);


### PR DESCRIPTION
Resolves: #4878

by setting it to null or `~`

That for example allows to speed up local e2e tests by diabling certain neos specific projections:

```yaml
Neos:
  ContentRepositoryRegistry:
    presets:
      'default':
        projections:
          'Neos.Neos:DocumentUriPathProjection':
            catchUpHooks:
              'Neos.Neos:FlushRouteCache': ~
          'Neos.Neos:PendingChangesProjection': ~
          'Neos.ContentRepository:ContentGraph':
            catchUpHooks:
              'Neos.Neos:FlushContentCache': ~
          'Neos.Neos:AssetUsage': ~
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
