### PR TITLE
BUGFIX: Strip image to prevent wrong orientation information in exif data

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -141,6 +141,9 @@ class ImageService
             $imagineImage->usePalette(new RGB());
         }
 
+        $stripFilter = new \Imagine\Filter\Basic\Strip();
+        $stripFilter->apply($imagineImage);
+
         if ($this->imagineService instanceof Imagine && $originalResource->getFileExtension() === 'gif' && $this->isAnimatedGif(file_get_contents($resourceUri)) === true) {
             $imagineImage->layers()->coalesce();
             $layers = $imagineImage->layers();

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -141,8 +141,7 @@ class ImageService
             $imagineImage->usePalette(new RGB());
         }
 
-        $stripFilter = new \Imagine\Filter\Basic\Strip();
-        $stripFilter->apply($imagineImage);
+        $imagineImage->strip();
 
         if ($this->imagineService instanceof Imagine && $originalResource->getFileExtension() === 'gif' && $this->isAnimatedGif(file_get_contents($resourceUri)) === true) {
             $imagineImage->layers()->coalesce();


### PR DESCRIPTION
After autorotating the thumbnail image we need to remove the according exif data for the thumbnail, to prevent the thumbnail is shown rotated again.

See also: https://github.com/php-imagine/Imagine/issues/467

Fixes: #3148 

![image](https://github.com/neos/neos-development-collection/assets/13046100/c039f852-623c-4d8a-9848-416f0ab27498)
