### PR TITLE
TASK: Export event cleanup and error handling for catchupd events

### DIFF
--- a/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
@@ -165,7 +165,9 @@ final class EventNormalizer
                 1651839461
             );
         }
-        assert(is_array($eventDataAsArray));
+        if (!is_array($eventDataAsArray)) {
+            throw new \RuntimeException(sprintf('Expected array got %s', $eventDataAsArray));
+        }
         /** {@see EventInterface::fromArray()} */
         $eventInstance = $eventClassName::fromArray($eventDataAsArray);
         return match ($eventInstance::class) {

--- a/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
@@ -161,7 +161,7 @@ final class EventNormalizer
             $eventDataAsArray = json_decode($event->data->value, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $exception) {
             throw new \InvalidArgumentException(
-                sprintf('Failed to decode data of event "%s": %s', $event->id->value, $exception->getMessage()),
+                sprintf('Failed to decode data of event with type "%s" and id "%s": %s', $event->type->value, $event->id->value, $exception->getMessage()),
                 1651839461
             );
         }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUp.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUp.php
@@ -104,7 +104,11 @@ final class CatchUp
                 if ($eventEnvelope->sequenceNumber->value <= $highestAppliedSequenceNumber->value) {
                     continue;
                 }
-                ($this->eventHandler)($eventEnvelope);
+                try {
+                    ($this->eventHandler)($eventEnvelope);
+                } catch (\Exception $e) {
+                    throw new \RuntimeException(sprintf('Exception while catching up to sequence number %d', $eventEnvelope->sequenceNumber->value), 1710707311, $e);
+                }
                 $iteration++;
                 if ($this->batchSize === 1 || $iteration % $this->batchSize === 0) {
                     if ($this->onBeforeBatchCompletedHook) {

--- a/Neos.ContentRepository.Export/src/Event/ValueObject/ExportedEvent.php
+++ b/Neos.ContentRepository.Export/src/Event/ValueObject/ExportedEvent.php
@@ -7,22 +7,27 @@ use Neos\EventStore\Model\Event;
 final class ExportedEvent implements \JsonSerializable
 {
     /**
+     * The Neos.ContentRepository.Core's domain events require the payload to be a json array string
+     * {@see \Neos\ContentRepository\Core\EventStore\EventInterface}
+     * This exporter will enforce this as well (by using array as payload type).
+     *
      * @param array<mixed> $payload
      * @param array<mixed> $metadata
      */
     public function __construct(
         public readonly string $identifier,
         public readonly string $type,
-        public readonly array $payload, // TODO: string
+        public readonly array $payload,
         public readonly array $metadata,
-    ) {}
+    ) {
+    }
 
     public static function fromRawEvent(Event $event): self
     {
         return new self(
             $event->id->value,
             $event->type->value,
-            \json_decode($event->data->value, true),
+            \json_decode($event->data->value, true, 512, JSON_THROW_ON_ERROR),
             $event->metadata?->value ?? [],
         );
     }
@@ -30,16 +35,11 @@ final class ExportedEvent implements \JsonSerializable
     public static function fromJson(string $json): self
     {
         try {
-            ///** @var array{identifier: string, type: string, payload: array<mixed>, metadata: array<mixed>} $data */
-            /** @var array<mixed> $data */
+            /** @var array{identifier: string, type: string, payload: array<mixed>, metadata: array<mixed>} $data */
             $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             throw new \InvalidArgumentException(sprintf('Failed to decode JSON "%s": %s', $json, $e->getMessage()), 1638432979, $e);
         }
-        assert(isset($data['identifier']) && is_string($data['identifier']));
-        assert(isset($data['type']) && is_string($data['type']));
-        assert(isset($data['payload']) && is_array($data['payload']));
-        assert(isset($data['metadata']) && is_array($data['metadata']));
         return new self(
             $data['identifier'],
             $data['type'],
@@ -80,12 +80,8 @@ final class ExportedEvent implements \JsonSerializable
         }
     }
 
-    /**
-     * @return array{identifier: string, type: string, payload: array<mixed>, metadata?: ?array<mixed>, streamName?: string, version?: int, sequenceNumber?: int, recordedAt?: string}
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        /** @phpstan-ignore-next-line */
         return get_object_vars($this);
     }
 }


### PR DESCRIPTION
We fixed the root source for the frequent problem of workspace rebase failed events having a too big payload https://github.com/neos/neos-development-collection/issues/4545, which might be clamped when dumping the events table and importing it elsewhere where it cannot be decoded.

But i think enriching the error with the sequence number makes sense, as the event id might not really be known to developers.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
