### PR TITLE
BUGFIX: Remove br from role tooltip and improve readability

### DIFF
--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/Roles.html
@@ -5,5 +5,6 @@
 	</span>
 </f:for>
 
-<f:section name="tooltip">{neos:backend.translate(id: 'package', value: 'Package')}: {role.packageKey}<br />
-<f:if condition="{role.parentRoles}">{neos:backend.translate(id: 'parentRoles', value: 'Parent role(s)')}: <f:for each="{role.parentRoles}" as="parentRole" iteration="iteration">{parentRole}{f:if(condition: iteration.isLast, else: ', ')}</f:for></f:if></f:section>
+<f:section name="tooltip">{neos:backend.translate(id: 'package', value: 'Package')}: {role.packageKey}&#13;
+<f:if condition="{role.parentRoles}">{neos:backend.translate(id: 'parentRoles', value: 'Parent role(s)')}:&#13;
+<f:for each="{role.parentRoles}" as="parentRole" iteration="iteration">- {parentRole.name} ({parentRole.identifier}){f:if(condition: iteration.isLast, else: '&#13;')}</f:for></f:if></f:section>


### PR DESCRIPTION
A `<br>` was displayed as text in the title of roles in the user management module.
With this change it is replaced by a proper line break and the parent roles are now displayed as list with their name and identifier.

Before:

![CleanShot 2024-04-11 at 13 37 07@2x](https://github.com/neos/neos-development-collection/assets/596967/d1fc5f07-f5bd-454c-ab7d-196222537ad3)

After:

![CleanShot 2024-04-11 at 13 40 50@2x](https://github.com/neos/neos-development-collection/assets/596967/1cc40c6b-6222-495f-a22c-60f1592ed24b)
