### PR TITLE
TASK: Remove i18n labels that are obsolete after neos/neos-ui#3759

### DIFF
--- a/Neos.Neos/Resources/Private/Translations/ar/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ar/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">تجاهل الكل</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">تجاهل كل التغييرات</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">هل انت متأكد انك تريد ان تتجاهل كل التغييرات فى مساحة العمل هذه ؟</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">هل أنت متأكد أنك تريد إزالة (تغيير) {numberOfChanges} في مجال العمل هذا؟</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">انشر الكل</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">انشر كل التغييرات</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">هل أنت متأكد من انك تريد ان تنشر كل التغييرات؟</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/cs/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/cs/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="needs-translation">Discard all</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="needs-translation">Discard all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard all changes in this workspace?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="needs-translation">Publish all</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Publikovat všechny změny</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="needs-translation">Are you sure that you want to publish all changes?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/da/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/da/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Kassér alle</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Kassér alle ændringer</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Er du sikker på at du vil slette alle ændringer i dette arbejdsrum?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Er du sikker på at du vil slette {numberOfChanges} ændring(er) i dette arbejdsrum?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Publicér alle</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Publicér alle ændringer</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Er du sikker på, at du ønsker at publicere alle ændringerne?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/de/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Alle verwerfen</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Alle Änderungen verwerfen</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Sind Sie sicher, dass Sie alle Änderungen in diesem Workspace verwerfen möchten?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="final">Sind Sie sicher, dass Sie {numberOfChanges} Änderung(en) in diesem Arbeitsbereich verwerfen möchten?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Alles veröffentlichen</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Alle Änderungen veröffentlichen</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Sind Sie sicher, dass Sie alle Änderungen veröffentlichen möchten?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/el/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/el/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="needs-translation">Discard all</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="needs-translation">Discard all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard all changes in this workspace?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="needs-translation">Publish all</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="needs-translation">Publish all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="needs-translation">Are you sure that you want to publish all changes?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Main.xlf
@@ -400,23 +400,8 @@
 			<trans-unit id="discardAll" xml:space="preserve">
 				<source>Discard all</source>
 			</trans-unit>
-			<trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-				<source>Discard all changes</source>
-			</trans-unit>
-			<trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-				<source>Are you sure that you want to discard all changes in this workspace?</source>
-			</trans-unit>
-			<trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-				<source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-			</trans-unit>
 			<trans-unit id="publishAll" xml:space="preserve">
 				<source>Publish all</source>
