### PR TITLE
TASK: Declare fusion core classes as internal

### DIFF
--- a/Neos.Fusion.Afx/Classes/Dsl/AfxDslImplementation.php
+++ b/Neos.Fusion.Afx/Classes/Dsl/AfxDslImplementation.php
@@ -32,7 +32,7 @@ class AfxDslImplementation implements DslInterface
      * @return string
      * @throws Fusion\Exception
      */
-    public function transpile($code)
+    public function transpile(string $code): string
     {
         try {
             return AfxService::convertAfxToFusion($code);

--- a/Neos.Fusion/Classes/Core/DslFactory.php
+++ b/Neos.Fusion/Classes/Core/DslFactory.php
@@ -20,6 +20,7 @@ use Neos\Fusion;
  * This dsl factory takes care of instantiating a Fusion dsl transpilers.
  *
  * @Flow\Scope("singleton")
+ * @internal the factory is internal but implementing a DSL is api.
  */
 class DslFactory
 {

--- a/Neos.Fusion/Classes/Core/DslInterface.php
+++ b/Neos.Fusion/Classes/Core/DslInterface.php
@@ -16,6 +16,26 @@ use Neos\Fusion;
 /**
  * Contract for a Fusion DSL parser
  *
+ * A dsl can be registered like:
+ *
+ *     Neos:
+ *       Fusion:
+ *         dsl:
+ *           afx: Neos\Fusion\Afx\Dsl\AfxDslImplementation
+ *
+ * And will be available via its identifier in Fusion:
+ *
+ *     root = afx`
+ *         <div>Hello World</div>
+ *     `
+ * The returned string must be a valid fusion string,
+ * which is parsed again:
+ *
+ *     Neos.Fusion:Tag {
+ *         tagName = 'div'
+ *         content = 'Hello World'
+ *     }
+ *
  * @api
  */
 interface DslInterface
@@ -27,5 +47,5 @@ interface DslInterface
      * @return string
      * @throws Fusion\Exception
      */
-    public function transpile($code);
+    public function transpile(string $code): string;
 }

--- a/Neos.Fusion/Classes/Core/FusionConfiguration.php
+++ b/Neos.Fusion/Classes/Core/FusionConfiguration.php
@@ -16,15 +16,16 @@ namespace Neos\Fusion\Core;
 /**
  * This holds the parsed Fusion Configuration and can be used to pass it to the Runtime via
  * {@see RuntimeFactory::createFromConfiguration()}
- * The contents of this DTO are internal and can change at any time!
+ *
+ * @internal The Fusion parsing is considered internal.
  */
 final class FusionConfiguration
 {
     /**
      * @internal
-     * @param array<int|string, mixed> $fusionConfiguration
+     * @param array<int|string, mixed> $fusionConfiguration The representation of the configuration as array is fully internal and only allowed to be accessed by the Runtime
      */
-    protected function __construct(
+    private function __construct(
         private array $fusionConfiguration
     ) {
     }

--- a/Neos.Fusion/Classes/Core/FusionSourceCode.php
+++ b/Neos.Fusion/Classes/Core/FusionSourceCode.php
@@ -13,11 +13,19 @@ namespace Neos\Fusion\Core;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Fusion;
 
+/**
+ * @internal The Fusion parsing is considered internal.
+ *           For interacting with Fusion from the outside a FusionView should be used.
+ */
 final class FusionSourceCode
 {
-    protected function __construct(
+    /**
+     * @Flow\Autowiring(false)
+     */
+    private function __construct(
         private ?string $filePath,
         private string|\Closure $sourceCodeOrFactory,
     ) {

--- a/Neos.Fusion/Classes/Core/FusionSourceCodeCollection.php
+++ b/Neos.Fusion/Classes/Core/FusionSourceCodeCollection.php
@@ -17,7 +17,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * @implements \IteratorAggregate<int, FusionSourceCode>
- * @api
+ * @internal The Fusion parsing is considered internal.
+ *           For interacting with Fusion from the outside a FusionView should be used.
  */
 final class FusionSourceCodeCollection implements \IteratorAggregate, \Countable
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractNode.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractNode.php
@@ -19,7 +19,7 @@ use Neos\Flow\Annotations as Flow;
 
 /** @internal */
 #[Flow\Proxy(false)]
-abstract class AbstractNode
+abstract readonly class AbstractNode
 {
     abstract public function visit(AstNodeVisitorInterface $visitor, mixed ...$args);
 }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractNode.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractNode.php
@@ -17,6 +17,7 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 use Neos\Flow\Annotations as Flow;
 
+/** @internal */
 #[Flow\Proxy(false)]
 abstract class AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractOperation.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractOperation.php
@@ -17,6 +17,6 @@ use Neos\Flow\Annotations as Flow;
 
 /** @internal */
 #[Flow\Proxy(false)]
-abstract class AbstractOperation extends AbstractNode
+abstract readonly class AbstractOperation extends AbstractNode
 {
 }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractOperation.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractOperation.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 
 use Neos\Flow\Annotations as Flow;
 
+/** @internal */
 #[Flow\Proxy(false)]
 abstract class AbstractOperation extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathSegment.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 
 use Neos\Flow\Annotations as Flow;
 
+/** @internal */
 #[Flow\Proxy(false)]
 abstract class AbstractPathSegment extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathSegment.php
@@ -17,6 +17,6 @@ use Neos\Flow\Annotations as Flow;
 
 /** @internal */
 #[Flow\Proxy(false)]
-abstract class AbstractPathSegment extends AbstractNode
+abstract readonly class AbstractPathSegment extends AbstractNode
 {
 }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathValue.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 
 use Neos\Flow\Annotations as Flow;
 
+/** @internal */
 #[Flow\Proxy(false)]
 abstract class AbstractPathValue extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractPathValue.php
@@ -17,6 +17,6 @@ use Neos\Flow\Annotations as Flow;
 
 /** @internal */
 #[Flow\Proxy(false)]
-abstract class AbstractPathValue extends AbstractNode
+abstract readonly class AbstractPathValue extends AbstractNode
 {
 }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractStatement.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 
 use Neos\Flow\Annotations as Flow;
 
+/** @internal */
 #[Flow\Proxy(false)]
 abstract class AbstractStatement extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AbstractStatement.php
@@ -17,6 +17,6 @@ use Neos\Flow\Annotations as Flow;
 
 /** @internal */
 #[Flow\Proxy(false)]
-abstract class AbstractStatement extends AbstractNode
+abstract readonly class AbstractStatement extends AbstractNode
 {
 }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AssignedObjectPath.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AssignedObjectPath.php
@@ -18,12 +18,10 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class AssignedObjectPath extends AbstractNode
+final readonly class AssignedObjectPath extends AbstractNode
 {
     public function __construct(
-        /** @psalm-readonly */
         public ObjectPath $objectPath,
-        /** @psalm-readonly */
         public bool $isRelative
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AssignedObjectPath.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/AssignedObjectPath.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class AssignedObjectPath extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/Block.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/Block.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class Block extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/Block.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/Block.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class Block extends AbstractNode
+final readonly class Block extends AbstractNode
 {
     public function __construct(
-        /** @psalm-readonly */
         public StatementList $statementList
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/BoolValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/BoolValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class BoolValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/BoolValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/BoolValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class BoolValue extends AbstractPathValue
+final readonly class BoolValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public bool $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/DslExpressionValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/DslExpressionValue.php
@@ -18,12 +18,10 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class DslExpressionValue extends AbstractPathValue
+final readonly class DslExpressionValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $identifier,
-        /** @psalm-readonly */
         public string $code
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/DslExpressionValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/DslExpressionValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class DslExpressionValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/EelExpressionValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/EelExpressionValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class EelExpressionValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/EelExpressionValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/EelExpressionValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class EelExpressionValue extends AbstractPathValue
+final readonly class EelExpressionValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FloatValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FloatValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class FloatValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FloatValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FloatValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class FloatValue extends AbstractPathValue
+final readonly class FloatValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public float $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionFile.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionFile.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class FusionFile extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionFile.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionFile.php
@@ -18,12 +18,10 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class FusionFile extends AbstractNode
+final readonly class FusionFile extends AbstractNode
 {
     public function __construct(
-        /** @psalm-readonly */
         public StatementList $statementList,
-        /** @psalm-readonly */
         public ?string $contextPathAndFileName
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionObjectValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionObjectValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class FusionObjectValue extends AbstractPathValue
+final readonly class FusionObjectValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionObjectValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/FusionObjectValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class FusionObjectValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IncludeStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IncludeStatement.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class IncludeStatement extends AbstractStatement
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IncludeStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IncludeStatement.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class IncludeStatement extends AbstractStatement
+final readonly class IncludeStatement extends AbstractStatement
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $filePattern
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IntValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IntValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class IntValue extends AbstractPathValue
+final readonly class IntValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public int $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IntValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/IntValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class IntValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/MetaPathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/MetaPathSegment.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class MetaPathSegment extends AbstractPathSegment
+final readonly class MetaPathSegment extends AbstractPathSegment
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $identifier
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/MetaPathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/MetaPathSegment.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class MetaPathSegment extends AbstractPathSegment
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/NullValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/NullValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class NullValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/NullValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/NullValue.php
@@ -18,7 +18,7 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class NullValue extends AbstractPathValue
+final readonly class NullValue extends AbstractPathValue
 {
     public function visit(AstNodeVisitorInterface $visitor, mixed ...$args)
     {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectPath.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectPath.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class ObjectPath extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectPath.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectPath.php
@@ -18,13 +18,12 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class ObjectPath extends AbstractNode
+final readonly class ObjectPath extends AbstractNode
 {
     /**
-     * @psalm-readonly
      * @var AbstractPathSegment[]
      */
-    public $segments;
+    public array $segments;
 
     public function __construct(AbstractPathSegment ...$segments)
     {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectStatement.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class ObjectStatement extends AbstractStatement
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectStatement.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ObjectStatement.php
@@ -18,16 +18,12 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class ObjectStatement extends AbstractStatement
+final readonly class ObjectStatement extends AbstractStatement
 {
     public function __construct(
-        /** @psalm-readonly */
         public ObjectPath $path,
-        /** @psalm-readonly */
         public ValueAssignment|ValueCopy|ValueUnset|null $operation,
-        /** @psalm-readonly */
         public ?Block $block,
-        /** @psalm-readonly */
         public int $cursor
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PathSegment.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class PathSegment extends AbstractPathSegment
+final readonly class PathSegment extends AbstractPathSegment
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $identifier
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PathSegment.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class PathSegment extends AbstractPathSegment
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PrototypePathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PrototypePathSegment.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class PrototypePathSegment extends AbstractPathSegment
+final readonly class PrototypePathSegment extends AbstractPathSegment
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $identifier
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PrototypePathSegment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/PrototypePathSegment.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class PrototypePathSegment extends AbstractPathSegment
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StatementList.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StatementList.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class StatementList extends AbstractNode
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StatementList.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StatementList.php
@@ -18,13 +18,12 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class StatementList extends AbstractNode
+final readonly class StatementList extends AbstractNode
 {
     /**
-     * @psalm-readonly
      * @var AbstractStatement[]
      */
-    public $statements = [];
+    public array $statements;
 
     public function __construct(AbstractStatement ...$statements)
     {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StringValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StringValue.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class StringValue extends AbstractPathValue
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StringValue.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/StringValue.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class StringValue extends AbstractPathValue
+final readonly class StringValue extends AbstractPathValue
 {
     public function __construct(
-        /** @psalm-readonly */
         public string $value
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueAssignment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueAssignment.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class ValueAssignment extends AbstractOperation
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueAssignment.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueAssignment.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class ValueAssignment extends AbstractOperation
+final readonly class ValueAssignment extends AbstractOperation
 {
     public function __construct(
-        /** @psalm-readonly */
         public AbstractPathValue $pathValue
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueCopy.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueCopy.php
@@ -18,10 +18,9 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class ValueCopy extends AbstractOperation
+final readonly class ValueCopy extends AbstractOperation
 {
     public function __construct(
-        /** @psalm-readonly */
         public AssignedObjectPath $assignedObjectPath
     ) {
     }

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueCopy.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueCopy.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class ValueCopy extends AbstractOperation
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueUnset.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueUnset.php
@@ -16,6 +16,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\Ast;
 use Neos\Flow\Annotations as Flow;
 use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
+/** @internal */
 #[Flow\Proxy(false)]
 class ValueUnset extends AbstractOperation
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueUnset.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Ast/ValueUnset.php
@@ -18,7 +18,7 @@ use Neos\Fusion\Core\ObjectTreeParser\AstNodeVisitorInterface;
 
 /** @internal */
 #[Flow\Proxy(false)]
-class ValueUnset extends AbstractOperation
+final readonly class ValueUnset extends AbstractOperation
 {
     public function visit(AstNodeVisitorInterface $visitor, mixed ...$args)
     {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/AstNodeVisitorInterface.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/AstNodeVisitorInterface.php
@@ -35,6 +35,9 @@ use Neos\Fusion\Core\ObjectTreeParser\Ast\ValueCopy;
 use Neos\Fusion\Core\ObjectTreeParser\Ast\AssignedObjectPath;
 use Neos\Fusion\Core\ObjectTreeParser\Ast\ValueUnset;
 
+/**
+ * @internal
+ */
 interface AstNodeVisitorInterface
 {
     public function visitFusionFile(FusionFile $fusionFile);

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserException.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserException.php
@@ -18,6 +18,7 @@ use Neos\Fusion\Exception;
 
 /**
  * 'Fluent' exception for the Fusion Parser.
+ * @internal although ${exception.headingMessagePart} ${exception.asciiPreviewMessagePart} and ${exception.helperMessagePart} are used outside for custom error display
  */
 class ParserException extends Exception
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserException.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserException.php
@@ -18,7 +18,7 @@ use Neos\Fusion\Exception;
 
 /**
  * 'Fluent' exception for the Fusion Parser.
- * @internal although ${exception.headingMessagePart} ${exception.asciiPreviewMessagePart} and ${exception.helperMessagePart} are used outside for custom error display
+ * @internal
  */
 class ParserException extends Exception
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserUnexpectedCharException.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Exception/ParserUnexpectedCharException.php
@@ -17,6 +17,7 @@ use Neos\Fusion\Exception;
 
 /**
  * This exception is thrown when the Parser encounters an unexpected character
+ * @internal
  */
 class ParserUnexpectedCharException extends Exception
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageCreator.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageCreator.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Core\ObjectTreeParser\ExceptionMessage;
 
 /**
  * Creates exception messages for the Fusion parser
+ * @internal
  */
 class MessageCreator
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ExceptionMessage/MessageLinePart.php
@@ -13,6 +13,9 @@ namespace Neos\Fusion\Core\ObjectTreeParser\ExceptionMessage;
  * source code.
  */
 
+/**
+ * @internal
+ */
 class MessageLinePart
 {
     public function __construct(

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -19,6 +19,7 @@ use Neos\Utility\Files;
 /**
  * Resolve files after a pattern.
  * The returned files will not be checked for recursion and for readability.
+ * @internal
  */
 class FilePatternResolver
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php
@@ -13,6 +13,9 @@ namespace Neos\Fusion\Core\ObjectTreeParser;
  * source code.
  */
 
+/**
+ * @internal
+ */
 class Lexer
 {
     // Difference to: Neos\Eel\Package::EelExpressionRecognizer

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTree.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTree.php
@@ -16,6 +16,9 @@ namespace Neos\Fusion\Core\ObjectTreeParser;
 use Neos\Fusion;
 use Neos\Utility\Arrays;
 
+/**
+ * @internal
+ */
 class MergedArrayTree
 {
     public function __construct(

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTreeVisitor.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTreeVisitor.php
@@ -39,6 +39,7 @@ use Neos\Fusion\Core\ObjectTreeParser\Exception\ParserException;
 
 /**
  * Builds the merged array tree for the Fusion runtime
+ * @internal
  */
 class MergedArrayTreeVisitor implements AstNodeVisitorInterface
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/ObjectTreeParser.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/ObjectTreeParser.php
@@ -47,6 +47,7 @@ use Neos\Fusion\Core\ObjectTreeParser\Exception\ParserUnexpectedCharException;
 
 /**
  * Parses a Fusion File to object ast-nodes
+ * @internal
  */
 class ObjectTreeParser
 {

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/Token.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/Token.php
@@ -15,6 +15,9 @@ namespace Neos\Fusion\Core\ObjectTreeParser;
 
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class Token
 {
     public const EOF = 1;

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -25,7 +25,8 @@ use Neos\Flow\Annotations as Flow;
 /**
  * The Fusion Parser
  *
- * @api
+ * @internal The Fusion parsing is considered internal.
+ *           For interacting with Fusion from the outside a FusionView should be used.
  */
 class Parser
 {

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -55,7 +55,6 @@ class Parser
      * @param FusionSourceCodeCollection $sourceCode The Fusion source code to parse
      * @return FusionConfiguration The fusion configuration for the Fusion runtime
      * @throws Fusion\Exception
-     * @api
      */
     public function parseFromSource(FusionSourceCodeCollection $sourceCode): FusionConfiguration
     {
@@ -81,7 +80,6 @@ class Parser
      * @return array<int|string, mixed> The merged array tree for the Fusion runtime, generated from the source code
      * @throws Fusion\Exception
      * @deprecated with Neos 8.3 – will be removed with Neos 9.0, use {@link parseFromSource} instead
-     * @api
      */
     public function parse(string $sourceCode, ?string $contextPathAndFilename = null, array $mergedArrayTreeUntilNow = []): array
     {

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -48,6 +48,13 @@ use Neos\Utility\PositionalArraySorter;
  * The Fusion object can then add or replace variables to this context using pushContext()
  * or pushContextArray(), before rendering sub-Fusion objects. After rendering
  * these, it must call popContext() to reset the context to the last state.
+ *
+ * @internal The Fusion Runtime is considered internal.
+ *           For interacting with Fusion from the outside a FusionView should be used.
+ *           But custom Fusion object implementations might rely on manipulating/calling the Runtime directly,
+ *           if the abstractions in the AbstractFusionObject doesn't suffice.
+ *           TODO For that use case we should implement a more powerful and clean abstraction:
+ *           https://github.com/neos/neos-development-collection/issues/4910
  */
 class Runtime
 {
@@ -137,7 +144,7 @@ class Runtime
     protected ?AbstractRenderingExceptionHandler $overriddenExceptionHandler = null;
 
     /**
-     * @internal use {@see RuntimeFactory} for instantiating.
+     * @internal the {@see RuntimeFactory} must be used for instantiating, to make the EEL helpers available.
      */
     public function __construct(
         FusionConfiguration $fusionConfiguration,

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -220,7 +220,6 @@ class Runtime
      * @param string $key
      * @param string $value
      * @return void
-     * @api
      */
     public function addCacheTag($key, $value)
     {

--- a/Neos.Fusion/Classes/Core/RuntimeConfiguration.php
+++ b/Neos.Fusion/Classes/Core/RuntimeConfiguration.php
@@ -8,6 +8,7 @@ use Neos\Utility\Arrays;
 
 /**
  * @Flow\Proxy(false)
+ * @internal helper for the Fusion Runtime to calculate fusion path configurations
  */
 final class RuntimeConfiguration
 {

--- a/Neos.Fusion/Classes/Core/RuntimeFactory.php
+++ b/Neos.Fusion/Classes/Core/RuntimeFactory.php
@@ -22,7 +22,8 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
 
 /**
  * @Flow\Scope("singleton")
- * @api
+ * @internal The Fusion Runtime is considered internal.
+ *           For interacting with Fusion from the outside a FusionView should be used.
  */
 class RuntimeFactory
 {

--- a/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/FusionObjectExpressionTestDslImplementation.php
+++ b/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/FusionObjectExpressionTestDslImplementation.php
@@ -15,7 +15,7 @@ use Neos\Fusion\Core\DslInterface;
 
 class FusionObjectExpressionTestDslImplementation implements DslInterface
 {
-    public function transpile($code)
+    public function transpile(string $code): string
     {
         $config = json_decode($code, true);
 

--- a/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/PassthroughTestDslImplementation.php
+++ b/Neos.Fusion/Tests/Functional/Parser/Fixtures/Dsl/PassthroughTestDslImplementation.php
@@ -15,7 +15,7 @@ use Neos\Fusion\Core\DslInterface;
 
 class PassthroughTestDslImplementation implements DslInterface
 {
-    public function transpile($code)
+    public function transpile(string $code): string
     {
         return $code;
     }

--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -21,7 +21,7 @@ use Neos\Fusion\Core\Parser;
 use Neos\Neos\Domain\Model\Site;
 
 /**
- * @api
+ * @internal For interacting with Fusion from the outside a FusionView should be used.
  */
 #[Flow\Scope('singleton')]
 class FusionService

--- a/Neos.Neos/Classes/Domain/Service/FusionSourceCodeFactory.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionSourceCodeFactory.php
@@ -25,6 +25,9 @@ use Neos\Neos\Domain\Exception as NeosDomainException;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal For interacting with Fusion from the outside a FusionView should be used.
+ */
 class FusionSourceCodeFactory
 {
     /**


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

- Marks newer super internal low level Fusion parsing details as internal
  - This structure was introduced with the new Fusion Parser in Neos 8 https://github.com/neos/neos-development-collection/pull/3497
- Declares Fusion's Core as @internal
  - For interacting with Fusion from the outside a FusionView should be used

Custom Fusion object implementations might still rely on manipulating/calling the Runtime directly,
if the abstractions in the AbstractFusionObject doesn't suffice.
For that use case we should implement a more powerful and clean abstraction:
https://github.com/neos/neos-development-collection/issues/4910

Also i cleaned up the new Fusion parsers AST objects to use modern php 8.2 that wasnt available two years ago :D

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
