### PR TITLE
BUGFIX: Sort properties in raw content mode

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Utility\ObjectAccess;
+use Neos\Utility\PositionalArraySorter;
 
 /**
  * Some Functional Programming Array helpers for Eel contexts
@@ -88,6 +89,14 @@ class ArrayHelper implements ProtectedContextAwareInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Sorts the input array by the $positionProperty of each element.
+     */
+    public function sortByPropertyPath(array $set, $positionPropertyPath = 'position'): array
+    {
+        return (new PositionalArraySorter($set, $positionPropertyPath))->toArray();
     }
 
     /**

--- a/Neos.Neos/Documentation/References/EelHelpersReference.rst
+++ b/Neos.Neos/Documentation/References/EelHelpersReference.rst
@@ -1214,6 +1214,16 @@ The input is assumed to be an array or Collection of objects. Groups this input 
 
 **Return** (array)
 
+Neos.Array.sortByPropertyPath(set, positionPropertyPath)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The input is assumed to be an array. Sorts this input by the $positionPropertyPath property of each element.
+
+* ``set`` (array)
+* ``positionPropertyPath`` (string)
+
+**Return** (array)
+
 
 
 
@@ -2467,8 +2477,3 @@ Get the variable type
 * ``variable`` (mixed)
 
 **Return** (string)
-
-
-
-
-

--- a/Neos.Neos/Resources/Private/Fusion/RawContent/NodeProperties.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContent/NodeProperties.fusion
@@ -1,7 +1,12 @@
 prototype(Neos.Neos:RawContent.NodeProperties) < prototype(Neos.Fusion:Component) {
+  @private {
+    items = ${node.nodeType.properties}
+    items.@process.sort = ${Neos.Array.sortByPropertyPath(value, 'ui.inspector.position')}
+  }
+
   renderer = afx`
     <dl class="neos-raw-content-properties" @if={!String.isBlank(this.content)}>
-      <Neos.Fusion:Loop items={node.nodeType.properties} itemKey="propertyName" itemName="propertyConfiguration">
+      <Neos.Fusion:Loop items={private.items} itemKey="propertyName" itemName="propertyConfiguration">
         <Neos.Neos:RawContent.NodeProperty propertyName={propertyName} propertyConfiguration={propertyConfiguration}/>
       </Neos.Fusion:Loop>
     </dl>


### PR DESCRIPTION
Previously there was no obvious sorting for properties in the `Raw content` mode and the resulting order of properties appeared "random", which is an issue if the properties don't appear in the order the editor should edit them.

With this change the sorting option which is also used for the inspector is used to sort the items and therefore giving an option to the integrator on their arrangement.

That the inspector order is used for the raw content is not the cleanest solution, but introducing another sorting option also doesn't seem the right choice at this point.