### PR TITLE
FEATURE: Add `ContentRepository::subgraphForNode`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -305,7 +305,7 @@ final class ContentGraph implements ContentGraphInterface
         try {
             return (int)$result->fetchOne();
         } catch (DriverException | DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to fetch rows from database: %s', $e->getMessage()), 1701444590, $e);
+            throw new \RuntimeException(sprintf('Failed to count rows in database: %s', $e->getMessage()), 1701444590, $e);
         }
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -171,6 +171,7 @@ final class ContentGraph implements ContentGraphInterface
 
         return $this->nodeFactory->mapNodeRowsToNodeAggregate(
             $this->fetchRows($queryBuilder),
+            $this->workspaceName,
             $this->contentStreamId,
             VisibilityConstraints::withoutRestrictions()
         );
@@ -232,6 +233,7 @@ final class ContentGraph implements ContentGraphInterface
 
         return $this->nodeFactory->mapNodeRowsToNodeAggregate(
             $this->fetchRows($queryBuilder),
+            $this->workspaceName,
             $this->contentStreamId,
             VisibilityConstraints::withoutRestrictions()
         );
@@ -328,6 +330,7 @@ final class ContentGraph implements ContentGraphInterface
     {
         return $this->nodeFactory->mapNodeRowsToNodeAggregates(
             $this->fetchRows($queryBuilder),
+            $this->workspaceName,
             $this->contentStreamId,
             VisibilityConstraints::withoutRestrictions()
         );

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -92,7 +92,6 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
-        /** @phpstan-ignore-next-line  */
         private readonly WorkspaceName $workspaceName,
         private readonly ContentStreamId $contentStreamId,
         private readonly DimensionSpacePoint $dimensionSpacePoint,
@@ -290,7 +289,13 @@ final class ContentSubgraph implements ContentSubgraphInterface
         foreach (array_reverse($result) as $nodeData) {
             $nodeAggregateId = $nodeData['nodeaggregateid'];
             $parentNodeAggregateId = $nodeData['parentNodeAggregateId'];
-            $node = $this->nodeFactory->mapNodeRowToNode($nodeData, $this->contentStreamId, $this->dimensionSpacePoint, $this->visibilityConstraints);
+            $node = $this->nodeFactory->mapNodeRowToNode(
+                $nodeData,
+                $this->workspaceName,
+                $this->contentStreamId,
+                $this->dimensionSpacePoint,
+                $this->visibilityConstraints
+            );
             $subtree = new Subtree((int)$nodeData['level'], $node, array_key_exists($nodeAggregateId, $subtreesByParentNodeId) ? array_reverse($subtreesByParentNodeId[$nodeAggregateId]) : []);
             if ($subtree->level === 0) {
                 return $subtree;
@@ -319,6 +324,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         return $this->nodeFactory->mapNodeRowsToNodes(
             $nodeRows,
+            $this->workspaceName,
             $this->contentStreamId,
             $this->dimensionSpacePoint,
             $this->visibilityConstraints
@@ -374,6 +380,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         );
         return $this->nodeFactory->mapNodeRowsToNodes(
             $nodeRows,
+            $this->workspaceName,
             $this->contentStreamId,
             $this->dimensionSpacePoint,
             $this->visibilityConstraints
@@ -391,7 +398,13 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
         $queryBuilderCte->addOrderBy('level')->addOrderBy('position');
         $nodeRows = $this->fetchCteResults($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
-        return $this->nodeFactory->mapNodeRowsToNodes($nodeRows, $this->contentStreamId, $this->dimensionSpacePoint, $this->visibilityConstraints);
+        return $this->nodeFactory->mapNodeRowsToNodes(
+            $nodeRows,
+            $this->workspaceName,
+            $this->contentStreamId,
+            $this->dimensionSpacePoint,
+            $this->visibilityConstraints
+        );
     }
 
     public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, CountDescendantNodesFilter $filter): int
@@ -668,6 +681,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
         return $this->nodeFactory->mapNodeRowToNode(
             $nodeRow,
+            $this->workspaceName,
             $this->contentStreamId,
             $this->dimensionSpacePoint,
             $this->visibilityConstraints
@@ -681,7 +695,13 @@ final class ContentSubgraph implements ContentSubgraphInterface
         } catch (DbalDriverException | DbalException $e) {
             throw new \RuntimeException(sprintf('Failed to fetch nodes: %s', $e->getMessage()), 1678292896, $e);
         }
-        return $this->nodeFactory->mapNodeRowsToNodes($nodeRows, $this->contentStreamId, $this->dimensionSpacePoint, $this->visibilityConstraints);
+        return $this->nodeFactory->mapNodeRowsToNodes(
+            $nodeRows,
+            $this->workspaceName,
+            $this->contentStreamId,
+            $this->dimensionSpacePoint,
+            $this->visibilityConstraints
+        );
     }
 
     private function fetchCount(QueryBuilder $queryBuilder): int
@@ -700,7 +720,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         } catch (DbalDriverException | DbalException $e) {
             throw new \RuntimeException(sprintf('Failed to fetch references: %s', $e->getMessage()), 1678364944, $e);
         }
-        return $this->nodeFactory->mapReferenceRowsToReferences($referenceRows, $this->contentStreamId, $this->dimensionSpacePoint, $this->visibilityConstraints);
+        return $this->nodeFactory->mapReferenceRowsToReferences($referenceRows, $this->workspaceName, $this->contentStreamId, $this->dimensionSpacePoint, $this->visibilityConstraints);
     }
 
     /**

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -278,11 +278,11 @@ final class NodeFactory
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePointsByNodeAggregate
                     [$rawNodeAggregateId][$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
-                    $nodeRow,
-                    $workspaceName,
-                    $contentStreamId,
-                    $occupiedDimensionSpacePoint->toDimensionSpacePoint(),
-                    $visibilityConstraints
+                        $nodeRow,
+                        $workspaceName,
+                        $contentStreamId,
+                        $occupiedDimensionSpacePoint->toDimensionSpacePoint(),
+                        $visibilityConstraints
                     );
                 $occupiedDimensionSpacePointsByNodeAggregate[$rawNodeAggregateId][]
                     = $occupiedDimensionSpacePoint;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -79,7 +79,7 @@ final class NodeFactory
                 $this->contentRepositoryId,
                 $workspaceName,
                 $dimensionSpacePoint,
-                $nodeId = NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
+                NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
             ),
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
@@ -87,7 +87,6 @@ final class NodeFactory
                 $dimensionSpacePoint,
                 $visibilityConstraints
             ),
-            $nodeId,
             $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -75,22 +75,13 @@ final class NodeFactory
             : null;
 
         return Node::create(
-            NodeAddress::create(
-                $this->contentRepositoryId,
-                $workspaceName,
-                $dimensionSpacePoint,
-                NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
-            ),
-            ContentSubgraphIdentity::create(
-                $this->contentRepositoryId,
-                $contentStreamId,
-                $dimensionSpacePoint,
-                $visibilityConstraints
-            ),
+            $this->contentRepositoryId,
+            $workspaceName,
+            $dimensionSpacePoint,
+            NodeAggregateId::fromString($nodeRow['nodeaggregateid']),
             $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),
-            $nodeType,
             $this->createPropertyCollectionFromJsonString($nodeRow['properties']),
             isset($nodeRow['name']) ? NodeName::fromString($nodeRow['name']) : null,
             self::extractNodeTagsFromJson($nodeRow['subtreetags']),
@@ -100,6 +91,9 @@ final class NodeFactory
                 isset($nodeRow['lastmodified']) ? self::parseDateTimeString($nodeRow['lastmodified']) : null,
                 isset($nodeRow['originallastmodified']) ? self::parseDateTimeString($nodeRow['originallastmodified']) : null,
             ),
+            $visibilityConstraints,
+            $nodeType,
+            $contentStreamId
         );
     }
 

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -79,23 +79,14 @@ final class NodeFactory
             : null;
 
         return Node::create(
-            NodeAddress::create(
-                $this->contentRepositoryId,
-                // todo use actual workspace name
-                WorkspaceName::fromString('missing'),
-                $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
-                NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
-            ),
-            ContentSubgraphIdentity::create(
-                $this->contentRepositoryId,
-                $contentStreamId ?: ContentStreamId::fromString($nodeRow['contentstreamid']),
-                $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
-                $visibilityConstraints
-            ),
+            $this->contentRepositoryId,
+            // todo use actual workspace name
+            WorkspaceName::fromString('missing'),
+            $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
+            NodeAggregateId::fromString($nodeRow['nodeaggregateid']),
             OriginDimensionSpacePoint::fromJsonString($nodeRow['origindimensionspacepoint']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),
-            $nodeType,
             new PropertyCollection(
                 SerializedPropertyValues::fromJsonString($nodeRow['properties']),
                 $this->propertyConverter
@@ -110,6 +101,9 @@ final class NodeFactory
                 isset($nodeRow['lastmodified']) ? self::parseDateTimeString($nodeRow['lastmodified']) : null,
                 isset($nodeRow['originallastmodified']) ? self::parseDateTimeString($nodeRow['originallastmodified']) : null,
             ),
+            $visibilityConstraints,
+            $nodeType,
+            $contentStreamId ?: ContentStreamId::fromString($nodeRow['contentstreamid']),
         );
     }
 

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -84,7 +84,7 @@ final class NodeFactory
                 // todo use actual workspace name
                 WorkspaceName::fromString('missing'),
                 $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
-                $nodeId = NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
+                NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
             ),
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
@@ -92,7 +92,6 @@ final class NodeFactory
                 $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
                 $visibilityConstraints
             ),
-            $nodeId,
             OriginDimensionSpacePoint::fromJsonString($nodeRow['origindimensionspacepoint']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -37,11 +37,13 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Timestamps;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * The node factory for mapping database rows to nodes and node aggregates
@@ -77,13 +79,20 @@ final class NodeFactory
             : null;
 
         return Node::create(
+            NodeAddress::create(
+                $this->contentRepositoryId,
+                // todo use actual workspace name
+                WorkspaceName::fromString('missing'),
+                $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
+                $nodeId = NodeAggregateId::fromString($nodeRow['nodeaggregateid'])
+            ),
             ContentSubgraphIdentity::create(
                 $this->contentRepositoryId,
                 $contentStreamId ?: ContentStreamId::fromString($nodeRow['contentstreamid']),
                 $dimensionSpacePoint ?: DimensionSpacePoint::fromJsonString($nodeRow['dimensionspacepoint']),
                 $visibilityConstraints
             ),
-            NodeAggregateId::fromString($nodeRow['nodeaggregateid']),
+            $nodeId,
             OriginDimensionSpacePoint::fromJsonString($nodeRow['origindimensionspacepoint']),
             NodeAggregateClassification::from($nodeRow['classification']),
             NodeTypeName::fromString($nodeRow['nodetypename']),

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -40,6 +40,7 @@ use Neos\ContentRepository\Core\Projection\ProjectionStatuses;
 use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceFinder;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryStatus;
+use Neos\ContentRepository\Core\SharedModel\Exception\ForeignContentRepositoryUsed;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -254,6 +255,12 @@ final class ContentRepository
      */
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
+        if (!$this->id->equals($node->contentRepositoryId)) {
+            throw new ForeignContentRepositoryUsed(
+                sprintf('ContentRepository "%s" cannot get subgraph for Node of ContentRepository "%s".', $this->id->value, $node->contentRepositoryId->value),
+                1715531407
+            );
+        }
         return $this->getContentGraph($node->workspaceName)->getSubgraph(
             $node->dimensionSpacePoint,
             $node->visibilityConstraints

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -30,6 +30,8 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\CatchUp;
 use Neos\ContentRepository\Core\Projection\CatchUpOptions;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentStream\ContentStreamFinder;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionsAndCatchUpHooks;
@@ -245,6 +247,17 @@ final class ContentRepository
     public function getContentGraph(WorkspaceName $workspaceName): ContentGraphInterface
     {
         return $this->projectionState(ContentGraphFinder::class)->getByWorkspaceName($workspaceName);
+    }
+
+    /**
+     * Simple utility method to get the subgraph for a node using the public API {@see getContentGraph()}
+     */
+    public function subgraphForNode(Node $node): ContentSubgraphInterface
+    {
+        return $this->getContentGraph($node->workspaceName)->getSubgraph(
+            $node->dimensionSpacePoint,
+            $node->visibilityConstraints
+        );
     }
 
     public function getWorkspaceFinder(): WorkspaceFinder

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
@@ -19,8 +19,6 @@ use Neos\ContentRepository\Core\Dimension;
 /**
  * A point in the dimension space with coordinates DimensionName => DimensionValue.
  * E.g.: ["language" => "es", "country" => "ar"]
- *
- * Implements CacheAwareInterface because of Fusion Runtime caching and Routing
  * @api
  */
 final class DimensionSpacePoint extends AbstractDimensionSpacePoint

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
@@ -4,6 +4,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
@@ -31,7 +32,8 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  * usually need this method instead of the Origin DimensionSpacePoint inside the read model; and you'll
  * need the OriginDimensionSpacePoint when constructing commands on the write side.
  *
- * @api
+ * @deprecated please use the {@see NodeAddress} instead {@see Node::$subgraphIdentity}. Will be removed before the Final Neos 9 release.
+ * @internal
  */
 final readonly class ContentSubgraphIdentity implements \JsonSerializable
 {
@@ -46,9 +48,6 @@ final readonly class ContentSubgraphIdentity implements \JsonSerializable
     ) {
     }
 
-    /**
-     * @api
-     */
     public static function create(
         ContentRepositoryId $contentRepositoryId,
         ContentStreamId $contentStreamId,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -58,6 +58,7 @@ final readonly class Node
         public NodeAddress $address,
         /** @deprecated will be removed before the final 9.0 release */
         public ContentSubgraphIdentity $subgraphIdentity,
+        /** @deprecated will be removed before the final 9.0 release (use address.aggregateId instead) */
         public NodeAggregateId $nodeAggregateId,
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
         public NodeAggregateClassification $classification,
@@ -76,9 +77,9 @@ final readonly class Node
     /**
      * @internal The signature of this method can change in the future!
      */
-    public static function create(NodeAddress $address, ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
+    public static function create(NodeAddress $address, ContentSubgraphIdentity $subgraphIdentity, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
     {
-        return new self($address, $subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
+        return new self($address, $subgraphIdentity, $address->aggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -190,9 +190,14 @@ final readonly class Node
         return $this->nodeType?->getNodeLabelGenerator()->getLabel($this) ?: $this->nodeTypeName->value;
     }
 
+    /**
+     * Checks if the node's "Read Model" identity equals with the given one
+     */
     public function equals(Node $other): bool
     {
-        return $this->subgraphIdentity->equals($other->subgraphIdentity)
-            && $this->nodeAggregateId->equals($other->nodeAggregateId);
+        return $this->contentRepositoryId->equals($other->contentRepositoryId)
+            && $this->workspaceName->equals($other->workspaceName)
+            && $this->dimensionSpacePoint->equals($other->dimensionSpacePoint)
+            && $this->aggregateId->equals($other->aggregateId);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
@@ -34,11 +35,14 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
  * call findChildNodes() {@see ContentSubgraphInterface::findChildNodes()}
  * on the subgraph.
  *
+ * The identity of a node is summarized here {@see NodeAddress}
+ *
  * @api Note: The constructor is not part of the public API
  */
 final readonly class Node
 {
     /**
+     * @param NodeAddress $address The node's "Read Model" identity.
      * @param ContentSubgraphIdentity $subgraphIdentity This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}. With this information, you can fetch a Subgraph using {@see ContentGraphInterface::getSubgraph()}.
      * @param NodeAggregateId $nodeAggregateId NodeAggregateId (identifier) of this node. This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}
      * @param OriginDimensionSpacePoint $originDimensionSpacePoint The DimensionSpacePoint the node originates in. Usually needed to address a Node in a NodeAggregate in order to update it.
@@ -51,6 +55,8 @@ final readonly class Node
      * @param Timestamps $timestamps Creation and modification timestamps of this node
      */
     private function __construct(
+        public NodeAddress $address,
+        /** @deprecated will be removed before the final 9.0 release */
         public ContentSubgraphIdentity $subgraphIdentity,
         public NodeAggregateId $nodeAggregateId,
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
@@ -70,9 +76,9 @@ final readonly class Node
     /**
      * @internal The signature of this method can change in the future!
      */
-    public static function create(ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
+    public static function create(NodeAddress $address, ContentSubgraphIdentity $subgraphIdentity, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
     {
-        return new self($subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
+        return new self($address, $subgraphIdentity, $nodeAggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Node.php
@@ -14,13 +14,17 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection\ContentGraph;
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * Main read model of the {@see ContentSubgraphInterface}.
@@ -28,23 +32,80 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
  * Immutable, Read Only. In case you want to modify it, you need
  * to create Commands and send them to ContentRepository::handle.
  *
+ * ## Identity of a Node
+ *
+ * The node's "Read Model" identity is summarized here {@see NodeAddress}, consisting of:
+ *
+ * - {@see ContentRepositoryId}
+ * - {@see WorkspaceName}
+ * - {@see DimensionSpacePoint}
+ * - {@see NodeAggregateId}
+ *
+ * The node address can be constructed via {@see NodeAddress::fromNode()} and serialized.
+ *
+ * ## Traversing the graph
+ *
  * The node does not have structure information, i.e. no infos
  * about its children. To f.e. fetch children, you need to fetch
- * the subgraph {@see ContentGraphInterface::getSubgraph()} via
- * $subgraphIdentity {@see Node::$subgraphIdentity}. and then
- * call findChildNodes() {@see ContentSubgraphInterface::findChildNodes()}
- * on the subgraph.
+ * the subgraph and use findChildNodes on the subgraph:
  *
- * The identity of a node is summarized here {@see NodeAddress}
+ *     $subgraph = $contentRepository->getContentGraph($node->workspaceName)->getSubgraph(
+ *         $node->dimensionSpacePoint,
+ *         $node->visibilityConstraints
+ *     );
+ *     $childNodes = $subgraph->findChildNodes($node->aggregateId, FindChildNodesFilter::create());
+ *
+ * ## A note about the {@see DimensionSpacePoint} and the {@see OriginDimensionSpacePoint}
+ *
+ * The {@see Node::dimensionSpacePoint} is the DimensionSpacePoint this node has been accessed in,
+ * and NOT the DimensionSpacePoint where the node is "at home".
+ * The DimensionSpacePoint where the node is (at home) is called the ORIGIN DimensionSpacePoint,
+ * and this can be accessed using {@see Node::originDimensionSpacePoint}. If in doubt, you'll
+ * usually need the DimensionSpacePoint instead of the OriginDimensionSpacePoint;
+ * you'll only need the OriginDimensionSpacePoint when constructing commands on the write side.
  *
  * @api Note: The constructor is not part of the public API
  */
 final readonly class Node
 {
     /**
-     * @param NodeAddress $address The node's "Read Model" identity.
-     * @param ContentSubgraphIdentity $subgraphIdentity This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}. With this information, you can fetch a Subgraph using {@see ContentGraphInterface::getSubgraph()}.
-     * @param NodeAggregateId $nodeAggregateId NodeAggregateId (identifier) of this node. This is part of the node's "Read Model" identity which is defined by: {@see self::subgraphIdentity} and {@see self::nodeAggregateId}
+     * This was intermediate part of the node's "Read Model" identity.
+     * Please use {@see $contentRepositoryId} {@see $workspaceName} {@see $dimensionSpacePoint} and {@see $aggregateId} instead,
+     * or see {@see NodeAddress::fromNode()} for passing the identity around.
+     * The visibility-constraints now reside in {@see $visibilityConstraints}.
+     * There is no replacement for the previously attached content-stream-id. Please refactor the code to use the newly available workspace-name.
+     * @deprecated will be removed before the final 9.0 release
+     */
+    public ContentSubgraphIdentity $subgraphIdentity;
+
+    /**
+     * In PHP please use {@see $aggregateId} instead.
+     *
+     * For Fusion please use the upcoming FlowQuery operation:
+     * ```
+     * ${q(node).id()}
+     * ```
+     * @deprecated will be removed before the final 9.0 release
+     */
+    public NodeAggregateId $nodeAggregateId;
+
+    /**
+     * In PHP please fetch the NodeType via the NodeTypeManager or the NodeTypeWithFallbackProvider trait instead.
+     * {@see $nodeTypeName}
+     *
+     * For Fusion please use the EEL Helper:
+     * ```
+     * ${Neos.Node.getNodeType(node)}
+     * ```
+     * @deprecated will be removed before the final 9.0 release
+     */
+    public ?NodeType $nodeType;
+
+    /**
+     * @param ContentRepositoryId $contentRepositoryId The content-repository this Node belongs to
+     * @param WorkspaceName $workspaceName The workspace of this Node
+     * @param DimensionSpacePoint $dimensionSpacePoint DimensionSpacePoint a node has been accessed in
+     * @param NodeAggregateId $aggregateId NodeAggregateId (identifier) of this node. This is part of the node's "Read Model" identity, which is defined in {@see NodeAddress}
      * @param OriginDimensionSpacePoint $originDimensionSpacePoint The DimensionSpacePoint the node originates in. Usually needed to address a Node in a NodeAggregate in order to update it.
      * @param NodeAggregateClassification $classification The classification (regular, root, tethered) of this node
      * @param NodeTypeName $nodeTypeName The node's node type name; always set, even if unknown to the NodeTypeManager
@@ -53,33 +114,44 @@ final readonly class Node
      * @param NodeName|null $nodeName The optionally named hierarchy relation to the node's parent.
      * @param NodeTags $tags explicit and inherited SubtreeTags of this node
      * @param Timestamps $timestamps Creation and modification timestamps of this node
+     * @param VisibilityConstraints $visibilityConstraints Information which subgraph filter was used to access this node
      */
     private function __construct(
-        public NodeAddress $address,
-        /** @deprecated will be removed before the final 9.0 release */
-        public ContentSubgraphIdentity $subgraphIdentity,
-        /** @deprecated will be removed before the final 9.0 release (use address.aggregateId instead) */
-        public NodeAggregateId $nodeAggregateId,
+        public ContentRepositoryId $contentRepositoryId,
+        public WorkspaceName $workspaceName,
+        public DimensionSpacePoint $dimensionSpacePoint,
+        public NodeAggregateId $aggregateId,
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
         public NodeAggregateClassification $classification,
         public NodeTypeName $nodeTypeName,
-        public ?NodeType $nodeType,
         public PropertyCollection $properties,
         public ?NodeName $nodeName,
         public NodeTags $tags,
         public Timestamps $timestamps,
+        public VisibilityConstraints $visibilityConstraints,
+        ?NodeType $nodeType,
+        ContentStreamId $contentStreamId
     ) {
         if ($this->classification->isTethered() && $this->nodeName === null) {
             throw new \InvalidArgumentException('The NodeName must be set if the Node is tethered.', 1695118377);
         }
+        // legacy to be removed before Neos9
+        $this->nodeAggregateId = $this->aggregateId;
+        $this->nodeType = $nodeType;
+        $this->subgraphIdentity = ContentSubgraphIdentity::create(
+            $contentRepositoryId,
+            $contentStreamId,
+            $dimensionSpacePoint,
+            $visibilityConstraints
+        );
     }
 
     /**
      * @internal The signature of this method can change in the future!
      */
-    public static function create(NodeAddress $address, ContentSubgraphIdentity $subgraphIdentity, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, ?NodeType $nodeType, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps): self
+    public static function create(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, NodeAggregateId $aggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateClassification $classification, NodeTypeName $nodeTypeName, PropertyCollection $properties, ?NodeName $nodeName, NodeTags $tags, Timestamps $timestamps, VisibilityConstraints $visibilityConstraints, ?NodeType $nodeType, ContentStreamId $contentStreamId): self
     {
-        return new self($address, $subgraphIdentity, $address->aggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $nodeType, $properties, $nodeName, $tags, $timestamps);
+        return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $aggregateId, $originDimensionSpacePoint, $classification, $nodeTypeName, $properties, $nodeName, $tags, $timestamps, $visibilityConstraints, $nodeType, $contentStreamId);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -65,6 +65,7 @@ final readonly class NodeAggregate
      * @param OriginByCoverage $occupationByCovered
      * @param DimensionSpacePointsBySubtreeTags $dimensionSpacePointsBySubtreeTags dimension space points for every subtree tag this aggregate is *explicitly* tagged with (excluding inherited tags)
      */
+    // todo add workspace name and content repository id and remove cs id
     public function __construct(
         public ContentStreamId $contentStreamId,
         public NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
@@ -39,6 +39,10 @@ final readonly class VisibilityConstraints implements \JsonSerializable
         return md5(implode('|', $this->tagConstraints->toStringArray()));
     }
 
+    /**
+     * A non restricted subgraph can find all nodes without filtering.
+     * Disabled nodes are this way also findable.
+     */
     public static function withoutRestrictions(): self
     {
         return new self(SubtreeTags::createEmpty());

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ForeignContentRepositoryUsed.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ForeignContentRepositoryUsed.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Exception;
+
+use Neos\ContentRepository\Core\ContentRepository;
+
+/**
+ * @api because exception might be thrown on invalid interactions with a foreign ContentRepository instance
+ */
+class ForeignContentRepositoryUsed extends \DomainException
+{
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  *          $nodeAddress->dimensionSpacePoint,
  *          VisibilityConstraints::withoutRestrictions()
  *      );
- *      $node = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
+ *      $node = $subgraph->findNodeById($nodeAddress->aggregateId);
  *
  * @api
  */
@@ -29,7 +29,7 @@ final readonly class NodeAddress implements \JsonSerializable
         public ContentRepositoryId $contentRepositoryId,
         public WorkspaceName $workspaceName,
         public DimensionSpacePoint $dimensionSpacePoint,
-        public NodeAggregateId $nodeAggregateId,
+        public NodeAggregateId $aggregateId,
     ) {
     }
 
@@ -37,9 +37,9 @@ final readonly class NodeAddress implements \JsonSerializable
         ContentRepositoryId $contentRepositoryId,
         WorkspaceName $workspaceName,
         DimensionSpacePoint $dimensionSpacePoint,
-        NodeAggregateId $nodeAggregateId,
+        NodeAggregateId $aggregateId,
     ): self {
-        return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $nodeAggregateId);
+        return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $aggregateId);
     }
 
     /**
@@ -51,7 +51,7 @@ final readonly class NodeAddress implements \JsonSerializable
             ContentRepositoryId::fromString($array['contentRepositoryId']),
             WorkspaceName::fromString($array['workspaceName']),
             DimensionSpacePoint::fromArray($array['dimensionSpacePoint']),
-            NodeAggregateId::fromString($array['nodeAggregateId'])
+            NodeAggregateId::fromString($array['aggregateId'])
         );
     }
 
@@ -60,9 +60,9 @@ final readonly class NodeAddress implements \JsonSerializable
         return self::fromArray(\json_decode($jsonString, true, JSON_THROW_ON_ERROR));
     }
 
-    public function withNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    public function withAggregateId(NodeAggregateId $aggregateId): self
     {
-        return new self($this->contentRepositoryId, $this->workspaceName, $this->dimensionSpacePoint, $nodeAggregateId);
+        return new self($this->contentRepositoryId, $this->workspaceName, $this->dimensionSpacePoint, $aggregateId);
     }
 
     public function equals(self $other): bool
@@ -70,7 +70,7 @@ final readonly class NodeAddress implements \JsonSerializable
         return $this->contentRepositoryId->equals($other->contentRepositoryId)
             && $this->workspaceName->equals($other->workspaceName)
             && $this->dimensionSpacePoint->equals($other->dimensionSpacePoint)
-            && $this->nodeAggregateId->equals($other->nodeAggregateId);
+            && $this->aggregateId->equals($other->aggregateId);
     }
 
     public function toJson(): string
@@ -84,7 +84,7 @@ final readonly class NodeAddress implements \JsonSerializable
             'contentRepositoryId' => $this->contentRepositoryId,
             'workspaceName' => $this->workspaceName,
             'dimensionSpacePoint' => $this->dimensionSpacePoint,
-            'nodeAggregateId' => $this->nodeAggregateId
+            'aggregateId' => $this->aggregateId
         ];
     }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Node;
+
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * The content-repository-id workspace-name dimension-space-point and the node-aggregate-id
+ * Are used in combination to distinctly identify a single node.
+ *
+ * By using the content graph for the content repository
+ * one can build a subgraph with the right perspective to find this node:
+ *
+ *      $subgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)->getSubgraph(
+ *          $nodeAddress->dimensionSpacePoint,
+ *          VisibilityConstraints::withoutRestrictions()
+ *      );
+ *      $node = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
+ *
+ * @api
+ */
+final readonly class NodeAddress implements \JsonSerializable
+{
+    private function __construct(
+        public ContentRepositoryId $contentRepositoryId,
+        public WorkspaceName $workspaceName,
+        public DimensionSpacePoint $dimensionSpacePoint,
+        public NodeAggregateId $nodeAggregateId,
+    ) {
+    }
+
+    public static function create(
+        ContentRepositoryId $contentRepositoryId,
+        WorkspaceName $workspaceName,
+        DimensionSpacePoint $dimensionSpacePoint,
+        NodeAggregateId $nodeAggregateId,
+    ): self {
+        return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $nodeAggregateId);
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            ContentRepositoryId::fromString($array['contentRepositoryId']),
+            WorkspaceName::fromString($array['workspaceName']),
+            DimensionSpacePoint::fromArray($array['dimensionSpacePoint']),
+            NodeAggregateId::fromString($array['nodeAggregateId'])
+        );
+    }
+
+    public static function fromJsonString(string $jsonString): self
+    {
+        return self::fromArray(\json_decode($jsonString, true, JSON_THROW_ON_ERROR));
+    }
+
+    public function withNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    {
+        return new self($this->contentRepositoryId, $this->workspaceName, $this->dimensionSpacePoint, $nodeAggregateId);
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->contentRepositoryId->equals($other->contentRepositoryId)
+            && $this->workspaceName->equals($other->workspaceName)
+            && $this->dimensionSpacePoint->equals($other->dimensionSpacePoint)
+            && $this->nodeAggregateId->equals($other->nodeAggregateId);
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this, JSON_THROW_ON_ERROR);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'contentRepositoryId' => $this->contentRepositoryId,
+            'workspaceName' => $this->workspaceName,
+            'dimensionSpacePoint' => $this->dimensionSpacePoint,
+            'nodeAggregateId' => $this->nodeAggregateId
+        ];
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\SharedModel\Node;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * The content-repository-id workspace-name dimension-space-point and the node-aggregate-id
- * Are used in combination to distinctly identify a single node.
+ * This describes a node's read model identity namely:
+ *
+ * - {@see ContentRepositoryId}
+ * - {@see WorkspaceName}
+ * - {@see DimensionSpacePoint} (not to be confused with the {@see Node::$originDimensionSpacePoint})
+ * - {@see NodeAggregateId}
+ *
+ * In combination the parts can be used to distinctly identify a single node.
  *
  * By using the content graph for the content repository
  * one can build a subgraph with the right perspective to find this node:
@@ -40,6 +47,16 @@ final readonly class NodeAddress implements \JsonSerializable
         NodeAggregateId $aggregateId,
     ): self {
         return new self($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $aggregateId);
+    }
+
+    public static function fromNode(Node $node): self
+    {
+        return new self(
+            $node->contentRepositoryId,
+            $node->workspaceName,
+            $node->dimensionSpacePoint,
+            $node->nodeAggregateId
+        );
     }
 
     /**

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
@@ -9,8 +9,8 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 trait CreateNodeHashTrait
 {
     /**
-     * Create a string hash containing the nodeAggregateId, cr-id, contentStream->id, dimensionSpacePoint->hash
-     * and visibilityConstraints->hash. To be used for ensuring uniqueness or removing nodes.
+     * Create a string hash containing the node-aggregateId, cr-id, workspace-name, dimensionSpacePoint-hash
+     * and visibilityConstraints-hash. To be used for ensuring uniqueness or removing nodes.
      *
      * @see Node::equals() for comparison
      */
@@ -21,9 +21,9 @@ trait CreateNodeHashTrait
                 ':',
                 [
                     $node->nodeAggregateId->value,
-                    $node->subgraphIdentity->contentRepositoryId->value,
-                    $node->subgraphIdentity->contentStreamId->value,
-                    $node->subgraphIdentity->dimensionSpacePoint->hash,
+                    $node->address->contentRepositoryId->value,
+                    $node->address->workspaceName->value,
+                    $node->address->dimensionSpacePoint->hash,
                     $node->subgraphIdentity->visibilityConstraints->getHash()
                 ]
             )

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
@@ -21,10 +21,10 @@ trait CreateNodeHashTrait
                 ':',
                 [
                     $node->nodeAggregateId->value,
-                    $node->address->contentRepositoryId->value,
-                    $node->address->workspaceName->value,
-                    $node->address->dimensionSpacePoint->hash,
-                    $node->subgraphIdentity->visibilityConstraints->getHash()
+                    $node->contentRepositoryId->value,
+                    $node->workspaceName->value,
+                    $node->dimensionSpacePoint->hash,
+                    $node->visibilityConstraints->getHash()
                 ]
             )
         );

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
@@ -62,6 +62,8 @@ use Neos\Flow\Annotations as Flow;
  */
 class FindOperation extends AbstractOperation
 {
+    use CreateNodeHashTrait;
+
     /**
      * {@inheritdoc}
      *
@@ -179,7 +181,7 @@ class FindOperation extends AbstractOperation
         $uniqueResult = [];
         $usedKeys = [];
         foreach ($result as $item) {
-            $identifier = $item->subgraphIdentity->contentStreamId->value . '@' . $item->subgraphIdentity->dimensionSpacePoint->hash . '@' . $item->nodeAggregateId->value;
+            $identifier = $this->createNodeHash($item);
             if (!isset($usedKeys[$identifier])) {
                 $uniqueResult[] = $item;
                 $usedKeys[$identifier] = $identifier;
@@ -199,8 +201,8 @@ class FindOperation extends AbstractOperation
         foreach ($contextNodes as $contextNode) {
             assert($contextNode instanceof Node);
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
-            $subgraphIdentifier = md5($contextNode->subgraphIdentity->contentStreamId->value
-                . '@' . $contextNode->subgraphIdentity->dimensionSpacePoint->toJson());
+            $subgraphIdentifier = md5($subgraph->getIdentity()->contentStreamId->value
+                . '@' . $contextNode->address->dimensionSpacePoint->toJson());
             if (!isset($entryPoints[(string) $subgraphIdentifier])) {
                 $entryPoints[(string) $subgraphIdentifier] = [
                     'subgraph' => $subgraph,

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
@@ -202,7 +202,7 @@ class FindOperation extends AbstractOperation
             assert($contextNode instanceof Node);
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
             $subgraphIdentifier = md5($subgraph->getIdentity()->contentStreamId->value
-                . '@' . $contextNode->address->dimensionSpacePoint->toJson());
+                . '@' . $contextNode->dimensionSpacePoint->toJson());
             if (!isset($entryPoints[(string) $subgraphIdentifier])) {
                 $entryPoints[(string) $subgraphIdentifier] = [
                     'subgraph' => $subgraph,

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -41,7 +41,6 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         );
 
         $this->tetheredNodeAdjustments = new TetheredNodeAdjustments(
-            $contentRepository,
             $projectedNodeIterator,
             $nodeTypeManager,
             $interDimensionalVariationGraph,

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -35,10 +35,12 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Timestamps;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -87,13 +89,19 @@ final class NodeSubjectProvider
     ): Node {
         $serializedDefaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->propertyConverter);
         return Node::create(
+            NodeAddress::create(
+                ContentRepositoryId::fromString('default'),
+                WorkspaceName::forLive(),
+                DimensionSpacePoint::createWithoutDimensions(),
+                $id = NodeAggregateId::create()
+            ),
             ContentSubgraphIdentity::create(
                 ContentRepositoryId::fromString('default'),
                 ContentStreamId::fromString('cs-id'),
                 DimensionSpacePoint::createWithoutDimensions(),
                 VisibilityConstraints::withoutRestrictions()
             ),
-            NodeAggregateId::create(),
+            $id,
             OriginDimensionSpacePoint::createWithoutDimensions(),
             NodeAggregateClassification::CLASSIFICATION_REGULAR,
             $nodeType->name,

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -93,7 +93,7 @@ final class NodeSubjectProvider
                 ContentRepositoryId::fromString('default'),
                 WorkspaceName::forLive(),
                 DimensionSpacePoint::createWithoutDimensions(),
-                $id = NodeAggregateId::create()
+                NodeAggregateId::create()
             ),
             ContentSubgraphIdentity::create(
                 ContentRepositoryId::fromString('default'),
@@ -101,7 +101,6 @@ final class NodeSubjectProvider
                 DimensionSpacePoint::createWithoutDimensions(),
                 VisibilityConstraints::withoutRestrictions()
             ),
-            $id,
             OriginDimensionSpacePoint::createWithoutDimensions(),
             NodeAggregateClassification::CLASSIFICATION_REGULAR,
             $nodeType->name,

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -89,22 +89,13 @@ final class NodeSubjectProvider
     ): Node {
         $serializedDefaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->propertyConverter);
         return Node::create(
-            NodeAddress::create(
-                ContentRepositoryId::fromString('default'),
-                WorkspaceName::forLive(),
-                DimensionSpacePoint::createWithoutDimensions(),
-                NodeAggregateId::create()
-            ),
-            ContentSubgraphIdentity::create(
-                ContentRepositoryId::fromString('default'),
-                ContentStreamId::fromString('cs-id'),
-                DimensionSpacePoint::createWithoutDimensions(),
-                VisibilityConstraints::withoutRestrictions()
-            ),
+            ContentRepositoryId::fromString('default'),
+            WorkspaceName::forLive(),
+            DimensionSpacePoint::createWithoutDimensions(),
+            NodeAggregateId::create(),
             OriginDimensionSpacePoint::createWithoutDimensions(),
             NodeAggregateClassification::CLASSIFICATION_REGULAR,
             $nodeType->name,
-            $nodeType,
             new PropertyCollection(
                 $propertyValues
                     ? $serializedDefaultPropertyValues->merge($propertyValues)
@@ -118,7 +109,10 @@ final class NodeSubjectProvider
                 new \DateTimeImmutable(),
                 new \DateTimeImmutable(),
                 new \DateTimeImmutable()
-            )
+            ),
+            VisibilityConstraints::withoutRestrictions(),
+            $nodeType,
+            ContentStreamId::fromString('cs-id'),
         );
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -15,7 +15,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ProjectionCatchUpTriggerInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
-use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
 use Neos\ContentRepositoryRegistry\Exception\ContentRepositoryNotFoundException;
@@ -93,13 +92,9 @@ final class ContentRepositoryRegistry
 
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
-        $contentRepository = $this->get($node->subgraphIdentity->contentRepositoryId);
+        $contentRepository = $this->get($node->address->contentRepositoryId);
 
-        // FIXME: node->workspace
-        /** @var Workspace $workspace */
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($node->subgraphIdentity->contentStreamId);
-
-        return $contentRepository->getContentGraph($workspace->workspaceName)->getSubgraph(
+        return $contentRepository->getContentGraph($node->address->workspaceName)->getSubgraph(
             $node->subgraphIdentity->dimensionSpacePoint,
             $node->subgraphIdentity->visibilityConstraints
         );

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -92,12 +92,7 @@ final class ContentRepositoryRegistry
 
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
-        $contentRepository = $this->get($node->contentRepositoryId);
-
-        return $contentRepository->getContentGraph($node->workspaceName)->getSubgraph(
-            $node->dimensionSpacePoint,
-            $node->visibilityConstraints
-        );
+        return $this->get($node->contentRepositoryId)->subgraphForNode($node);
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -92,11 +92,11 @@ final class ContentRepositoryRegistry
 
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
-        $contentRepository = $this->get($node->address->contentRepositoryId);
+        $contentRepository = $this->get($node->contentRepositoryId);
 
-        return $contentRepository->getContentGraph($node->address->workspaceName)->getSubgraph(
-            $node->subgraphIdentity->dimensionSpacePoint,
-            $node->subgraphIdentity->visibilityConstraints
+        return $contentRepository->getContentGraph($node->workspaceName)->getSubgraph(
+            $node->dimensionSpacePoint,
+            $node->visibilityConstraints
         );
     }
 

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -870,10 +870,10 @@ class WorkspacesController extends AbstractModuleController
      */
     protected function getOriginalNode(
         Node $modifiedNode,
-        WorkspaceName $workspaceName,
+        WorkspaceName $baseWorkspaceName,
         ContentRepository $contentRepository,
     ): ?Node {
-        $baseSubgraph = $contentRepository->getContentGraph($workspaceName)->getSubgraph(
+        $baseSubgraph = $contentRepository->getContentGraph($baseWorkspaceName)->getSubgraph(
             $modifiedNode->subgraphIdentity->dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );

--- a/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
@@ -18,7 +18,6 @@ namespace Neos\Neos\Domain\Service;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
@@ -42,13 +41,9 @@ final class SiteNodeUtility
      * To find the site node for the live workspace in a 0 dimensional content repository use:
      *
      * ```php
-     * $contentRepository = $this->contentRepositoryRegistry->get($site->getConfiguration()->contentRepositoryId);
-     * $liveWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::forLive())
-     *   ?? throw new \RuntimeException('Expected live workspace to exist.');
-     *
      * $siteNode = $this->siteNodeUtility->findSiteNodeBySite(
      *     $site,
-     *     $liveWorkspace->currentContentStreamId,
+     *     WorkspaceName::forLive(),
      *     DimensionSpacePoint::createWithoutDimensions(),
      *     VisibilityConstraints::frontend()
      * );

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
@@ -31,7 +31,9 @@ use Neos\Flow\Annotations as Flow;
  *
  * It is used in Neos Routing to build a URI to a node.
  *
- * @api
+ * @deprecated will be removed before Final 9.0
+ * The NodeAddress was added 6 years ago without the concept of multiple crs
+ * Its usages will be replaced by the new node attached node address
  */
 #[Flow\Proxy(false)]
 final readonly class NodeAddress

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * @api
+ * @deprecated will be removed before Final 9.0
  */
 class NodeAddressFactory
 {

--- a/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
@@ -8,6 +8,7 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
@@ -73,20 +74,20 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
 
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($serializedNode['workspaceName']));
-        if (!$workspace) {
+        try {
+            $workspaceName = WorkspaceName::fromString($serializedNode['workspaceName']);
+            $subgraph = $contentRepository->getContentGraph($workspaceName)->getSubgraph(
+                DimensionSpacePoint::fromArray($serializedNode['dimensionSpacePoint']),
+                $workspaceName->isLive()
+                    ? VisibilityConstraints::frontend()
+                    : VisibilityConstraints::withoutRestrictions()
+            );
+        } catch (WorkspaceDoesNotExist $exception) {
             // in case the workspace was deleted the rendering should probably not come to this very point
             // still if it does we fail silently
             // this is also the behaviour for when the property mapper is used
             return null;
         }
-
-        $subgraph = $contentRepository->getContentGraph($workspace->workspaceName)->getSubgraph(
-            DimensionSpacePoint::fromArray($serializedNode['dimensionSpacePoint']),
-            $workspace->isPublicWorkspace()
-                ? VisibilityConstraints::frontend()
-                : VisibilityConstraints::withoutRestrictions()
-        );
 
         $node = $subgraph->findNodeById(NodeAggregateId::fromString($serializedNode['nodeAggregateId']));
         if (!$node) {

--- a/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
@@ -89,7 +89,7 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
             return null;
         }
 
-        $node = $subgraph->findNodeById(NodeAggregateId::fromString($serializedNode['nodeAggregateId']));
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString($serializedNode['aggregateId']));
         if (!$node) {
             // instead of crashing the whole rendering, by silently returning null we will most likely just break
             // rendering of the sub part here that needs the node
@@ -104,22 +104,7 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
      */
     private function serializeNode(Node $source): array
     {
-        $contentRepository = $this->contentRepositoryRegistry->get(
-            $source->subgraphIdentity->contentRepositoryId
-        );
-
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($source->subgraphIdentity->contentStreamId);
-
-        if (!$workspace) {
-            throw new \RuntimeException(sprintf('Could not fetch workspace for node (%s) in content stream (%s).', $source->nodeAggregateId->value, $source->subgraphIdentity->contentStreamId->value), 1699780153);
-        }
-
-        return [
-            'contentRepositoryId' => $source->subgraphIdentity->contentRepositoryId->value,
-            'workspaceName' => $workspace->workspaceName->value,
-            'dimensionSpacePoint' => $source->subgraphIdentity->dimensionSpacePoint->jsonSerialize(),
-            'nodeAggregateId' => $source->nodeAggregateId->value
-        ];
+        return $source->address->jsonSerialize();
     }
 
     public function supportsDenormalization(mixed $data, string $type, string $format = null)

--- a/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
@@ -101,7 +101,7 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
      */
     private function serializeNode(Node $source): array
     {
-        return $source->address->jsonSerialize();
+        return NodeAddress::fromNode($source)->jsonSerialize();
     }
 
     public function supportsDenormalization(mixed $data, string $type, string $format = null)

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Core\Dimension\ContentDimensionId;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 
 /**
@@ -59,12 +60,11 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         $interDimensionalVariationGraph = $dimensionMenuItemsImplementationInternals->interDimensionalVariationGraph;
         $currentDimensionSpacePoint = $currentNode->subgraphIdentity->dimensionSpacePoint;
         $contentDimensionIdentifierToLimitTo = $this->getContentDimensionIdentifierToLimitTo();
-        // FIXME: node->workspaceName
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($currentNode->subgraphIdentity->contentStreamId);
-        if (is_null($workspace)) {
+        try {
+            $contentGraph = $contentRepository->getContentGraph($currentNode->address->workspaceName);
+        } catch (WorkspaceDoesNotExist) {
             return $menuItems;
         }
-        $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
 
         foreach ($interDimensionalVariationGraph->getDimensionSpacePoints() as $dimensionSpacePoint) {
             $variant = null;

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -61,7 +61,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         $currentDimensionSpacePoint = $currentNode->subgraphIdentity->dimensionSpacePoint;
         $contentDimensionIdentifierToLimitTo = $this->getContentDimensionIdentifierToLimitTo();
         try {
-            $contentGraph = $contentRepository->getContentGraph($currentNode->address->workspaceName);
+            $contentGraph = $contentRepository->getContentGraph($currentNode->workspaceName);
         } catch (WorkspaceDoesNotExist) {
             return $menuItems;
         }

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -135,11 +135,11 @@ class CachingHelper implements ProtectedContextAwareInterface
         }
 
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->address->contentRepositoryId
+            $node->contentRepositoryId
         );
 
         $currentWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(
-            $node->address->workspaceName
+            $node->workspaceName
         );
         $workspaceChain = [];
         // TODO: Maybe write CTE here

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -135,17 +135,15 @@ class CachingHelper implements ProtectedContextAwareInterface
         }
 
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
+            $node->address->contentRepositoryId
         );
 
-
-        /** @var Workspace $currentWorkspace */
-        $currentWorkspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
-            $node->subgraphIdentity->contentStreamId
+        $currentWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(
+            $node->address->workspaceName
         );
         $workspaceChain = [];
         // TODO: Maybe write CTE here
-        while ($currentWorkspace instanceof Workspace) {
+        while ($currentWorkspace !== null) {
             $workspaceChain[$currentWorkspace->workspaceName->value] = $currentWorkspace;
             $currentWorkspace = $currentWorkspace->baseWorkspaceName
                 ? $contentRepository->getWorkspaceFinder()->findOneByName($currentWorkspace->baseWorkspaceName)

--- a/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
@@ -143,15 +143,15 @@ final class DimensionHelper implements ProtectedContextAwareInterface
     {
         $contentDimensionId = is_string($dimensionName) ? new ContentDimensionId($dimensionName) : $dimensionName;
         $contentDimensionValue = is_string($dimensionValue) ? new ContentDimensionValue($dimensionValue) : $dimensionValue;
-        $contentRepository = $this->contentRepositoryRegistry->get($node->address->contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
 
         try {
             return $contentRepository
-                ->getContentGraph($node->address->workspaceName)
+                ->getContentGraph($node->workspaceName)
                 ->getSubgraph(
-                    $node->address->dimensionSpacePoint->vary($contentDimensionId, $contentDimensionValue->value),
-                    $node->subgraphIdentity->visibilityConstraints
-                )->findNodeById($node->nodeAggregateId);
+                    $node->dimensionSpacePoint->vary($contentDimensionId, $contentDimensionValue->value),
+                    $node->visibilityConstraints
+                )->findNodeById($node->aggregateId);
         } catch (WorkspaceDoesNotExist) {
             return null;
         }

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -350,10 +350,10 @@ class LinkingService
         $this->lastLinkedNode = $node;
 
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->address->contentRepositoryId
+            $node->contentRepositoryId
         );
         $workspace = $contentRepository->getWorkspaceFinder()->findOneByName(
-            $node->address->workspaceName
+            $node->workspaceName
         );
         $request = $controllerContext->getRequest()->getMainRequest();
         $uriBuilder = clone $controllerContext->getUriBuilder();

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -350,10 +350,10 @@ class LinkingService
         $this->lastLinkedNode = $node;
 
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
+            $node->address->contentRepositoryId
         );
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId(
-            $node->subgraphIdentity->contentStreamId
+        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName(
+            $node->address->workspaceName
         );
         $request = $controllerContext->getRequest()->getMainRequest();
         $uriBuilder = clone $controllerContext->getUriBuilder();

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -16,6 +16,7 @@ namespace Neos\Neos\View;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
@@ -105,27 +106,26 @@ class FusionExceptionView extends AbstractView
             return $this->renderErrorWelcomeScreen();
         }
 
-        $contentRepository = $this->contentRepositoryRegistry->get($siteDetectionResult->contentRepositoryId);
         $fusionExceptionViewInternals = $this->contentRepositoryRegistry->buildService(
             $siteDetectionResult->contentRepositoryId,
             new FusionExceptionViewInternalsFactory()
         );
         $dimensionSpacePoint = $fusionExceptionViewInternals->getArbitraryDimensionSpacePoint();
 
-        $liveWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::forLive());
-
-        $currentSiteNode = null;
         $site = $this->siteRepository->findOneByNodeName($siteDetectionResult->siteNodeName);
-        if ($liveWorkspace && $site) {
+
+        if (!$site) {
+            return $this->renderErrorWelcomeScreen();
+        }
+
+        try {
             $currentSiteNode = $this->siteNodeUtility->findSiteNodeBySite(
                 $site,
-                $liveWorkspace->workspaceName,
+                WorkspaceName::forLive(),
                 $dimensionSpacePoint,
                 VisibilityConstraints::frontend()
             );
-        }
-
-        if (!$currentSiteNode) {
+        } catch (WorkspaceDoesNotExist|\RuntimeException $exception) {
             return $this->renderErrorWelcomeScreen();
         }
 

--- a/Neos.Neos/Classes/View/FusionExceptionView.php
+++ b/Neos.Neos/Classes/View/FusionExceptionView.php
@@ -125,7 +125,7 @@ class FusionExceptionView extends AbstractView
                 $dimensionSpacePoint,
                 VisibilityConstraints::frontend()
             );
-        } catch (WorkspaceDoesNotExist|\RuntimeException $exception) {
+        } catch (WorkspaceDoesNotExist | \RuntimeException) {
             return $this->renderErrorWelcomeScreen();
         }
 

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -14,6 +14,8 @@ namespace Neos\Neos\Tests\Unit\Fusion\Helper;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\Flow\Tests\UnitTestCase;
@@ -198,21 +200,20 @@ class CachingHelperTest extends UnitTestCase
     {
         $now = new \DateTimeImmutable();
         return Node::create(
-            ContentSubgraphIdentity::create(
-                ContentRepositoryId::fromString("default"),
-                ContentStreamId::fromString("cs-identifier"),
-                DimensionSpacePoint::createWithoutDimensions(),
-                VisibilityConstraints::withoutRestrictions()
-            ),
+            ContentRepositoryId::fromString("default"),
+            WorkspaceName::forLive(),
+            DimensionSpacePoint::createWithoutDimensions(),
             $nodeAggregateId,
             OriginDimensionSpacePoint::createWithoutDimensions(),
             NodeAggregateClassification::CLASSIFICATION_REGULAR,
             NodeTypeName::fromString("SomeNodeTypeName"),
-            null,
             new PropertyCollection(SerializedPropertyValues::fromArray([]), new PropertyConverter(new Serializer([], []))),
             null,
             NodeTags::createEmpty(),
-            Timestamps::create($now, $now, null, null)
+            Timestamps::create($now, $now, null, null),
+            VisibilityConstraints::withoutRestrictions(),
+            null,
+            ContentStreamId::fromString("cs-identifier"),
         );
     }
 }

--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -42,14 +42,9 @@ class TimeableNodeVisibilityService
     public function handleExceededNodeDates(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): ChangedVisibilities
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-        $liveWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName($workspaceName);
-        if ($liveWorkspace === null) {
-            throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
-        }
-
         $now = new \DateTimeImmutable();
 
-        $nodes = $this->getNodesWithExceededDates($contentRepository, $liveWorkspace, $now);
+        $nodes = $this->getNodesWithExceededDates($contentRepository, $workspaceName, $now);
         $results = [];
 
         /** @var Node $node */
@@ -58,7 +53,7 @@ class TimeableNodeVisibilityService
             if ($this->needsEnabling($node, $now) && $nodeIsDisabled) {
                 $contentRepository->handle(
                     EnableNodeAggregate::create(
-                        $liveWorkspace->workspaceName,
+                        $workspaceName,
                         $node->nodeAggregateId,
                         $node->subgraphIdentity->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
@@ -72,7 +67,7 @@ class TimeableNodeVisibilityService
             if ($this->needsDisabling($node, $now) && !$nodeIsDisabled) {
                 $contentRepository->handle(
                     DisableNodeAggregate::create(
-                        $liveWorkspace->workspaceName,
+                        $workspaceName,
                         $node->nodeAggregateId,
                         $node->subgraphIdentity->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
@@ -89,13 +84,13 @@ class TimeableNodeVisibilityService
     /**
      * @return \Generator<Node>
      */
-    private function getNodesWithExceededDates(ContentRepository $contentRepository, Workspace $liveWorkspace, \DateTimeImmutable $now): \Generator
+    private function getNodesWithExceededDates(ContentRepository $contentRepository, WorkspaceName $workspaceName, \DateTimeImmutable $now): \Generator
     {
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
 
         foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
 
-            $contentGraph = $contentRepository->getContentGraph($liveWorkspace->workspaceName);
+            $contentGraph = $contentRepository->getContentGraph($workspaceName);
 
             // We fetch without restriction to get also all disabled nodes
             $subgraph = $contentGraph->getSubgraph(


### PR DESCRIPTION
Seeing code like this

```php
$subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
$nodeTypeManager = $this->contentRepositoryRegistry->get($node->contentRepositoryId)->getNodeTypeManager();
```

this seems just double because the contentRepository is fetched twice and not passed
```php
$subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
$contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
$contentRepository-> ...
```

makes me rethink if were not going to far with `contentRepositoryRegistry->subgraphForNode`, id like to fetch the cr more often in code directly and then get the subgraph:

```php
$contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
$subgraph = $contentRepository->subgraphForNode($node);
$nodeTypeManager = $contentRepository->getNodeTypeManager();
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
