### PR TITLE
BUGFIX: Fix propertyValueCriteriaMatcherTest

### DIFF
--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/PropertyValue/PropertyValueCriteriaMatcherTest.php
@@ -33,9 +33,8 @@ class PropertyValueCriteriaMatcherTest extends TestCase
     public function setUp(): void
     {
         $this->serializedPropertyValues = SerializedPropertyValues::fromArray([
-            'nullProperty' => new SerializedPropertyValue(null, 'null'),
-            'stringProperty' => new SerializedPropertyValue('foo', 'string'),
-            'integerProperty' => new SerializedPropertyValue(123, 'int')
+            'stringProperty' => SerializedPropertyValue::create('foo', 'string'),
+            'integerProperty' => SerializedPropertyValue::create(123, 'int')
         ]);
 
         $this->propertyCollection = new PropertyCollection(


### PR DESCRIPTION
The constructor of `SerializedPropertyValue` has been declared abstract.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
