### PR TITLE
BUGFIX: Remove invalid `isDisabledContentShown()` method

### DIFF
--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/Query/QueryUtility.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/Query/QueryUtility.php
@@ -28,18 +28,9 @@ final class QueryUtility
         string $tableNamePrefix,
         string $prefix = ''
     ): string {
-        if ($visibilityConstraints->isDisabledContentShown()) {
-            return '';
-        }
+        // TODO evaluate $visibilityConstraints->tagConstraints {@see Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentSubgraph::addSubtreeTagConstraints}
 
-        return '
-            AND NOT EXISTS (
-                SELECT 1
-                FROM ' . $tableNamePrefix . '_restrictionhyperrelation rest
-                WHERE rest.contentstreamid = ' . $prefix . 'h.contentstreamid
-                    AND rest.dimensionspacepointhash = ' . $prefix . 'h.dimensionspacepointhash
-                    AND ' . $prefix . 'n.nodeaggregateid = ANY(rest.affectednodeaggregateids)
-            )';
+        return '';
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
@@ -34,11 +34,6 @@ final readonly class VisibilityConstraints implements \JsonSerializable
     ) {
     }
 
-    public function isDisabledContentShown(): bool
-    {
-        return $this->tagConstraints->contain(SubtreeTag::disabled());
-    }
-
     public function getHash(): string
     {
         return md5(implode('|', $this->tagConstraints->toStringArray()));


### PR DESCRIPTION
This is a follow-up to the Subtree Tags introduction (#4659) that removes the now unsued `VisibilityConstraints::isDisabledContentShown()`

*Note:* The implementation of this method was incorrect but instead of fixing that I decided to remove it since we should no longer rely on this and instead refer to the public `VisibilityConstraints::tagConstraints` field

Related #4550
