### PR TITLE
WIP: BUGFIX: Enable `WorkspaceRuntimeCache` and `ContentSubgraphWithRuntimeCaches` after disabling

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
@@ -138,6 +138,7 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
         $this->getDatabaseConnection()->exec('TRUNCATE ' . $this->tableName);
         $this->checkpointStorage->acquireLock();
         $this->checkpointStorage->updateAndReleaseLock(SequenceNumber::none());
+        $this->workspaceRuntimeCache->enableCache();
     }
 
     public function canHandle(EventInterface $event): bool

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceRuntimeCache.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceRuntimeCache.php
@@ -36,14 +36,17 @@ final class WorkspaceRuntimeCache
      */
     private array $cachedWorkspacesByContentStreamId = [];
 
+    public function enableCache(): void
+    {
+        $this->resetCache(true);
+    }
+
     /**
      * @return void
      */
     public function disableCache(): void
     {
-        $this->cacheEnabled = false;
-        $this->cachedWorkspacesByName = [];
-        $this->cachedWorkspacesByContentStreamId = [];
+        $this->resetCache(false);
     }
 
     public function getWorkspaceByName(WorkspaceName $name): ?Workspace
@@ -73,5 +76,15 @@ final class WorkspaceRuntimeCache
             return $this->cachedWorkspacesByContentStreamId[$contentStreamId->value];
         }
         return null;
+    }
+
+    /**
+     * @param bool $isEnabled if TRUE, the caches work; if FALSE, they do not store anything.
+     */
+    private function resetCache(bool $isEnabled): void
+    {
+        $this->cacheEnabled = $isEnabled;
+        $this->cachedWorkspacesByName = [];
+        $this->cachedWorkspacesByContentStreamId = [];
     }
 }


### PR DESCRIPTION
@kitsunet and me stumbled upon that we only ever disable the workspace runtime cache but never reenable it.
For the subgraph cache, we enable it also again on reset:

https://github.com/neos/neos-development-collection/blob/882b572509d15a32248fc901ca5298527ca4b7c9/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php#L169


But it seems reenabling on reset is too simple. Reset will not actually be executed in a normal live cycle.
Maybe we can just flush the cache instead of disable and it is still hot?


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
