### PR TITLE
TASK: Workspace based tests

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
@@ -20,7 +20,7 @@ Feature: Run integrity violation detection regarding hierarchy relations and nod
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
@@ -20,7 +20,7 @@ Feature: Run integrity violation detection regarding parent relations
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -23,7 +23,7 @@ Feature: Run integrity violation detection regarding reference relations
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
@@ -20,7 +20,7 @@ Feature: Run integrity violation detection regarding sibling sorting
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
@@ -20,7 +20,7 @@ Feature: Run integrity violation detection regarding subtree tag inheritance
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
@@ -20,7 +20,7 @@ Feature: Run projection integrity violation detection regarding naming of tether
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
@@ -22,7 +22,7 @@ Feature: Sibling positions are properly resolved
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -43,7 +43,7 @@ Feature: Sibling positions are properly resolved
 
 
   Scenario: Trigger position update in DBAL graph
-    Given I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    Given I am in workspace "live" and dimension space point {"example": "general"}
     # distance i to x: 128
     # distance ii to x: 64
     When the command MoveNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
@@ -27,7 +27,7 @@ Feature: Create a root node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
@@ -25,7 +25,7 @@ Feature: Create a root node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
   Scenario: Create the initial root node aggregate using valid payload without dimensions
     When the command CreateRootNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -38,7 +38,7 @@ Feature: Create a root node aggregate with tethered children
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And I am user identified by "initiating-user-identifier"
 
   Scenario: Create root node with tethered children
@@ -133,7 +133,7 @@ Feature: Create a root node aggregate with tethered children
       | Key  | Value                |
       | text | "my sub sub default" |
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -40,7 +40,7 @@ Feature: Create a root node aggregate with tethered children
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am user identified by "initiating-user-identifier"
 
   Scenario: Create root node with tethered children
@@ -173,7 +173,7 @@ Feature: Create a root node aggregate with tethered children
       | Key  | Value                |
       | text | "my sub sub default" |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:
@@ -202,7 +202,7 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:
@@ -232,7 +232,7 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:
@@ -262,7 +262,7 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en_US"}
+    When I am in workspace "live" and dimension space point {"language": "en_US"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
@@ -26,7 +26,7 @@ Feature: Create a root node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
   Scenario: Create the initial root node aggregate using valid payload with dimensions
     When the command CreateRootNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -38,7 +38,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
@@ -40,7 +40,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -30,7 +30,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
@@ -149,7 +149,7 @@ Feature: Create node aggregate with node
       | Key         | Value        |
       | defaultText | "my default" |
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect the subgraph projection to consist of exactly 4 nodes
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
@@ -201,7 +201,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
@@ -241,7 +241,7 @@ Feature: Create node aggregate with node
       | nodeAggregateClassification | "regular"                                                      |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
@@ -285,7 +285,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
@@ -407,7 +407,7 @@ Feature: Create node aggregate with node
       | Key  | Value                |
       | text | "my sub sub default" |
 
-    When I am in the active content stream of workspace "live" and dimension space point []
+    When I am in workspace "live" and dimension space point []
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no parent node
     And I expect this node to have the following child nodes:
@@ -469,7 +469,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -30,7 +30,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -55,7 +55,7 @@ Feature: Create a node aggregate with complex default values
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And I am in dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -32,7 +32,6 @@ Feature: Create node aggregate with node
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
-    And I am in workspace "live"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -41,8 +40,7 @@ Feature: Create node aggregate with node
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in content stream "cs-identifier"
-    And I am in dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
@@ -26,7 +26,7 @@ Feature: Create node variant
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"market":"DE", "language":"gsw"}
+    And I am in workspace "live" and dimension space point {"market":"DE", "language":"gsw"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -30,7 +30,7 @@ Feature: Create node specialization
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -49,7 +49,7 @@ Feature: Create node specialization
       | invariable-mc-nodeface | invariable-document | nody-mc-nodeface       |                                  | Neos.ContentRepository.Testing:LeafDocument | {}                                                                                         |
 
   Scenario: check the tree state before the specialization
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    When I am in workspace "live" and dimension space point {"example":"source"}
     And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 3 levels deep should be:
       | Level | nodeAggregateId        |
       | 0     | lady-eleonode-rootford |
@@ -106,7 +106,7 @@ Feature: Create node specialization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]
@@ -143,7 +143,7 @@ Feature: Create node specialization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"spec"}
+    When I am in workspace "live" and dimension space point {"example":"spec"}
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 3 levels deep should be:
@@ -218,7 +218,7 @@ Feature: Create node specialization
       | cs-identifier;eldest-mc-nodeface;{"example":"source"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"leafSpec"}
+    When I am in workspace "live" and dimension space point {"example":"leafSpec"}
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -335,7 +335,7 @@ Feature: Create node specialization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]
@@ -372,7 +372,7 @@ Feature: Create node specialization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"spec"}
+    When I am in workspace "live" and dimension space point {"example":"spec"}
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -436,7 +436,7 @@ Feature: Create node specialization
       | cs-identifier;eldest-mc-nodeface;{"example":"source"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"leafSpec"}
+    When I am in workspace "live" and dimension space point {"example":"leafSpec"}
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -30,7 +30,7 @@ Feature: Create node generalization
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -123,7 +123,7 @@ Feature: Create node generalization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"general"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"rootGeneral"},{"example":"general"},{"example":"source"},{"example":"specB"}]
@@ -160,7 +160,7 @@ Feature: Create node generalization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"},{"example":"general"}]
     And I expect this node aggregate to cover dimension space points [{"example":"general"},{"example":"source"},{"example":"specB"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    When I am in workspace "live" and dimension space point {"example":"source"}
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -221,7 +221,7 @@ Feature: Create node generalization
       | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"general"}
+    When I am in workspace "live" and dimension space point {"example":"general"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -286,7 +286,7 @@ Feature: Create node generalization
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"rootGeneral"}
+    When I am in workspace "live" and dimension space point {"example":"rootGeneral"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
@@ -299,7 +299,7 @@ Feature: Create node generalization
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"specB"}
+    When I am in workspace "live" and dimension space point {"example":"specB"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -439,7 +439,7 @@ Feature: Create node generalization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"rootGeneral"},{"example":"general"},{"example":"source"},{"example":"specB"}]
@@ -472,7 +472,7 @@ Feature: Create node generalization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"general"}
+    When I am in workspace "live" and dimension space point {"example":"general"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -511,7 +511,7 @@ Feature: Create node generalization
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "specB"}
+    When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -625,7 +625,7 @@ Feature: Create node generalization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"rootGeneral"},{"example":"general"},{"example":"source"},{"example":"specB"}]
@@ -658,7 +658,7 @@ Feature: Create node generalization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"general"}
+    When I am in workspace "live" and dimension space point {"example":"general"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -697,7 +697,7 @@ Feature: Create node generalization
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "specB"}
+    When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -811,7 +811,7 @@ Feature: Create node generalization
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"rootGeneral"},{"example":"general"},{"example":"source"},{"example":"specB"}]
@@ -844,7 +844,7 @@ Feature: Create node generalization
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"rootGeneral"}
+    When I am in workspace "live" and dimension space point {"example":"rootGeneral"}
     Then I expect the subgraph projection to consist of exactly 4 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -867,7 +867,7 @@ Feature: Create node generalization
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -906,7 +906,7 @@ Feature: Create node generalization
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "specB"}
+    When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -30,7 +30,7 @@ Feature: Create node peer variant
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -132,7 +132,7 @@ Feature: Create node peer variant
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"peer"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"peer"},{"example":"peerSpec"}]
@@ -169,7 +169,7 @@ Feature: Create node peer variant
     And I expect this node aggregate to occupy dimension space points [{"example":"source"},{"example":"peer"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"peer"},{"example":"peerSpec"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    When I am in workspace "live" and dimension space point {"example":"source"}
     Then I expect the subgraph projection to consist of exactly 7 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -206,7 +206,7 @@ Feature: Create node peer variant
       | cs-identifier;elder-mc-nodeface;{"example":"source"} |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"peer"}
+    When I am in workspace "live" and dimension space point {"example":"peer"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -271,7 +271,7 @@ Feature: Create node peer variant
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"peerSpec"}
+    When I am in workspace "live" and dimension space point {"example":"peerSpec"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -410,7 +410,7 @@ Feature: Create node peer variant
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"peer"},{"example":"peerSpec"}]
@@ -443,7 +443,7 @@ Feature: Create node peer variant
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"peer"}
+    When I am in workspace "live" and dimension space point {"example":"peer"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -473,7 +473,7 @@ Feature: Create node peer variant
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peerSpec"}
+    When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -577,7 +577,7 @@ Feature: Create node peer variant
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"peer"},{"example":"peerSpec"}]
@@ -610,7 +610,7 @@ Feature: Create node peer variant
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"peer"}
+    When I am in workspace "live" and dimension space point {"example":"peer"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -640,7 +640,7 @@ Feature: Create node peer variant
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peerSpec"}
+    When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -721,7 +721,7 @@ Feature: Create node peer variant
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"peer"},{"example":"peerSpec"}]
@@ -754,7 +754,7 @@ Feature: Create node peer variant
     And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example":"peer"}
+    When I am in workspace "live" and dimension space point {"example":"peer"}
     Then I expect the subgraph projection to consist of exactly 4 nodes
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -772,7 +772,7 @@ Feature: Create node peer variant
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-child-mc-nodeface" and node path "elder-document/elder-child-document" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peerSpec"}
+    When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 4 nodes
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
@@ -26,7 +26,7 @@ Feature: Set node properties: Constraint checks
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -64,7 +64,7 @@ Feature: Set properties
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
@@ -37,7 +37,7 @@ Feature: Set node properties with different scopes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
@@ -46,7 +46,7 @@ Feature: Constraint checks on SetNodeReferences
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
@@ -51,7 +51,7 @@ Feature: Node References without Dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
@@ -30,7 +30,7 @@ Feature: Node References with Dimensions
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -49,7 +49,7 @@ Feature: Node References with Dimensions
       | references                    | [{"target": "anthony-destinode"}] |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -59,7 +59,7 @@ Feature: Node References with Dimensions
       | Name              | Node                                               | Properties |
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
@@ -44,7 +44,7 @@ Feature: Set node properties with different scopes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -120,7 +120,7 @@ Feature: Set node properties with different scopes
       | references                      | [{"target": "anthony-destinode"}] |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "mul"}
