### PR TITLE
TASK: remove obsolete contentStreamId argument for commands in behat

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -158,7 +158,6 @@ Feature: Create node aggregate with node
   Scenario: Try to create a node aggregate with a property the node type does not declare
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                   | Value                                 |
-      | contentStreamId       | "cs-identifier"                       |
       | nodeAggregateId       | "nody-mc-nodeface"                    |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -304,7 +304,6 @@ Feature: Create node specialization
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"CH", "language":"en"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -182,7 +182,6 @@ Feature: Create node generalization
   Scenario: Create generalization of node to dimension space point with further generalizations
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                             |
-      | contentStreamId | "cs-identifier"                   |
       | nodeAggregateId | "sir-david-nodenborough"          |
       | sourceOrigin    | {"market":"CH", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"gsw"} |
@@ -293,7 +292,6 @@ Feature: Create node generalization
   Scenario: Create generalization of node to dimension space point with specializations that are partially occupied and covered
     Given the command CreateNodeVariant is executed with payload:
       | Key             | Value                             |
-      | contentStreamId | "cs-identifier"                   |
       | nodeAggregateId | "sir-david-nodenborough"          |
       | sourceOrigin    | {"market":"CH", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"de"}  |
@@ -301,7 +299,6 @@ Feature: Create node generalization
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                             |
-      | contentStreamId | "cs-identifier"                   |
       | nodeAggregateId | "sir-david-nodenborough"          |
       | sourceOrigin    | {"market":"CH", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"en"}  |
@@ -433,7 +430,6 @@ Feature: Create node generalization
   Scenario: Create generalization of a node to a dimension space point that is already covered by a more general generalization
     Given the command CreateNodeVariant is executed with payload:
       | Key             | Value                             |
-      | contentStreamId | "cs-identifier"                   |
       | nodeAggregateId | "sir-david-nodenborough"          |
       | sourceOrigin    | {"market":"CH", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"en"}  |
@@ -441,7 +437,6 @@ Feature: Create node generalization
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                             |
-      | contentStreamId | "cs-identifier"                   |
       | nodeAggregateId | "sir-david-nodenborough"          |
       | sourceOrigin    | {"market":"CH", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"de"}  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -55,7 +55,6 @@ Feature: Create node peer variant
   Scenario: Create peer variant of node to dimension space point without specializations
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"CH", "language":"fr"} |
@@ -248,7 +247,6 @@ Feature: Create node peer variant
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "madame-lanode"                  |
       | sourceOrigin    | {"market":"CH", "language":"fr"} |
       | targetOrigin    | {"market":"DE", "language":"en"} |
@@ -452,7 +450,6 @@ Feature: Create node peer variant
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "madame-lanode"                  |
       | sourceOrigin    | {"market":"CH", "language":"fr"} |
       | targetOrigin    | {"market":"DE", "language":"de"} |
@@ -680,14 +677,12 @@ Feature: Create node peer variant
   Scenario: Create a peer node variant to a dimension space point with specializations and where the parent node aggregate is already specialized in
     Given the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |
     And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"fr"} |
       | targetOrigin    | {"market":"CH", "language":"fr"} |
