### PR TITLE
BUGFIX: 4915 fusion `ParsePartials` cache not flushed for symlinked packages

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheFlusher.php
@@ -14,6 +14,7 @@ namespace Neos\Fusion\Core\Cache;
  */
 
 use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface;
 
 /**
  * Helper around the ParsePartials Cache.
@@ -50,10 +51,21 @@ class ParserCacheFlusher
 
         $identifiersToFlush = [];
         foreach ($changedFiles as $changedFile => $status) {
-            // flow already returns absolute file paths from the file monitor, so we don't have to call realpath.
-            // attempting to use realpath can even result in an error as the file might be removed and thus no realpath can be resolved via file system.
-            // https://github.com/neos/neos-development-collection/pull/4509
-            $identifiersToFlush[] = $this->getCacheIdentifierForAbsoluteUnixStyleFilePathWithoutDirectoryTraversal($changedFile);
+            // flow returns linux style file paths without directory traversal from the file monitor.
+            // As discovered via https://github.com/neos/neos-development-collection/issues/4915 the paths will point to symlinks instead of the actual file.
+            // Thus, we still need to invoke `realpath` as the cache invalidation otherwise would not work (due to a different hash)
+            // But attempting to use realpath on removed/moved files fails because it surely cannot be resolved via file system.
+            if ($status === ChangeDetectionStrategyInterface::STATUS_DELETED) {
+                // Ignoring removed files means we cannot flush removed files, but this is a compromise for now.
+                // See https://github.com/neos/neos-development-collection/issues/4415 as reminder that flushing is disabled for deleted files
+                continue;
+            }
+            $fusionFileRealPath = realpath($changedFile);
+            if ($fusionFileRealPath === false) {
+                // should not happen as we ignored deleted files beforehand.
+                throw new \RuntimeException("Couldn't resolve realpath for: '$changedFile'", 1709122619);
+            }
+            $identifiersToFlush[] = $this->getCacheIdentifierForAbsoluteUnixStyleFilePathWithoutDirectoryTraversal($fusionFileRealPath);
         }
 
         if ($identifiersToFlush !== []) {

--- a/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
+++ b/Neos.Fusion/Classes/Core/Cache/ParserCacheIdentifierTrait.php
@@ -33,9 +33,10 @@ trait ParserCacheIdentifierTrait
      *  - /Users/marc/Code/neos-project/Packages/Neos
      *
      * its crucial that the path
-     *  - is absolute
+     *  - is absolute (starting with /)
      *  - the path separator is in unix style: forward-slash /
      *  - doesn't contain directory traversal /../ or /./
+     *  - is not a symlink
      *
      * to be absolutely sure the path matches the criteria, {@see realpath} can be used.
      *


### PR DESCRIPTION
Resolves #4915
By reverting fix https://github.com/neos/neos-development-collection/pull/4838
Which will lead to the original problem to resurface https://github.com/neos/neos-development-collection/issues/4415 (but silently this time, no one will notice the cache flodding :D) 

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
