### PR TITLE
BUGFIX: Catch not completely covered node aggregates

### DIFF
--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\StructureAdjustment\Adjustment;
 
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\VariantType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -29,6 +30,16 @@ class DimensionAdjustment
             return [];
         }
         if ($nodeType->isOfType(NodeTypeName::ROOT_NODE_TYPE_NAME)) {
+            foreach ($this->projectedNodeIterator->nodeAggregatesOfType($nodeTypeName) as $nodeAggregate) {
+                if (
+                    !$nodeAggregate->coveredDimensionSpacePoints->equals($this->interDimensionalVariationGraph->getDimensionSpacePoints())
+                ) {
+                    throw new \Exception(
+                        'Cannot determine structure adjustments for root node type ' . $nodeTypeName->value
+                        . ', run UpdateRootNodeAggregateDimensions first'
+                    );
+                }
+            }
             return [];
         }
         foreach ($this->projectedNodeIterator->nodeAggregatesOfType($nodeTypeName) as $nodeAggregate) {


### PR DESCRIPTION
 .. when resolving structure adjustments.

Root node coverage adjustments are done via the UpdateRootNodeAggregateDimensions command, so when handling structure adjustments on root nodes, we need to stop there if the command has not been executed before, otherwise things go bad

see also https://github.com/neos/neos-development-collection/pull/4969, where we
have to use the `And the command UpdateRootNodeAggregateDimensions is executed with payload:` in the feature as the test should would fail otherwise.


**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