-			</trans-unit>
-			<trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-				<source>Publish all changes</source>
-			</trans-unit>
-			<trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-				<source>Are you sure that you want to publish all changes?</source>
 			</trans-unit>
 			<trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
 				<source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/es/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/es/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Descartar todo</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Descartar todos los cambios</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">¿Está seguro de que desea descartar todos los cambios en este espacio de trabajo?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">¿Estás seguro que deseas descartar {numberOfChanges} cambios en este espacio de trabajo?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Publicar todo</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Publicar todos los cambios</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">¿Seguro que quiere publicar todos los cambios?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/fi/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/fi/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Hylkää kaikki</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Hylkää kaikki muutokset</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Oletko varma että haluat hylätä kaikki työtilan muutokset?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Julkaise kaikki</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Julkaise kaikki muutokset</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Oletko varma että haluat julkaista kaikki muutokset?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/fr/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/fr/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">ReJeter tous</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Ignorer toutes les modifications</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Êtes-vous sûr de vouloir ignorer toutes les modifications dans cet espace de travail ?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Êtes-vous sûr de vouloir ignorer {numberOfChanges} modification(s) dans cet espace de travail ?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Publier tous</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Publier toutes les modifications</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Êtes-vous sûr de vouloir publier toutes les modifications ?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/hu/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/hu/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Összes elvetése</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Összes változtatás elvetése</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Biztos benne, hogy elveti az összes módosítást ezen a munkaterületen?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Biztos elvet {numberOfChanges} módosítást a munkafelületen?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Minden közzététele</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Minden változtatás közzététele</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Biztos benne, hogy közzéteszi az összes változást?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/id_ID/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/id_ID/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Membuang semua</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Buang semua perubahan</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Apakah Anda yakin bahwa Anda ingin membuang semua perubahan dalam bidang kerja ini?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Apakah Anda yakin ingin membuang perubahan {numberOfChanges} di ruang kerja ini?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Mempublikasikan semua</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Mempublikasikan semua perubahan</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Apakah Anda yakin bahwa Anda ingin mempublikasikan semua perubahan?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/it/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/it/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Scartare tutto</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Annullare tutte le modifiche</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Sei sicuro di voler eliminare tutte le modifiche in questa area di lavoro?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Sicuro di voler scartare {numberOfChanges} cambiamento/i in quest'area di lavoro?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Pubblicare tutto</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Pubblicare tutte le modifiche</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Sei sicuro di voler pubblicare tutti i cambiamenti?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/ja/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ja/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">すべてを破棄する</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">すべての変更を破棄する</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">このワークスペース内のすべての変更を破棄してもよろしいですか？</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">すべてを公開</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">すべての変更を公開する</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">すべての変更を公開してもよろしいでしょうか？</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/km/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/km/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">បេាះបង់ចោល</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">បោះបង់ការផ្លាស់ប្តូរទាំងអស់</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">ត់អ្នកពិតជាចង់បោះបង់ការកែរទាំងអស់ក្នុងលំហរការងារនេះមែនទេ?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">ចុះផ្សាយទាំងអស់</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">ផ្សាយរាល់ការផ្លាស់ប្តូរ</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">តើអ្នកពិតជាចង់ដាក់ផ្សាយការផ្លាស់ប្តូរទាំងអស់មែនឬទេ?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/lv/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/lv/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Atcelt visu</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Atcelt visas izmaiņas</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Vai esiet pārliecināti, ka vēlaties atcelt visas izmaiņas šajā vietā?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Vai esiet pārliecināti, ka vēlaties atcelt {numberOfChanges} izmaiņas šajā darba virsmā?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Publicēt visu</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Publicēt visas izmaiņas</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Vai tiešam vēlaties publicēt visas izmaiņas?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/nl/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/nl/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Alles annuleren</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Alle wijzigingen negeren</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Weet u zeker dat u wilt verwijderen van alle wijzigingen in deze workspace?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Weet u zeker dat u {numberOfChanges} verandering(en) in deze werkruimte wilt verwijderen?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Alles publiceren</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Alle wijzigingen publiceren</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Weet u zeker dat u wilt om alle wijzigingen te publiceren?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/no/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/no/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Forkast alt</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Forkast alle endringer</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Er du sikker på at du vil forkaste alle endringer i dette arbeidsområdet?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Publiser alt</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Publiser alle endringer</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Er du sikker på at du vil publisere alle endringer?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/pl/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pl/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Odrzuć wszystko</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Odrzuć wszystkie zmiany</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Czy na pewno chcesz odrzucić wszystkie zmiany w tym obszarze roboczym?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="final">Czy jesteś pewien, że chcesz odrzucić {numberOfChanges} zmianę(y) w tym obszarze roboczym?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Publikuj wszystko</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Publikuj wszystkie zmiany</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Czy jesteś pewien, że chcesz opublikować wszystkie zmiany?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/pt/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pt/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Descartar todos</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Descartar todas as alterações</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Tem certeza que deseja descartar todas as alterações neste espaço de trabalho?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Tem certeza de que deseja descartar {numberOfChanges} mudança(s) neste espaço de trabalho?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Publicar todos</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Publicar todas as alterações</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Tem certeza que deseja publicar todas as alterações?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/pt_BR/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/pt_BR/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Descartar todos</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Descartar todas as alterações</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Tem certeza que deseja descartar todas as alterações neste espaço de trabalho?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Você tem certeza de que você deseja descartar {numberOfChanges} mudança(s) neste espaço de trabalho?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Publicar todos</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Publicar todas as alterações</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Tem certeza que deseja publicar todas as alterações?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/ru/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/ru/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="final">Отменить все</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve" approved="yes">
-        <source>Discard all changes</source>
-        <target state="final">Отменить все изменения</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="final">Вы уверены, что хотите отменить все изменения в этой рабочей области?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="final">Вы уверены, что хотите отменить правки в количестве {numberOfChanges} шт. в этой рабочей области?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve" approved="yes">
         <source>Publish all</source>
         <target state="final">Опубликовать все</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve" approved="yes">
