### PR TITLE
BUGFIX: Reset workspace state to `OUTDATED` after discard

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/WorkspacePublishing/WorkspaceBasedContentPublishing.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/WorkspacePublishing/WorkspaceBasedContentPublishing.feature
@@ -264,3 +264,59 @@ Feature: Workspace based content publishing
     And I expect this node to have the following properties:
       | Key  | Value                        |
       | text | "Modified in live workspace" |
+
+  Scenario: Conflicting changes lead to OUTDATED_CONFLICT which can be recovered from via discard
+
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                        |
+      | workspaceName      | "user-ws-one"                |
+      | baseWorkspaceName  | "live"                       |
+      | newContentStreamId | "user-cs-one"                |
+      | workspaceOwner     | "owner-identifier"           |
+    And the graph projection is fully up to date
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                        |
+      | workspaceName      | "user-ws-two"                |
+      | baseWorkspaceName  | "live"                       |
+      | newContentStreamId | "user-cs-two"                |
+      | workspaceOwner     | "owner-identifier"           |
+    And the graph projection is fully up to date
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "nody-mc-nodeface"       |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | coveredDimensionSpacePoint   | {}                       |
+      | contentStreamId              | "user-cs-one"            |
+    And the graph projection is fully up to date
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                        |
+      | contentStreamId           | "user-cs-two"                |
+      | nodeAggregateId           | "nody-mc-nodeface"           |
+      | originDimensionSpacePoint | {}                           |
+      | propertyValues            | {"text": "Modified"}         |
+    And the graph projection is fully up to date
+
+    And the command PublishWorkspace is executed with payload:
+      | Key              | Value            |
+      | workspaceName    | "user-ws-one"    |
+    And the graph projection is fully up to date
+
+    Then workspace user-ws-two has status OUTDATED
+
+    When the command RebaseWorkspace is executed with payload:
+      | Key                            | Value                  |
+      | workspaceName                  | "user-ws-two"          |
+      | rebasedContentStreamId         | "user-cs-two-rebased"  |
+
+    Then workspace user-ws-two has status OUTDATED_CONFLICT
+
+    When the command DiscardWorkspace is executed with payload:
+      | Key                | Value                     |
+      | workspaceName      | "user-ws-two"             |
+      | newContentStreamId | "user-cs-two-discarded"   |
+    And the graph projection is fully up to date
+
+    Then workspace user-ws-two has status OUTDATED
+

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
@@ -238,6 +238,7 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
     private function whenWorkspaceWasDiscarded(WorkspaceWasDiscarded $event): void
     {
         $this->updateContentStreamId($event->newContentStreamId, $event->workspaceName);
+        $this->markWorkspaceAsOutdated($event->workspaceName);
         $this->markDependentWorkspacesAsOutdated($event->workspaceName);
     }
 
@@ -358,6 +359,20 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
         ', [
             'outdated' => WorkspaceStatus::OUTDATED->value,
             'baseWorkspaceName' => $baseWorkspaceName->value
+        ]);
+    }
+
+    private function markWorkspaceAsOutdated(WorkspaceName $workspaceName): void
+    {
+        $this->getDatabaseConnection()->executeUpdate('
+            UPDATE ' . $this->tableName . '
+            SET
+                status = :outdated
+            WHERE
+                workspacename = :workspaceName
+        ', [
+            'outdated' => WorkspaceStatus::OUTDATED->value,
+            'workspaceName' => $workspaceName->value
         ]);
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -175,6 +175,16 @@ trait CRTestSuiteTrait
     }
 
     /**
+     * @Then /^workspace ([^"]*) has status ([^"]*)$/
+     */
+    public function workspaceHasStatus(string $rawWorkspaceName, string $status): void
+    {
+        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($rawWorkspaceName));
+
+        Assert::assertSame($status, $workspace->status->value);
+    }
+
+    /**
      * @Then /^I expect the graph projection to consist of exactly (\d+) node(?:s)?$/
      * @param int $expectedNumberOfNodes
      */

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -22,6 +22,7 @@ use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlr
 use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\DeleteWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Command\RebaseWorkspace;
 use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\Service\WorkspaceMaintenanceServiceFactory;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
@@ -102,6 +103,33 @@ class WorkspaceCommandController extends CommandController
             $this->quit(1);
         }
         $this->outputLine('Discarded all nodes in workspace %s', [$workspace]);
+    }
+
+    /**
+     * Rebase workspace on base workspace
+     *
+     * This command rebases the given workspace on its base workspace, it may fail if the rebase is not possible.
+     *
+     * @param string $workspace Name of the workspace, for example "user-john"
+     * @param string $contentRepositoryIdentifier
+     * @throws StopCommandException
+     */
+    public function rebaseCommand(string $workspace, string $contentRepositoryIdentifier = 'default'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+
+        try {
+            $contentRepository->handle(
+                RebaseWorkspace::create(
+                    WorkspaceName::fromString($workspace),
+                )
+            )->block();
+        } catch (WorkspaceDoesNotExist $exception) {
+            $this->outputLine('Workspace "%s" does not exist', [$workspace]);
+            $this->quit(1);
+        }
+        $this->outputLine('Rebased workspace %s', [$workspace]);
     }
 
     /**


### PR DESCRIPTION
Currently a workspace can be discarded which removes all events but the status remains unchanged which is a problem in case of status `OUTDATED_CONFLICT`. This change resets the status of a discarded workspace to `OUTDATED` which allows to rebase the workspace and get a working state again.

In additions this adds the `./flow workspace rebase` command to rebase single workspaces via cli.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

Currently the neos ui does not do a full discard when a user clicks discasrdAll. This is probably to only reset changes of the current site / dimension. I suggest to add the option to perform a full review to the rebase dialog.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
