### PR TITLE
TASK: Allow to enable Fusion caching for Behat tests

### DIFF
--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -47,6 +47,8 @@ trait FusionTrait
 
     private ?\Throwable $lastRenderingException = null;
 
+    private $contentCacheEnabled = false;
+
     /**
      * @template T of object
      * @param class-string<T> $className
@@ -63,6 +65,7 @@ trait FusionTrait
         $this->fusionGlobalContext = [];
         $this->fusionContext = [];
         $this->fusionCode = null;
+        $this->contentCacheEnabled = false;
         $this->renderingResult = null;
     }
 
@@ -115,6 +118,14 @@ trait FusionTrait
     }
 
     /**
+     * @When I have Fusion content cache enabled
+     */
+    public function iHaveFusionContentCacheEnabled(): void
+    {
+        $this->contentCacheEnabled = true;
+    }
+
+    /**
      * @When I execute the following Fusion code:
      * @When I execute the following Fusion code on path :path:
      */
@@ -131,6 +142,7 @@ trait FusionTrait
         $fusionGlobals = FusionGlobals::fromArray($this->fusionGlobalContext);
 
         $fusionRuntime = (new RuntimeFactory())->createFromConfiguration($fusionAst, $fusionGlobals);
+        $fusionRuntime->setEnableContentCache($this->contentCacheEnabled);
         $fusionRuntime->overrideExceptionHandler($this->getObject(ThrowingHandler::class));
         $fusionRuntime->pushContextArray($this->fusionContext);
         try {

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -28,6 +28,7 @@ use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\RenderingModeService;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ServerRequestFactoryInterface;
+use Neos\Fusion\Core\Cache\ContentCache;
 
 /**
  * @internal only for behat tests within the Neos.Neos package
@@ -202,6 +203,14 @@ trait FusionTrait
         if ($this->lastRenderingException !== null) {
             throw new \RuntimeException(sprintf('The last rendering led to an error: %s', $this->lastRenderingException->getMessage()), 1698319254, $this->lastRenderingException);
         }
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function clearFusionCaches()
+    {
+        $this->getObject(ContentCache::class)->flush();
     }
 
 }

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
@@ -1,0 +1,66 @@
+@flowEntities @contentrepository
+Feature: Tests for Fusion ContentCache
+  Background:
+    Given I have Fusion content cache enabled
+    And I have the following Fusion setup:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    prototype(Neos.Neos:Test.ContentCache) < prototype(Neos.Fusion:Component) {
+        foo = ''
+        renderer = ${props.foo}
+        @cache {
+            mode = 'cached'
+            entryIdentifier {
+                test = 'test'
+            }
+        }
+    }
+
+"""
+
+  Scenario:
+    When I execute the following Fusion code:
+    """fusion
+        test = Neos.Neos:Test.ContentCache {
+            foo = 'test1'
+        }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    test1
+    """
+    When I execute the following Fusion code:
+    """fusion
+        test = Neos.Neos:Test.ContentCache {
+            foo = 'test2'
+        }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    test1
+    """
+
+
+  Scenario:
+    When I execute the following Fusion code:
+    """fusion
+        test = Neos.Neos:Test.ContentCache {
+            foo = 'test2'
+        }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    test2
+    """
+    When I execute the following Fusion code:
+    """fusion
+        test = Neos.Neos:Test.ContentCache {
+            foo = 'test1'
+        }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    test2
+    """

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
@@ -20,47 +20,47 @@ Feature: Tests for Fusion ContentCache
 
 """
 
-  Scenario:
+  Scenario: Render a cached prototype and check if rerendering doesn't happen on second try
     When I execute the following Fusion code:
     """fusion
         test = Neos.Neos:Test.ContentCache {
-            foo = 'test1'
+            foo = 'some-cached-string'
         }
     """
     Then I expect the following Fusion rendering result:
     """
-    test1
+    some-cached-string
     """
     When I execute the following Fusion code:
     """fusion
         test = Neos.Neos:Test.ContentCache {
-            foo = 'test2'
+            foo = 'some-other-string'
         }
     """
     Then I expect the following Fusion rendering result:
     """
-    test1
+    some-cached-string
     """
 
 
-  Scenario:
+  Scenario: Check if cached got flushed before running a new scenario and no leftover of last test is there
     When I execute the following Fusion code:
     """fusion
         test = Neos.Neos:Test.ContentCache {
-            foo = 'test2'
+            foo = 'some-new-string'
         }
     """
     Then I expect the following Fusion rendering result:
     """
-    test2
+    some-new-string
     """
     When I execute the following Fusion code:
     """fusion
         test = Neos.Neos:Test.ContentCache {
-            foo = 'test1'
+            foo = 'totally-different-string'
         }
     """
     Then I expect the following Fusion rendering result:
     """
-    test2
+    some-new-string
     """


### PR DESCRIPTION
Allows to enable the ContentCache for Fusion renderings in Behat tests. The cache uses the TransientMemoryBackend and gets flushed before each scenario.

```
Given I have Fusion content cache enabled
```