### PR TITLE
BUGFIX: Workspace module: Tweak UX for collapsed rows in rewiew

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -16,7 +16,7 @@
 					<table class="neos-table">
 						<thead>
 						<tr>
-							<th class="check neos-priority1">
+							<th class="check neos-priority1" style="width: 30px">
 								<label for="check-all" class="neos-checkbox">
 									<input type="checkbox" id="check-all" /><span></span>
 								</label>
@@ -30,17 +30,10 @@
 							<f:for each="{site.documents}" key="dimension" as="dimensions">
 								<f:for each="{dimensions}" key="documentPath" as="document">
 									<tr class="neos-document" data-nodepath="{document.documentNode.path}" data-ismoved="{f:if(condition: document.isMoved, then: 'true', else: 'false')}" data-isnew="{f:if(condition: document.isNew, then: 'true', else: 'false')}">
-										<f:if condition="{document.changes -> f:count()} > 1">
-											<f:then>
-												<td class="check neos-priority1">
-													<label for="check-document-{document.documentNode.identifier}" class="neos-checkbox"><f:form.checkbox id="check-document-{document.documentNode.identifier}" class="neos-check-document" value="{document.documentNode.identifier}"/><span></span></label>
-												</td>
-												<td class="neos-priority1 path-caption">
-											</f:then>
-											<f:else>
-												<td colspan="2" class="neos-priority1 path-caption">
-											</f:else>
-										</f:if>
+										<td class="check neos-priority1">
+											<label for="check-document-{document.documentNode.identifier}" class="neos-checkbox"><f:form.checkbox id="check-document-{document.documentNode.identifier}" class="neos-check-document" value="{document.documentNode.identifier}"/><span></span></label>
+										</td>
+										<td class="neos-priority1 path-caption">
 										<div class="neos-row-fluid">
 											<div class="neos-span2">
 												{neos:backend.translate(id: 'pathCaption', source: 'Main', package: 'Neos.Neos')}:


### PR DESCRIPTION
This change adds a checkbox to all rows of the workspace review module in order to get a unified look and feel when collapsing those lines.

Previously, the checkbox was hidden for documents that only contained a single change:

![image](https://github.com/neos/neos-development-collection/assets/307571/fe3a4964-0604-4394-b9a3-29879880d76d)

With this change, the list looks cleaner and single changes can be selected more easily even when collapsed:

![image](https://github.com/neos/neos-development-collection/assets/307571/fd098312-6b58-4df1-b9d2-bdd23c9e7699)
