### PR TITLE
FEATURE: Improved CLI output for projection replay

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/Projections.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Projections.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Core\Projection;
  * @implements \IteratorAggregate<ProjectionInterface>
  * @internal
  */
-final class Projections implements \IteratorAggregate
+final class Projections implements \IteratorAggregate, \Countable
 {
     /**
      * @var array<class-string<ProjectionInterface<ProjectionStateInterface>>, ProjectionInterface<ProjectionStateInterface>>
@@ -92,5 +92,10 @@ final class Projections implements \IteratorAggregate
     public function getIterator(): \Traversable
     {
         yield from $this->projections;
+    }
+
+    public function count(): int
+    {
+        return count($this->projections);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayServiceFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/ProjectionReplayServiceFactory.php
@@ -24,6 +24,7 @@ final class ProjectionReplayServiceFactory implements ContentRepositoryServiceFa
         return new ProjectionReplayService(
             $serviceFactoryDependencies->projections,
             $serviceFactoryDependencies->contentRepository,
+            $serviceFactoryDependencies->eventStore,
         );
     }
 }


### PR DESCRIPTION
Adds debugging infos to the output of the `cr:projectionReplay` command and nested progress bars to the output of `cr:projectionReplayAll`.

Furthermore this adds the `until` flag to the `cr:projectionReplayAll` command
Related: #4777