+    When I am in workspace "live" and dimension space point {"language": "mul"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "mul"}
     And I expect this node to have the following references:
       | Name                          | Node                                                | Properties |
@@ -133,7 +133,7 @@ Feature: Set node properties with different scopes
       | nodeAggregateScopedReference  | cs-identifier;source-nodandaise;{"language": "mul"} | null       |
       | nodeAggregateScopedReferences | cs-identifier;source-nodandaise;{"language": "mul"} | null       |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name                            | Node                                                | Properties |
@@ -157,7 +157,7 @@ Feature: Set node properties with different scopes
       | unscopedReference               | cs-identifier;source-nodandaise;{"language": "de"} | null       |
       | unscopedReferences              | cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "gsw"}
     And I expect this node to have the following references:
       | Name                            | Node                                                | Properties |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
@@ -30,7 +30,7 @@ Feature: Node References with Dimensions
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -57,7 +57,7 @@ Feature: Node References with Dimensions
     And the graph projection is fully up to date
 
     # after specialization, the reference must still exist on the specialized node
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "ch"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -68,7 +68,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "ch"} | null       |
 
     # the reference must also exist on the non-touched nodes
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -89,7 +89,7 @@ Feature: Node References with Dimensions
     And the graph projection is fully up to date
 
     # reference to self (modified 2 lines above)
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "ch"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -99,7 +99,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "ch"} | null       |
 
     # unmodified on the untouched nodes
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -127,7 +127,7 @@ Feature: Node References with Dimensions
 
 
     # on the specialization, the reference exists.
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "ch"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -138,7 +138,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "ch"} | null       |
 
     # on the other nodes, the reference does not exist.
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have no references
@@ -170,7 +170,7 @@ Feature: Node References with Dimensions
     And the graph projection is fully up to date
 
     # after creating a peer, the reference must still exist on the peer node
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "en"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -181,7 +181,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "en"} | null       |
 
     # the reference must also exist on the non-touched nodes
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -191,7 +191,7 @@ Feature: Node References with Dimensions
       | Name              | Node                                               | Properties |
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -212,7 +212,7 @@ Feature: Node References with Dimensions
     And the graph projection is fully up to date
 
     # reference to self (modified 2 lines above)
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "en"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -222,7 +222,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "en"} | null       |
 
     # unmodified on the untouched nodes
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -232,7 +232,7 @@ Feature: Node References with Dimensions
       | Name              | Node                                               | Properties |
       | referenceProperty | cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -269,7 +269,7 @@ Feature: Node References with Dimensions
     And the graph projection is fully up to date
 
     # after generalizing, the reference must still exist on the generalized node
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "ch-only" to lead to node cs-identifier;ch-only;{"language": "de"}
     Then I expect this node to have the following references:
       | Name              | Node                                               | Properties |
@@ -280,7 +280,7 @@ Feature: Node References with Dimensions
       | referenceProperty | cs-identifier;ch-only;{"language": "de"} | null       |
 
     # the reference must also exist on the non-touched node
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "ch-only" to lead to node cs-identifier;ch-only;{"language": "ch"}
     Then I expect this node to have the following references:
       | Name              | Node                                               | Properties |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -23,7 +23,7 @@ Feature: Constraint checks on node aggregate disabling
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -24,7 +24,7 @@ Feature: Disable a node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -58,7 +58,7 @@ Feature: Disable a node aggregate
       | tag                          | "disabled"               |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
@@ -69,7 +69,7 @@ Feature: Disable a node aggregate
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -26,7 +26,7 @@ Feature: Disable a node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -68,7 +68,7 @@ Feature: Disable a node aggregate
       | tag                          | "disabled"                                                  |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
@@ -320,7 +320,7 @@ Feature: Disable a node aggregate
       | tag                          | "disabled"                                                                                         |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
@@ -23,7 +23,7 @@ Feature: Enable a node aggregate
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -24,7 +24,7 @@ Feature: Enable a node aggregate
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -64,7 +64,7 @@ Feature: Enable a node aggregate
       | tag                  | "disabled"               |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
@@ -75,7 +75,7 @@ Feature: Enable a node aggregate
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And VisibilityConstraints are set to "frontend"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -146,14 +146,14 @@ Feature: Enable a node aggregate
       | tag                  | "disabled"               |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
     And I expect the node aggregate "nody-mc-nodeface" to exist
     And I expect this node aggregate to disable dimension space points [{}]
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And VisibilityConstraints are set to "frontend"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
@@ -224,14 +224,14 @@ Feature: Enable a node aggregate
       | tag                  | "disabled"         |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{}]
     And I expect the node aggregate "nody-mc-nodeface" to exist
     And I expect this node aggregate to disable dimension space points []
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And VisibilityConstraints are set to "frontend"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -26,7 +26,7 @@ Feature: Enable a node aggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -82,7 +82,7 @@ Feature: Enable a node aggregate
       | tag                          | "disabled"                                                |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
@@ -378,7 +378,7 @@ Feature: Enable a node aggregate
       | tag                          | "disabled"                          |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
