### PR TITLE
TASK: Tweak composer scripts

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -13,10 +13,8 @@
   "provide": {
   },
   "scripts": {
-    "lint:phpcs-psr12": "../../bin/phpcs --colors --standard=PSR12 ./Neos.ContentGraph.DoctrineDbalAdapter/src ./Neos.ContentGraph.PostgreSQLAdapter/src ./Neos.ContentRepository.BehavioralTests/Classes ./Neos.ContentRepository.TestSuite/Classes ./Neos.ContentRepository.Core/Classes ./Neos.Neos/Classes",
-    "lint:phpcs": [
-      "@lint:phpcs-psr12 --exclude=Generic.Files.LineLength,PSR1.Files.SideEffects"
-    ],
+    "lint:phpcs": "../../bin/phpcs --colors",
+    "lint:phpcs:fix": "../../bin/phpcbf --colors",
     "lint:phpstan": "../../bin/phpstan analyse",
     "lint:phpstan-generate-baseline": "../../bin/phpstan analyse --generate-baseline",
     "lint:distributionintegrity": "[ -d 'Neos.ContentRepository' ] && { echo 'Package Neos.ContentRepository should not exist.' 1>&2; exit 1; } || exit 0;",
@@ -47,6 +45,10 @@
       "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
       "@test:behat-cli -c Neos.Neos/Tests/Behavior/behat.yml"
     ],
+    "test:behavioral:sync": [
+      "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
+      "@test:behavioral"
+    ],
     "test:behavioral:stop-on-failure": [
       "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist",
       "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/behat.yml.dist",
@@ -55,6 +57,10 @@
       "@test:behat-cli -vvv --stop-on-failure -c Neos.TimeableNodeVisibility/Tests/Behavior/behat.yml.dist",
       "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
       "@test:behat-cli -vvv --stop-on-failure -c Neos.Neos/Tests/Behavior/behat.yml"
+    ],
+    "test:behavioral:stop-on-failure:sync": [
+      "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
+      "@test:behavioral:stop-on-failure"
     ],
     "test": [
       "@test:unit",

--- a/.composer.json
+++ b/.composer.json
@@ -67,7 +67,8 @@
       "@test:functional",
       "@test:behavioral",
       "@test:parallel"
-    ]
+    ],
+    "build:composer-json": "php ../../Build/BuildEssentials/ComposerManifestMerger.php"
   },
   "autoload": {
   },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
           # DEBUG MODE: ALTERNATIVELY, comment in the following lines to dump the DB.
           # do not exit the script if the tests break; as we want to upload the database dumps afterwards.
           set +e
-          CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1 composer test:behavioral:stop-on-failure
+          composer test:behavioral:stop-on-failure:sync
           retVal=$?
 
           # automatically search for race conditions

--- a/Readme.rst
+++ b/Readme.rst
@@ -185,14 +185,15 @@ we use the right versions etc).
 
    .. code-block:: bash
 
-       bin/behat -c Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist
+       cd Packages/Neos
+       composer test:behavioral
 
 Running all tests can take a long time, depending on the hardware.
-To speed up the process, Behat tests can be executed in a "synchronous" mode by setting the `CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION` environment variable:
+To speed up the process, Behat tests can be executed in a "synchronous" mode:
 
    .. code-block:: bash
 
-       CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1 bin/behat -c Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist
+       composer test:behavioral:sync
 
 Alternatively, if you want to reproduce errors as they happen inside the CI system, but you
 develop on Mac OS, you might want to run the Behat tests in a Docker container (= a linux environment)
@@ -210,8 +211,5 @@ described below also makes it easy to run the race-condition-detector:
        FLOW_CONTEXT=Testing/Behat ../../../../../flow raceConditionTracker:reset
 
        ../../../../../bin/behat -c behat.yml.dist
-
-       # To run tests in speed mode, run CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1
-       CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1 ../../../../../bin/behat -c behat.yml.dist
 
        FLOW_CONTEXT=Testing/Behat ../../../../../flow raceConditionTracker:analyzeTrace

--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,8 @@
             "@test:functional",
             "@test:behavioral",
             "@test:parallel"
-        ]
+        ],
+        "build:composer-json": "php ../../Build/BuildEssentials/ComposerManifestMerger.php"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "neos/flow-development-collection": "9.0.x-dev",
         "doctrine/dbal": "^2.8",
         "doctrine/migrations": "*",
-        "neos/eventstore": "~1.0.0",
-        "neos/eventstore-doctrineadapter": "~1.0.0",
+        "neos/eventstore": "^1",
+        "neos/eventstore-doctrineadapter": "^1 || ^2",
         "php": "^8.2",
         "neos/error-messages": "*",
         "neos/utility-objecthandling": "*",