@@ -695,7 +690,6 @@ Feature: Create node peer variant
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
-      | contentStreamId | "cs-identifier"                  |
       | nodeAggregateId | "nody-mc-nodeface"               |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -91,7 +91,6 @@ Feature: Set properties
   Scenario: Set node properties
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                                                                                                                                                                                                                                                                                                                                         |
-      | contentStreamId           | "cs-identifier"                                                                                                                                                                                                                                                                                                                                               |
       | nodeAggregateId           | "nody-mc-nodeface"                                                                                                                                                                                                                                                                                                                                            |
       | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                                                                                                                                                                                                            |
       | propertyValues            | {"string":"My new string", "int":8472, "float":72.84, "bool":true, "array":{"givenName":"David", "familyName":"Nodenborough","age":84}, "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "postalAddress":"PostalAddress:anotherDummy", "price":"PriceSpecification:anotherDummy"} |
@@ -113,7 +112,6 @@ Feature: Set properties
   Scenario: Set node properties, partially
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                      |
-      | contentStreamId           | "cs-identifier"            |
       | nodeAggregateId           | "nody-mc-nodeface"         |
       | originDimensionSpacePoint | {"language": "de"}         |
       | propertyValues            | {"string":"My new string"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
@@ -64,7 +64,6 @@ Feature: Set node properties with different scopes
   Scenario: Set node properties
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                                                                                                                                                      |
-      | contentStreamId   | "cs-identifier"                                                                                                                                                            |
       | nodeAggregateId   | "nody-mc-nodeface"                                                                                                                                                         |
       | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                         |
       | propertyValues            | {"unscopedProperty":"My new string", "nodeScopedProperty":"My new string", "specializationsScopedProperty":"My new string", "nodeAggregateScopedProperty":"My new string"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
@@ -72,56 +72,48 @@ Feature: Set node properties with different scopes
   Scenario: Set node properties
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "unscopedReference"               |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "unscopedReferences"              |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "nodeScopedReference"             |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "nodeScopedReferences"            |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "nodeAggregateScopedReference"    |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "nodeAggregateScopedReferences"   |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "specializationsScopedReference"  |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
     And the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
-      | contentStreamId         | "cs-identifier"                   |
       | sourceNodeAggregateId   | "source-nodandaise"               |
       | referenceName                   | "specializationsScopedReferences" |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -80,7 +80,6 @@ Feature: On forking a content stream, node references should be copied as well.
     When I am in content stream "user-cs-identifier" and dimension space point {"language": "de"}
     And the command SetNodeProperties is executed with payload:
       | Key                     | Value                                  |
-      | contentStreamId | "user-cs-identifier"                   |
       | nodeAggregateId | "source-nodandaise"                    |
       | propertyValues          | {"text": "Modified in live workspace"} |
     And the graph projection is fully up to date

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
@@ -26,14 +26,12 @@ Feature: Add New Property
     And I am in the active content stream of workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
-      | contentStreamId             | "cs-identifier"               |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
-      | contentStreamId           | "cs-identifier"                           |
       | nodeAggregateId           | "sir-david-nodenborough"                  |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint | {}                                        |
@@ -44,7 +42,6 @@ Feature: Add New Property
     # Node /doc2
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
-      | contentStreamId           | "cs-identifier"                           |
       | nodeAggregateId           | "other"                                   |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint | {}                                        |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
@@ -59,7 +59,6 @@ Feature: Copy nodes (without dimensions)
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     When the command CopyNodesRecursively is executed, copying the current node aggregate with payload:
       | Key                                            | Value                                                             |
-      | contentStreamId                        | "cs-identifier"                                                   |
       | targetDimensionSpacePoint                      | {}                                                                |
       | targetParentNodeAggregateId            | "nody-mc-nodeface"                                                |
       | targetNodeName                                 | "target-nn"                                                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -62,7 +62,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
     And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
-      | contentStreamId | "cs-identifier"               |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the graph projection is fully up to date

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -88,7 +88,6 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
     And the current date and time is "2023-03-16T13:00:00+01:00"
     And the command SetNodeProperties is executed with payload:
       | Key             | Value                   |
-      | contentStreamId | "cs-identifier"         |
       | nodeAggregateId | "a2a5"                  |
       | propertyValues  | {"integerProperty": 20} |
     And the command DisableNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -88,7 +88,6 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
     And the current date and time is "2023-03-16T13:00:00+01:00"
     And the command SetNodeProperties is executed with payload:
       | Key             | Value                   |
-      | contentStreamId | "cs-identifier"         |
       | nodeAggregateId | "a2a2b"                 |
       | propertyValues  | {"integerProperty": 20} |
     And the command DisableNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -88,7 +88,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
     And the current date and time is "2023-03-16T12:30:00+01:00"
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value             |
-      | contentStreamId | "cs-user"         |
       | nodeAggregateId | "a"               |
       | sourceOrigin    | {"language":"de"} |
       | targetOrigin    | {"language":"ch"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -40,7 +40,6 @@ Feature: Tethered Nodes integrity violations
     And I am in the active content stream of workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                                | Value                                               |
-      | contentStreamId                    | "cs-identifier"                                     |
       | nodeAggregateId                    | "lady-eleonode-rootford"                            |
       | nodeTypeName                       | "Neos.ContentRepository:Root"                       |
       | tetheredDescendantNodeAggregateIds | {"originally-tethered-node": "originode-tetherton"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -159,7 +159,6 @@ Feature: Tag subtree without dimensions
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                      | Value           |
-      | contentStreamId          | "cs-identifier" |
       | nodeAggregateId          | "a1a"           |
       | newParentNodeAggregateId | "b1"            |
     And the graph projection is fully up to date


### PR DESCRIPTION
Followup for https://github.com/neos/neos-development-collection/pull/4708

The line `And I am in the active content stream of workspace "live" and dimension space point {}` will already set the workspaceName to use for the commands. The `contentStreamId` field is unused for these commands and will not be used to construct them.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