@@ -706,7 +706,7 @@ Feature: Enable a node aggregate
       | nodeVariantSelectionStrategy | "allVariants"      |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
     Then I expect the node aggregate "the-great-nodini" to exist
     And I expect this node aggregate to disable dimension space points []

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -22,7 +22,7 @@ Feature: Creation of nodes underneath disabled nodes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -24,7 +24,7 @@ Feature: Creation of nodes underneath disabled nodes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -22,7 +22,7 @@ Feature: Variation of hidden nodes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"mul"}
+    And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
@@ -27,7 +27,7 @@ Feature: Remove NodeAggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -24,7 +24,7 @@ Feature: Remove NodeAggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -26,7 +26,7 @@ Feature: Remove NodeAggregate
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"en"}
+    And I am in workspace "live" and dimension space point {"language":"en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -32,7 +32,7 @@ Feature: Recreate a node variant
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"en"}
+    And I am in workspace "live" and dimension space point {"language":"en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -94,7 +94,7 @@ Feature: Recreate a node variant
       | targetOrigin    | {"language":"de"}  |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-ws" and dimension space point {"language": "de"}
+    When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node new-user-cs-id;sir-david-nodenborough;{"language": "de"}
     Then I expect node aggregate identifier "nodimus-prime" and node path "document/tethered-document" to lead to node new-user-cs-id;nodimus-prime;{"language": "de"}
     Then I expect node aggregate identifier "nodimus-mediocre" and node path "document/tethered-document/tethered" to lead to node new-user-cs-id;nodimus-mediocre;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -31,7 +31,7 @@ Feature: Create node specialization
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -69,7 +69,7 @@ Feature: Create node specialization
     And I expect a node identified by cs-identifier;younger-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -32,7 +32,7 @@ Feature: Create node specialization
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -79,7 +79,7 @@ Feature: Create node specialization
     And I expect a node identified by cs-identifier;younger-mc-nodeface;{"example":"source"} to exist in the content graph
     And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
 
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to occupy dimension space points [{}]
     And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
@@ -36,7 +36,7 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    And I am in workspace "live" and dimension space point {"example": "source"}
     And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
@@ -25,7 +25,7 @@ Feature: Move a node with content dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -59,7 +59,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -70,7 +70,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -81,7 +81,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -91,7 +91,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -126,7 +126,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                              |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -137,7 +137,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -148,7 +148,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -158,7 +158,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -194,7 +194,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -206,7 +206,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -218,7 +218,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -228,7 +228,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -258,7 +258,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -270,7 +270,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -282,7 +282,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -294,7 +294,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -331,7 +331,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                             |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -343,7 +343,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -355,7 +355,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -366,7 +366,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -403,7 +403,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -415,7 +415,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -427,7 +427,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -439,7 +439,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -469,7 +469,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -480,7 +480,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -491,7 +491,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -502,7 +502,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -538,7 +538,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -549,7 +549,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -560,7 +560,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -570,7 +570,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -606,7 +606,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                     |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -618,7 +618,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -630,7 +630,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -640,7 +640,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -670,7 +670,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                                       |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -682,7 +682,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -694,7 +694,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -706,7 +706,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -743,7 +743,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                                                                                                                       |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -755,7 +755,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -767,7 +767,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -778,7 +778,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -815,7 +815,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                                                                                                         |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -827,7 +827,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -839,7 +839,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -851,7 +851,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -883,7 +883,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -895,7 +895,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -906,7 +906,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -916,7 +916,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -952,7 +952,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -964,7 +964,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -975,7 +975,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -985,7 +985,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1022,7 +1022,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1034,7 +1034,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1046,7 +1046,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1056,7 +1056,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1086,7 +1086,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1098,7 +1098,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1110,7 +1110,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1122,7 +1122,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1159,7 +1159,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1171,7 +1171,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1183,7 +1183,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1194,7 +1194,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1231,7 +1231,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1243,7 +1243,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1255,7 +1255,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1267,7 +1267,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1297,7 +1297,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1309,7 +1309,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1320,7 +1320,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1331,7 +1331,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1368,7 +1368,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1380,7 +1380,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1391,7 +1391,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1401,7 +1401,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1438,7 +1438,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1450,7 +1450,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1462,7 +1462,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1472,7 +1472,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1502,7 +1502,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1514,7 +1514,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1526,7 +1526,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1538,7 +1538,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1575,7 +1575,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1587,7 +1587,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1599,7 +1599,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1610,7 +1610,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1647,7 +1647,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1659,7 +1659,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1671,7 +1671,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1683,7 +1683,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1715,7 +1715,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1727,7 +1727,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1738,7 +1738,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1749,7 +1749,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1789,7 +1789,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1801,7 +1801,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1811,7 +1811,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1822,7 +1822,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1852,7 +1852,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1864,7 +1864,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1876,7 +1876,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1888,7 +1888,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1926,7 +1926,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1938,7 +1938,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1949,7 +1949,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1961,7 +1961,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1998,7 +1998,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2010,7 +2010,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2020,7 +2020,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2031,7 +2031,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2068,7 +2068,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2080,7 +2080,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2090,7 +2090,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2101,7 +2101,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2131,7 +2131,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                      |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2143,7 +2143,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2155,7 +2155,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2167,7 +2167,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -25,7 +25,7 @@ Feature: Move a node with content dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -64,7 +64,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -75,7 +75,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -86,7 +86,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -97,7 +97,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -133,7 +133,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                          |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -144,7 +144,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -155,7 +155,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -165,7 +165,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -201,7 +201,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                       |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -213,7 +213,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -225,7 +225,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -235,7 +235,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -265,7 +265,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                       |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -277,7 +277,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -289,7 +289,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -301,7 +301,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -336,7 +336,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                         |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -348,7 +348,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -360,7 +360,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -371,7 +371,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -408,7 +408,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                 |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -420,7 +420,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -432,7 +432,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -442,7 +442,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -472,7 +472,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -483,7 +483,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -494,7 +494,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -505,7 +505,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -541,7 +541,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -552,7 +552,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -563,7 +563,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -573,7 +573,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -609,7 +609,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                             |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -621,7 +621,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -633,7 +633,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -643,7 +643,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -673,7 +673,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -685,7 +685,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -697,7 +697,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -709,7 +709,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -746,7 +746,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -758,7 +758,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -770,7 +770,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -781,7 +781,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -818,7 +818,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                                                                                                                                                                    |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -830,7 +830,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -842,7 +842,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     # The given preceding sibling cannot be resolved and since elder-mc-nodeface isn't given as a succeeding sibling, the node is moved at the end
@@ -853,7 +853,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;elder-mc-nodeface;{"example": "general"}    |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -885,7 +885,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -895,7 +895,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -906,7 +906,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -917,7 +917,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -952,7 +952,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                 |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -962,7 +962,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -973,7 +973,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -983,7 +983,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1018,7 +1018,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1028,7 +1028,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1040,7 +1040,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1050,7 +1050,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1078,7 +1078,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1088,7 +1088,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1100,7 +1100,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1112,7 +1112,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1147,7 +1147,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1157,7 +1157,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1169,7 +1169,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1180,7 +1180,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1215,7 +1215,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1225,7 +1225,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1237,7 +1237,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1247,7 +1247,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1275,7 +1275,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1285,7 +1285,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1296,7 +1296,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1307,7 +1307,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1342,7 +1342,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1352,7 +1352,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1363,7 +1363,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1373,7 +1373,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1408,7 +1408,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1418,7 +1418,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1430,7 +1430,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1440,7 +1440,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1468,7 +1468,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                    |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1478,7 +1478,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1490,7 +1490,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1502,7 +1502,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1537,7 +1537,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                                                    |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1547,7 +1547,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1559,7 +1559,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1570,7 +1570,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1605,7 +1605,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1615,7 +1615,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1627,7 +1627,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1638,7 +1638,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;elder-mc-nodeface;{"example": "general"}    |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1668,7 +1668,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"eldest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1678,7 +1678,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1689,7 +1689,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1699,7 +1699,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1738,7 +1738,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1748,7 +1748,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1758,7 +1758,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
@@ -1768,7 +1768,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1796,7 +1796,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1806,7 +1806,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1818,7 +1818,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1828,7 +1828,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1864,7 +1864,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1874,7 +1874,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1885,7 +1885,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1895,7 +1895,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1930,7 +1930,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1940,7 +1940,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1950,7 +1950,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1960,7 +1960,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}   |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -1995,7 +1995,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2005,7 +2005,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2015,7 +2015,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2025,7 +2025,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;eldest-mc-nodeface;{"example": "general"}  |
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2053,7 +2053,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-david-nodenborough"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2063,7 +2063,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2073,7 +2073,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                               |
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2085,7 +2085,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                         |
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -2128,5 +2128,5 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":null}] |
 
     And the graph projection is fully up to date
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface-ii" to lead to node cs-identifier;nody-mc-nodeface-ii;{"example": "general"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
@@ -22,7 +22,7 @@ Feature: Move a node with content dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -68,7 +68,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "sir-nodeward-nodington-iii"                                                                                                                                           |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"bustling-destinode"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"younger-destinode"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -78,7 +78,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -90,7 +90,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;bustling-destinode;{"example": "general"} |
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -101,7 +101,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                      |
       | cs-identifier;younger-destinode;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -137,7 +137,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "bustling-destinode"                                                                                                                    |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -147,19 +147,19 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/bustling-target-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/bustling-target-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -195,7 +195,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-destinode"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -206,7 +206,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                      |
       | cs-identifier;younger-destinode;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -217,7 +217,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;elder-destinode;{"example": "general"}   |
       | cs-identifier;younger-destinode;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/esquire-child/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;nodimus-mediocre;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -227,7 +227,7 @@ Feature: Move a node with content dimensions
       | NodeDiscriminator                                            |
       | cs-identifier;younger-child-destinode;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -273,7 +273,7 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | null                                                                                                                                                                    |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"bustling-destinode"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"bustling-destinode"}] |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -284,7 +284,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;bustling-destinode;{"example": "general"} |
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -295,7 +295,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;bustling-destinode;{"example": "general"} |
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "elder-destinode" and node path "esquire/esquire-child/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;nodimus-mediocre;{"example": "general"}
     And I expect this node to have the following preceding siblings:
@@ -306,7 +306,7 @@ Feature: Move a node with content dimensions
       | cs-identifier;bustling-destinode;{"example": "general"}      |
       | cs-identifier;younger-child-destinode;{"example": "general"} |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -28,7 +28,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -60,7 +60,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -71,7 +71,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -82,7 +82,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -93,7 +93,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -121,7 +121,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -132,7 +132,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -143,7 +143,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -154,7 +154,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -184,7 +184,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -195,7 +195,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -206,7 +206,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -217,7 +217,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -245,7 +245,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -256,7 +256,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -267,7 +267,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -278,7 +278,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -309,7 +309,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -320,7 +320,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -331,7 +331,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -342,7 +342,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -371,7 +371,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -382,7 +382,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -393,7 +393,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -404,7 +404,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -443,7 +443,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -454,7 +454,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -465,7 +465,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -476,7 +476,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -513,7 +513,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -524,7 +524,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -535,7 +535,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -546,7 +546,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -583,7 +583,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -594,7 +594,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -605,7 +605,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -616,7 +616,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -653,7 +653,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -664,7 +664,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -675,7 +675,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -686,7 +686,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -723,7 +723,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -734,7 +734,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -745,7 +745,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -756,7 +756,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -793,7 +793,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -804,7 +804,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -815,7 +815,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -826,7 +826,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -863,7 +863,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -874,7 +874,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -885,7 +885,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -896,7 +896,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -933,7 +933,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -944,7 +944,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -955,7 +955,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -966,7 +966,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1005,7 +1005,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1016,7 +1016,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1027,7 +1027,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1038,7 +1038,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1075,7 +1075,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1086,7 +1086,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1097,7 +1097,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1108,7 +1108,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1145,7 +1145,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1156,7 +1156,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1167,7 +1167,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1178,7 +1178,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1215,7 +1215,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1226,7 +1226,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1237,7 +1237,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1248,7 +1248,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1285,7 +1285,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1296,7 +1296,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1307,7 +1307,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1318,7 +1318,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1355,7 +1355,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1366,7 +1366,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1377,7 +1377,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1388,7 +1388,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1425,7 +1425,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1436,7 +1436,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1447,7 +1447,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1458,7 +1458,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1495,7 +1495,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1506,7 +1506,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1517,7 +1517,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
@@ -1528,7 +1528,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1559,7 +1559,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1570,7 +1570,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1581,7 +1581,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1592,7 +1592,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1621,7 +1621,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1632,7 +1632,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1643,7 +1643,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1654,7 +1654,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1693,7 +1693,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1704,7 +1704,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1715,7 +1715,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1726,7 +1726,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1763,7 +1763,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1774,7 +1774,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1785,7 +1785,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1796,7 +1796,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1833,7 +1833,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1844,7 +1844,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1855,7 +1855,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1866,7 +1866,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1903,7 +1903,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1914,7 +1914,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1925,7 +1925,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1936,7 +1936,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1973,7 +1973,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1984,7 +1984,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -1995,7 +1995,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2006,7 +2006,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2043,7 +2043,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2054,7 +2054,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2065,7 +2065,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2076,7 +2076,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2113,7 +2113,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2124,7 +2124,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2135,7 +2135,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2146,7 +2146,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2183,7 +2183,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2194,7 +2194,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2205,7 +2205,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2216,7 +2216,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2255,7 +2255,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2266,7 +2266,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2277,7 +2277,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2288,7 +2288,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2325,7 +2325,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2336,7 +2336,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2347,7 +2347,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2358,7 +2358,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2395,7 +2395,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2406,7 +2406,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2417,7 +2417,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2428,7 +2428,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2465,7 +2465,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2476,7 +2476,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2487,7 +2487,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2498,7 +2498,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2535,7 +2535,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2546,7 +2546,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2557,7 +2557,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2568,7 +2568,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2605,7 +2605,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2616,7 +2616,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2627,7 +2627,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2638,7 +2638,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2675,7 +2675,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2686,7 +2686,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2697,7 +2697,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2708,7 +2708,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2745,7 +2745,7 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2756,7 +2756,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "source"}
+    When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2767,7 +2767,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "spec"}
+    When I am in workspace "live" and dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
@@ -2778,7 +2778,7 @@ Feature: Move a node aggregate into and out of a tagged parent
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"example": "peer"}
+    When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
@@ -18,7 +18,7 @@ Feature: Additional constraint checks after move node capabilities are introduce
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example": "general"}
+    And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -24,7 +24,7 @@ Feature: Move a node without content dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -78,7 +78,7 @@ Feature: Move a node without content dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -113,7 +113,7 @@ Feature: Move a node without content dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -167,7 +167,7 @@ Feature: Move a node without content dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -213,7 +213,7 @@ Feature: Move a node without content dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
@@ -24,7 +24,7 @@ Feature: ForkContentStream Without Dimensions
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -23,7 +23,7 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -24,7 +24,7 @@ Feature: ForkContentStream Without Dimensions
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -29,7 +29,7 @@ Feature: On forking a content stream, node references should be copied as well.
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
@@ -72,7 +72,7 @@ Feature: Add Dimension Specialization
               to: { language: 'ch' }
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live"
+    When I am in workspace "live"
     And I am in dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
