### PR TITLE
TASK: WIP Prepare for synchronous content repository

### DIFF
--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandResult.php
@@ -5,75 +5,23 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\CommandHandler;
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\Projection\ProjectionInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\EventStore\Model\Event\SequenceNumber;
-use Neos\EventStore\Model\Event\Version;
-use Neos\EventStore\Model\EventStore\CommitResult;
 
 /**
- * Result of the {@see ContentRepository::handle()} method to be able to block until the projections were updated.
+ * Was the result of the {@see ContentRepository::handle()} method.
+ * Previously one would need this to be able to block until the projections were updated.
  *
- * {@see PendingProjections} for a detailed explanation how the blocking works.
+ * This will no longer be required in the future see https://github.com/neos/neos-development-collection/pull/4988
  *
+ * @deprecated this b/c layer will be removed with the next beta or before Neos 9 final release
  * @api
  */
 final readonly class CommandResult
 {
-    public function __construct(
-        private PendingProjections $pendingProjections,
-        public CommitResult $commitResult,
-    ) {
-    }
-
     /**
-     * an empty command result which should not result in projection updates
-     * @return self
-     */
-    public static function empty(): self
-    {
-        return new self(
-            PendingProjections::empty(),
-            new CommitResult(
-                Version::first(),
-                SequenceNumber::none()
-            )
-        );
-    }
-
-    /**
-     * Wait until all projections are up to date; i.e. have processed the events.
-     *
-     * @return void
-     * @api
+     * We block by default thus you must not call this method or use this legacy stub
+     * @deprecated this b/c layer will be removed with the next beta or before Neos 9 final release
      */
     public function block(): void
     {
-        foreach ($this->pendingProjections->projections as $pendingProjection) {
-            $expectedSequenceNumber = $this->pendingProjections->getExpectedSequenceNumber($pendingProjection);
-            $this->blockProjection($pendingProjection, $expectedSequenceNumber);
-        }
-    }
-
-    /**
-     * @param ProjectionInterface<ProjectionStateInterface> $projection
-     */
-    private function blockProjection(ProjectionInterface $projection, SequenceNumber $expectedSequenceNumber): void
-    {
-        $attempts = 0;
-        while ($projection->getCheckpointStorage()->getHighestAppliedSequenceNumber()->value < $expectedSequenceNumber->value) {
-            usleep(50000); // 50000μs = 50ms
-            if (++$attempts > 100) { // 5 seconds
-                throw new \RuntimeException(
-                    sprintf(
-                        'TIMEOUT while waiting for projection "%s" to catch up to sequence number %d ' .
-                        '- check the error logs for details.',
-                        $projection::class,
-                        $expectedSequenceNumber->value
-                    ),
-                    1550232279
-                );
-            }
-        }
     }
 }

--- a/Neos.ContentRepository.Core/Classes/EventStore/EventPersister.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventPersister.php
@@ -11,8 +11,6 @@ use Neos\ContentRepository\Core\Projection\Projections;
 use Neos\ContentRepository\Core\Projection\WithMarkStaleInterface;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\ConcurrencyException;
-use Neos\EventStore\Model\Event;
-use Neos\EventStore\Model\Event\EventId;
 use Neos\EventStore\Model\Events;
 
 /**
@@ -39,7 +37,7 @@ final readonly class EventPersister
     public function publishEvents(EventsToPublish $eventsToPublish): CommandResult
     {
         if ($eventsToPublish->events->isEmpty()) {
-            return CommandResult::empty();
+            return new CommandResult();
         }
         // the following logic could also be done in an AppEventStore::commit method (being called
         // directly from the individual Command Handlers).
@@ -66,8 +64,6 @@ final readonly class EventPersister
             }
         }
         $this->projectionCatchUpTrigger->triggerCatchUp($pendingProjections->projections);
-
-        // The CommandResult can be used to block until projections are up to date.
-        return new CommandResult($pendingProjections, $commitResult);
+        return new CommandResult();
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/CatchUpTriggerWithSynchronousOption.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/ProjectionCatchUpTrigger/CatchUpTriggerWithSynchronousOption.php
@@ -23,6 +23,7 @@ use Neos\Flow\Annotations as Flow;
  * We will hopefully get rid of this class at some point; by introducing a NodeAggregate
  * which will take care of constraint enforcement then.
  *
+ * @deprecated remove me https://github.com/neos/neos-development-collection/pull/4988
  * @internal
  */
 class CatchUpTriggerWithSynchronousOption implements ProjectionCatchUpTriggerInterface
@@ -33,7 +34,10 @@ class CatchUpTriggerWithSynchronousOption implements ProjectionCatchUpTriggerInt
      */
     protected $contentRepositoryRegistry;
 
-    private static bool $synchronousEnabled = false;
+    /**
+     * Hack by setting to true to be always sync mode: https://github.com/neos/neos-development-collection/pull/4988
+     */
+    private static bool $synchronousEnabled = true;
 
     /**
      * INTERNAL


### PR DESCRIPTION
In preparation for https://github.com/neos/neos-development-collection/pull/4988 this will adjust the cr to be synchronous already via a hack and adds a slim b/c `block` layer which will be removed with the next beta to ease migration.

**Upgrade instructions**

The `CommandResult::block` calls must be removed as the backwards compatibility layer will be removed with next beta.

```diff
- $contentRepository->handle($command)->block();
+ $contentRepository->handle($command);
```

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
