### PR TITLE
BUGFIX: Fix handling of unset/nulled DataStructure keys

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -121,6 +121,9 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
 
         $result = [];
         foreach ($sortedChildFusionKeys as $key) {
+            if ($this->isUnset($key)) {
+                continue;
+            }
             $propertyPath = $key;
             if ($defaultFusionPrototypeName !== null && $this->isUntyped($key)) {
                 $propertyPath .= '<' . $defaultFusionPrototypeName . '>';
@@ -205,6 +208,21 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
     }
 
     /**
+     * Returns TRUE if the given fusion key has been removed via ">"
+     *
+     * @param string|int $key fusion child key path to check
+     * @return bool
+     */
+    protected function isUnset(string|int $key): bool
+    {
+        $property = $this->properties[$key];
+        if (!is_array($property) ) {
+            return false;
+        }
+        return isset($property['__stopInheritanceChain']) && $property['__stopInheritanceChain'] === true;
+    }
+
+    /**
      * Returns TRUE if the given fusion key has no type, meaning neither
      * having a fusion objectType, eelExpression or value
      *
@@ -217,6 +235,8 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
         if (!is_array($property)) {
             return false;
         }
-        return !isset($property['__objectType']) && !isset($property['__eelExpression']) && !isset($property['__value']);
+        return !array_key_exists('__objectType', $property)
+            && !array_key_exists('__eelExpression', $property)
+            && !array_key_exists('__value', $property);
     }
 }

--- a/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
+++ b/Neos.Fusion/Classes/FusionObjects/AbstractArrayFusionObject.php
@@ -215,11 +215,7 @@ abstract class AbstractArrayFusionObject extends AbstractFusionObject implements
      */
     protected function isUnset(string|int $key): bool
     {
-        $property = $this->properties[$key];
-        if (!is_array($property) ) {
-            return false;
-        }
-        return isset($property['__stopInheritanceChain']) && $property['__stopInheritanceChain'] === true;
+        return $this->properties[$key] === ['__stopInheritanceChain' => true];
     }
 
     /**

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -12,6 +12,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 
 use Neos\Fusion\Exception\MissingFusionImplementationException;
+use Neos\Utility\PositionalArraySorter;
 
 /**
  * Testcase for the Fusion Dictionary
@@ -144,5 +145,36 @@ class DataStructureTest extends AbstractFusionObjectTest
         $view = $this->buildView();
         $view->setFusionPath('dataStructure/unsetUntypedChildKeyWillRenderAsDataStructure');
         self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function unsetChildKeyWillNotRender(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/unsetChildKeyWillNotRender');
+        self::assertEquals(['foo' => 'bar'], $view->render());
+    }
+
+    /**
+     * @test
+     * NOTE: This test mainly documents the current behavior. "null1" is removed by the {@see PositionalArraySorter} currently
+     */
+    public function nulledChildKeyWillRenderAsNull(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/nulledChildKeyWillRenderAsNull');
+        self::assertEquals(['foo' => 'bar', 'null2' => null], $view->render());
+    }
+
+    /**
+     * @test
+     */
+    public function appliedNullValueWillRenderAsNull(): void
+    {
+        $view = $this->buildView();
+        $view->setFusionPath('dataStructure/appliedNullValueWillRenderAsNull');
+        self::assertEquals(['nullAttribute' => null], $view->render());
     }
 }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/DataStructure.fusion
@@ -153,3 +153,20 @@ dataStructure.unsetUntypedChildKeyWillRenderAsDataStructure = Neos.Fusion:DataSt
   }
   buz = 456
 }
+
+dataStructure.unsetChildKeyWillNotRender = Neos.Fusion:DataStructure {
+  foo = 'bar'
+  baz >
+}
+
+dataStructure.nulledChildKeyWillRenderAsNull = Neos.Fusion:DataStructure {
+  foo = 'bar'
+  null1 = null
+  null2 = ${null}
+}
+
+dataStructure.appliedNullValueWillRenderAsNull = Neos.Fusion:DataStructure {
+  @apply.attributes = ${{
+    nullAttribute: null
+  }}
+}

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/DataStructure.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/DataStructure.feature
@@ -1,0 +1,78 @@
+@fixtures
+Feature: Tests for the "Neos.Fusion:DataStructure" Fusion prototype
+
+  Background:
+    Given I have the following Fusion setup:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    prototype(Neos.Neos:Test.DataStructure.Example) < prototype(Neos.Fusion:DataStructure) {
+      foo = 'string'
+      bar {
+        baz = true
+        foos {
+          bars = 123
+          removed >
+          null1 = null
+          null2 = ${null}
+        }
+      }
+    }
+    """
+
+  Scenario: DataStructure (default)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.DataStructure.Example {
+      @process.toJson = ${Json.stringify(value)}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    {"foo":"string","bar":{"baz":true,"foos":{"bars":123,"null2":null}}}
+    """
+
+  Scenario: DataStructure (with nulled keys)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.DataStructure.Example {
+      added = 123.45
+      bar.foos >
+      @process.toJson = ${Json.stringify(value)}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    {"foo":"string","bar":{"baz":true},"added":123.45}
+    """
+
+  Scenario: DataStructure (with removed keys)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.DataStructure.Example {
+      added = 123.45
+      bar.foos >
+      @process.toJson = ${Json.stringify(value)}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    {"foo":"string","bar":{"baz":true},"added":123.45}
+    """
+
+    # @see https://github.com/neos/neos-development-collection/issues/3859
+  Scenario: DataStructure (applied null keys)
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      @apply.attributes = ${{
+        nullAttribute: null
+      }}
+      @process.toJson = ${Json.stringify(value)}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    {"nullAttribute":null}
+    """


### PR DESCRIPTION
Re-establishes the Neos < 8.0 behavior of removed/nulled data structure keys

## Background:

With #3645 a lot of Fusion core logic was refactored. As an unwanted side-effect, `Neos.Fusion:DataStructure` prototypes (effectively all implementations of the `AbstractArrayFusionObject`) now behave differently when it comes to removed or nulled keys and

```fusion
Neos.Fusion:DataStructure {
    someProperty >
}
```

led to an array with:

```json
{"someProperty":[]}
```

in Neos 8.0+.

This fix reverts this side-effect, making the above return

```json
[]
```

again.

Fixes: #3859
Related: #3577, #3646