### PR TITLE
!!! BUGFIX: Fix schema of hierarchy relation table

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -66,7 +66,10 @@ class DoctrineDbalContentGraphSchemaBuilder
         ]);
 
         return $table
-            ->setPrimaryKey(['childnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'parentnodeanchor'])
+            ->addIndex(['childnodeanchor'])
+            ->addIndex(['contentstreamid'])
+            ->addIndex(['parentnodeanchor'])
+            ->addIndex(['contentstreamid', 'childnodeanchor', 'dimensionspacepointhash'])
             ->addIndex(['contentstreamid', 'dimensionspacepointhash']);
     }
 


### PR DESCRIPTION
Partially reverts #4790 that changed the indexes of the `cr_<crid>_p_graph_hierarchyrelation` table.

Note that this needs a `./flow cr:setup` and `./flow cr:projectionreplay --projection contentGraph`