### PR TITLE
!!! BUGFIX: Actually execute moveSubtreeTags tests and fix moveSubtreeTags

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
@@ -56,7 +56,6 @@ trait NodeMove
                     );
                     $this->moveSubtreeTags(
                         $event->contentStreamId,
-                        $event->nodeAggregateId,
                         $event->newParentNodeAggregateId,
                         $succeedingSiblingForCoverage->dimensionSpacePoint
                     );

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -167,8 +167,7 @@ trait SubtreeTagging
                 JOIN ' . $this->getTableNamePrefix() . '_hierarchyrelation dh
                     ON
                         dh.parentnodeanchor = cte.childnodeanchor
-                    WHERE
-                        dh.contentstreamid = :contentStreamId
+                        AND dh.contentstreamid = :contentStreamId
                         AND dh.dimensionspacepointhash = :dimensionSpacePointHash
               )
               SELECT * FROM cte

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -458,7 +458,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -469,7 +469,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -539,7 +539,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -609,7 +609,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -679,7 +679,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1020,7 +1020,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1031,7 +1031,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1101,7 +1101,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1171,7 +1171,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1241,7 +1241,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
-    And I expect this node to exactly inherit the tags "tag1"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1788,7 +1788,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
-    And I expect this node to be exactly explicitly tagged "tag1"
+    And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
@@ -1811,7 +1811,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                |
-      | nodeAggregateId              | "nody-mc-nodeface"   |
+      | nodeAggregateId              | "sir-david-nodenborough"   |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
@@ -1881,7 +1881,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                |
-      | nodeAggregateId              | "nody-mc-nodeface"   |
+      | nodeAggregateId              | "sir-david-nodenborough"   |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
@@ -1951,7 +1951,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                 |
-      | nodeAggregateId              | "nody-mc-nodeface"    |
+      | nodeAggregateId              | "sir-david-nodenborough"    |
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
@@ -2021,7 +2021,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                 |
-      | nodeAggregateId              | "nody-mc-nodeface"    |
+      | nodeAggregateId              | "sir-david-nodenborough"    |
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
@@ -2091,7 +2091,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                |
-      | nodeAggregateId              | "nody-mc-nodeface"   |
+      | nodeAggregateId              | "sir-david-nodenborough"   |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
@@ -2161,7 +2161,7 @@ Feature: Move a node aggregate into and out of a tagged parent
 
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                |
-      | nodeAggregateId              | "nody-mc-nodeface"   |
+      | nodeAggregateId              | "sir-david-nodenborough"   |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -173,11 +173,11 @@ Feature: Tag subtree without dimensions
     """
     b (tag2*)
      b1 (tag3*,tag2)
-      a1a (tag4*,tag3,tag2)
-       a1a1 (tag4*,tag1*,tag3,tag2)
-        a1a1a (tag4*,tag3,tag2)
-        a1a1b (tag4*,tag3,tag2)
-       a1a2 (tag4*,tag3,tag2)
+      a1a (tag4*,tag2,tag3)
+       a1a1 (tag1*,tag2,tag3,tag4)
+        a1a1a (tag1,tag2,tag3,tag4)
+        a1a1b (tag1,tag2,tag3,tag4)
+       a1a2 (tag2,tag3,tag4)
     """
 
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -189,12 +189,12 @@ Feature: Tag subtree without dimensions
     """
     b (tag2*)
      b1 (tag3*,tag2)
-      a1a (tag4*,tag3,tag2)
-       a1a1 (tag4*,tag1*,tag3,tag2)
-        a1a1a (tag4*,tag3,tag2)
-        a1a1b (tag4*,tag3,tag2)
-       a1a2 (tag4*,tag3,tag2)
-       a1a3 (tag4,tag3,tag2)
+      a1a (tag4*,tag2,tag3)
+       a1a1 (tag1*,tag2,tag3,tag4)
+        a1a1a (tag1,tag2,tag3,tag4)
+        a1a1b (tag1,tag2,tag3,tag4)
+       a1a2 (tag2,tag3,tag4)
+       a1a3 (tag2,tag3,tag4)
     """
 
     When the command UntagSubtree is executed with payload:
@@ -206,10 +206,10 @@ Feature: Tag subtree without dimensions
     """
     b (tag2*)
      b1 (tag3*,tag2)
-      a1a (tag3,tag2)
-       a1a1 (tag4*,tag1*,tag3,tag2)
-        a1a1a (tag4*,tag3,tag2)
-        a1a1b (tag4*,tag3,tag2)
-       a1a2 (tag4*,tag3,tag2)
-       a1a3 (tag3,tag2)
+      a1a (tag2,tag3)
+       a1a1 (tag1*,tag2,tag3)
+        a1a1a (tag1,tag2,tag3)
+        a1a1b (tag1,tag2,tag3)
+       a1a2 (tag2,tag3)
+       a1a3 (tag2,tag3)
     """

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTags.php
@@ -23,7 +23,7 @@ use Traversable;
  *
  * Internally, this consists of two collection:
  * - One for tags that are _explicitly_ set on the respective node.
