### PR TITLE
FEATURE: Allow `neos/eventstore-doctrineadapter` v2

### DIFF
--- a/Neos.ContentRepository.Core/composer.json
+++ b/Neos.ContentRepository.Core/composer.json
@@ -11,8 +11,8 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/eventstore": "~1.0.0",
-        "neos/eventstore-doctrineadapter": "~1.0.0",
+        "neos/eventstore": "^1",
+        "neos/eventstore-doctrineadapter": "^1 || ^2",
         "php": "^8.2",
         "neos/error-messages": "*",
         "neos/utility-objecthandling": "*",


### PR DESCRIPTION
Relaxes composer contraints for `neos/eventstore-doctrineadapter` to allow for installation of 2.x (which is compatible to `doctrine/dbal` v3+)