-        <source>Publish all changes</source>
-        <target state="final">Опубликовать все изменения</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve" approved="yes">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="final">Вы уверены, что хотите опубликовать все изменения?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve" approved="yes">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/sr/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/sr/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="needs-translation">Discard all</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="needs-translation">Discard all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard all changes in this workspace?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="needs-translation">Publish all</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="needs-translation">Publish all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="needs-translation">Are you sure that you want to publish all changes?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/sv/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/sv/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Ignorera alla</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Ignorera alla ändringar</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Är du säker på att du vill ignorera alla ändringar i den här arbetsytan?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Är du säker på att du vill ignorera {numberOfChanges} ändring(ar) i denna arbetsyta?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Publicera alla</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Publicera alla ändringar</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Är du säker på att du vill publicera alla ändringar?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/tl_PH/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/tl_PH/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="needs-translation">Discard all</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="needs-translation">Discard all changes</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Sigurado kaba na gusto mong itapon ang lahat na mga pagbabago sa workspace na ito?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Ilathala lahat</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Ilathala lahat ng mga pagbabago</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="needs-translation">Are you sure that you want to publish all changes?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/tr/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/tr/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Hepsini iptal et</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Bütün değişiklikleri iptal et</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Bu çalışma alanındaki tüm değişiklikleri iptal etmek istediğinizden emin misiniz?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">Bu çalışma alanındaki ({numberOfChanges} tane) değişikliği geri almak istediğinden emin misin?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Tümünü yayımla</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Tüm değişiklikleri yayımla</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Tüm değişiklikleri yayımlamak istediğinizden emin misiniz?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/uk/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/uk/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="needs-translation">Discard all</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Скасувати всі зміни</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Ви дійсно бажаєте скасувати всі зміни в робочій області?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="needs-translation">Publish all</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Опублікувати всі зміни</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Ви впевнені, що ви хочете опублікувати всі зміни?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/vi/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/vi/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">Loại bỏ tất cả</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">Loại bỏ tất cả thay đổi</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">Bạn có chắc bạn muốn loại bỏ tất cả những thay đổi trong không gian làm việc này?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">Công khai tất cả</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">Công khai tất cả thay đổi</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">Bạn có chắc chắn muốn công khai tất cả thay đổi</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/zh/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/zh/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">放弃所有</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">舍弃所有更改</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">你确定要舍弃此工作区中的所有更改吗?</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="needs-translation">Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">发布所有</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">发布所有更改</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">你确定要发布所有更改吗?</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>

--- a/Neos.Neos/Resources/Private/Translations/zh_TW/Main.xlf
+++ b/Neos.Neos/Resources/Private/Translations/zh_TW/Main.xlf
@@ -519,29 +519,9 @@
         <source>Discard all</source>
         <target state="translated">捨棄全部</target>
       </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesHeader" xml:space="preserve">
-        <source>Discard all changes</source>
-        <target state="translated">捨棄全部變更</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardAllChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard all changes in this workspace?</source>
-        <target state="translated">你確定要放棄所有在此工作區的變更？</target>
-      </trans-unit>
-      <trans-unit id="content.components.discardAllDialog.discardXChangesSubheader" xml:space="preserve">
-        <source>Are you sure that you want to discard {numberOfChanges} change(s) in this workspace?</source>
-        <target state="translated">您確定要放棄 {numberOfChanges} 筆在此工作區所做的修改?</target>
-      </trans-unit>
       <trans-unit id="publishAll" xml:space="preserve">
         <source>Publish all</source>
         <target state="translated">發布全部</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.header" xml:space="preserve">
-        <source>Publish all changes</source>
-        <target state="translated">發布全部變更</target>
-      </trans-unit>
-      <trans-unit id="content.components.publishAllDialog.subheader" xml:space="preserve">
-        <source>Are you sure that you want to publish all changes?</source>
-        <target state="translated">您確定要發布所有變更？</target>
       </trans-unit>
       <trans-unit id="content.components.dirtyWorkspaceDialog.dirtyWorkspaceHeader" xml:space="preserve">
         <source>Pending changes</source>


### PR DESCRIPTION
The publishing workflow in the UI has changes significantly with https://github.com/neos/neos-ui/pull/3759 and requires an entirely new set of labels. Those labels are now located in the UI repository.

The following labels are therefore obsolete after https://github.com/neos/neos-ui/pull/3759 gets merged:

- Neos.Neos:Main:content.components.discardAllDialog.discardXChangesSubheader 
- Neos.Neos:Main:content.components.discardAllDialog.discardAllChangesHeader 
- Neos.Neos:Main:content.components.discardAllDialog.discardAllChangesSubheader 
- Neos.Neos:Main:content.components.publishAllDialog.header 
- Neos.Neos:Main:content.components.publishAllDialog.subheader

This PR removes these labels from all translation files.

*Marked as draft as long as https://github.com/neos/neos-ui/pull/3759 is still open*