@@ -124,12 +124,12 @@ Feature: Add Dimension Specialization
       | text | "changed" |
 
     # the original content stream was untouched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to have the following properties:
       | Key  | Value   |
       | text | "hello" |
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
 
     When I run integrity violation detection
@@ -145,7 +145,7 @@ Feature: Add Dimension Specialization
     And the graph projection is fully up to date
 
     # ensure the node is disabled
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
@@ -23,7 +23,7 @@ Feature: Add New Property
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -75,7 +75,7 @@ Feature: Add New Property
               type: 'DateTime'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
@@ -29,7 +29,7 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                   |
@@ -79,19 +79,19 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
 
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to have the following properties:
       | Key  | Value           |
       | text | "Original text" |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to have the following properties:
       | Key  | Value           |
       | text | "Original text" |
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
@@ -24,7 +24,7 @@ Feature: Change Property
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -59,7 +59,7 @@ Feature: Change Property
               newSerializedValue: 'fixed value'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
@@ -23,7 +23,7 @@ Feature: Filter - Node Name
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -81,7 +81,7 @@ Feature: Filter - Node Name
               newSerializedValue: 'fixed value'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "na-name1" to lead to node cs-identifier;na-name1;{}
     And I expect this node to have the following properties:
       | Key  | Value            |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
@@ -24,7 +24,7 @@ Feature: Filter - Property not empty
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -91,7 +91,7 @@ Feature: Filter - Property not empty
               newSerializedValue: 'fixed value'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "na-name1" to lead to node cs-identifier;na-name1;{}
     And I expect this node to have the following properties:
       | Key  | Value            |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
@@ -23,7 +23,7 @@ Feature: Filter - Property Value
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -92,7 +92,7 @@ Feature: Filter - Property Value
               newSerializedValue: 'fixed value'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "na-name1" to lead to node cs-identifier;na-name1;{}
     And I expect this node to have the following properties:
       | Key  | Value            |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
@@ -35,7 +35,7 @@ Feature: Move dimension space point
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -96,7 +96,7 @@ Feature: Move dimension space point
     And the graph projection is fully up to date
 
     # ensure the node is disabled
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
@@ -120,7 +120,7 @@ Feature: Move dimension space point
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
@@ -30,7 +30,7 @@ Feature: Adjust node types with a node migration
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId     | "lady-eleonode-rootford"                                                   |
@@ -75,11 +75,11 @@ Feature: Adjust node types with a node migration
               newType: 'Neos.ContentRepository.Testing:OtherDocument'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
     # ... also in the fallback dimension
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
@@ -28,7 +28,7 @@ Feature: Adjust node types with a node migration
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -73,7 +73,7 @@ Feature: Adjust node types with a node migration
               newType: 'Neos.ContentRepository.Testing:OtherDocument'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
@@ -27,7 +27,7 @@ Feature: Remove Nodes
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                       |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                    |
@@ -72,13 +72,13 @@ Feature: Remove Nodes
             type: 'RemoveNode'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in de and gsw (virtual specialization)
@@ -118,13 +118,13 @@ Feature: Remove Nodes
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in de and gsw, since it is a specialization
@@ -188,13 +188,13 @@ Feature: Remove Nodes
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in gsw
@@ -229,13 +229,13 @@ Feature: Remove Nodes
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in gsw
@@ -275,13 +275,13 @@ Feature: Remove Nodes
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in gsw
@@ -313,13 +313,13 @@ Feature: Remove Nodes
     """
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "gsw"}
+    When I am in workspace "live" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "de"}
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    When I am in workspace "live" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language": "en"}
 
     # the node was removed inside the new content stream, but only in gsw

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
@@ -24,7 +24,7 @@ Feature: Remove Property
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -58,7 +58,7 @@ Feature: Remove Property
               property: 'text'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
@@ -27,7 +27,7 @@ Feature: Rename Node Aggregate
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId     | "lady-eleonode-rootford"                                                   |
@@ -72,10 +72,10 @@ Feature: Rename Node Aggregate
 
 
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect the node "sir-david-nodenborough" to have the name "foo"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language": "ch"}
+    When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect the node "sir-david-nodenborough" to have the name "foo"
 
     # the node was changed inside the new content stream, across all dimensions

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
@@ -24,7 +24,7 @@ Feature: Rename Property
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -72,7 +72,7 @@ Feature: Rename Property
               to: 'newText'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
@@ -24,7 +24,7 @@ Feature: Strip Tags on Property
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -58,7 +58,7 @@ Feature: Strip Tags on Property
               property: 'text'
     """
     # the original content stream has not been touched
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value                  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
@@ -16,7 +16,7 @@ Feature: Copy nodes (without dimensions)
       | workspaceDescription           | "The live workspace"                   |
       | newContentStreamId     | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |
@@ -54,7 +54,7 @@ Feature: Copy nodes (without dimensions)
     And the graph projection is fully up to date
 
   Scenario: Copy
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     # node to copy (currentNode): "sir-nodeward-nodington-iii"
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     When the command CopyNodesRecursively is executed, copying the current node aggregate with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
@@ -17,7 +17,7 @@ Feature: Node Property Conversion
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -35,7 +35,7 @@ Feature: Node Property Conversion
 
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key          | Value                          |
@@ -58,7 +58,7 @@ Feature: Node Property Conversion
       | propertyValues            | {"dateProperty": "Date:1997-07-19T19:20:30+05:00"} |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key          | Value                          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -24,7 +24,7 @@ Feature: Disable a node aggregate
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -65,7 +65,7 @@ Feature: Disable a node aggregate
       | nodeName                      | "child-document"                          |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
@@ -76,7 +76,7 @@ Feature: Disable a node aggregate
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And VisibilityConstraints are set to "frontend"
     Then the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
       | Level | nodeAggregateId |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -20,7 +20,7 @@ Feature: Remove NodeAggregate
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "live-cs-identifier"                   |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | nodeAggregateId  | "lady-eleonode-nodesworth"             |
@@ -65,11 +65,11 @@ Feature: Remove NodeAggregate
     Then I expect the graph projection to consist of exactly 1 node
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
 
-    When I am in content stream "live-cs-identifier" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
 
-    When I am in content stream "live-cs-identifier" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
 
@@ -82,7 +82,7 @@ Feature: Remove NodeAggregate
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "user-test"
+    And I am in workspace "user-test"
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -97,22 +97,22 @@ Feature: Remove NodeAggregate
     And I expect a node identified by live-cs-identifier;nody-mc-nodeface;{"language":"gsw"} to exist in the content graph
     And I expect a node identified by live-cs-identifier;nodimus-prime;{"language":"de"} to exist in the content graph
 
-    When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node user-cs-identifier;lady-eleonode-nodesworth;{}
 
