### PR TITLE
BUGFIX: Throw explicit transaction has been marked for rollback only exception

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalCheckpointStorage.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalCheckpointStorage.php
@@ -115,6 +115,9 @@ final class DbalCheckpointStorage implements CheckpointStorageInterface
         if (!$this->connection->isTransactionActive()) {
             throw new \RuntimeException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because no transaction is active', $this->subscriberId), 1652279314);
         }
+        if ($this->connection->isRollbackOnly()) {
+            throw new \RuntimeException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because the transaction has been marked for rollback only', $this->subscriberId), 1711964313);
+        }
         try {
             if (!$this->lockedSequenceNumber->equals($sequenceNumber)) {
                 $this->connection->update($this->tableName, ['appliedsequencenumber' => $sequenceNumber->value], ['subscriberid' => $this->subscriberId]);

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/DbalCheckpointStorage.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/DbalCheckpointStorage.php
@@ -116,7 +116,8 @@ final class DbalCheckpointStorage implements CheckpointStorageInterface
             throw new \RuntimeException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because no transaction is active', $this->subscriberId), 1652279314);
         }
         if ($this->connection->isRollbackOnly()) {
-            throw new \RuntimeException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because the transaction has been marked for rollback only', $this->subscriberId), 1711964313);
+            // TODO as described in https://github.com/neos/neos-development-collection/issues/4970 we are in a bad state and cannot commit after a nested transaction was rolled back.
+            throw new \RuntimeException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because the transaction has been marked for rollback only. See https://github.com/neos/neos-development-collection/issues/4970', $this->subscriberId), 1711964313);
         }
         try {
             if (!$this->lockedSequenceNumber->equals($sequenceNumber)) {

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUp.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUp.php
@@ -121,11 +121,9 @@ final class CatchUp
                 if ($this->onBeforeBatchCompletedHook) {
                     ($this->onBeforeBatchCompletedHook)();
                 }
-            } catch (\Throwable $e) {
+            } finally {
                 $this->checkpointStorage->updateAndReleaseLock($highestAppliedSequenceNumber);
-                throw $e;
             }
-            $this->checkpointStorage->updateAndReleaseLock($highestAppliedSequenceNumber);
         }
         return $highestAppliedSequenceNumber;
     }


### PR DESCRIPTION
related https://github.com/neos/neos-development-collection/issues/4970

improves the error message from totally obscured:

> Failed to update and commit highest applied sequence number for subscriber "Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjection". Please run Neos\ContentRepository\Core\Infrastructure\DbalCheckpointStorage::setUp()

to partially obscure:

>  Failed to update and commit checkpoint for subscriber "Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjection" because the transaction has been marked for rollback only. See https://github.com/neos/neos-development-collection/issues/4970


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
