### PR TITLE
TASK: Reimplement ContentCacheFlush DebugMode and performance improvement

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -39,7 +39,6 @@ use Psr\Log\LoggerInterface;
  */
 class ContentCacheFlusher
 {
-
     #[Flow\InjectConfiguration(path: "fusion.contentCacheDebugMode")]
     protected bool $debugMode;
 

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -39,17 +39,16 @@ use Psr\Log\LoggerInterface;
  */
 class ContentCacheFlusher
 {
-    /**
-     * @Flow\Inject
-     * @var ContentCache
-     */
-    protected $contentCache;
 
-    /**
-     * @Flow\Inject
-     * @var LoggerInterface
-     */
-    protected $systemLogger;
+    #[Flow\InjectConfiguration(path: "fusion.contentCacheDebugMode")]
+    protected bool $debugMode;
+
+
+    public function __construct(
+        protected ContentCache $contentCache,
+        protected LoggerInterface $systemLogger,
+    ) {
+    }
 
     /**
      * Main entry point to *directly* flush the caches of a given NodeAggregate
@@ -231,15 +230,20 @@ class ContentCacheFlusher
      */
     protected function flushTags(array $tagsToFlush): void
     {
-        foreach ($tagsToFlush as $tag => $logMessage) {
-            $affectedEntries = $this->contentCache->flushByTag($tag);
-            if ($affectedEntries > 0) {
-                $this->systemLogger->debug(sprintf(
-                    'Content cache: Removed %s entries %s',
-                    $affectedEntries,
-                    $logMessage
-                ));
+        if ($this->debugMode) {
+            foreach ($tagsToFlush as $tag => $logMessage) {
+                $affectedEntries = $this->contentCache->flushByTag($tag);
+                if ($affectedEntries > 0) {
+                    $this->systemLogger->debug(sprintf(
+                        'Content cache: Removed %s entries %s',
+                        $affectedEntries,
+                        $logMessage
+                    ));
+                }
             }
+        } else {
+            $affectedEntries = $this->contentCache->flushByTags(array_keys($tagsToFlush));
+            $this->systemLogger->debug(sprintf('Content cache: Removed %s entries', $affectedEntries));
         }
     }
 


### PR DESCRIPTION
During upmerges we got lost a performance improvement for cache flushing and a debug mode which keeps a detailed logging for cache flushing.

Original PR: https://github.com/neos/neos-development-collection/pull/3631