### PR TITLE
TASK: Add `force` strategy to the rebase workspace command

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -30,6 +30,7 @@ use Neos\ContentRepository\Core\Feature\WorkspacePublication\Dto\NodeIdsToPublis
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardIndividualNodesFromWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishIndividualNodesFromWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\WorkspaceRebaseStatistics;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Command\CreateContentStream;
 use Neos\ContentRepository\Core\Feature\ContentStreamForking\Command\ForkContentStream;
@@ -385,7 +386,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         $rebaseStatistics = new WorkspaceRebaseStatistics();
         $this->withContentStreamIdToUse(
             $command->rebasedContentStreamId,
-            function () use ($originalCommands, $contentRepository, $rebaseStatistics, $workspaceContentStreamName, $baseWorkspace): void {
+            function () use ($originalCommands, $contentRepository, $rebaseStatistics): void {
                 foreach ($originalCommands as $i => $originalCommand) {
                     // We no longer need to adjust commands as the workspace stays the same
                     try {
@@ -393,25 +394,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         // if we came this far, we know the command was applied successfully.
                         $rebaseStatistics->commandRebaseSuccess();
                     } catch (\Exception $e) {
-                        $fullCommandListSoFar = '';
-                        for ($a = 0; $a <= $i; $a++) {
-                            $fullCommandListSoFar .= "\n - " . get_class($originalCommands[$a]);
-
-                            if ($originalCommands[$a] instanceof \JsonSerializable) {
-                                $fullCommandListSoFar .= ' ' . json_encode($originalCommands[$a]);
-                            }
-                        }
-
                         $rebaseStatistics->commandRebaseError(sprintf(
-                            "The content stream %s cannot be rebased. Error with command %d (%s)"
-                            . " - see nested exception for details.\n\n The base workspace %s is at content stream %s."
-                            . "\n The full list of commands applied so far is: %s",
-                            $workspaceContentStreamName->value,
-                            $i,
+                            "Error with command %s in sequence-number %d",
                             get_class($originalCommand),
-                            $baseWorkspace->workspaceName->value,
-                            $baseWorkspace->currentContentStreamId->value,
-                            $fullCommandListSoFar
+                            $i
                         ), $e);
                     }
                 }
@@ -419,7 +405,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
 
         // if we got so far without an Exception, we can switch the Workspace's active Content stream.
-        if (!$rebaseStatistics->hasErrors()) {
+        if ($command->rebaseErrorHandlingStrategy === RebaseErrorHandlingStrategy::STRATEGY_FORCE || $rebaseStatistics->hasErrors() === false) {
             $events = Events::with(
                 new WorkspaceWasRebased(
                     $command->workspaceName,
@@ -479,7 +465,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                  * The "fromArray" might be declared via {@see RebasableToOtherWorkspaceInterface::fromArray()}
                  * or any other command can just implement it.
                  */
-                $commands[] = $commandToRebaseClass::fromArray($commandToRebasePayload);
+                $commands[$eventEnvelope->sequenceNumber->value] = $commandToRebaseClass::fromArray($commandToRebasePayload);
             }
         }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Command/RebaseWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Command/RebaseWorkspace.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\WorkspaceRebase\Command;
 
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -31,13 +32,14 @@ final readonly class RebaseWorkspace implements CommandInterface
      */
     private function __construct(
         public WorkspaceName $workspaceName,
-        public ContentStreamId $rebasedContentStreamId
+        public ContentStreamId $rebasedContentStreamId,
+        public RebaseErrorHandlingStrategy $rebaseErrorHandlingStrategy
     ) {
     }
 
     public static function create(WorkspaceName $workspaceName): self
     {
-        return new self($workspaceName, ContentStreamId::create());
+        return new self($workspaceName, ContentStreamId::create(), RebaseErrorHandlingStrategy::STRATEGY_FAIL);
     }
 
     /**
@@ -45,6 +47,14 @@ final readonly class RebaseWorkspace implements CommandInterface
      */
     public function withRebasedContentStreamId(ContentStreamId $newContentStreamId): self
     {
-        return new self($this->workspaceName, $newContentStreamId);
+        return new self($this->workspaceName, $newContentStreamId, $this->rebaseErrorHandlingStrategy);
+    }
+
+    /**
+     * Call this method if you want to run this command with a specific error handling strategy like force
+     */
+    public function withErrorHandlingStrategy(RebaseErrorHandlingStrategy $rebaseErrorHandlingStrategy): self
+    {
+        return new self($this->workspaceName, $this->rebasedContentStreamId, $rebaseErrorHandlingStrategy);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Dto/RebaseErrorHandlingStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Dto/RebaseErrorHandlingStrategy.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto;
+
+/**
+ * The strategy how to handle errors during workspace rebase
+ *
+ * - fail (default) ensures conflicts are not ignored but reported
+ * - force will rebase even if some conflicting events could have to be rebased
+ *
+ * @api DTO of {@see RebaseWorkspace} command
+ */
+enum RebaseErrorHandlingStrategy: string implements \JsonSerializable
+{
+    /**
+     * This strategy rebasing will fail if conflicts are detected and the "WorkspaceRebaseFailed" event is added.
+     */
+    case STRATEGY_FAIL = 'fail';
+
+    /**
+     * This strategy means all events that can be applied are rebased and conflicting events are ignored
+     */
+    case STRATEGY_FORCE = 'force';
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceCreation.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features;
 
 use Behat\Gherkin\Node\TableNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
@@ -104,6 +105,9 @@ trait WorkspaceCreation
         );
         if (isset($commandArguments['rebasedContentStreamId'])) {
             $command = $command->withRebasedContentStreamId(ContentStreamId::fromString($commandArguments['rebasedContentStreamId']));
+        }
+        if (isset($commandArguments['rebaseErrorHandlingStrategy'])) {
+            $command = $command->withErrorHandlingStrategy(RebaseErrorHandlingStrategy::from($commandArguments['rebaseErrorHandlingStrategy']));
         }
 
         $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -23,7 +23,9 @@ use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\DeleteWork
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Command\RebaseWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
+use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceStatus;
 use Neos\ContentRepository\Core\Service\WorkspaceMaintenanceServiceFactory;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\User\UserId;
@@ -112,23 +114,33 @@ class WorkspaceCommandController extends CommandController
      *
      * @param string $workspace Name of the workspace, for example "user-john"
      * @param string $contentRepositoryIdentifier
+     * @param bool $force Rebase all events that do not conflict
      * @throws StopCommandException
      */
-    public function rebaseCommand(string $workspace, string $contentRepositoryIdentifier = 'default'): void
+    public function rebaseCommand(string $workspace, string $contentRepositoryIdentifier = 'default', bool $force = false): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         try {
-            $contentRepository->handle(
-                RebaseWorkspace::create(
-                    WorkspaceName::fromString($workspace),
-                )
-            )->block();
+            $rebaseCommand = RebaseWorkspace::create(
+                WorkspaceName::fromString($workspace),
+            );
+            if ($force) {
+                $rebaseCommand = $rebaseCommand->withErrorHandlingStrategy(RebaseErrorHandlingStrategy::STRATEGY_FORCE);
+            }
+            $contentRepository->handle($rebaseCommand)->block();
         } catch (WorkspaceDoesNotExist $exception) {
             $this->outputLine('Workspace "%s" does not exist', [$workspace]);
             $this->quit(1);
         }
+
+        $workspaceObject = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($workspace));
+        if ($workspaceObject && $workspaceObject->status === WorkspaceStatus::OUTDATED_CONFLICT) {
+            $this->outputLine('Rebasing of workspace %s is not possible due to conflicts. You can try the --force option.', [$workspace]);
+            $this->quit(1);
+        }
+
         $this->outputLine('Rebased workspace %s', [$workspace]);
     }
 


### PR DESCRIPTION
This change allows to specify the error handling strategy for the rebaseWorkspace command and introduces a force option there. If no strategy is specified the `fail` strategy is uses which is the same behavior as before.

Based on this the workspace:rebase command is extended with a new --force option that allows to rebase even workspaces in state OUTDATED_CONFLICT by ignoring all conflicting events and preserving the rest.

Partially solves: #4866  (cli part)

In addition the number of logged informations when a rebase failed is reduced to a sane size that does not grow exponentially. Resolves: #4545

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

I suggest to add a `workspace:duplicate` command in a separate pr that can be run before `workspace:rebase --force` to keep the changes for later reference.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
