### PR TITLE
BUGFIX: Add missing type converts for asset subtypes

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -201,6 +201,33 @@ Neos:
               features:
                 upload: true
                 mediaBrowser: true
+          Neos\Media\Domain\Model\Audio:
+            typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
+            editor: Neos.Neos/Inspector/Editors/AssetEditor
+            editorOptions:
+              features:
+                upload: true
+                mediaBrowser: true
+              constraints:
+                mediaTypes:
+                  - 'audio/*'
+          Neos\Media\Domain\Model\Document:
+            typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
+            editor: Neos.Neos/Inspector/Editors/AssetEditor
+            editorOptions:
+              features:
+                upload: true
+                mediaBrowser: true
+          Neos\Media\Domain\Model\Video:
+            typeConverter: Neos\Neos\TypeConverter\EntityToIdentityConverter
+            editor: Neos.Neos/Inspector/Editors/AssetEditor
+            editorOptions:
+              features:
+                upload: true
+                mediaBrowser: true
+              constraints:
+                mediaTypes:
+                  - 'video/*'
           array<Neos\Media\Domain\Model\Asset>:
             typeConverter: Neos\Flow\Property\TypeConverter\TypedArrayConverter
             editor: Neos.Neos/Inspector/Editors/AssetEditor


### PR DESCRIPTION
This prevents the raw data from being base64 encoded into the rendered output of the Neos backend and included in xhr requests from the Neos UI.

Additionally the default settings for editor and constraints makes the usage of those affected types easier in nodetype properties.

Resolves: #5006

**Review instructions**

Example nodetype to use in the Neos backend with the raw content mode:

```
'Neos.Demo:Content.Test':
  superTypes:
    'Neos.Neos:Content': true
    'Neos.Demo:Constraint.Content.Column': true
    'Neos.Demo:Constraint.Content.Main': true
  ui:
    label: Test
    icon: picture
    position: start
    inspector:
      groups:
        settings:
          label: Test Settings
  properties:
    video:
      type: Neos\Media\Domain\Model\Video
      ui:
        label: 'Video'
        reloadIfChanged: true
        showInCreationDialog: true
        inspector:
          group: 'settings'
          editor: Neos.Neos/Inspector/Editors/AssetEditor
    document:
      type: Neos\Media\Domain\Model\Document
      ui:
        label: Document
        inspector:
          group: 'settings'
          editor: Neos.Neos/Inspector/Editors/AssetEditor
    audio:
      type: Neos\Media\Domain\Model\Audio
      ui:
        label: Audio
        inspector:
          group: 'settings'
          editor: Neos.Neos/Inspector/Editors/AssetEditor
```

Without the change in this PR, setting the 3 properties will each increase the size of the `preview` html and node change requests.
Also errors are thrown if the editor for each property is not defined.

With this change, the size of the output does not increase and the editor does not need to be defined anymore.