### PR TITLE
BUGFIX: Fix handling of unset/nulled DataStructure keys

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -105,6 +105,9 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
 
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
+            if ($this->isUnset($key)) {
+                continue;
+            }
             $propertyPath = $key;
             if ($defaultFusionPrototypeName !== null && $this->isUntyped($key)) {
                 $propertyPath .= '<' . $defaultFusionPrototypeName . '>';
@@ -154,6 +157,21 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     }
 
     /**
+     * Returns TRUE if the given fusion key has been removed via ">"
+     *
+     * @param string|int $key fusion child key path to check
+     * @return bool
+     */
+    protected function isUnset(string|int $key): bool
+    {
+        $property = $this->properties[$key];
+        if (!is_array($property) ) {
+            return false;
+        }
+        return isset($property['__stopInheritanceChain']) && $property['__stopInheritanceChain'] === true;
+    }
+
+    /**
      * Returns TRUE if the given fusion key has no type, meaning neither
      * having a fusion objectType, eelExpression or value
      *
@@ -166,6 +184,8 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
         if (!is_array($property)) {
             return false;
         }
-        return !isset($property['__objectType']) && !isset($property['__eelExpression']) && !isset($property['__value']);
+        return !array_key_exists('__objectType', $property)
+            && !array_key_exists('__eelExpression', $property)
+            && !array_key_exists('__value', $property);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -105,11 +105,12 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
 
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
-            if ($this->isUnset($key)) {
+            $isUntyped = $this->isUntyped($key);
+            if ($isUntyped && $this->isUnset($key)) {
                 continue;
             }
             $propertyPath = $key;
-            if ($defaultFusionPrototypeName !== null && $this->isUntyped($key)) {
+            if ($defaultFusionPrototypeName !== null && $isUntyped) {
                 $propertyPath .= '<' . $defaultFusionPrototypeName . '>';
             }
             try {
@@ -168,7 +169,8 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
         if (!is_array($property)) {
             return false;
         }
-        return isset($property['__stopInheritanceChain']) && $property['__stopInheritanceChain'] === true;
+        return array_key_exists('__stopInheritanceChain', $property)
+            && $property['__stopInheritanceChain'] === true;
     }
 
     /**

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -165,7 +165,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     protected function isUnset(string|int $key): bool
     {
         $property = $this->properties[$key];
-        if (!is_array($property) ) {
+        if (!is_array($property)) {
             return false;
         }
         return isset($property['__stopInheritanceChain']) && $property['__stopInheritanceChain'] === true;

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -139,10 +139,40 @@ class DataStructureTest extends AbstractFusionObjectTest
     /**
      * @test
      */
-    public function unsetUntypedChildKeysWillRenderAsDataStructure(): void
+    public function unsetChildKeyWillNotRender(): void
     {
         $view = $this->buildView();
-        $view->setFusionPath('dataStructure/unsetUntypedChildKeyWillRenderAsDataStructure');
-        self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
+        $view->setFusionPath('dataStructure/unsetChildKeyWillNotRender');
+        self::assertEquals(['foo' => 'bar'], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function unsetUntypedChildKeyWillNotRender(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/unsetUntypedChildKeyWillNotRender');
+        self::assertEquals(['buz' => 456], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function nulledChildKeyWillRenderAsNull(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/nulledChildKeyWillRenderAsNull');
+        self::assertEquals(['foo' => 'bar', 'null2' => null], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function appliedNullValueWillRenderAsNull(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/appliedNullValueWillRenderAsNull');
+        self::assertEquals(['nullAttribute' => null], $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -143,7 +143,12 @@ dataStructure.untypedChildKeysWithPositionOrdering = Neos.Fusion:DataStructure {
   }
 }
 
-dataStructure.unsetUntypedChildKeyWillRenderAsDataStructure = Neos.Fusion:DataStructure {
+dataStructure.unsetChildKeyWillNotRender = Neos.Fusion:DataStructure {
+  foo = 'bar'
+  baz >
+}
+
+dataStructure.unsetUntypedChildKeyWillNotRender = Neos.Fusion:DataStructure {
   keyWithUnsetType = Neos.Fusion:Value {
     value = 123
   }
@@ -152,4 +157,16 @@ dataStructure.unsetUntypedChildKeyWillRenderAsDataStructure = Neos.Fusion:DataSt
     bat = 123
   }
   buz = 456
+}
+
+dataStructure.nulledChildKeyWillRenderAsNull = Neos.Fusion:DataStructure {
+  foo = 'bar'
+  null1 = null
+  null2 = ${null}
+}
+
+dataStructure.appliedNullValueWillRenderAsNull = Neos.Fusion:DataStructure {
+  @apply.attributes = ${{
+    nullAttribute: null
+  }}
 }


### PR DESCRIPTION
Re-establishes the Neos < 8.0 behavior of removed/nulled data structure keys

## Background:

With #3645 a lot of Fusion core logic was refactored. As an unwanted side-effect, `Neos.Fusion:DataStructure` prototypes (effectively all implementations of the `AbstractArrayFusionObject`) now behave differently when it comes to removed or nulled keys and

```fusion
Neos.Fusion:DataStructure {
    someProperty >
}
```

led to an array with:

```json
{"someProperty":[]}
```

in Neos 8.0+.

This fix reverts this side-effect, making the above return

```json
[]
```

again.

Fixes: #3859
Related: #3577, #3646