### PR TITLE
TASK: Change loading of objects notation in behat tests

### DIFF
--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -113,20 +113,21 @@ class FeatureContext implements BehatContext
     protected function deserializeProperties(array $properties): PropertyValuesToWrite
     {
         $properties = array_map(
-            $this->loadFlowObjectsRecursive(...),
+            $this->loadObjectsRecursive(...),
             $properties
         );
 
         return $this->deserializePropertiesCrTestSuiteTrait($properties);
     }
 
-    public function loadFlowObjectsRecursive(mixed $value): mixed
+    private function loadObjectsRecursive(mixed $value): mixed
     {
-        if (is_array($value) && isset($value['__flow_object_type'])) {
-            return $this->persistenceManager->getObjectByIdentifier($value['__identifier'], $value['__flow_object_type'], true);
+        if (is_string($value) && str_starts_with($value, 'Asset:')) {
+            $assetIdentier = substr($value, strlen('Asset:'));
+            return $this->persistenceManager->getObjectByIdentifier($assetIdentier, 'Neos\\Media\\Domain\\Model\\Asset', true);
         } elseif (is_array($value)) {
             return array_map(
-                $this->loadFlowObjectsRecursive(...),
+                $this->loadObjectsRecursive(...),
                 $value
             );
         }

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
@@ -60,13 +60,13 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
       | nodeTypeName    | "Neos.Neos:Sites" |
     And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                                                                                                                                        | nodeName |
-      | a               | root                  | Neos.Neos:Site               | {}                                                                                                                                                           | site     |
-      | a1              | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1", "title": "Node a1", "asset": {"__flow_object_type":"Neos\\Media\\Domain\\Model\\Asset","__identifier":"an-asset-to-change"}}        | a1       |
-      | a1-1            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-1", "title": "Node a1-1", "assets": [{"__flow_object_type":"Neos\\Media\\Domain\\Model\\Asset","__identifier":"an-asset-to-change"}]} | a1-1     |
-      | a1-2            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-2", "title": "Node a1-2", "asset": {"__flow_object_type":"Neos\\Media\\Domain\\Model\\Asset","__identifier":"some-other-asset"}}      | a1-2     |
-      | a2              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2", "text": "Link to asset://an-asset-to-change."}                                                                  | a2       |
-      | a3              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2", "text": "Link to asset://some-other-asset."}                                                                    | a3       |
+      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                                                                       | nodeName |
+      | a               | root                  | Neos.Neos:Site               | {}                                                                                          | site     |
+      | a1              | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1", "title": "Node a1", "asset": "Asset:an-asset-to-change"}           | a1       |
+      | a1-1            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-1", "title": "Node a1-1", "assets": ["Asset:an-asset-to-change"]}    | a1-1     |
+      | a1-2            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-2", "title": "Node a1-2", "asset": "Asset:some-other-asset"}         | a1-2     |
+      | a2              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2", "text": "Link to asset://an-asset-to-change."} | a2       |
+      | a3              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2", "text": "Link to asset://some-other-asset."}   | a3       |
     When the command RebaseWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |


### PR DESCRIPTION
Allows to use "Asset" objects in Behat tests during creation of nodes or changing of node properties:

```
Asset:asset-identifier
```

gets replaced by an object of `Neos\Media\Domain\Model\Asset` with id `asset-identifier`