@@ -112,8 +112,13 @@
             "../../bin/phpunit --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/UnitTests.xml Neos.ContentRepository.Core/Tests/Unit",
             "../../bin/phpunit --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/UnitTests.xml Neos.ContentRepositoryRegistry/Tests/Unit"
         ],
+        "test:parallel": [
+            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php",
+            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php",
+            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php"
+        ],
         "test:functional": [
-            "FLOW_CONTEXT=Testing ../../bin/phpunit --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.Core/Tests/Functional"
+            "../../bin/phpunit --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.Core/Tests/Functional"
         ],
         "test:behat-cli": "../../bin/behat -f progress --strict --no-interaction",
         "test:behavioral": [
@@ -141,11 +146,6 @@
         "test:behavioral:stop-on-failure:sync": [
             "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
             "@test:behavioral:stop-on-failure"
-        ],
-        "test:parallel": [
-            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php",
-            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php",
-            "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php"
         ],
         "test": [
             "@test:unit",
@@ -310,9 +310,8 @@
         "roave/security-advisories": "dev-latest",
         "phpstan/phpstan": "^1.8",
         "squizlabs/php_codesniffer": "^3.6",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.0",
         "neos/behat": "*",
-        "brianium/paratest": "^6.11",
         "league/flysystem-memory": "^3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -98,10 +98,8 @@
         "neos/contentrepositoryregistry-storageclient": "self.version"
     },
     "scripts": {
-        "lint:phpcs-psr12": "../../bin/phpcs --colors --standard=PSR12 ./Neos.ContentGraph.DoctrineDbalAdapter/src ./Neos.ContentGraph.PostgreSQLAdapter/src ./Neos.ContentRepository.BehavioralTests/Classes ./Neos.ContentRepository.TestSuite/Classes ./Neos.ContentRepository.Core/Classes ./Neos.Neos/Classes",
-        "lint:phpcs": [
-            "@lint:phpcs-psr12 --exclude=Generic.Files.LineLength,PSR1.Files.SideEffects"
-        ],
+        "lint:phpcs": "../../bin/phpcs --colors",
+        "lint:phpcs:fix": "../../bin/phpcbf --colors",
         "lint:phpstan": "../../bin/phpstan analyse",
         "lint:phpstan-generate-baseline": "../../bin/phpstan analyse --generate-baseline",
         "lint:distributionintegrity": "[ -d 'Neos.ContentRepository' ] && { echo 'Package Neos.ContentRepository should not exist.' 1>&2; exit 1; } || exit 0;",
@@ -127,6 +125,10 @@
             "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
             "@test:behat-cli -c Neos.Neos/Tests/Behavior/behat.yml"
         ],
+        "test:behavioral:sync": [
+            "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
+            "@test:behavioral"
+        ],
         "test:behavioral:stop-on-failure": [
             "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist",
             "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/behat.yml.dist",
@@ -135,6 +137,10 @@
             "@test:behat-cli -vvv --stop-on-failure -c Neos.TimeableNodeVisibility/Tests/Behavior/behat.yml.dist",
             "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
             "@test:behat-cli -vvv --stop-on-failure -c Neos.Neos/Tests/Behavior/behat.yml"
+        ],
+        "test:behavioral:stop-on-failure:sync": [
+            "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
+            "@test:behavioral:stop-on-failure"
         ],
         "test:parallel": [
             "FLOW_CONTEXT=Testing/Behat ../../bin/paratest --debug -v --functional --group parallel --processes 2 --colors --stop-on-failure -c ../../Build/BuildEssentials/PhpUnit/FunctionalTests.xml Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<ruleset name="PSR12">
+    <description>The PSR12 coding standard – without line length limitation</description>
+
+    <file>./Neos.ContentGraph.DoctrineDbalAdapter/src</file>
+    <file>./Neos.ContentGraph.PostgreSQLAdapter/src</file>
+    <file>./Neos.ContentRepository.BehavioralTests/Classes</file>
+    <file>./Neos.ContentRepository.TestSuite/Classes</file>
+    <file>./Neos.ContentRepository.Core/Classes</file>
+    <file>./Neos.Neos/Classes</file>
+
+    <rule ref="PSR12">
+        <exclude name="Generic.Files.LineLength.TooLong" />
+    </rule>
+</ruleset>


### PR DESCRIPTION
* Move PHPCS configuration to `phpcs.xml.dist`
* Add script `lint:phpcs:fix` to allow fixing of PHPCS errors
* Reenable `PSR1.Files.SideEffects` PHPCS sniff (that was excluded with a864ced0eb0fd94e35a252efc9bdf923b021652f but that seems no longer to be necessary)
* Add scripts `test:behavioral:sync` and `test:behavioral:stop-on-failure:sync` to centralize `CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION` hack