-    When I am in content stream "user-cs-identifier" and dimension space point {"language":"gsw"}
+    When I am in workspace "user-test" and dimension space point {"language":"gsw"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node user-cs-identifier;lady-eleonode-nodesworth;{}
 
     # ensure LIVE ContentStream is untouched
-    When I am in content stream "live-cs-identifier" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect node aggregate identifier "nodimus-prime" and node path "document/child-document" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
 
-    When I am in content stream "live-cs-identifier" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"gsw"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/01_ChangeNodeAggregateName_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/01_ChangeNodeAggregateName_ConstraintChecks.feature
@@ -24,7 +24,7 @@ Feature: Change node name
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
 
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRenaming/ChangeNodeAggregateName.feature
@@ -18,7 +18,7 @@ Feature: Change node name
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
 
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -64,7 +64,7 @@ Feature: Change node name
       | nodeAggregateClassification | "regular"                                |
     And the graph projection is fully up to date
     # we read the node initially, to ensure it is filled in the cache (to check whether cache clearing actually works)
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name | NodeDiscriminator                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_BasicErrorCases.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_BasicErrorCases.feature
@@ -50,7 +50,7 @@ Feature: Change node aggregate type - basic error cases
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_DeleteStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_DeleteStrategy.feature
@@ -66,7 +66,7 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -101,13 +101,13 @@ Feature: Change node aggregate type - behavior of DELETE strategy
     And the graph projection is fully up to date
 
     # the type has changed
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:ParentNodeTypeB"
 
     # the child nodes have been removed
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
   Scenario: Try to change to a node type that disallows already present grandchildren with the delete conflict resolution strategy
@@ -138,19 +138,19 @@ Feature: Change node aggregate type - behavior of DELETE strategy
     And the graph projection is fully up to date
 
     # the type has changed
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "parent2-na" to lead to node cs-identifier;parent2-na;{"language":"de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:ParentNodeTypeB"
 
     # the child nodes still exist
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "autocreated-child" to lead to node cs-identifier;autocreated-child;{"language":"de"}
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "autocreated-child" to lead to node cs-identifier;autocreated-child;{"language":"de"}
 
     # the grandchild nodes have been removed
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
 
@@ -181,11 +181,11 @@ Feature: Change node aggregate type - behavior of DELETE strategy
     And the graph projection is fully up to date
 
     # the type has changed
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "nodea-identifier-de" to lead to node cs-identifier;nodea-identifier-de;{"language":"de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nodea-identifier-de" to lead to node cs-identifier;nodea-identifier-de;{"language":"gsw"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB"
     And I expect this node to have the following child nodes:
@@ -220,7 +220,7 @@ Feature: Change node aggregate type - behavior of DELETE strategy
     And the graph projection is fully up to date
 
     # the type has changed
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "nodea-identifier-de" to lead to node cs-identifier;nodea-identifier-de;{"language":"de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -59,7 +59,7 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -147,11 +147,11 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
     And the graph projection is fully up to date
 
     # the type has changed
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "nodea-identifier-de" to lead to node cs-identifier;nodea-identifier-de;{"language":"de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"language":"gsw"}
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nodea-identifier-de" to lead to node cs-identifier;nodea-identifier-de;{"language":"gsw"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -51,7 +51,7 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -65,7 +65,7 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -51,7 +51,7 @@ Feature: Find nodes using the findClosestNode query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
@@ -53,7 +53,7 @@ Feature: Find nodes using the countNodes query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -65,7 +65,7 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -64,7 +64,7 @@ Feature: Find nodes using the findNodeById query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
@@ -67,7 +67,7 @@ Feature: Find nodes using the findNodeByPath query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
@@ -64,7 +64,7 @@ Feature: Find nodes using the findNodeByPath query with node name as path argume
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -64,7 +64,7 @@ Feature: Find nodes using the findParentNodes query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
@@ -24,7 +24,7 @@ Feature: Find root nodes by type
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -53,7 +53,7 @@ Feature: Find nodes using the findSubtree query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
@@ -74,7 +74,7 @@ Feature: Find and count references and their target nodes using the findReferenc
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -54,7 +54,7 @@ Feature: Find nodes using the retrieveNodePath query
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
@@ -64,7 +64,7 @@ Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedi
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -75,7 +75,7 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | newContentStreamId | "cs-user"   |
       | workspaceOwner     | "some-user" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "user-test" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -103,12 +103,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId           | "a"                 |
       | propertyValues            | {"text": "Changed"} |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
@@ -121,12 +121,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "a"         |
       | newNodeName     | "a-renamed" |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
@@ -141,7 +141,7 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | referenceName                   | "ref"              |
       | references                      | [{"target": "b"}]  |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
@@ -149,7 +149,7 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
@@ -166,12 +166,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | newNodeTypeName | "Neos.ContentRepository.Testing:SpecialPage" |
       | strategy        | "happypath"                                  |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
@@ -184,12 +184,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | sourceOrigin    | {"language":"de"} |
       | targetOrigin    | {"language":"en"} |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"en"}
+    When I am in workspace "user-test" and dimension space point {"language":"en"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 13:00:00 | 2023-03-16 13:00:00 |              |                      |
@@ -202,12 +202,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"mul"} |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"mul"}
+    When I am in workspace "user-test" and dimension space point {"language":"mul"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 13:00:00 | 2023-03-16 13:00:00 |              |                      |
@@ -223,12 +223,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId              | "a"                     |
       | newParentNodeAggregateId     | "b"                     |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 |              |                      |
@@ -239,12 +239,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 |              |                      |
@@ -258,13 +258,13 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId              | "a"                  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 |              |                      |
@@ -277,12 +277,12 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId              | "a"                  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
     And the graph projection is fully up to date
-    And I am in content stream "cs-user" and dimension space point {"language":"de"}
+    And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    When I am in content stream "cs-user" and dimension space point {"language":"ch"}
+    When I am in workspace "user-test" and dimension space point {"language":"ch"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:30:00 | 2023-03-16 12:30:00 |              |                      |
@@ -303,15 +303,15 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | workspaceName | "user-test" |
     And the graph projection is fully up to date
 
-    And I am in content stream "cs-user"
+    And I am in workspace "user-test"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
-      | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 | 2023-03-16 13:00:00 | 2023-03-16 13:00:00  |
+      | 2023-03-16 14:00:00 | 2023-03-16 12:00:00 | 2023-03-16 14:00:00 | 2023-03-16 13:00:00  |
     And I expect the node "b" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
-      | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |
+      | 2023-03-16 14:00:00 | 2023-03-16 12:00:00 |              |                      |
 
-    And I am in content stream "cs-review"
+    And I am in workspace "review"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 14:00:00 | 2023-03-16 12:00:00 | 2023-03-16 14:00:00 | 2023-03-16 13:00:00  |
@@ -324,7 +324,7 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | Key           | Value    |
       | workspaceName | "review" |
     And the graph projection is fully up to date
-    And I am in content stream "cs-live"
+    And I am in workspace "live"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
       | 2023-03-16 15:00:00 | 2023-03-16 12:00:00 | 2023-03-16 15:00:00 | 2023-03-16 13:00:00  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
@@ -20,7 +20,7 @@ Feature: Run projection integrity violation detection to find nodes that do not 
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
@@ -20,7 +20,7 @@ Feature: Create two nodes with the same node aggregate identifier in the same su
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                     |
       | nodeAggregateId     | "lady-eleonode-rootford"                  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
@@ -20,7 +20,7 @@ Feature: Run projection integrity violation detection regarding node aggregate c
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
@@ -22,7 +22,7 @@ Feature: Run projection integrity violation detection regarding node aggregate t
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                     |
       | nodeAggregateId     | "lady-eleonode-rootford"                  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -20,7 +20,7 @@ Feature: Run integrity violation detection regarding reference relations
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language":"de"}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId     | "lady-eleonode-rootford"                                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
@@ -20,7 +20,7 @@ Feature: Update Root Node aggregate dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
@@ -25,7 +25,7 @@ Feature: Dimension mismatch
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language": "en"}
+    And I am in workspace "live" and dimension space point {"language": "en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                    |
       | nodeAggregateId     | "lady-eleonode-rootford"                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
@@ -31,7 +31,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -85,7 +85,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
 
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
 
 
@@ -121,7 +121,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -184,6 +184,6 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
 
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:SubDocument"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:SubDocument"
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "subdoc" to lead to no node
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
@@ -31,7 +31,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
@@ -25,7 +25,7 @@ Feature: Properties
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
@@ -57,7 +57,7 @@ Feature: Properties
 
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no properties
 
@@ -79,7 +79,7 @@ Feature: Properties
 
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key       | Value |
@@ -131,6 +131,6 @@ Feature: Properties
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no properties

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -37,7 +37,7 @@ Feature: Tethered Nodes integrity violations
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                                | Value                                               |
       | nodeAggregateId                    | "lady-eleonode-rootford"                            |
@@ -144,7 +144,7 @@ Feature: Tethered Nodes integrity violations
     When I adjust the node structure for node type "Neos.ContentRepository:Root"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
 
-    When I am in the active content stream of workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
+    When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
     And I get the node at path "document/some-new-child"
     And I expect this node to have the following properties:
       | Key | Value                |
@@ -203,7 +203,7 @@ Feature: Tethered Nodes integrity violations
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
     When I adjust the node structure for node type "Neos.ContentRepository:Root"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
-    When I am in the active content stream of workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
+    When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
     Then I expect node aggregate identifier "nodewyn-tetherton" to lead to no node
     Then I expect node aggregate identifier "nodimer-tetherton" to lead to no node
     And  I expect path "tethered-node" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
@@ -26,7 +26,7 @@ Feature: Tethered Nodes Reordering Structure changes
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -71,7 +71,7 @@ Feature: Tethered Nodes Reordering Structure changes
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I get the node at path "document/tethered-node"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                        |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
@@ -18,7 +18,7 @@ Feature: Unknown node types
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -47,6 +47,6 @@ Feature: Unknown node types
 
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
-    When I am in the active content stream of workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
+    When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -23,7 +23,7 @@ Feature: Tag subtree with dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "root"                        |
@@ -180,7 +180,7 @@ Feature: Tag subtree with dimensions
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "user-ws" and dimension space point {"language":"gsw"}
+    And I am in workspace "user-ws" and dimension space point {"language":"gsw"}
     And I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
     """
     a (tag1*)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -21,7 +21,7 @@ Feature: Tag subtree without dimensions
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "root"                        |
@@ -108,10 +108,10 @@ Feature: Tag subtree without dimensions
       | tag                          | "tag1"          |
 
     When the graph projection is fully up to date
-    And I am in content stream "cs-identifier"
+    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 12 nodes
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect the node with aggregate identifier "a1" to be explicitly tagged "tag1"
     Then I expect the node with aggregate identifier "a1a" to inherit the tag "tag1"
     Then I expect the node with aggregate identifier "a1a1" to inherit the tag "tag1"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
@@ -30,7 +30,7 @@ Feature: Workspace discarding - complex chained functionality
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    And I am in workspace "live" and dimension space point {"language": "de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -84,5 +84,5 @@ Feature: Workspace discarding - complex chained functionality
       | workspaceName      | "user-ws"                                                                                                                                                                                                                                                                                                                                             |
       | newContentStreamId | "user-cs-id-yet-again-rebased"                                                                                                                                                                                                                                                                                                                                |
     And the graph projection is fully up to date
-    When I am in the active content stream of workspace "user-ws" and dimension space point {"language": "de"}
+    When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id-yet-again-rebased;nody-mc-nodeface;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
@@ -30,7 +30,7 @@ Feature: Discard individual nodes (basics)
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -108,7 +108,7 @@ Feature: Discard individual nodes (basics)
 
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |
@@ -130,7 +130,7 @@ Feature: Discard individual nodes (basics)
       | newContentStreamId | "user-cs-identifier-new" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |
@@ -152,7 +152,7 @@ Feature: Discard individual nodes (basics)
       | newContentStreamId | "user-cs-identifier-new"                                                                                                                                                                                                                                                                                                                                |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value        |
@@ -175,7 +175,7 @@ Feature: Discard individual nodes (basics)
     And the graph projection is fully up to date
 
     # live WS does not change because of a discard
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value        |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
@@ -33,7 +33,7 @@ Feature: Rebasing auto-created nodes works
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -59,7 +59,7 @@ Feature: Rebasing auto-created nodes works
       | originDimensionSpacePoint     | {}                                       |
       | parentNodeAggregateId | "lady-eleonode-rootford"                 |
     And the graph projection is fully up to date
-    And I am in content stream "user-cs-identifier" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     When I get the node at path "mcnodeface/foo"
     And I expect this node to be a child of node user-cs-identifier;nody-mc-nodeface;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -23,7 +23,7 @@ Feature: Workspace rebasing - conflicting changes
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
@@ -23,7 +23,7 @@ Feature: Workspace based content publishing
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -91,13 +91,13 @@ Feature: Workspace based content publishing
       | propertyValues            | {"text": "Modified"} |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
       | text | "Original" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
@@ -109,7 +109,7 @@ Feature: Workspace based content publishing
       | workspaceName | "user-test" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
@@ -151,7 +151,7 @@ Feature: Workspace based content publishing
       | workspaceName | "user-test" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
 
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
@@ -174,7 +174,7 @@ Feature: Workspace based content publishing
       | Key           | Value       |
       | workspaceName | "user-test" |
     And the graph projection is fully up to date
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
 
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                     |
@@ -191,7 +191,7 @@ Feature: Workspace based content publishing
       | workspaceName | "user-test" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
@@ -30,7 +30,7 @@ Feature: Workspace publication - complex chained functionality
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"language": "de"}
+    And I am in workspace "live" and dimension space point {"language": "de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -76,5 +76,5 @@ Feature: Workspace publication - complex chained functionality
       | workspaceName      | "user-ws"                                                                                                                                                                                                                                                                                                                                             |
       | newContentStreamId | "user-cs-id-yet-again-rebased"                                                                                                                                                                                                                                                                                                                                |
     And the graph projection is fully up to date
-    When I am in the active content stream of workspace "user-ws" and dimension space point {"language": "de"}
+    When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id-yet-again-rebased;nody-mc-nodeface;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
@@ -44,7 +44,7 @@ Feature: Individual node publication
   Scenario: It is possible to publish a single node; and only this one is live.
     # create nodes in user WS
     Given I am in workspace "user-test"
-    And I am in the active content stream of workspace "user-test"
+    And I am in workspace "user-test"
     And I am in dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds |
@@ -60,7 +60,7 @@ Feature: Individual node publication
       | contentStreamIdForMatchingPart  | "user-cs-identifier-matching"                                                                            |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
 
     Then I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
@@ -30,7 +30,7 @@ Feature: Publishing individual nodes (basics)
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -108,7 +108,7 @@ Feature: Publishing individual nodes (basics)
       | contentStreamIdForMatchingPart  | "user-cs-identifier-matching"                                                                                          |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value        |
@@ -122,7 +122,7 @@ Feature: Publishing individual nodes (basics)
       | Key   | Value            |
       | image | "Modified image" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-remaining;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |
@@ -144,7 +144,7 @@ Feature: Publishing individual nodes (basics)
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value        |
@@ -158,7 +158,7 @@ Feature: Publishing individual nodes (basics)
       | Key   | Value           |
       | image | "Initial image" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-remaining;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |
@@ -180,7 +180,7 @@ Feature: Publishing individual nodes (basics)
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining"                                                                                                                                                                                                                                                                                                                          |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |
@@ -194,7 +194,7 @@ Feature: Publishing individual nodes (basics)
       | Key   | Value            |
       | image | "Modified image" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-remaining;sir-david-nodenborough;{}
     And I expect this node to have the following properties:
       | Key  | Value         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -39,7 +39,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -83,7 +83,7 @@ Feature: Publishing hide/show scenario of nodes
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "user-test"
+    And I am in workspace "user-test"
 
     # SETUP: hide two nodes in USER workspace
     Given the command DisableNodeAggregate is executed with payload:
@@ -106,7 +106,7 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForMatchingPart  | "matching-cs-id"                                                                                  |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
@@ -160,12 +160,12 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{}
@@ -200,13 +200,13 @@ Feature: Publishing hide/show scenario of nodes
     #  | nodesToPublish | [{"nodeAggregateId": "sir-david-nodenborough", "contentStreamId": "user-cs-identifier", "dimensionSpacePoint": {}}] |
     #And the graph projection is fully up to date
 
-   # When I am in the active content stream of workspace "live" and dimension space point {}
+   # When I am in workspace "live" and dimension space point {}
    ## Then I expect the node aggregate "lady-eleonode-rootford" to have the following child nodes:
     #  | Name     | nodeAggregateId    |
     #  | text1mod | sir-david-nodenborough     |
      # | image    | sir-nodeward-nodington-iii |
 
-   # When I am in the active content stream of workspace "user-test" and dimension space point {}
+   # When I am in workspace "user-test" and dimension space point {}
    # Then I expect the node aggregate "lady-eleonode-rootford" to have the following child nodes:
    #   | Name     | nodeAggregateId    |
    #   | text1mod | sir-david-nodenborough     |
@@ -244,12 +244,12 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
@@ -284,12 +284,12 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish           | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
@@ -327,7 +327,7 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following references:
       | Name              | Node                                        | Properties |
@@ -340,7 +340,7 @@ Feature: Publishing hide/show scenario of nodes
       | Name              | Node                                    | Properties |
       | referenceProperty | cs-identifier;sir-david-nodenborough;{} | null       |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
     And I expect this node to have the following references:
       | Name              | Node                                                      | Properties |
@@ -389,11 +389,11 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                         |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "new1-agg" to lead to node cs-identifier;new1-agg;{}
     Then I expect node aggregate identifier "new2-agg" to lead to no node
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier-modified;new1-agg;{}
     Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier-modified;new2-agg;{}
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -23,7 +23,7 @@ Feature: Publishing moved nodes without dimensions
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live"
+    And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |
@@ -89,7 +89,7 @@ Feature: Publishing moved nodes without dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -129,7 +129,7 @@ Feature: Publishing moved nodes without dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -180,7 +180,7 @@ Feature: Publishing moved nodes without dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
@@ -224,7 +224,7 @@ Feature: Publishing moved nodes without dimensions
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
@@ -23,7 +23,7 @@ Feature: Workspace discarding - basic functionality
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -58,7 +58,7 @@ Feature: Workspace discarding - basic functionality
       | propertyValues            | {"text": "Modified"} |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
@@ -71,7 +71,7 @@ Feature: Workspace discarding - basic functionality
       | newContentStreamId | "user-cs-identifier-modified" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
@@ -101,7 +101,7 @@ Feature: Workspace discarding - basic functionality
       | newContentStreamId | "user-cs-identifier-modified" |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value                        |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
@@ -17,7 +17,7 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -73,26 +73,26 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | propertyValues.text.value | "Changed"                    |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value      |
       | text | "Original" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value     |
       | text | "Changed" |
 
-    When I am in the active content stream of workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nodingers-cat" and node path "child/pet" to lead to node cs-identifier;nodingers-cat;{}
     When I go to the parent node of node aggregate "nodingers-cat"
     Then I expect this node to have the following properties:
       | Key  | Value      |
       | text | "Original" |
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nodingers-cat" and node path "child/pet" to lead to node user-cs-identifier;nodingers-cat;{}
     When I go to the parent node of node aggregate "nodingers-cat"
     Then I expect this node to have the following properties:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -14,7 +14,7 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | nodeAggregateId  | "root-node"                            |
@@ -47,7 +47,7 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName            | "user-test"                  |
     And the graph projection is fully up to date
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then the current content stream has state "IN_USE_BY_WORKSPACE"
     And the content stream "user-cs-identifier" has state "NO_LONGER_IN_USE"
 
@@ -72,7 +72,7 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     When I am in content stream "user-cs-identifier" and dimension space point {}
     Then I expect node aggregate identifier "root-node" to lead to no node
 
-    When I am in the active content stream of workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-rebased;root-node;{}
 
   Scenario: NO_LONGER_IN_USE content streams can be cleaned up completely (simple case)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
@@ -19,7 +19,7 @@ Feature: Single Node operations on live workspace
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
@@ -51,7 +51,7 @@ Feature: Single Node operations on live workspace
       | propertyValues.text.value | "Hello"                      |
 
     When the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value   |

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -112,20 +112,6 @@ trait CRTestSuiteRuntimeVariables
     }
 
     /**
-     * @Given /^I am in the active content stream of workspace "([^"]*)"$/
-     * @throws \Exception
-     */
-    public function iAmInTheActiveContentStreamOfWorkspace(string $workspaceName): void
-    {
-        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($workspaceName));
-        if ($workspace === null) {
-            throw new \Exception(sprintf('Workspace "%s" does not exist, projection not yet up to date?', $workspaceName), 1548149355);
-        }
-        $this->currentWorkspaceName = WorkspaceName::fromString($workspaceName);
-        $this->currentContentStreamId = $workspace->currentContentStreamId;
-    }
-
-    /**
      * @Given /^I am in dimension space point (.*)$/
      */
     public function iAmInDimensionSpacePoint(string $dimensionSpacePoint): void
@@ -149,16 +135,6 @@ trait CRTestSuiteRuntimeVariables
     public function iAmInContentStreamAndDimensionSpacePoint(string $contentStreamId, string $dimensionSpacePoint): void
     {
         $this->iAmInContentStream($contentStreamId);
-        $this->iAmInDimensionSpacePoint($dimensionSpacePoint);
-    }
-
-    /**
-     * @Given /^I am in the active content stream of workspace "([^"]*)" and dimension space point (.*)$/
-     * @throws \Exception
-     */
-    public function iAmInTheActiveContentStreamOfWorkspaceAndDimensionSpacePoint(string $workspaceName, string $dimensionSpacePoint): void
-    {
-        $this->iAmInTheActiveContentStreamOfWorkspace($workspaceName);
         $this->iAmInDimensionSpacePoint($dimensionSpacePoint);
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -123,7 +123,6 @@ trait CRTestSuiteTrait
                 $propertyOrMethodName = \mb_substr($line['Value'], \mb_strlen('$this->'));
                 $value = match ($propertyOrMethodName) {
                     'currentNodeAggregateId' => $this->getCurrentNodeAggregateId()->value,
-                    'contentStreamId' => $this->currentContentStreamId->value,
                     default => method_exists($this, $propertyOrMethodName) ? (string)$this->$propertyOrMethodName() : (string)$this->$propertyOrMethodName,
                 };
             } else {
@@ -287,7 +286,13 @@ trait CRTestSuiteTrait
      */
     public function theCurrentContentStreamHasState(string $expectedState): void
     {
-        $this->theContentStreamHasState($this->currentContentStreamId->value, $expectedState);
+        $this->theContentStreamHasState(
+            $this->currentContentRepository
+                ->getWorkspaceFinder()
+                ->findOneByName($this->currentWorkspaceName)
+                ->currentContentStreamId->value,
+            $expectedState
+        );
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamClosing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamClosing.php
@@ -35,11 +35,7 @@ trait ContentStreamClosing
     public function theCommandCloseContentStreamIsExecutedWithPayload(TableNode $payloadTable): void
     {
         $commandArguments = $this->readPayloadTable($payloadTable);
-        $contentStreamId = isset($commandArguments['contentStreamId'])
-            ? ContentStreamId::fromString($commandArguments['contentStreamId'])
-            : $this->currentContentStreamId;
-
-        $command = CloseContentStream::create($contentStreamId);
+        $command = CloseContentStream::create(ContentStreamId::fromString($commandArguments['contentStreamId']));
 
         $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamForking.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamForking.php
@@ -36,13 +36,9 @@ trait ContentStreamForking
     public function theCommandForkContentStreamIsExecutedWithPayload(TableNode $payloadTable): void
     {
         $commandArguments = $this->readPayloadTable($payloadTable);
-        $sourceContentStreamId = isset($commandArguments['sourceContentStreamId'])
-            ? ContentStreamId::fromString($commandArguments['sourceContentStreamId'])
-            : $this->currentContentStreamId;
-
         $command = ForkContentStream::create(
             ContentStreamId::fromString($commandArguments['contentStreamId']),
-            $sourceContentStreamId,
+            ContentStreamId::fromString($commandArguments['sourceContentStreamId']),
         );
 
         $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
@@ -94,9 +94,6 @@ trait NodeCreation
     public function theEventRootNodeAggregateWithNodeWasCreatedWasPublishedToStreamWithPayload(TableNode $payloadTable)
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
-        if (!isset($eventPayload['contentStreamId'])) {
-            $eventPayload['contentStreamId'] = $this->currentContentStreamId?->value;
-        }
         $contentStreamId = ContentStreamId::fromString($eventPayload['contentStreamId']);
         $nodeAggregateId = NodeAggregateId::fromString($eventPayload['nodeAggregateId']);
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeModification.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeModification.php
@@ -85,9 +85,6 @@ trait NodeModification
     public function theEventNodePropertiesWereSetWasPublishedWithPayload(TableNode $payloadTable)
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
-        if (!isset($eventPayload['contentStreamId'])) {
-            $eventPayload['contentStreamId'] = $this->currentContentStreamId->value;
-        }
         if (!isset($eventPayload['originDimensionSpacePoint'])) {
             $eventPayload['originDimensionSpacePoint'] = json_encode($this->currentDimensionSpacePoint);
         }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeMove.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeMove.php
@@ -97,9 +97,6 @@ trait NodeMove
     public function theEventNodeAggregateWasMovedWasPublishedWithPayload(TableNode $payloadTable)
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
-        if (!isset($eventPayload['contentStreamId'])) {
-            $eventPayload['contentStreamId'] = $this->currentContentStreamId->value;
-        }
         $contentStreamId = ContentStreamId::fromString($eventPayload['contentStreamId']);
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId);
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeReferencing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeReferencing.php
@@ -100,9 +100,6 @@ trait NodeReferencing
     public function theEventNodeReferencesWereSetWasPublishedWithPayload(TableNode $payloadTable)
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
-        if (!isset($eventPayload['contentStreamId'])) {
-            $eventPayload['contentStreamId'] = $this->currentContentStreamId;
-        }
         $contentStreamId = ContentStreamId::fromString($eventPayload['contentStreamId']);
         $streamName = ContentStreamEventStreamName::fromContentStreamId(
             $contentStreamId

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRemoval.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRemoval.php
@@ -86,9 +86,6 @@ trait NodeRemoval
     public function theEventNodeAggregateWasRemovedWasPublishedWithPayload(TableNode $payloadTable)
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
-        if (!isset($eventPayload['contentStreamId'])) {
-            $eventPayload['contentStreamId'] = $this->currentContentStreamId->value;
-        }
         $contentStreamId = ContentStreamId::fromString($eventPayload['contentStreamId']);
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId);
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/SubtreeTagging.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/SubtreeTagging.php
@@ -86,9 +86,7 @@ trait SubtreeTagging
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
         $streamName = ContentStreamEventStreamName::fromContentStreamId(
-            array_key_exists('contentStreamId', $eventPayload)
-                ? ContentStreamId::fromString($eventPayload['contentStreamId'])
-                : $this->currentContentStreamId
+            ContentStreamId::fromString($eventPayload['contentStreamId'])
         );
 
         $this->publishEvent('SubtreeWasTagged', $streamName->getEventStreamName(), $eventPayload);
@@ -104,9 +102,7 @@ trait SubtreeTagging
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
         $streamName = ContentStreamEventStreamName::fromContentStreamId(
-            array_key_exists('contentStreamId', $eventPayload)
-                ? ContentStreamId::fromString($eventPayload['contentStreamId'])
-                : $this->currentContentStreamId
+            ContentStreamId::fromString($eventPayload['contentStreamId'])
         );
 
         $this->publishEvent('SubtreeWasUntagged', $streamName->getEventStreamName(), $eventPayload);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeAggregateTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeAggregateTrait.php
@@ -43,7 +43,7 @@ trait ProjectedNodeAggregateTrait
         $nodeAggregateId = NodeAggregateId::fromString($serializedNodeAggregateId);
         $this->initializeCurrentNodeAggregate(function (ContentGraphInterface $contentGraph) use ($nodeAggregateId) {
             $currentNodeAggregate = $contentGraph->findNodeAggregateById($nodeAggregateId);
-            Assert::assertNotNull($currentNodeAggregate, sprintf('Node aggregate "%s" was not found in the current content stream "%s".', $nodeAggregateId->value, $this->currentContentStreamId->value));
+            Assert::assertNotNull($currentNodeAggregate, sprintf('Node aggregate "%s" was not found in the current workspace "%s".', $nodeAggregateId->value, $this->currentWorkspaceName->value));
             return $currentNodeAggregate;
         });
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -81,22 +81,23 @@ trait ProjectedNodeTrait
     public function iExpectANodeIdentifiedByXToExistInTheContentGraph(string $serializedNodeDiscriminator): void
     {
         $nodeDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
-        $this->currentContentStreamId = $nodeDiscriminator->contentStreamId;
-        $this->initializeCurrentNodeFromContentGraph(function (ContentGraphInterface $contentGraph) use ($nodeDiscriminator) {
-            $currentNodeAggregate = $contentGraph->findNodeAggregateById(
-                $nodeDiscriminator->nodeAggregateId
-            );
-            Assert::assertTrue(
-                $currentNodeAggregate?->occupiesDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint),
-                'Node with aggregate id "' . $nodeDiscriminator->nodeAggregateId->value
-                . '" and originating in dimension space point "' . $nodeDiscriminator->originDimensionSpacePoint->toJson()
-                . '" was not found in content stream "' . $nodeDiscriminator->contentStreamId->value . '"'
-            );
-
-            return $currentNodeAggregate->getNodeByOccupiedDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint);
-        });
+        $contentGraphFinder = $this->currentContentRepository->projectionState(ContentGraphFinder::class);
+        $contentGraphFinder->forgetInstances();
+        $workspaceName = $this->currentContentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
+            $nodeDiscriminator->contentStreamId
+        )->workspaceName;
+        $contentGraph = $this->currentContentRepository->getContentGraph($workspaceName);
+        $currentNodeAggregate = $contentGraph->findNodeAggregateById(
+            $nodeDiscriminator->nodeAggregateId
+        );
+        Assert::assertTrue(
+            $currentNodeAggregate?->occupiesDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint),
+            'Node with aggregate id "' . $nodeDiscriminator->nodeAggregateId->value
+            . '" and originating in dimension space point "' . $nodeDiscriminator->originDimensionSpacePoint->toJson()
+            . '" was not found in content stream "' . $nodeDiscriminator->contentStreamId->value . '"'
+        );
+        $this->currentNode = $currentNodeAggregate->getNodeByOccupiedDimensionSpacePoint($nodeDiscriminator->originDimensionSpacePoint);
     }
-
 
     /**
      * @Then /^I expect node aggregate identifier "([^"]*)" to lead to node (.*)$/
@@ -109,7 +110,7 @@ trait ProjectedNodeTrait
         $expectedDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
-            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"');
+            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
             $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
@@ -126,7 +127,7 @@ trait ProjectedNodeTrait
         if (!is_null($nodeByAggregateId)) {
             Assert::fail(
                 'A node was found by node aggregate id "' . $nodeAggregateId->value
-                . '" in content subgraph {' . $this->currentDimensionSpacePoint->toJson() . ',' . $this->currentContentStreamId->value . '}'
+                . '" in content subgraph {' . $this->currentDimensionSpacePoint->toJson() . ',' . $this->currentWorkspaceName->value . '}'
             );
         }
     }
@@ -146,7 +147,7 @@ trait ProjectedNodeTrait
         $expectedDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodePath, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
-            Assert::assertNotNull($currentNode, 'No node could be found by node path "' . $nodePath->serializeToString() . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"');
+            Assert::assertNotNull($currentNode, 'No node could be found by node path "' . $nodePath->serializeToString() . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
             $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
@@ -168,7 +169,7 @@ trait ProjectedNodeTrait
         Assert::assertNull(
             $nodeByPath,
             'A node was found by node path "' . $nodePath->serializeToString()
-                . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"'
+                . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"'
         );
     }
 
@@ -206,7 +207,7 @@ trait ProjectedNodeTrait
         $expectedTag = SubtreeTag::fromString($serializedTag);
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedTag) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
-            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"');
+            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
             Assert::assertTrue($currentNode->tags->withoutInherited()->contain($expectedTag));
             return $currentNode;
         });
@@ -221,7 +222,7 @@ trait ProjectedNodeTrait
         $expectedTag = SubtreeTag::fromString($serializedTag);
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedTag) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
-            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"');
+            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
             Assert::assertTrue($currentNode->tags->onlyInherited()->contain($expectedTag));
             return $currentNode;
         });
@@ -236,8 +237,8 @@ trait ProjectedNodeTrait
         $expectedTag = SubtreeTag::fromString($serializedTag);
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedTag) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
-            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentContentStreamId->value . '"');
-            Assert::assertFalse($currentNode->tags->contain($expectedTag), sprintf('Node with id "%s" in content subgraph "%s@%s", was not expected to contain the subtree tag "%s" but it does', $nodeAggregateId->value, $this->currentDimensionSpacePoint->toJson(), $this->currentContentStreamId->value, $expectedTag->value));
+            Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
+            Assert::assertFalse($currentNode->tags->contain($expectedTag), sprintf('Node with id "%s" in content subgraph "%s@%s", was not expected to contain the subtree tag "%s" but it does', $nodeAggregateId->value, $this->currentDimensionSpacePoint->toJson(), $this->currentWorkspaceName->value, $expectedTag->value));
             return $currentNode;
         });
     }
@@ -272,18 +273,6 @@ trait ProjectedNodeTrait
                 $actualTags,
             );
         });
-    }
-
-    protected function initializeCurrentNodeFromContentGraph(callable $query): void
-    {
-        $contentGraphFinder = $this->currentContentRepository->projectionState(ContentGraphFinder::class);
-        $contentGraphFinder->forgetInstances();
-        if (isset($this->currentContentStreamId)) {
-            $contentGraph = $contentGraphFinder->getByWorkspaceNameAndContentStreamId($this->currentWorkspaceName, $this->currentContentStreamId);
-        } else {
-            $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
-        }
-        $this->currentNode = $query($contentGraph);
     }
 
     protected function initializeCurrentNodeFromContentSubgraph(callable $query): void

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
@@ -122,9 +122,7 @@ trait BrowserTrait
             $this->currentContentStreamId,
             $this->currentDimensionSpacePoint,
             $nodeAggregateId,
-            $this->currentContentRepository->getWorkspaceFinder()
-                ->findOneByCurrentContentStreamId($this->currentContentStreamId)
-                ->workspaceName
+            $this->currentWorkspaceName,
         );
     }
 
@@ -147,9 +145,7 @@ trait BrowserTrait
             $this->currentContentStreamId,
             $this->currentDimensionSpacePoint,
             $node->nodeAggregateId,
-            $this->currentContentRepository->getWorkspaceFinder()
-                ->findOneByCurrentContentStreamId($this->currentContentStreamId)
-                ->workspaceName
+            $this->currentWorkspaceName,
         );
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
@@ -53,7 +53,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |
@@ -260,7 +260,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
 
   Scenario: ContentCache gets flushed for user workspace when a referenced asset in a property text has changed
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     And the Fusion context node is a2
 
     And I execute the following Fusion code:
@@ -274,11 +274,11 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
     cacheVerifier=first execution, text=Link to asset://an-asset-to-change.
     """
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     Then the asset "an-asset-to-change" has the title "First changed asset"
     And the ContentCacheFlusher flushes all collected tags
 
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     Then the Fusion context node is a2
     And I execute the following Fusion code:
     """fusion

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
@@ -36,7 +36,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |
@@ -135,7 +135,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
 
   Scenario: ContentCache doesn't get flushed when target node changes in different workspace
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2
 
     And I execute the following Fusion code:
@@ -149,7 +149,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
     cacheVerifier=first execution, title=Node a2, link=Some value with node URI: /a1.
     """
 
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     When the command SetNodeProperties is executed with payload:
       | Key             | Value                        |
       | contentStreamId | "cs-identifier"              |
@@ -158,7 +158,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
     And the graph projection is fully up to date
     And The documenturipath projection is up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2
     And I execute the following Fusion code:
     """fusion

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
@@ -33,7 +33,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
@@ -38,7 +38,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |
@@ -121,7 +121,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
 
   Scenario: ContentCache doesn't get flushed when a property of a node in other workspace has changed
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
 
     And I execute the following Fusion code:
@@ -135,7 +135,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
     cacheVerifier=first execution, title=Node a1
     """
 
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     When the command SetNodeProperties is executed with payload:
       | Key             | Value                    |
       | contentStreamId | "cs-identifier"          |
@@ -143,7 +143,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | propertyValues  | {"title": "Node a1 new"} |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
     And I execute the following Fusion code:
     """fusion
@@ -158,7 +158,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
 
   Scenario: ContentCache gets not flushed when a property of another node has changed in different workspace
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
 
     And I execute the following Fusion code:
@@ -171,7 +171,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
     """
     cacheVerifier=first execution, title=Node a1
     """
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     When the command SetNodeProperties is executed with payload:
       | Key             | Value                    |
       | contentStreamId | "cs-identifier"          |
@@ -179,7 +179,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | propertyValues  | {"title": "Node a2 new"} |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
     And I execute the following Fusion code:
     """fusion
@@ -194,7 +194,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
 
   Scenario: ContentCache doesn't get flushed when a property of a node has changed by NodeType name in different workspace
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2
     And I execute the following Fusion code:
     """fusion
@@ -207,7 +207,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
     cacheVerifier=first execution, title=Node a2
     """
 
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     When the command SetNodeProperties is executed with payload:
       | Key             | Value                    |
       | contentStreamId | "cs-identifier"          |
@@ -215,7 +215,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | propertyValues  | {"title": "Node a1 new"} |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2
     And I execute the following Fusion code:
     """fusion
@@ -230,7 +230,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
 
   Scenario: ContentCache doesn't get flushed when a property of a node has changed of a descendant node in different workspace
     Given I have Fusion content cache enabled
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is "a1"
     And I execute the following Fusion code:
     """fusion
@@ -243,7 +243,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
     cacheVerifier=first execution, title=Node a1
     """
 
-    And I am in the active content stream of workspace "user-test" and dimension space point {}
+    And I am in workspace "user-test" and dimension space point {}
     When the command SetNodeProperties is executed with payload:
       | Key             | Value                    |
       | contentStreamId | "cs-identifier"          |
@@ -251,7 +251,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | propertyValues  | {"title": "Node a1-1 new"} |
     And the graph projection is fully up to date
 
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the Fusion context node is "a1"
     And I execute the following Fusion code:
     """fusion

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
@@ -31,7 +31,7 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
@@ -45,7 +45,7 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
     #        earl-o-documentbourgh
     #      nody-mc-nodeface
     #
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues                    | nodeName |
       | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "ignore-me"}          | node1    |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
@@ -43,7 +43,7 @@ Feature: Routing functionality with multiple content dimensions
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {"market":"DE", "language":"en"}
+    And I am in workspace "live" and dimension space point {"market":"DE", "language":"en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                                                                                                                                                     |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                                                                                                                                                  |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -30,7 +30,7 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
@@ -39,7 +39,7 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
@@ -236,7 +236,7 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | "c"     | "lady-eleonode-rootford/shernode-homes/c"    | "c"                      | "shernode-homes"         | "b"                      | null                      | "Neos.Neos:Test.Routing.Page" |
 
   Scenario: ab(> b1, b2 > b2a)c => a(> b2 > b2a)b(> b1)c (moving b1 below a)
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues     | nodeName |
       | b1              | b                     | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "b1"}  | b1       |
@@ -261,7 +261,7 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | "c"        | "lady-eleonode-rootford/shernode-homes/c"        | "c"                      | "shernode-homes"         | "b"                      | null                      | "Neos.Neos:Test.Routing.Page" |
 
   Scenario: ab(> b1, b2 > b2a)c => b(> b1, a, b2 > b2a)c (moving a below b)
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues     | nodeName |
       | b1              | b                     | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "b1"}  | b1       |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
@@ -39,7 +39,7 @@ Feature: Linking between multiple websites
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
@@ -28,7 +28,7 @@ Feature: Test cases for node creation edge cases
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -28,7 +28,7 @@ Feature: Test cases for node variation edge cases
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
@@ -137,7 +137,7 @@ Feature: Test cases for node variation edge cases
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
@@ -235,7 +235,7 @@ Feature: Test cases for node variation edge cases
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And the graph projection is fully up to date
-    And I am in the active content stream of workspace "live" and dimension space point {"example":"source"}
+    And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
@@ -30,7 +30,7 @@ Feature: Route cache invalidation
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
@@ -44,7 +44,7 @@ Feature: Route cache invalidation
     #        earl-o-documentbourgh
     #      nody-mc-nodeface
     #
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues                    | nodeName |
       | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "ignore-me"}          | node1    |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
@@ -47,7 +47,7 @@ Feature: Routing behavior of shortcut nodes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
@@ -244,7 +244,7 @@ Feature: Routing behavior of shortcut nodes
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "http://www.neos.io/"
 
   Scenario: Change shortcut targetMode from "parentNode" to "firstChildNode"
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                                       | initialPropertyValues           | nodeName |
       | new-child-node  | shortcut-parent-node  | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "new-child"} | new      |
@@ -333,7 +333,7 @@ Feature: Routing behavior of shortcut nodes
     Then The node "invalid-shortcut-selected-node" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
   Scenario: Recursive shortcuts
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName       | initialPropertyValues                                                                                      | nodeName |
       | level-1         | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "level1", "targetMode": "selectedTarget", "target": "node://level-2"}                   | level1   |
@@ -344,7 +344,7 @@ Feature: Routing behavior of shortcut nodes
     Then the node "level-2" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/first-child-node"
 
   Scenario: Unlimited recursive shortcuts
-    And I am in content stream "cs-identifier" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName       | initialPropertyValues                                                              | nodeName |
       | node-a          | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "a", "targetMode": "selectedTarget", "target": "node://node-b"} | node-a   |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
@@ -30,7 +30,7 @@ Feature: Tests for site node child documents. These are special in that they hav
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -24,7 +24,7 @@ Feature: Basic routing functionality (match & resolve nodes with unknown types)
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
@@ -33,7 +33,7 @@ Feature: Tests for the "Neos.Neos:ContentCase" Fusion prototype
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
@@ -41,7 +41,7 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -30,7 +30,7 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -46,7 +46,7 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -33,7 +33,7 @@ Feature: Simple handling of nodes with exceeded enableAfter and disableAfter dat
       | newContentStreamId | "cs-identifier" |
     And the graph projection is fully up to date
     And I am in workspace "live"
-    And I am in the active content stream of workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |


### PR DESCRIPTION
Resolves partially #5034

This  adjusts the test suite to operate directly on workspace names instead of content stream IDs

**Upgrade instructions**

**Review instructions**

Most changes are purely search/replace, with a few exceptions:

https://github.com/neos/neos-development-collection/compare/5034-workspaceBasedTests?expand=1#diff-2e50430c540d541e90b7b2233957a44a9d2fb4e8240d3de077bbc93192d3cc65R306

Here we check the timestamps in the new content stream instead of the closed one as before, thus the change in payload, as discussed with @bwaidelich in Slack

https://github.com/neos/neos-development-collection/compare/5034-workspaceBasedTests?expand=1#diff-a3b3697e967ca37986b11850c79037b9594ba0742f7cf2da5a140f31f85701a3L81

Has been refactored to use the given content stream id and the matching workspace instead of the unrelated current workspace name.

Also, we cannot remove content stream checks as we have test cases for content stream forking without workspaces being involved. Also, structure adjustments don't use workspaces, so we have to again check content streams

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