- * - And one that contains tags that are _inherited_ by one of the ancestor nodes
+ * - And one that contains tags that are only _inherited_ by one of the ancestor nodes and _not_ explicitly set
  *
  * In most cases, it shouldn't matter whether a tag is inherited or set explicitly. But sometimes the behavior is slightly different (e.g. the "disabled" checkbox in the Neos UI inspector is only checked if the node has the `disabled` tag set explicitly)
  *

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -248,7 +248,11 @@ trait NodeTraversalTrait
             $subtree = array_shift($subtreeStack);
             $tags = [];
             if ($withTags !== null) {
-                $tags = [...array_map(static fn(string $tag) => $tag . '*', $subtree->node->tags->withoutInherited()->toStringArray()), ...$subtree->node->tags->onlyInherited()->toStringArray()];
+                $explicitTags = $subtree->node->tags->withoutInherited()->toStringArray();
+                sort($explicitTags);
+                $inheritedTags = $subtree->node->tags->onlyInherited()->toStringArray();
+                sort($inheritedTags);
+                $tags = [...array_map(static fn(string $tag) => $tag . '*', $explicitTags), ...$inheritedTags];
             }
             $result[] = str_repeat(' ', $subtree->level) . $subtree->node->nodeAggregateId->value . ($tags !== [] ? ' (' . implode(',', $tags) . ')' : '');
             $subtreeStack = [...$subtree->children, ...$subtreeStack];

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -243,23 +243,29 @@ trait ProjectedNodeTrait
 
     /**
      * @Then /^I expect this node to be exactly explicitly tagged "(.*)"$/
-     * @param string $tagList the comma-separated list of tag names
+     * @param string $expectedTagList the comma-separated list of tag names
      */
-    public function iExpectThisNodeToBeExactlyExplicitlyTagged(string $tagList): void
+    public function iExpectThisNodeToBeExactlyExplicitlyTagged(string $expectedTagList): void
     {
-        $this->assertOnCurrentNode(function (Node $currentNode) use ($tagList) {
-            $currentNode->tags->withoutInherited()->toStringArray() === explode(',', $tagList);
+        $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedTagList) {
+            Assert::assertSame(
+                ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
+                $currentNode->tags->withoutInherited()->toStringArray()
+            );
         });
     }
 
     /**
      * @Then /^I expect this node to exactly inherit the tags "(.*)"$/
-     * @param string $tagList the comma-separated list of tag names
+     * @param string $expectedTagList the comma-separated list of tag names
      */
-    public function iExpectThisNodeToExactlyInheritTheTags(string $tagList): void
+    public function iExpectThisNodeToExactlyInheritTheTags(string $expectedTagList): void
     {
-        $this->assertOnCurrentNode(function (Node $currentNode) use ($tagList) {
-            $currentNode->tags->onlyInherited()->toStringArray() === explode(',', $tagList);
+        $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedTagList) {
+            Assert::assertSame(
+                ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
+                $currentNode->tags->onlyInherited()->toStringArray(),
+            );
         });
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -248,9 +248,11 @@ trait ProjectedNodeTrait
     public function iExpectThisNodeToBeExactlyExplicitlyTagged(string $expectedTagList): void
     {
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedTagList) {
+            $actualTags = $currentNode->tags->withoutInherited()->toStringArray();
+            sort($actualTags);
             Assert::assertSame(
                 ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
-                $currentNode->tags->withoutInherited()->toStringArray()
+                $actualTags
             );
         });
     }
@@ -262,9 +264,11 @@ trait ProjectedNodeTrait
     public function iExpectThisNodeToExactlyInheritTheTags(string $expectedTagList): void
     {
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedTagList) {
+            $actualTags = $currentNode->tags->onlyInherited()->toStringArray();
+            sort($actualTags);
             Assert::assertSame(
                 ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
-                $currentNode->tags->onlyInherited()->toStringArray(),
+                $actualTags,
             );
         });
     }


### PR DESCRIPTION
Fixup https://github.com/neos/neos-development-collection/pull/4993

This now actually asserts stuff when testing moveSubtreeTags, thanks to @mhsdesign for detecting this.

Also, the acutal moveSubtreeTags method is fixed to properly apply tags to the moved node and its descendants

**Upgrade instructions**

This raises the supported database platforms. Mariadb 10.4 for example will no longer be supported.See https://github.com/neos/neos-development-collection/issues/4337

Additionally there are cases where it would make sense to replay the projection to apply this fix:

```
./flow cr:projectionReplay contentGraph
```



**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
