### PR TITLE
BUGFIX: Fix `contentgraphintegrity:runviolationdetection`

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
@@ -11,8 +11,12 @@ namespace Neos\ContentRepositoryRegistry\Command;
  * source code.
  */
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunner;
+use Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory;
+use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Error\Messages\Result;
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 
 final class ContentGraphIntegrityCommandController extends CommandController
@@ -20,20 +24,22 @@ final class ContentGraphIntegrityCommandController extends CommandController
     private const OUTPUT_MODE_CONSOLE = 'console';
     private const OUTPUT_MODE_LOG = 'log';
 
-    private ProjectionIntegrityViolationDetectionRunner $detectionRunner;
+    #[Flow\Inject()]
+    protected DbalClientInterface $dbalClient;
 
+    #[Flow\Inject()]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    public function __construct(ProjectionIntegrityViolationDetectionRunner $detectionRunner)
+    public function runViolationDetectionCommand(string $contentRepository = 'default', string $outputMode = null): void
     {
-        $this->detectionRunner = $detectionRunner;
-        parent::__construct();
-    }
+        $detectionRunner = $this->contentRepositoryRegistry->buildService(
+            ContentRepositoryId::fromString($contentRepository),
+            new DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory($this->dbalClient)
+        );
 
-    public function runViolationDetectionCommand(string $outputMode = null): void
-    {
         $outputMode = $this->resolveOutputMode($outputMode);
         /** @var Result $result */
-        $result = $this->detectionRunner->run();
+        $result = $detectionRunner->run();
         switch ($outputMode) {
             case self::OUTPUT_MODE_CONSOLE:
                 foreach ($result->getErrors() as $error) {


### PR DESCRIPTION
The wiring for `flow contentgraphintegrity:runviolationdetection` was wrong and needed to be redone.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
