### PR TITLE
TASK: 4942 - refactor global transformation commands…

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/Common/RebasableToOtherWorkspaceInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/RebasableToOtherWorkspaceInterface.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\Common;
 
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -30,7 +29,6 @@ interface RebasableToOtherWorkspaceInterface
 {
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): CommandInterface;
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Command/AddDimensionShineThrough.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Command/AddDimensionShineThrough.php
@@ -25,7 +25,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  * basically making all content available not just in the source(original) DSP,
  * but also in the target-DimensionSpacePoint.
  *
- * NOTE: the Source Dimension Space Point must be a parent of the target Dimension Space Point.
+ * NOTE: the Source Dimension Space Point must be a generalization of the target Dimension Space Point.
  *
  * This is needed if "de" exists, and you want to create a "de_CH" specialization.
  *
@@ -39,27 +39,28 @@ final readonly class AddDimensionShineThrough implements
     RebasableToOtherWorkspaceInterface
 {
     /**
-     * @param ContentStreamId $contentStreamId The id of the content stream to perform the operation in.
-     *      This content stream is specifically created for this operation and thus not prone to conflicts,
-     *      thus we don't need the workspace name
+     * @param WorkspaceName $workspaceName The name of the workspace to perform the operation in.
      * @param DimensionSpacePoint $source source dimension space point
      * @param DimensionSpacePoint $target target dimension space point
      */
     private function __construct(
-        public ContentStreamId $contentStreamId,
+        public WorkspaceName $workspaceName,
         public DimensionSpacePoint $source,
         public DimensionSpacePoint $target
     ) {
     }
 
     /**
-     * @param ContentStreamId $contentStreamId The id of the content stream to perform the operation in
+     * @param WorkspaceName $workspaceName The name of the workspace to perform the operation in
      * @param DimensionSpacePoint $source source dimension space point
      * @param DimensionSpacePoint $target target dimension space point
      */
-    public static function create(ContentStreamId $contentStreamId, DimensionSpacePoint $source, DimensionSpacePoint $target): self
-    {
-        return new self($contentStreamId, $source, $target);
+    public static function create(
+        WorkspaceName $workspaceName,
+        DimensionSpacePoint $source,
+        DimensionSpacePoint $target
+    ): self {
+        return new self($workspaceName, $source, $target);
     }
 
     /**
@@ -68,16 +69,16 @@ final readonly class AddDimensionShineThrough implements
     public static function fromArray(array $array): self
     {
         return new self(
-            ContentStreamId::fromString($array['contentStreamId']),
+            WorkspaceName::fromString($array['workspaceName']),
             DimensionSpacePoint::fromArray($array['source']),
             DimensionSpacePoint::fromArray($array['target'])
         );
     }
 
-    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName, ContentStreamId $targetContentStreamId): self
+    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName): self
     {
         return new self(
-            $targetContentStreamId,
+            $targetWorkspaceName,
             $this->source,
             $this->target
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Command/MoveDimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Command/MoveDimensionSpacePoint.php
@@ -17,7 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command;
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterface;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -35,27 +34,28 @@ final readonly class MoveDimensionSpacePoint implements
     RebasableToOtherWorkspaceInterface
 {
     /**
-     * @param ContentStreamId $contentStreamId The id of the content stream to perform the operation in.
-     *       This content stream is specifically created for this operation and thus not prone to conflicts,
-     *       thus we don't need the workspace name
+     * @param WorkspaceName $workspaceName The name of the workspace to perform the operation in.
      * @param DimensionSpacePoint $source source dimension space point
      * @param DimensionSpacePoint $target target dimension space point
      */
     private function __construct(
-        public ContentStreamId $contentStreamId,
+        public WorkspaceName $workspaceName,
         public DimensionSpacePoint $source,
-        public DimensionSpacePoint $target
+        public DimensionSpacePoint $target,
     ) {
     }
 
     /**
-     * @param ContentStreamId $contentStreamId The id of the content stream to perform the operation in
+     * @param WorkspaceName $workspaceName The name of the workspace to perform the operation in
      * @param DimensionSpacePoint $source source dimension space point
      * @param DimensionSpacePoint $target target dimension space point
      */
-    public static function create(ContentStreamId $contentStreamId, DimensionSpacePoint $source, DimensionSpacePoint $target): self
-    {
-        return new self($contentStreamId, $source, $target);
+    public static function create(
+        WorkspaceName $workspaceName,
+        DimensionSpacePoint $source,
+        DimensionSpacePoint $target
+    ): self {
+        return new self($workspaceName, $source, $target);
     }
 
     /**
@@ -64,7 +64,7 @@ final readonly class MoveDimensionSpacePoint implements
     public static function fromArray(array $array): self
     {
         return new self(
-            ContentStreamId::fromString($array['contentStreamId']),
+            WorkspaceName::fromString($array['workspaceName']),
             DimensionSpacePoint::fromArray($array['source']),
             DimensionSpacePoint::fromArray($array['target'])
         );
@@ -72,10 +72,9 @@ final readonly class MoveDimensionSpacePoint implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
-            $targetContentStreamId,
+            $targetWorkspaceName,
             $this->source,
             $this->target
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
@@ -145,7 +145,6 @@ final readonly class CreateNodeAggregateWithNodeAndSerializedProperties implemen
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/DisableNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/DisableNodeAggregate.php
@@ -91,7 +91,6 @@ final readonly class DisableNodeAggregate implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/EnableNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/EnableNodeAggregate.php
@@ -91,7 +91,6 @@ final readonly class EnableNodeAggregate implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
@@ -156,7 +156,6 @@ final readonly class CopyNodesRecursively implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetSerializedNodeProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetSerializedNodeProperties.php
@@ -110,7 +110,6 @@ final readonly class SetSerializedNodeProperties implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Command/MoveNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Command/MoveNodeAggregate.php
@@ -120,7 +120,6 @@ final readonly class MoveNodeAggregate implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetSerializedNodeReferences.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetSerializedNodeReferences.php
@@ -98,7 +98,6 @@ final readonly class SetSerializedNodeReferences implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Command/RemoveNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Command/RemoveNodeAggregate.php
@@ -111,7 +111,6 @@ final readonly class RemoveNodeAggregate implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/Command/ChangeNodeAggregateName.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/Command/ChangeNodeAggregateName.php
@@ -85,7 +85,6 @@ final readonly class ChangeNodeAggregateName implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
@@ -109,7 +109,6 @@ final readonly class ChangeNodeAggregateType implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Command/CreateNodeVariant.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Command/CreateNodeVariant.php
@@ -90,7 +90,6 @@ final readonly class CreateNodeVariant implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Command/CreateRootNodeAggregateWithNode.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Command/CreateRootNodeAggregateWithNode.php
@@ -127,7 +127,6 @@ final readonly class CreateRootNodeAggregateWithNode implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Command/UpdateRootNodeAggregateDimensions.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Command/UpdateRootNodeAggregateDimensions.php
@@ -72,7 +72,6 @@ final readonly class UpdateRootNodeAggregateDimensions implements
 
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
-        ContentStreamId $targetContentStreamId
     ): self {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Command/TagSubtree.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Command/TagSubtree.php
@@ -78,7 +78,7 @@ final readonly class TagSubtree implements
         );
     }
 
-    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName, ContentStreamId $targetContentStreamId): self
+    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName): self
     {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Command/UntagSubtree.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Command/UntagSubtree.php
@@ -79,7 +79,7 @@ final readonly class UntagSubtree implements
         );
     }
 
-    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName, ContentStreamId $targetContentStreamId): self
+    public function createCopyForWorkspace(WorkspaceName $targetWorkspaceName): self
     {
         return new self(
             $targetWorkspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -519,7 +519,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             // 4) using the new content stream, apply the matching commands
             ContentStreamIdOverride::applyContentStreamIdToClosure(
                 $command->contentStreamIdForMatchingPart,
-                function () use ($matchingCommands, $contentRepository, $baseWorkspace, $command): void {
+                function () use ($matchingCommands, $contentRepository, $baseWorkspace): void {
                     foreach ($matchingCommands as $matchingCommand) {
                         if (!($matchingCommand instanceof RebasableToOtherWorkspaceInterface)) {
                             throw new \RuntimeException(
@@ -530,7 +530,6 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
                         $contentRepository->handle($matchingCommand->createCopyForWorkspace(
                             $baseWorkspace->workspaceName,
-                            $command->contentStreamIdForMatchingPart
                         ))->block();
                     }
                 }
@@ -656,7 +655,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         try {
             ContentStreamIdOverride::applyContentStreamIdToClosure(
                 $command->newContentStreamId,
-                function () use ($commandsToKeep, $contentRepository, $baseWorkspace, $command): void {
+                function () use ($commandsToKeep, $contentRepository, $baseWorkspace): void {
                     foreach ($commandsToKeep as $matchingCommand) {
                         if (!($matchingCommand instanceof RebasableToOtherWorkspaceInterface)) {
                             throw new \RuntimeException(
@@ -667,7 +666,6 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
                         $contentRepository->handle($matchingCommand->createCopyForWorkspace(
                             $baseWorkspace->workspaceName,
-                            $command->newContentStreamId
                         ))->block();
                     }
                 }

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
@@ -128,7 +128,7 @@ readonly class NodeMigrationService implements ContentRepositoryServiceInterface
         }
 
         if ($transformations->containsGlobal()) {
-            $transformations->executeGlobalAndBlock($workspaceForReading->workspaceName, $contentStreamForWriting);
+            $transformations->executeGlobalAndBlock($workspaceNameForWriting);
         } elseif ($transformations->containsNodeAggregateBased()) {
             foreach ($this->contentRepository->getContentGraph()->findUsedNodeTypeNames() as $nodeTypeName) {
                 foreach (

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\CommandHandler\CommandResult;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\AddDimensionShineThrough;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -50,12 +49,11 @@ class AddDimensionShineThroughTransformationFactory implements TransformationFac
             }
 
             public function execute(
-                WorkspaceName $workspaceNameForReading,
-                ContentStreamId $contentStreamForWriting
+                WorkspaceName $workspaceNameForWriting,
             ): CommandResult {
                 return $this->contentRepository->handle(
                     AddDimensionShineThrough::create(
-                        $contentStreamForWriting,
+                        $workspaceNameForWriting,
                         $this->from,
                         $this->to
                     )

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
@@ -26,7 +26,6 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 interface GlobalTransformationInterface
 {
     public function execute(
-        WorkspaceName $workspaceNameForReading,
-        ContentStreamId $contentStreamForWriting
+        WorkspaceName $workspaceNameForWriting,
     ): CommandResult;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\CommandHandler\CommandResult;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\MoveDimensionSpacePoint;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -48,12 +47,11 @@ class MoveDimensionSpacePointTransformationFactory implements TransformationFact
             }
 
             public function execute(
-                WorkspaceName $workspaceNameForReading,
-                ContentStreamId $contentStreamForWriting
+                WorkspaceName $workspaceNameForWriting,
             ): CommandResult {
                 return $this->contentRepository->handle(
                     MoveDimensionSpacePoint::create(
-                        $contentStreamForWriting,
+                        $workspaceNameForWriting,
                         $this->from,
                         $this->to
                     )

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
@@ -91,11 +91,10 @@ final class Transformations
     }
 
     public function executeGlobalAndBlock(
-        WorkspaceName $workspaceNameForReading,
-        ContentStreamId $contentStreamForWriting
+        WorkspaceName $workspaceNameForWriting,
     ): void {
         foreach ($this->globalTransformations as $globalTransformation) {
-            $globalTransformation->execute($workspaceNameForReading, $contentStreamForWriting)->block();
+            $globalTransformation->execute($workspaceNameForWriting)->block();
         }
     }
 

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
@@ -114,7 +114,7 @@ final class ContentCommandController extends CommandController
 
         $contentRepositoryInstance->handle(
             MoveDimensionSpacePoint::create(
-                $workspaceInstance->currentContentStreamId,
+                $workspaceInstance->workspaceName,
                 $sourceDimensionSpacePoint,
                 $targetDimensionSpacePoint
             )


### PR DESCRIPTION
… to also work with workspaces

Resolves #4942 

**Upgrade instructions**

I think the command structure migration has to be adjusted and re-run, @mhsdesign could you please take care of that?

**Review instructions**

the global transformations interface has been stripped of the content stream id, because both were implemented as commands that didn't need them. maybe we should keep it for non-command implementations?

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
