### PR TITLE
TASK: Remove explicit deprecated command blocking

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -45,10 +45,6 @@
       "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
       "@test:behat-cli -c Neos.Neos/Tests/Behavior/behat.yml"
     ],
-    "test:behavioral:sync": [
-      "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
-      "@test:behavioral"
-    ],
     "test:behavioral:stop-on-failure": [
       "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist",
       "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/behat.yml.dist",
@@ -57,10 +53,6 @@
       "@test:behat-cli -vvv --stop-on-failure -c Neos.TimeableNodeVisibility/Tests/Behavior/behat.yml.dist",
       "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
       "@test:behat-cli -vvv --stop-on-failure -c Neos.Neos/Tests/Behavior/behat.yml"
-    ],
-    "test:behavioral:stop-on-failure:sync": [
-      "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
-      "@test:behavioral:stop-on-failure"
     ],
     "test": [
       "@test:unit",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
           # DEBUG MODE: ALTERNATIVELY, comment in the following lines to dump the DB.
           # do not exit the script if the tests break; as we want to upload the database dumps afterwards.
           set +e
-          composer test:behavioral:stop-on-failure:sync
+          composer test:behavioral:stop-on-failure
           retVal=$?
 
           # automatically search for race conditions

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -44,7 +44,6 @@ class FeatureContext implements BehatContext
         self::bootstrapFlow();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
 
-        $this->setupCRTestSuiteTrait();
         $this->setupDbalGraphAdapterIntegrityViolationTrait();
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
@@ -19,7 +19,6 @@ Feature: Run integrity violation detection regarding hierarchy relations and nod
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
@@ -35,7 +34,6 @@ Feature: Run integrity violation detection regarding hierarchy relations and nod
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                 |
       | nodeName                    | "child-document"                                         |
       | nodeAggregateClassification | "regular"                                                |
-    And the graph projection is fully up to date
 
   Scenario: Detach a hierarchy relation from its parent
     When I add the following hierarchy relation:

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
@@ -19,7 +19,6 @@ Feature: Run integrity violation detection regarding parent relations
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
@@ -55,7 +54,6 @@ Feature: Run integrity violation detection regarding parent relations
       | parentNodeAggregateId       | "sir-david-nodenborough"                                 |
       | nodeName                    | "child-document"                                         |
       | nodeAggregateClassification | "regular"                                                |
-    And the graph projection is fully up to date
 
   Scenario: Set a second parent for Nody McNodeface
     And I add the following hierarchy relation:

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -22,7 +22,6 @@ Feature: Run integrity violation detection regarding reference relations
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
@@ -46,7 +45,6 @@ Feature: Run integrity violation detection regarding reference relations
       | coveredDimensionSpacePoints | [{"language":"de"},{"language":"gsw"},{"language":"fr"}] |
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                 |
       | nodeAggregateClassification | "regular"                                                |
-    And the graph projection is fully up to date
 
   Scenario: Detach a reference relation from its source
     When the command SetNodeReferences is executed with payload:
@@ -55,7 +53,6 @@ Feature: Run integrity violation detection regarding reference relations
       | sourceNodeAggregateId           | "source-nodandaise"               |
       | referenceName                   | "referenceProperty"               |
       | references                      | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
     And I detach the following reference relation from its source:
       | Key                        | Value               |
       | contentStreamId            | "cs-identifier"     |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
@@ -19,13 +19,11 @@ Feature: Run integrity violation detection regarding sibling sorting
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |
       | nodeTypeName                | "Neos.ContentRepository:Root"                            |
-    And the graph projection is fully up to date
 
   Scenario: Create two siblings and set the sorting to the same value
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -46,7 +44,6 @@ Feature: Run integrity violation detection regarding sibling sorting
       | coveredDimensionSpacePoints | [{"language":"de"},{"language":"gsw"},{"language":"fr"}] |
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                 |
       | nodeAggregateClassification | "regular"                                                |
-    And the graph projection is fully up to date
     And I set the following position:
       | Key                  | Value              |
       | contentStreamId      | "cs-identifier"    |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
@@ -19,13 +19,11 @@ Feature: Run integrity violation detection regarding subtree tag inheritance
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |
       | nodeTypeName                | "Neos.ContentRepository:Root"                            |
-    And the graph projection is fully up to date
 
   Scenario: Create nodes, disable the topmost and remove some restriction edges manually
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -64,7 +62,6 @@ Feature: Run integrity violation detection regarding subtree tag inheritance
       | nodeAggregateId              | "sir-david-nodenborough"                                 |
       | affectedDimensionSpacePoints | [{"language":"de"},{"language":"gsw"},{"language":"fr"}] |
       | tag                          | "disabled"                                               |
-    And the graph projection is fully up to date
     And I remove the following subtree tag:
       | Key                   | Value                        |
       | contentStreamId       | "cs-identifier"              |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
@@ -19,7 +19,6 @@ Feature: Run projection integrity violation detection regarding naming of tether
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -35,7 +34,6 @@ Feature: Run projection integrity violation detection regarding naming of tether
       | parentNodeAggregateId       | "lady-eleonode-rootford"                  |
       | nodeName                    | "document"                                |
       | nodeAggregateClassification | "regular"                                 |
-    And the graph projection is fully up to date
 
   Scenario: Remove tethered node's name
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -48,7 +46,6 @@ Feature: Run projection integrity violation detection regarding naming of tether
       | parentNodeAggregateId       | "sir-david-nodenborough"                  |
       | nodeName                    | "to-be-hacked-to-null"                    |
       | nodeAggregateClassification | "tethered"                                |
-    And the graph projection is fully up to date
     And I change the following node's name:
       | Key                       | Value               |
       | contentStreamId           | "cs-identifier"     |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
@@ -21,7 +21,6 @@ Feature: Sibling positions are properly resolved
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -50,49 +49,41 @@ Feature: Sibling positions are properly resolved
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-ii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    And the graph projection is fully up to date
     # distance iii to x: 32
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                        |
       | nodeAggregateId                     | "lady-nodette-nodington-iii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"   |
-    And the graph projection is fully up to date
     # distance iv to x: 16
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-iv" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    And the graph projection is fully up to date
     # distance v to x: 8
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                      |
       | nodeAggregateId                     | "lady-nodette-nodington-v" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x" |
-    And the graph projection is fully up to date
     # distance vi to x: 4
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-vi" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    And the graph projection is fully up to date
     # distance vii to x: 2
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                        |
       | nodeAggregateId                     | "lady-nodette-nodington-vii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"   |
-    And the graph projection is fully up to date
     # distance viii to x: 1 -> reorder -> 128
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                         |
       | nodeAggregateId                     | "lady-nodette-nodington-viii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"    |
-    And the graph projection is fully up to date
     # distance ix to x: 64 after reorder
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-ix" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Classes/Command/PerformanceMeasurementCommandController.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/Command/PerformanceMeasurementCommandController.php
@@ -59,7 +59,7 @@ final class PerformanceMeasurementCommandController extends CommandController
     public function testPerformanceCommand(): void
     {
         $time = microtime(true);
-        $this->performanceMeasurementService->forkContentStream()
+        $this->performanceMeasurementService->forkContentStream();
 
         $timeElapsed = microtime(true) - $time;
         $this->outputLine('Time: ' . $timeElapsed);

--- a/Neos.ContentRepository.BehavioralTests/Classes/Command/PerformanceMeasurementCommandController.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/Command/PerformanceMeasurementCommandController.php
@@ -16,7 +16,6 @@ namespace Neos\ContentRepository\BehavioralTests\Command;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\ContentRepositoryRegistry\Factory\ProjectionCatchUpTrigger\CatchUpTriggerWithSynchronousOption;
 use Neos\Flow\Cli\CommandController;
 use Neos\Neos\Fusion\Cache\GraphProjectorCatchUpHookForCacheFlushing;
 
@@ -47,10 +46,8 @@ final class PerformanceMeasurementCommandController extends CommandController
     {
         $this->performanceMeasurementService->removeEverything();
         $this->outputLine("All removed. Starting to fill.");
-        CatchUpTriggerWithSynchronousOption::synchronously(
-            fn() => GraphProjectorCatchUpHookForCacheFlushing::disabled(
-                fn() => $this->performanceMeasurementService->createNodesForPerformanceTest($nodesPerLevel, $levels)
-            )
+        GraphProjectorCatchUpHookForCacheFlushing::disabled(
+            fn() => $this->performanceMeasurementService->createNodesForPerformanceTest($nodesPerLevel, $levels)
         );
     }
 
@@ -62,9 +59,7 @@ final class PerformanceMeasurementCommandController extends CommandController
     public function testPerformanceCommand(): void
     {
         $time = microtime(true);
-        CatchUpTriggerWithSynchronousOption::synchronously(
-            fn() => $this->performanceMeasurementService->forkContentStream()
-        );
+        $this->performanceMeasurementService->forkContentStream()
 
         $timeElapsed = microtime(true) - $time;
         $this->outputLine('Time: ' . $timeElapsed);

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -29,6 +29,7 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress;
@@ -59,7 +60,7 @@ class FeatureContext implements BehatContext
     {
         self::bootstrapFlow();
 
-        $this->dbal = $this->getObject(Connection::class);
+        $this->dbalClient = $this->getObject(DbalClientInterface::class);
         $this->setUpInterleavingLogger();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
     }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/../../../../Neos.ContentGraph.DoctrineDbalAdapter/Tests
 
 use Behat\Behat\Context\Context as BehatContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Doctrine\DBAL\Connection;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Behat\FlowBootstrapTrait;
 use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\ProjectionIntegrityViolationDetectionTrait;
@@ -28,7 +29,6 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress;
@@ -59,8 +59,7 @@ class FeatureContext implements BehatContext
     {
         self::bootstrapFlow();
 
-        $this->dbalClient = $this->getObject(DbalClientInterface::class);
-        $this->setupCRTestSuiteTrait();
+        $this->dbal = $this->getObject(Connection::class);
         $this->setUpInterleavingLogger();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
     }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
@@ -26,13 +26,11 @@ Feature: Create a root node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: Try to create a root node aggregate in a workspace that currently does not exist:
     When the command CreateRootNodeAggregateWithNode is executed with payload and exceptions are caught:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
@@ -24,7 +24,6 @@ Feature: Create a root node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
 
   Scenario: Create the initial root node aggregate using valid payload without dimensions
@@ -42,7 +41,6 @@ Feature: Create a root node aggregate
       | coveredDimensionSpacePoints | [[]]                          |
       | nodeAggregateClassification | "root"                        |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to be classified as "root"
     And I expect this node aggregate to be of type "Neos.ContentRepository:Root"
@@ -75,7 +73,6 @@ Feature: Create a root node aggregate
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -91,7 +88,6 @@ Feature: Create a root node aggregate
       | coveredDimensionSpacePoints | [[]]                          |
       | nodeAggregateClassification | "root"                        |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to have no parent node aggregates
     And I expect this node aggregate to have no child node aggregates

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -37,7 +37,6 @@ Feature: Create a root node aggregate with tethered children
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And I am user identified by "initiating-user-identifier"
 
@@ -47,7 +46,6 @@ Feature: Create a root node aggregate with tethered children
       | nodeAggregateId                    | "lady-eleonode-rootford"                                                          |
       | nodeTypeName                       | "Neos.ContentRepository.Testing:RootWithTetheredChildNodes"                       |
       | tetheredDescendantNodeAggregateIds | {"child-node": "nody-mc-nodeface", "child-node/grandchild-node": "nodimus-prime"} |
-    And the graph projection is fully up to date
 
     Then I expect exactly 4 events to be published on stream "ContentStream:cs-identifier"
     And event at index 1 is of type "RootNodeAggregateWithNodeWasCreated" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -39,7 +39,6 @@ Feature: Create a root node aggregate with tethered children
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am user identified by "initiating-user-identifier"
 
@@ -49,7 +48,6 @@ Feature: Create a root node aggregate with tethered children
       | nodeAggregateId                    | "lady-eleonode-rootford"                                                          |
       | nodeTypeName                       | "Neos.ContentRepository.Testing:RootWithTetheredChildNodes"                       |
       | tetheredDescendantNodeAggregateIds | {"child-node": "nody-mc-nodeface", "child-node/grandchild-node": "nodimus-prime"} |
-    And the graph projection is fully up to date
 
     Then I expect exactly 6 events to be published on stream "ContentStream:cs-identifier"
     And event at index 1 is of type "RootNodeAggregateWithNodeWasCreated" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
@@ -25,7 +25,6 @@ Feature: Create a root node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
 
   Scenario: Create the initial root node aggregate using valid payload with dimensions
@@ -45,7 +44,6 @@ Feature: Create a root node aggregate
     And event metadata at index 1 is:
       | Key              | Expected                     |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to be classified as "root"
     And I expect this node aggregate to be of type "Neos.ContentRepository:Root"
@@ -89,7 +87,6 @@ Feature: Create a root node aggregate
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -105,7 +102,6 @@ Feature: Create a root node aggregate
       | coveredDimensionSpacePoints | [{"language":"mul"},{"language":"de"},{"language":"en"},{"language":"gsw"}] |
       | nodeAggregateClassification | "root"                                                                      |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to have no parent node aggregates
     And I expect this node aggregate to have no child node aggregates

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -37,13 +37,11 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: Try to create a node aggregate in a workspace that currently does not exist:
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
@@ -144,7 +142,6 @@ Feature: Create node aggregate with node
       | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
       | nodeName              | "document"                            |
-    And the graph projection is fully up to date
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                       | Value                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                    |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
@@ -39,14 +39,12 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: Try to create a node aggregate in an origin dimension space point the parent node does not cover:
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -55,7 +53,6 @@ Feature: Create node aggregate with node
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
       | originDimensionSpacePoint | {"example":"spec"}                    |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                       | Value                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                    |
@@ -72,7 +69,6 @@ Feature: Create node aggregate with node
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
       | nodeName                  | "document"                            |
-    And the graph projection is fully up to date
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                       | Value                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                    |
@@ -92,7 +88,6 @@ Feature: Create node aggregate with node
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
       | originDimensionSpacePoint | {"example":"source"}                  |
       | nodeName                  | "document"                            |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                       | Value                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                    |
@@ -109,7 +104,6 @@ Feature: Create node aggregate with node
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
       | originDimensionSpacePoint | {"example":"source"}                  |
-    And the graph projection is fully up to date
     Given I change the node types in content repository "default" to:
     """yaml
     'Neos.ContentRepository.Testing:LeafNode': {}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -29,7 +29,6 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
@@ -37,7 +36,6 @@ Feature: Create node aggregate with node
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId            | nodeName   | parentNodeAggregateId  | nodeTypeName                                                 | initialPropertyValues    |
@@ -200,7 +198,6 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
@@ -208,7 +205,6 @@ Feature: Create node aggregate with node
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     Given the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                                          |
@@ -217,7 +213,6 @@ Feature: Create node aggregate with node
       | originDimensionSpacePoint | {}                                                             |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                                       |
       | nodeName                  | "node"                                                         |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                              | Value                                                          |
       | nodeAggregateId                  | "sir-nodeward-nodington-iii"                                   |
@@ -240,7 +235,6 @@ Feature: Create node aggregate with node
       | initialPropertyValues       | []                                                             |
       | nodeAggregateClassification | "regular"                                                      |
 
-    When the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
@@ -284,7 +278,6 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
@@ -292,7 +285,6 @@ Feature: Create node aggregate with node
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                                | Value                                                                             |
@@ -302,7 +294,6 @@ Feature: Create node aggregate with node
       | parentNodeAggregateId              | "lady-eleonode-rootford"                                                          |
       | nodeName                           | "node"                                                                            |
       | tetheredDescendantNodeAggregateIds | {"child-node": "nody-mc-nodeface", "child-node/grandchild-node": "nodimus-prime"} |
-    And the graph projection is fully up to date
 
     Then I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
     And event at index 2 is of type "NodeAggregateWithNodeWasCreated" with payload:
@@ -468,7 +459,6 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And I am user identified by "initiating-user-identifier"
@@ -476,7 +466,6 @@ Feature: Create node aggregate with node
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                                | Value                                                                                   |
@@ -486,7 +475,6 @@ Feature: Create node aggregate with node
       | parentNodeAggregateId              | "lady-eleonode-rootford"                                                                |
       | nodeName                           | "node"                                                                                  |
       | tetheredDescendantNodeAggregateIds | {"invalidcasedname": "nody-mc-nodeface", "invalidcharactors": "lord-from-nodding-hill"} |
-    And the graph projection is fully up to date
 
     And I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to be classified as "root"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -29,13 +29,11 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario:  Create node aggregate with initial node with content dimensions
     When the following CreateNodeAggregateWithNode commands are executed:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -54,14 +54,12 @@ Feature: Create a node aggregate with complex default values
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: Create a node aggregate with complex default values
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -69,7 +67,6 @@ Feature: Create a node aggregate with complex default values
       | nodeAggregateId       | "nody-mc-nodeface"                    |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
 
     And I expect this node to have the following serialized properties:
@@ -102,7 +99,6 @@ Feature: Create a node aggregate with complex default values
       | nodeTypeName          | "Neos.ContentRepository.Testing:Node"                                                                                                                                                                                 |
       | parentNodeAggregateId | "lady-eleonode-rootford"                                                                                                                                                                                              |
       | initialPropertyValues | {"dayOfWeek":"DayOfWeek:https://schema.org/Friday","postalAddress":"PostalAddress:anotherDummy", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "price":"PriceSpecification:anotherDummy"} |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
     And I expect this node to have the following properties:
       | Key           | Value                                           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -39,13 +39,11 @@ Feature: Create node aggregate with node
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   # Direct allowance via grandchild NodeType constraints overrule deny all on NodeType
   # issue https://github.com/neos/neos-development-collection/issues/4351
@@ -56,7 +54,6 @@ Feature: Create node aggregate with node
       | nodeTypeName          | "Neos.ContentRepository.Testing.TetheredCollection" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
       | tetheredDescendantNodeAggregateIds | { "collection": "collection-node-id"} |
-    And the graph projection is fully up to date
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     Then I expect the node aggregate "collection-node-id" to exist
     # TetheredCollection
@@ -68,7 +65,6 @@ Feature: Create node aggregate with node
       | nodeAggregateId           | "nody-mc-nodeface"                    |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "collection-node-id"                  |
-    And the graph projection is fully up to date
     Then I expect the node aggregate "nody-mc-nodeface" to exist
 
     # allowed via grant parent node constraints: PrettyNode
@@ -77,7 +73,6 @@ Feature: Create node aggregate with node
       | nodeAggregateId           | "pretty-node"                               |
       | nodeTypeName              | "Neos.ContentRepository.Testing:PrettyNode" |
       | parentNodeAggregateId     | "collection-node-id"                        |
-    And the graph projection is fully up to date
     Then I expect the node aggregate "pretty-node" to exist
 
     # disallowed via grant parent node constraints: UglyNode
@@ -94,13 +89,11 @@ Feature: Create node aggregate with node
       | nodeAggregateId       | "sir-david-nodenborough"              |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
-    And the graph projection is fully up to date
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                                 |
       | nodeAggregateId           | "collection-node-id"                                  |
       | nodeTypeName              | "Neos.ContentRepository.Testing:RestrictedCollection" |
       | parentNodeAggregateId     | "sir-david-nodenborough"                              |
-    And the graph projection is fully up to date
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     Then I expect the node aggregate "collection-node-id" to exist
     # Node
@@ -112,7 +105,6 @@ Feature: Create node aggregate with node
       | nodeAggregateId           | "pretty-node"                               |
       | nodeTypeName              | "Neos.ContentRepository.Testing:PrettyNode" |
       | parentNodeAggregateId     | "collection-node-id"                        |
-    And the graph projection is fully up to date
     Then I expect the node aggregate "pretty-node" to exist
 
     # disallowed via grant parent node constraints: UglyNode

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
@@ -25,13 +25,11 @@ Feature: Create node variant
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"market":"DE", "language":"gsw"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -29,13 +29,11 @@ Feature: Create node specialization
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeName            | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                | tetheredDescendantNodeAggregateIds                                                         |
@@ -91,7 +89,6 @@ Feature: Create node specialization
       | specializationOrigin   | {"example":"spec"}                                                                                                                        |
       | specializationSiblings | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"leafSpec"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 12 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"example":"source"} to exist in the content graph
@@ -288,7 +285,6 @@ Feature: Create node specialization
       | nodeAggregateId | "nody-mc-nodeface"     |
       | sourceOrigin    | {"example":"source"}   |
       | targetOrigin    | {"example":"leafSpec"} |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | nodeAggregateId | "nody-mc-nodeface"   |
@@ -317,7 +313,6 @@ Feature: Create node specialization
       | specializationOrigin   | {"example":"spec"}                                                  |
       | specializationSiblings | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 15 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"example":"source"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -29,13 +29,11 @@ Feature: Create node generalization
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | originDimensionSpacePoint | nodeName            | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                                   | tetheredDescendantNodeAggregateIds                                                            |
     # We have to add another node since root nodes have no origin dimension space points and thus cannot be varied.
@@ -56,13 +54,11 @@ Feature: Create node generalization
       | nodeAggregateId | "nody-mc-nodeface"    |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "elder-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                  |
       | nodeAggregateId | "youngest-mc-nodeface" |
@@ -106,7 +102,6 @@ Feature: Create node generalization
       | generalizationOrigin      | {"example":"general"}                                                                                                                     |
       | variantSucceedingSiblings | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"specB"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 14 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"general"} to exist in the content graph
@@ -370,7 +365,6 @@ Feature: Create node generalization
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"specB"}  |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
@@ -421,7 +415,6 @@ Feature: Create node generalization
       | generalizationOrigin      | {"example":"general"}                                                  |
       | variantSucceedingSiblings | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 15 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"general"} to exist in the content graph
@@ -556,7 +549,6 @@ Feature: Create node generalization
       | nodeAggregateId | "nody-mc-nodeface"    |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
@@ -607,7 +599,6 @@ Feature: Create node generalization
       | peerOrigin             | {"example":"specB"}                                                  |
       | peerSucceedingSiblings | [{"dimensionSpacePoint":{"example":"specB"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 15 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"general"} to exist in the content graph
@@ -742,7 +733,6 @@ Feature: Create node generalization
       | nodeAggregateId | "nody-mc-nodeface"        |
       | sourceOrigin    | {"example":"source"}      |
       | targetOrigin    | {"example":"rootGeneral"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
@@ -793,7 +783,6 @@ Feature: Create node generalization
       | generalizationOrigin      | {"example":"general"}                                                                                                                     |
       | variantSucceedingSiblings | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"specB"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 15 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"general"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -29,13 +29,11 @@ Feature: Create node peer variant
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | originDimensionSpacePoint | nodeName            | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                                   | tetheredDescendantNodeAggregateIds                                                            |
     # We have to add another node since root nodes have no origin dimension space points and thus cannot be varied.
@@ -55,13 +53,11 @@ Feature: Create node peer variant
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | nodeAggregateId | "elder-mc-nodeface"  |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     # Complete the sibling set with a node in the target DSP between the middle and last node
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                                            |
@@ -70,7 +66,6 @@ Feature: Create node peer variant
       | parentNodeAggregateId     | "lady-eleonode-rootford"                                         |
       | originDimensionSpacePoint | {"example":"peer"}                                               |
       | nodeName                  | "younger-document"                                               |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                  |
       | nodeAggregateId | "youngest-mc-nodeface" |
@@ -115,7 +110,6 @@ Feature: Create node peer variant
       | peerOrigin             | {"example":"peer"}                                                                                                                        |
       | peerSucceedingSiblings | [{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peerSpec"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 14 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"example":"source"} to exist in the content graph
@@ -342,7 +336,6 @@ Feature: Create node peer variant
       | nodeAggregateId | "nody-mc-nodeface"     |
       | sourceOrigin    | {"example":"source"}   |
       | targetOrigin    | {"example":"peerSpec"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
@@ -393,7 +386,6 @@ Feature: Create node peer variant
       | peerOrigin             | {"example":"peer"}                                                  |
       | peerSucceedingSiblings | [{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 14 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"peer"} to exist in the content graph
@@ -509,7 +501,6 @@ Feature: Create node peer variant
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                  |
@@ -560,7 +551,6 @@ Feature: Create node peer variant
       | peerOrigin             | {"example":"peerSpec"}                                                  |
       | peerSucceedingSiblings | [{"dimensionSpacePoint":{"example":"peerSpec"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 14 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"peer"} to exist in the content graph
@@ -684,7 +674,6 @@ Feature: Create node peer variant
       | nodeAggregateId | "elder-mc-nodeface"  |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                     |
       | nodeAggregateId | "elder-child-mc-nodeface" |
@@ -707,7 +696,6 @@ Feature: Create node peer variant
       | peerOrigin             | {"example":"peer"}                                                                                                                        |
       | peerSucceedingSiblings | [{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peerSpec"},"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 11 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"peer"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
@@ -25,13 +25,11 @@ Feature: Set node properties: Constraint checks
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -63,13 +63,11 @@ Feature: Set properties
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:
@@ -80,13 +78,11 @@ Feature: Set properties
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language":"mul"} |
       | targetOrigin    | {"language":"de"}  |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language":"mul"} |
       | targetOrigin    | {"language":"gsw"} |
-    And the graph projection is fully up to date
 
   Scenario: Set node properties
     And the command SetNodeProperties is executed with payload:
@@ -94,7 +90,6 @@ Feature: Set properties
       | nodeAggregateId           | "nody-mc-nodeface"                                                                                                                                                                                                                                                                                                                                            |
       | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                                                                                                                                                                                                            |
       | propertyValues            | {"string":"My new string", "int":8472, "float":72.84, "bool":true, "array":{"givenName":"David", "familyName":"Nodenborough","age":84}, "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io", "postalAddress":"PostalAddress:anotherDummy", "price":"PriceSpecification:anotherDummy"} |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"de"} to exist in the content graph
     And I expect this node to have the following properties:
       | Key           | Value                                                         |
@@ -115,7 +110,6 @@ Feature: Set properties
       | nodeAggregateId           | "nody-mc-nodeface"         |
       | originDimensionSpacePoint | {"language": "de"}         |
       | propertyValues            | {"string":"My new string"} |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"de"} to exist in the content graph
     And I expect this node to have the following properties:
       | Key           | Value                                                      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
@@ -36,13 +36,11 @@ Feature: Set node properties with different scopes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:
@@ -53,13 +51,11 @@ Feature: Set node properties with different scopes
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin            | {"language":"mul"} |
       | targetOrigin            | {"language":"de"}  |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin            | {"language":"mul"} |
       | targetOrigin            | {"language":"gsw"} |
-    And the graph projection is fully up to date
 
   Scenario: Set node properties
     And the command SetNodeProperties is executed with payload:
@@ -67,7 +63,6 @@ Feature: Set node properties with different scopes
       | nodeAggregateId   | "nody-mc-nodeface"                                                                                                                                                         |
       | originDimensionSpacePoint | {"language": "de"}                                                                                                                                                         |
       | propertyValues            | {"unscopedProperty":"My new string", "nodeScopedProperty":"My new string", "specializationsScopedProperty":"My new string", "nodeAggregateScopedProperty":"My new string"} |
-    And the graph projection is fully up to date
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
     And I expect this node to have the following properties:
       | Key                           | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
@@ -45,13 +45,11 @@ Feature: Constraint checks on SetNodeReferences
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                                      | parentNodeAggregateId |
       | source-nodandaise       | Neos.ContentRepository.Testing:NodeWithReferences | lady-eleonode-rootford        |
@@ -163,7 +161,6 @@ Feature: Constraint checks on SetNodeReferences
       | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
       | originDimensionSpacePoint     | {"language":"en"}                                   |
       | parentNodeAggregateId | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
 
     When the command SetNodeReferences is executed with payload and exceptions are caught:
       | Key                             | Value                                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
@@ -50,13 +50,11 @@ Feature: Node References without Dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId   | parentNodeAggregateId  | nodeTypeName                                      |
       | source-nodandaise | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithReferences |
@@ -71,7 +69,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"               |
       | referenceName         | "referenceProperty"               |
       | references            | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -89,7 +86,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                                                                       |
       | referenceName         | "referencePropertyWithProperty"                                                                           |
       | references            | [{"target": "anthony-destinode", "properties":{"text":"my text", "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "postalAddress":"PostalAddress:dummy"}}] |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -107,7 +103,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                           |
       | referenceName         | "referencesProperty"                                          |
       | references            | [{"target": "berta-destinode"}, {"target": "carl-destinode"}] |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -131,7 +126,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                                                                                                                                                                                      |
       | referenceName         | "referencesPropertyWithProperty"                                                                                                                                                                                         |
       | references            | [{"target":"berta-destinode", "properties":{"text":"my text", "dayOfWeek":"DayOfWeek:https://schema.org/Wednesday", "postalAddress":"PostalAddress:dummy"}}, {"target":"carl-destinode", "properties":{"text":"my other text", "dayOfWeek":"DayOfWeek:https://schema.org/Friday", "postalAddress":"PostalAddress:anotherDummy"}}] |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -155,14 +149,12 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                           |
       | references            | [{"target": "berta-destinode"}, {"target": "carl-destinode"}] |
       | referenceName         | "referencesProperty"                                          |
-    And the graph projection is fully up to date
 
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                             |
       | sourceNodeAggregateId | "source-nodandaise"               |
       | references            | [{"target": "anthony-destinode"}] |
       | referenceName         | "referencesProperty"              |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -187,14 +179,12 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                           |
       | references            | [{"target": "berta-destinode"}, {"target": "carl-destinode"}] |
       | referenceName         | "referencesProperty"                                          |
-    And the graph projection is fully up to date
 
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                                                         |
       | sourceNodeAggregateId | "source-nodandaise"                                           |
       | references            | [{"target": "carl-destinode"}, {"target": "berta-destinode"}] |
       | referenceName         | "referencesProperty"                                          |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:
@@ -209,7 +199,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"                                           |
       | references            | [{"target": "berta-destinode"}, {"target": "carl-destinode"}] |
       | referenceName         | "referencesProperty"                                          |
-    And the graph projection is fully up to date
 
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                |
@@ -217,7 +206,6 @@ Feature: Node References without Dimensions
       | references            | []                   |
       | referenceName         | "referencesProperty" |
 
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have no references
@@ -235,14 +223,12 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"               |
       | references            | [{"target": "anthony-destinode"}] |
       | referenceName         | "referenceProperty"               |
-    And the graph projection is fully up to date
 
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                             |
       | sourceNodeAggregateId | "node-wan-kenodi"                 |
       | references            | [{"target": "anthony-destinode"}] |
       | referenceName         | "referenceProperty"               |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "anthony-destinode" to lead to node cs-identifier;anthony-destinode;{}
     And I expect this node to be referenced by:
@@ -256,7 +242,6 @@ Feature: Node References without Dimensions
       | sourceNodeAggregateId | "source-nodandaise"               |
       | references            | [{"target": "anthony-destinode"}] |
       | referenceName         | "restrictedReferenceProperty"     |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{}
     And I expect this node to have the following references:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
@@ -29,13 +29,11 @@ Feature: Node References with Dimensions
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                                      | parentNodeAggregateId |
       | source-nodandaise       | Neos.ContentRepository.Testing:NodeWithReferences | lady-eleonode-rootford        |
@@ -47,7 +45,6 @@ Feature: Node References with Dimensions
       | sourceNodeAggregateId | "source-nodandaise"               |
       | referenceName                 | "referenceProperty"               |
       | references                    | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
@@ -43,13 +43,11 @@ Feature: Set node properties with different scopes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:
@@ -61,13 +59,11 @@ Feature: Set node properties with different scopes
       | nodeAggregateId | "source-nodandaise" |
       | sourceOrigin            | {"language":"mul"}  |
       | targetOrigin            | {"language":"de"}   |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key                     | Value               |
       | nodeAggregateId | "source-nodandaise" |
       | sourceOrigin            | {"language":"mul"}  |
       | targetOrigin            | {"language":"gsw"}  |
-    And the graph projection is fully up to date
 
   Scenario: Set node properties
     And the command SetNodeReferences is executed with payload:
@@ -118,7 +114,6 @@ Feature: Set node properties with different scopes
       | referenceName                   | "specializationsScopedReferences" |
       | sourceOriginDimensionSpacePoint | {"language": "de"}                |
       | references                      | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"language": "mul"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node cs-identifier;source-nodandaise;{"language": "mul"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
@@ -29,13 +29,11 @@ Feature: Node References with Dimensions
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                                      | parentNodeAggregateId |
       | source-nodandaise       | Neos.ContentRepository.Testing:NodeWithReferences | lady-eleonode-rootford        |
@@ -47,14 +45,12 @@ Feature: Node References with Dimensions
       | sourceNodeAggregateId | "source-nodandaise"               |
       | referenceName                 | "referenceProperty"               |
       | references                    | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value               |
       | nodeAggregateId | "source-nodandaise" |
       | sourceOrigin            | {"language":"de"}   |
       | targetOrigin            | {"language":"ch"}   |
-    And the graph projection is fully up to date
 
     # after specialization, the reference must still exist on the specialized node
     When I am in workspace "live" and dimension space point {"language": "ch"}
@@ -86,7 +82,6 @@ Feature: Node References with Dimensions
       | sourceOriginDimensionSpacePoint | {"language": "ch"}                |
       | referenceName                   | "referenceProperty"               |
       | references                      | [{"target": "source-nodandaise"}] |
-    And the graph projection is fully up to date
 
     # reference to self (modified 2 lines above)
     When I am in workspace "live" and dimension space point {"language": "ch"}
@@ -115,7 +110,6 @@ Feature: Node References with Dimensions
       | nodeAggregateId | "source-nodandaise" |
       | sourceOrigin            | {"language":"de"}   |
       | targetOrigin            | {"language":"ch"}   |
-    And the graph projection is fully up to date
 
     When the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
@@ -123,7 +117,6 @@ Feature: Node References with Dimensions
       | sourceOriginDimensionSpacePoint | {"language": "ch"}                |
       | referenceName                   | "referenceProperty"               |
       | references                      | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
 
     # on the specialization, the reference exists.
@@ -153,21 +146,18 @@ Feature: Node References with Dimensions
       | nodeAggregateId | "anthony-destinode" |
       | sourceOrigin            | {"language":"de"}   |
       | targetOrigin            | {"language":"en"}   |
-    And the graph projection is fully up to date
 
     When the command SetNodeReferences is executed with payload:
       | Key                           | Value                             |
       | sourceNodeAggregateId | "source-nodandaise"               |
       | referenceName                 | "referenceProperty"               |
       | references                    | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value               |
       | nodeAggregateId | "source-nodandaise" |
       | sourceOrigin            | {"language":"de"}   |
       | targetOrigin            | {"language":"en"}   |
-    And the graph projection is fully up to date
 
     # after creating a peer, the reference must still exist on the peer node
     When I am in workspace "live" and dimension space point {"language": "en"}
@@ -209,7 +199,6 @@ Feature: Node References with Dimensions
       | sourceOriginDimensionSpacePoint | {"language": "en"}                |
       | referenceName                   | "referenceProperty"               |
       | references                      | [{"target": "source-nodandaise"}] |
-    And the graph projection is fully up to date
 
     # reference to self (modified 2 lines above)
     When I am in workspace "live" and dimension space point {"language": "en"}
@@ -250,7 +239,6 @@ Feature: Node References with Dimensions
       | originDimensionSpacePoint     | {"language": "ch"}                                  |
       | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
 
     When the command SetNodeReferences is executed with payload:
       | Key                             | Value                             |
@@ -258,7 +246,6 @@ Feature: Node References with Dimensions
       | sourceOriginDimensionSpacePoint | {"language": "ch"}                |
       | referenceName                   | "referenceProperty"               |
       | references                      | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     # here we generalize
     When the command CreateNodeVariant is executed with payload:
@@ -266,7 +253,6 @@ Feature: Node References with Dimensions
       | nodeAggregateId | "ch-only"         |
       | sourceOrigin            | {"language":"ch"} |
       | targetOrigin            | {"language":"de"} |
-    And the graph projection is fully up to date
 
     # after generalizing, the reference must still exist on the generalized node
     When I am in workspace "live" and dimension space point {"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -22,13 +22,11 @@ Feature: Constraint checks on node aggregate disabling
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName |
       | sir-david-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | document |
@@ -64,7 +62,6 @@ Feature: Constraint checks on node aggregate disabling
       | nodeAggregateId      | "sir-david-nodenborough"               |
       | coveredDimensionSpacePoint   | {"language": "de"}            |
       | nodeVariantSelectionStrategy | "allVariants"                          |
-    And the graph projection is fully up to date
 
       # Note: The behavior has been changed with https://github.com/neos/neos-development-collection/pull/4284 and the test was adjusted accordingly
     When the command DisableNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -23,13 +23,11 @@ Feature: Disable a node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId         | nodeTypeName                            | parentNodeAggregateId  | nodeName            |
       | preceding-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | preceding-document  |
@@ -41,7 +39,6 @@ Feature: Disable a node aggregate
       | sourceNodeAggregateId | "preceding-nodenborough"               |
       | referenceName         | "references"                           |
       | references            | [{"target": "sir-david-nodenborough"}] |
-    And the graph projection is fully up to date
 
   Scenario: Disable node with arbitrary strategy since dimensions are not involved
     When the command DisableNodeAggregate is executed with payload:
@@ -57,7 +54,6 @@ Feature: Disable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                          | "disabled"               |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -25,13 +25,11 @@ Feature: Disable a node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId         | nodeTypeName                            | parentNodeAggregateId  | nodeName            |
       | preceding-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | preceding-document  |
@@ -49,7 +47,6 @@ Feature: Disable a node aggregate
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"mul"}       |
       | targetOrigin    | {"language":"ltz"}       |
-    And the graph projection is fully up to date
     # Set the DSP to the "central" variant having variants of all kind
     And I am in dimension space point {"language":"de"}
 
@@ -67,7 +64,6 @@ Feature: Disable a node aggregate
       | affectedDimensionSpacePoints | [{"language":"de"}, {"language":"ltz"}, {"language":"gsw"}] |
       | tag                          | "disabled"                                                  |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -319,7 +315,6 @@ Feature: Disable a node aggregate
       | affectedDimensionSpacePoints | [{"language":"ltz"}, {"language":"mul"}, {"language":"de"}, {"language":"en"}, {"language":"gsw"}] |
       | tag                          | "disabled"                                                                                         |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
@@ -22,13 +22,11 @@ Feature: Enable a node aggregate
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName |
       | sir-david-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | document |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -23,13 +23,11 @@ Feature: Enable a node aggregate
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName            |
       | preceding-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | preceding-document  |
@@ -41,14 +39,12 @@ Feature: Enable a node aggregate
       | sourceNodeAggregateId | "preceding-nodenborough"               |
       | referenceName                 | "references"                           |
       | references                    | [{"target": "sir-david-nodenborough"}] |
-    And the graph projection is fully up to date
 
   Scenario: Enable a previously disabled node with arbitrary strategy since dimensions are not involved
     Given the command DisableNodeAggregate is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId      | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"       |
-    And the graph projection is fully up to date
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -63,7 +59,6 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                  | "disabled"               |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -126,12 +121,10 @@ Feature: Enable a node aggregate
       | Key                          | Value                    |
       | nodeAggregateId      | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"       |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId      | "nody-mc-nodeface" |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -145,7 +138,6 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                  | "disabled"               |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
 
     Then I expect the node aggregate "sir-david-nodenborough" to exist
@@ -204,12 +196,10 @@ Feature: Enable a node aggregate
       | Key                          | Value                    |
       | nodeAggregateId      | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"       |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId      | "nody-mc-nodeface" |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |
@@ -223,7 +213,6 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [[]]               |
       | tag                  | "disabled"         |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
 
     Then I expect the node aggregate "sir-david-nodenborough" to exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -25,13 +25,11 @@ Feature: Enable a node aggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId         | nodeTypeName                            | parentNodeAggregateId  | nodeName            |
       | preceding-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | preceding-document  |
@@ -50,19 +48,16 @@ Feature: Enable a node aggregate
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"mul"}       |
       | targetOrigin    | {"language":"ltz"}       |
-    And the graph projection is fully up to date
     # Disable our reference node aggregate in all variants
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
     # Explicitly disable a child node aggregate in all variants
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId              | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
     # Set the DSP to the "central" variant having variants of all kind
     And I am in dimension space point {"language":"de"}
 
@@ -81,7 +76,6 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [{"language":"de"},{"language":"ltz"},{"language":"gsw"}] |
       | tag                          | "disabled"                                                |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -377,7 +371,6 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [{"language":"mul"},{"language":"de"},{"language":"en"},{"language":"gsw"},{"language":"ltz"}] |
       | tag                          | "disabled"                          |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -705,7 +698,6 @@ Feature: Enable a node aggregate
       | nodeAggregateId              | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
 
     Then I expect the node aggregate "the-great-nodini" to exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -21,13 +21,11 @@ Feature: Creation of nodes underneath disabled nodes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName |
       | the-great-nodini        | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | document |
@@ -35,7 +33,6 @@ Feature: Creation of nodes underneath disabled nodes
       | Key                          | Value              |
       | nodeAggregateId      | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
 
   Scenario: When a new node is created underneath a hidden node, this one should be hidden as well
     When the following CreateNodeAggregateWithNode commands are executed:
@@ -49,6 +46,5 @@ Feature: Creation of nodes underneath disabled nodes
       | Key                          | Value              |
       | nodeAggregateId      | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
     Then I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{}
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -23,13 +23,11 @@ Feature: Creation of nodes underneath disabled nodes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName |
       | the-great-nodini        | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | document |
@@ -39,7 +37,6 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"mul"} |
       | targetOrigin            | {"language":"ltz"} |
-    And the graph projection is fully up to date
     And VisibilityConstraints are set to "frontend"
 
   Scenario: Create a new node with parent disabled with strategy allSpecializations
@@ -77,7 +74,6 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeAggregateId      | "the-great-nodini" |
       | coveredDimensionSpacePoint   | {"language":"de"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
@@ -124,7 +120,6 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeAggregateId      | "the-great-nodini" |
       | coveredDimensionSpacePoint   | {"language":"de"}  |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"mul"}
     And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -21,13 +21,11 @@ Feature: Variation of hidden nodes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"mul"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And VisibilityConstraints are set to "frontend"
 
   Scenario: Specialize a node where the specialization target is enabled
@@ -40,20 +38,17 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
     And the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"gsw"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"gsw"} |
-    And the graph projection is fully up to date
     And I am in dimension space point {"language":"de"}
     And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
 
@@ -70,14 +65,12 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"gsw"} |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
@@ -90,7 +83,6 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"gsw"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
@@ -105,14 +97,12 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"mul"} |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
@@ -132,20 +122,17 @@ Feature: Variation of hidden nodes
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"ltz"} |
       | targetOrigin            | {"language":"mul"} |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"mul"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini"    |
       | sourceOrigin            | {"language":"ltz"} |
       | targetOrigin            | {"language":"de"}  |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"ltz"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
@@ -158,7 +145,6 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"      |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
@@ -173,14 +159,12 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"en"}  |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
@@ -198,20 +182,17 @@ Feature: Variation of hidden nodes
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"mul"} |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"mul"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key                     | Value              |
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin            | {"language":"de"}  |
       | targetOrigin            | {"language":"en"}  |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
@@ -224,7 +205,6 @@ Feature: Variation of hidden nodes
       | nodeAggregateId      | "the-great-nodini"   |
       | coveredDimensionSpacePoint   | {"language":"en"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in dimension space point {"language":"en"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
@@ -26,13 +26,11 @@ Feature: Remove NodeAggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds |
       | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document | {"tethered":"nodewyn-tetherton"}   |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -23,13 +23,11 @@ Feature: Remove NodeAggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
       | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document |
@@ -54,7 +52,6 @@ Feature: Remove NodeAggregate
       | affectedOccupiedDimensionSpacePoints | [[]]            |
       | affectedCoveredDimensionSpacePoints  | [[]]            |
       | removalAttachmentPoint               | null            |
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 2 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
@@ -77,19 +74,16 @@ Feature: Remove NodeAggregate
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                   | Value                                     |
       | nodeAggregateId       | "nodingers-cat"                           |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName              | "pet"                                     |
-    And the graph projection is fully up to date
 
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points []
@@ -117,14 +111,12 @@ Feature: Remove NodeAggregate
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                   | Value                                     |
       | nodeAggregateId       | "nodingers-cat"                           |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName              | "pet"                                     |
-    And the graph projection is fully up to date
 
     Then I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -25,13 +25,11 @@ Feature: Remove NodeAggregate
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
       | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document |
@@ -57,7 +55,6 @@ Feature: Remove NodeAggregate
       | affectedOccupiedDimensionSpacePoints | [{"language":"en"}]                    |
       | affectedCoveredDimensionSpacePoints  | [{"language":"de"},{"language":"gsw"}] |
       | removalAttachmentPoint               | null                                   |
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"en"} to exist in the content graph
@@ -191,7 +188,6 @@ Feature: Remove NodeAggregate
       | nodeAggregateId | "nodingers-cat"   |
       | sourceOrigin    | {"language":"en"} |
       | targetOrigin    | {"language":"de"} |
-    And the graph projection is fully up to date
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value             |
@@ -206,7 +202,6 @@ Feature: Remove NodeAggregate
       | affectedOccupiedDimensionSpacePoints | [{"language":"de"},{"language":"en"}]                                      |
       | affectedCoveredDimensionSpacePoints  | [{"language":"de"},{"language":"en"},{"language":"gsw"},{"language":"fr"}] |
       | removalAttachmentPoint               | null                                                                       |
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 2 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"en"} to exist in the content graph
@@ -296,12 +291,10 @@ Feature: Remove NodeAggregate
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | nodeTypeName                            | parentNodeAggregateId  | nodeName |
       | nodingers-cat    | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | pet      |
@@ -351,19 +344,16 @@ Feature: Remove NodeAggregate
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId              | "nodingers-cat"      |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "nodingers-cat"   |
       | sourceOrigin    | {"language":"en"} |
       | targetOrigin    | {"language":"de"} |
-    And the graph projection is fully up to date
 
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points [{"language":"en"},{"language":"fr"}]

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -30,14 +30,12 @@ Feature: Recreate a node variant
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
 
     And I am in workspace "live" and dimension space point {"language":"en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | originDimensionSpacePoint | nodeName            | parentNodeAggregateId  | nodeTypeName                                                   | tetheredDescendantNodeAggregateIds                                                       |
       | sir-david-nodenborough | {"language":"en"}         | document            | lady-eleonode-rootford | Neos.ContentRepository.Testing:Document                        | {"tethered-document": "nodimus-prime", "tethered-document/tethered": "nodimus-mediocre"} |
@@ -48,7 +46,6 @@ Feature: Recreate a node variant
       | workspaceName      | "user-ws"    |
       | baseWorkspaceName  | "live"       |
       | newContentStreamId | "user-cs-id" |
-    And the graph projection is fully up to date
 
   Scenario: Create specialization variant of node, publish, delete it and recreate it
     When the command CreateNodeVariant is executed with payload:
@@ -57,19 +54,16 @@ Feature: Recreate a node variant
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"en"}        |
       | targetOrigin    | {"language":"de"}        |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language":"en"}  |
       | targetOrigin    | {"language":"de"}  |
-    And the graph projection is fully up to date
     And the command PublishWorkspace is executed with payload:
       | Key                | Value            |
       | workspaceName      | "user-ws"        |
       | newContentStreamId | "new-user-cs-id" |
-    And the graph projection is fully up to date
 
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -77,7 +71,6 @@ Feature: Recreate a node variant
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
-    And the graph projection is fully up to date
 
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                    |
@@ -85,14 +78,12 @@ Feature: Recreate a node variant
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"en"}        |
       | targetOrigin    | {"language":"de"}        |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language":"en"}  |
       | targetOrigin    | {"language":"de"}  |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node new-user-cs-id;sir-david-nodenborough;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -30,13 +30,11 @@ Feature: Create node specialization
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | nodeName          | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                | tetheredDescendantNodeAggregateIds |
@@ -52,7 +50,6 @@ Feature: Create node specialization
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example":"spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeName            | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                | tetheredDescendantNodeAggregateIds                                                         |
       | nody-mc-nodeface       | document            | lady-eleonode-rootford | younger-mc-nodeface              | Neos.ContentRepository.Testing:Document     | {"tethered-node": "nodewyn-tetherton", "tethered-node/tethered-leaf": "nodimer-tetherton"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -31,13 +31,11 @@ Feature: Create node specialization
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeName            | parentNodeAggregateId  | succeedingSiblingNodeAggregateId | nodeTypeName                                | tetheredDescendantNodeAggregateIds                                                         |
@@ -56,14 +54,12 @@ Feature: Create node specialization
       | nodeAggregateId              | "nody-mc-nodeface"   |
       | coveredDimensionSpacePoint   | {"example":"spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | contentStreamId | "cs-identifier"      |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"spec"}   |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 12 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
@@ -37,12 +37,10 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And I am in workspace "live" and dimension space point {"example": "source"}
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId            | originDimensionSpacePoint | nodeTypeName                                                 | parentNodeAggregateId      | nodeName              | tetheredDescendantNodeAggregateIds |
       | sir-david-nodenborough     | {"example": "source"}     | Neos.ContentRepository.Testing:DocumentWithTetheredChildNode | lady-eleonode-rootford     | document              | {"tethered": "nodewyn-tetherton"}  |
@@ -137,7 +135,6 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-david-nodenborough"     |
@@ -153,7 +150,6 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"example": "source"}    |
       | targetOrigin    | {"example": "general"}   |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-david-nodenborough"     |
@@ -168,7 +164,6 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | nodeAggregateId | "sir-nodeward-nodington-iii" |
       | sourceOrigin    | {"example": "source"}        |
       | targetOrigin    | {"example": "peer"}          |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | originDimensionSpacePoint | nodeTypeName                            | parentNodeAggregateId      | nodeName |
       | nody-mc-nodeface | {"example": "peer"}       | Neos.ContentRepository.Testing:Document | sir-nodeward-nodington-iii | document |
@@ -237,13 +232,11 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeAggregateId              | "rival-destinode"     |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
       | coveredDimensionSpacePoint   | {"example": "peer"}  |
       | nodeAggregateId              | "rival-destinode"    |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload and exceptions are caught:
       | Key                          | Value                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
@@ -24,7 +24,6 @@ Feature: Move a node with content dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -49,7 +48,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"  |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -107,7 +105,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -116,7 +113,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"  |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -175,7 +171,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -184,7 +179,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"   |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -248,7 +242,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"   |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -312,7 +305,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "elder-mc-nodeface"  |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -321,7 +313,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"   |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -384,7 +375,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                  |
@@ -393,7 +383,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                   |
       | newSucceedingSiblingNodeAggregateId | "youngest-mc-nodeface" |
       | relationDistributionStrategy        | "gatherAll"            |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -459,7 +448,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | null                  |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -519,7 +507,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -528,7 +515,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | null                  |
       | relationDistributionStrategy        | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -587,7 +573,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                 |
@@ -596,7 +581,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface" |
       | relationDistributionStrategy       | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -660,7 +644,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface" |
       | relationDistributionStrategy       | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -724,7 +707,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                 |
@@ -733,7 +715,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface" |
       | relationDistributionStrategy       | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -796,7 +777,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                 |
@@ -805,7 +785,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "eldest-mc-nodeface"  |
       | relationDistributionStrategy       | "gatherAll"           |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -873,7 +852,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"    |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -933,7 +911,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -942,7 +919,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"    |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1003,7 +979,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -1012,7 +987,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1076,7 +1050,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1140,7 +1113,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "elder-mc-nodeface"  |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -1149,7 +1121,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1212,7 +1183,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -1221,7 +1191,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | "youngest-mc-nodeface"  |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1287,7 +1256,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | null                    |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1349,7 +1317,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -1358,7 +1325,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                    |
       | newSucceedingSiblingNodeAggregateId | null                    |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1419,7 +1385,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                   |
@@ -1428,7 +1393,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                    |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"   |
       | relationDistributionStrategy       | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1492,7 +1456,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                    |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"   |
       | relationDistributionStrategy       | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1556,7 +1519,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                   |
@@ -1565,7 +1527,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                    |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"   |
       | relationDistributionStrategy       | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1628,7 +1589,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                   |
@@ -1637,7 +1597,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                    |
       | newPrecedingSiblingNodeAggregateId | "eldest-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1705,7 +1664,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"  |
       | relationDistributionStrategy        | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1770,7 +1728,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface"  |
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -1779,7 +1736,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"   |
       | relationDistributionStrategy        | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -1842,7 +1798,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"   |
       | relationDistributionStrategy        | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1916,7 +1871,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | null                  |
       | relationDistributionStrategy        | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:
@@ -1979,7 +1933,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "source"}  |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                 |
@@ -1988,7 +1941,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | null                  |
       | newSucceedingSiblingNodeAggregateId | null                  |
       | relationDistributionStrategy        | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -2049,7 +2001,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "source"}  |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                 |
@@ -2058,7 +2009,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface" |
       | relationDistributionStrategy       | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 9 is of type "NodeAggregateWasMoved" with payload:
@@ -2121,7 +2071,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | null                  |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface" |
       | relationDistributionStrategy       | "scatter"             |
-    And the graph projection is fully up to date
 
     Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasMoved" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -24,13 +24,11 @@ Feature: Move a node with content dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId            | nodeTypeName                            | parentNodeAggregateId      | nodeName          |
       | sir-david-nodenborough     | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford     | parent-document   |
@@ -54,7 +52,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -114,7 +111,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -123,7 +119,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -182,7 +177,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -191,7 +185,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -255,7 +248,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -319,14 +311,12 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "elder-mc-nodeface"  |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
       | nodeAggregateId                     | "nody-mc-nodeface"       |
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -389,7 +379,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -398,7 +387,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "youngest-mc-nodeface"   |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -462,7 +450,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -522,7 +509,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -531,7 +517,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -590,7 +575,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -599,7 +583,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -663,7 +646,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -727,7 +709,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -736,7 +717,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -799,7 +779,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -808,7 +787,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy       | "gatherAll"              |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -875,7 +853,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -933,7 +910,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -942,7 +918,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -999,7 +974,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1008,7 +982,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1068,7 +1041,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1128,7 +1100,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "elder-mc-nodeface"  |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1137,7 +1108,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1196,7 +1166,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1205,7 +1174,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "youngest-mc-nodeface"   |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1265,7 +1233,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1323,7 +1290,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1332,7 +1298,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1389,7 +1354,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -1398,7 +1362,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1458,7 +1421,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1518,7 +1480,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -1527,7 +1488,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1586,7 +1546,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -1595,7 +1554,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy       | "gatherSpecializations"  |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1658,7 +1616,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "eldest-mc-nodeface"     |
       | relationDistributionStrategy        | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1719,7 +1676,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "eldest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1728,7 +1684,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1786,7 +1741,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | "elder-mc-nodeface"      |
       | relationDistributionStrategy        | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1854,7 +1808,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -1911,7 +1864,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                    |
@@ -1920,7 +1872,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-david-nodenborough" |
       | newSucceedingSiblingNodeAggregateId | null                     |
       | relationDistributionStrategy        | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -1976,7 +1927,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId              | "youngest-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example": "spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                    |
@@ -1985,7 +1935,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
     And event at index 13 is of type "NodeAggregateWasMoved" with payload:
@@ -2043,7 +1992,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "sir-david-nodenborough" |
       | newPrecedingSiblingNodeAggregateId | "younger-mc-nodeface"    |
       | relationDistributionStrategy       | "scatter"                |
-    And the graph projection is fully up to date
 
     Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
     And event at index 12 is of type "NodeAggregateWasMoved" with payload:
@@ -2111,7 +2059,6 @@ Feature: Move a node with content dimensions
       | nodeAggregateId       | "nody-mc-nodeface-ii"                     |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "sir-david-nodenborough"                  |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -2127,6 +2074,5 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId      | "lady-eleonode-rootford"                                                                                                                               |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":null}] |
 
-    And the graph projection is fully up to date
     When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface-ii" to lead to node cs-identifier;nody-mc-nodeface-ii;{"example": "general"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
@@ -21,7 +21,6 @@ Feature: Move a node with content dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -49,7 +48,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "nodimus-mediocre"        |
       | newSucceedingSiblingNodeAggregateId | "younger-child-destinode" |
       | relationDistributionStrategy        | "scatter"                 |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                        |
@@ -58,7 +56,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "sir-nodeward-nodington-iii" |
       | newSucceedingSiblingNodeAggregateId | "bustling-destinode"         |
       | relationDistributionStrategy        | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     Then I expect exactly 15 events to be published on stream "ContentStream:cs-identifier"
     And event at index 14 is of type "NodeAggregateWasMoved" with payload:
@@ -119,7 +116,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "nodimus-mediocre"        |
       | newSucceedingSiblingNodeAggregateId | "younger-child-destinode" |
       | relationDistributionStrategy        | "scatter"                 |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -127,7 +123,6 @@ Feature: Move a node with content dimensions
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "bustling-destinode"    |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 15 events to be published on stream "ContentStream:cs-identifier"
     And event at index 14 is of type "NodeAggregateWasMoved" with payload:
@@ -177,7 +172,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "nodimus-mediocre"        |
       | newSucceedingSiblingNodeAggregateId | "younger-child-destinode" |
       | relationDistributionStrategy        | "scatter"                 |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -185,7 +179,6 @@ Feature: Move a node with content dimensions
       | dimensionSpacePoint                 | {"example": "source"}   |
       | newSucceedingSiblingNodeAggregateId | "elder-destinode"       |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 15 events to be published on stream "ContentStream:cs-identifier"
     And event at index 14 is of type "NodeAggregateWasMoved" with payload:
@@ -247,7 +240,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId            | "nodimus-mediocre"        |
       | newSucceedingSiblingNodeAggregateId | "younger-child-destinode" |
       | relationDistributionStrategy        | "scatter"                 |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                                | Value                |
       | nodeAggregateId                    | "elder-destinode"    |
@@ -255,7 +247,6 @@ Feature: Move a node with content dimensions
       | newParentNodeAggregateId           | "nodimus-mediocre"   |
       | newPrecedingSiblingNodeAggregateId | "bustling-destinode" |
       | relationDistributionStrategy       | "scatter"            |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
@@ -263,7 +254,6 @@ Feature: Move a node with content dimensions
       | dimensionSpacePoint                 | {"example": "source"}   |
       | newSucceedingSiblingNodeAggregateId | "bustling-destinode"    |
       | relationDistributionStrategy        | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     Then I expect exactly 16 events to be published on stream "ContentStream:cs-identifier"
     And event at index 15 is of type "NodeAggregateWasMoved" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -27,7 +27,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -50,7 +49,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -58,7 +56,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -111,7 +108,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -119,7 +115,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -174,7 +169,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -182,7 +176,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -235,7 +228,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -243,7 +235,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -299,7 +290,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -307,7 +297,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -361,7 +350,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -369,7 +357,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -425,7 +412,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -433,7 +419,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -441,7 +426,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -495,7 +479,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -503,7 +486,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -511,7 +493,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -565,7 +546,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -573,7 +553,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -581,7 +560,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -635,7 +613,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -643,7 +620,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -651,7 +627,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -705,7 +680,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -713,7 +687,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -721,7 +694,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -775,7 +747,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -783,7 +754,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -791,7 +761,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -845,7 +814,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -853,7 +821,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -861,7 +828,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -915,7 +881,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -923,7 +888,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -931,7 +895,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -987,7 +950,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -995,7 +957,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1003,7 +964,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1057,7 +1017,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1065,7 +1024,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1073,7 +1031,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1127,7 +1084,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1135,7 +1091,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1143,7 +1098,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1197,7 +1151,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1205,7 +1158,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1213,7 +1165,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1267,7 +1218,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1275,7 +1225,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1283,7 +1232,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1337,7 +1285,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1345,7 +1292,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1353,7 +1299,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1407,7 +1352,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1415,7 +1359,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -1423,7 +1366,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1477,7 +1419,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1485,7 +1426,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1493,7 +1433,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1549,7 +1488,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -1557,7 +1495,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1611,7 +1548,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}      |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
@@ -1619,7 +1555,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}        |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "gatherSpecializations"      |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1675,7 +1610,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                 |
@@ -1683,7 +1617,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1691,7 +1624,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1745,7 +1677,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -1753,7 +1684,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1761,7 +1691,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1815,7 +1744,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                 |
@@ -1823,7 +1751,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1831,7 +1758,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1885,7 +1811,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -1893,7 +1818,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1901,7 +1825,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -1955,7 +1878,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                 |
@@ -1963,7 +1885,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag2"                |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -1971,7 +1892,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2025,7 +1945,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag1"                |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -2033,7 +1952,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag2"               |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2041,7 +1959,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2095,7 +2012,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                 |
@@ -2103,7 +2019,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"} |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
       | tag                          | "tag2"                |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2111,7 +2026,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2165,7 +2079,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag1"               |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -2173,7 +2086,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | tag                          | "tag2"               |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2181,7 +2093,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2237,7 +2148,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2245,7 +2155,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2253,7 +2162,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2307,7 +2215,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2315,7 +2222,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2323,7 +2229,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2377,7 +2282,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}      |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2385,7 +2289,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2393,7 +2296,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2447,7 +2349,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}      |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2455,7 +2356,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag1"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2463,7 +2363,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2517,7 +2416,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2525,7 +2423,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2533,7 +2430,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2587,7 +2483,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2595,7 +2490,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2603,7 +2497,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2657,7 +2550,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}      |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2665,7 +2557,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "source"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2673,7 +2564,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
@@ -2727,7 +2617,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}      |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
       | tag                          | "tag1"                   |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -2735,7 +2624,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | coveredDimensionSpacePoint   | {"example": "spec"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"         |
       | tag                          | "tag2"                       |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                   |
@@ -2743,7 +2631,6 @@ Feature: Move a node aggregate into and out of a tagged parent
       | dimensionSpacePoint          | {"example": "source"}   |
       | newParentNodeAggregateId     | "nodimus-prime"         |
       | relationDistributionStrategy | "gatherSpecializations" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
@@ -17,7 +17,6 @@ Feature: Additional constraint checks after move node capabilities are introduce
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -38,21 +37,18 @@ Feature: Additional constraint checks after move node capabilities are introduce
       | dimensionSpacePoint          | {"example": "spec"}          |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
       | relationDistributionStrategy | "scatter"                    |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                       |
       | nodeAggregateId              | "bustling-mc-nodeface"      |
       | dimensionSpacePoint          | {"example": "peer"}         |
       | newParentNodeAggregateId     | "lady-abigail-nodenborough" |
       | relationDistributionStrategy | "scatter"                   |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                  |
       | nodeAggregateId              | "bustling-mc-nodeface" |
       | dimensionSpacePoint          | {"example": "general"} |
       | newParentNodeAggregateId     | "general-nodesworth"   |
       | relationDistributionStrategy | "scatter"              |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                   | Value                                     |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -23,7 +23,6 @@ Feature: Move a node without content dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -59,7 +58,6 @@ Feature: Move a node without content dimensions
       | parentNodeAggregateId       | "lady-eleonode-rootford"                  |
       | nodeName                    | "esquire"                                 |
       | nodeAggregateClassification | "regular"                                 |
-    And the graph projection is fully up to date
 
   Scenario: Move a node to the end of its siblings
     When the command MoveNodeAggregate is executed with payload:
@@ -69,7 +67,6 @@ Feature: Move a node without content dimensions
       | newParentNodeAggregateId            | null                     |
       | newSucceedingSiblingNodeAggregateId | null                     |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
@@ -104,7 +101,6 @@ Feature: Move a node without content dimensions
       | newParentNodeAggregateId            | null                         |
       | newSucceedingSiblingNodeAggregateId | "sir-david-nodenborough"     |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
@@ -142,7 +138,6 @@ Feature: Move a node without content dimensions
       | parentNodeAggregateId       | "sir-nodeward-nodington-iii"              |
       | nodeName                    | "other-document"                          |
       | nodeAggregateClassification | "regular"                                 |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload:
       | Key                      | Value                        |
       | nodeAggregateId          | "sir-david-nodenborough"     |
@@ -157,7 +152,6 @@ Feature: Move a node without content dimensions
       | newParentNodeAggregateId      | "sir-nodeward-nodington-iii"                         |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint": [],"nodeAggregateId":null}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
@@ -204,7 +198,6 @@ Feature: Move a node without content dimensions
       | newParentNodeAggregateId      | "lady-eleonode-rootford"                                                     |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint": [],"nodeAggregateId":"sir-nodeward-nodington-iii"}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
@@ -25,14 +25,12 @@ Feature: Change node name
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
 
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeName | nodeTypeName                            | parentNodeAggregateId  | tetheredDescendantNodeAggregateIds |
       | sir-david-nodenborough | null     | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | {"tethered": "nodewyn-tetherton"}  |
@@ -91,7 +89,6 @@ Feature: Change node name
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"example": "source"}    |
       | targetOrigin    | {"example": "peer"}      |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
       | nodeAggregateId           | "sir-nodeward-nodington-iii"              |
@@ -99,7 +96,6 @@ Feature: Change node name
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId     | "sir-david-nodenborough"                  |
       | nodeName                  | "esquire"                                 |
-    And the graph projection is fully up to date
     When the command ChangeNodeAggregateName is executed with payload and exceptions are caught:
       | Key             | Value              |
       | nodeAggregateId | "nody-mc-nodeface" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -23,14 +23,12 @@ Feature: Change node aggregate name
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
 
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                                            | originDimensionSpacePoint | parentNodeAggregateId  | nodeName            | tetheredDescendantNodeAggregateIds |
       | sir-david-nodenborough | Neos.ContentRepository.Testing:Node                     | {"example":"general"}     | lady-eleonode-rootford | parent-document     | {}                                 |
@@ -41,14 +39,12 @@ Feature: Change node aggregate name
       | nodeAggregateId | "nody-mc-nodeface"    |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
     # leave spec as a virtual variant
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "nody-mc-nodeface"    |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"peer"}    |
-    And the graph projection is fully up to date
 
   Scenario: Rename a child node aggregate with descendants
     When the command ChangeNodeAggregateName is executed with payload:
@@ -95,7 +91,6 @@ Feature: Change node aggregate name
       | dimensionSpacePoint                 | {"example": "peer"}       |
       | newParentNodeAggregateId            | "lady-eleonode-rootford"  |
       | relationDistributionStrategy        | "scatter"                 |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateName is executed with payload:
       | Key             | Value              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamClosing/01-CloseContentStream_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamClosing/01-CloseContentStream_ConstraintChecks.feature
@@ -13,7 +13,6 @@ Feature: Constraint check test cases for closing content streams
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
 
   Scenario: Try to close a non-existing content stream:
     And the command CloseContentStream is executed with payload and exceptions are caught:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
@@ -23,7 +23,6 @@ Feature: ForkContentStream Without Dimensions
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -22,7 +22,6 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -48,13 +47,11 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
       | parentNodeAggregateId       | "the-great-nodini"                       |
       | nodeName                    | "pet"                                    |
       | nodeAggregateClassification | "regular"                                |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId              | "the-great-nodini" |
       | coveredDimensionSpacePoint   | {}                 |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
 
   Scenario: on ForkContentStream, the disabled nodes in the target content stream should still be invisible.
     When the command ForkContentStream is executed with payload:
@@ -62,7 +59,6 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
       | sourceContentStreamId | "cs-identifier"      |
       | contentStreamId       | "user-cs-identifier" |
 
-    When the graph projection is fully up to date
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -23,7 +23,6 @@ Feature: ForkContentStream Without Dimensions
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -53,7 +52,6 @@ Feature: ForkContentStream Without Dimensions
       | Key                   | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in content stream "user-cs-identifier" and dimension space point {}
 
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
@@ -71,7 +69,6 @@ Feature: ForkContentStream Without Dimensions
       | affectedDimensionSpacePoints | [{}]                                                    |
       | propertyValues               | {"text": {"value": "modified value", "type": "string"}} |
       | propertiesToUnset            | {}                                                      |
-    And the graph projection is fully up to date
 
       # live
     When I am in content stream "cs-identifier" and dimension space point {}
@@ -101,7 +98,6 @@ Feature: ForkContentStream Without Dimensions
       | affectedDimensionSpacePoints | [{}]                                                    |
       | propertyValues               | {"text": {"value": "modified value", "type": "string"}} |
       | propertiesToUnset            | {}                                                      |
-    And the graph projection is fully up to date
 
     # live
     When I am in content stream "cs-identifier" and dimension space point {}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -28,13 +28,11 @@ Feature: On forking a content stream, node references should be copied as well.
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                                      | parentNodeAggregateId |
       | source-nodandaise       | Neos.ContentRepository.Testing:NodeWithReferences | lady-eleonode-rootford        |
@@ -46,13 +44,11 @@ Feature: On forking a content stream, node references should be copied as well.
       | sourceNodeAggregateId | "source-nodandaise"               |
       | referenceName                 | "referenceProperty"               |
       | references                    | [{"target": "anthony-destinode"}] |
-    And the graph projection is fully up to date
 
     When the command ForkContentStream is executed with payload:
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
 
     # after forking, the reference must still exist on the forked content stream (no surprises here).
     When I am in content stream "user-cs-identifier" and dimension space point {"language": "de"}
@@ -82,7 +78,6 @@ Feature: On forking a content stream, node references should be copied as well.
       | Key                     | Value                                  |
       | nodeAggregateId | "source-nodandaise"                    |
       | propertyValues          | {"text": "Modified in live workspace"} |
-    And the graph projection is fully up to date
     Then I expect node aggregate identifier "source-nodandaise" to lead to node user-cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                                    | Properties |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
@@ -37,13 +37,11 @@ Feature: Add Dimension Specialization
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
       | nodeAggregateId             | "lady-eleonode-rootford"                                 |
       | nodeTypeName                | "Neos.ContentRepository:Root"                            |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -52,7 +50,6 @@ Feature: Add Dimension Specialization
       | originDimensionSpacePoint | {"language": "de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "hello" }                        |
-    And the graph projection is fully up to date
 
   Scenario: Success Case - simple
     # we change the dimension configuration
@@ -110,7 +107,6 @@ Feature: Add Dimension Specialization
       | nodeAggregateId           | "sir-david-nodenborough" |
       | originDimensionSpacePoint | {"language": "de"}       |
       | propertyValues            | {"text": "changed"}      |
-    And the graph projection is fully up to date
     When I am in content stream "migration-cs" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"language": "de"}
     And I expect this node to have the following properties:
@@ -142,7 +138,6 @@ Feature: Add Dimension Specialization
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"language": "de"}       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
 
     # ensure the node is disabled
     When I am in workspace "live" and dimension space point {"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
@@ -22,13 +22,11 @@ Feature: Add New Property
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -37,7 +35,6 @@ Feature: Add New Property
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
     # Node /doc2
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -47,7 +44,6 @@ Feature: Add New Property
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {}                                        |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
@@ -28,13 +28,11 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                   |
       | nodeTypeName                | "Neos.ContentRepository:Root"                                              |
-    And the graph projection is fully up to date
     # Node /document (in "de")
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -43,7 +41,6 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | originDimensionSpacePoint | {"language": "de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
     # Node /document (in "en")
     When the command CreateNodeVariant is executed with payload:
@@ -51,7 +48,6 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"de"}        |
       | targetOrigin    | {"language":"en"}        |
-    And the graph projection is fully up to date
 
 
   Scenario: change materialized "de" node, should shine through in "ch", but not in "en"
@@ -124,7 +120,6 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"de"}        |
       | targetOrigin    | {"language":"ch"}        |
-    And the graph projection is fully up to date
 
     When I run the following node migration for workspace "live", creating content streams "migration-cs":
     """yaml
@@ -170,7 +165,6 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"de"}        |
       | targetOrigin    | {"language":"ch"}        |
-    And the graph projection is fully up to date
 
     When I run the following node migration for workspace "live", creating content streams "migration-cs":
     """yaml

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
@@ -23,13 +23,11 @@ Feature: Change Property
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -38,7 +36,6 @@ Feature: Change Property
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
@@ -24,12 +24,10 @@ Feature: Filter - Node Name
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And I am in workspace "live"
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /name1
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -39,7 +37,6 @@ Feature: Filter - Node Name
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original name1"}                |
-    And the graph projection is fully up to date
 
     # Node /name2
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -50,7 +47,6 @@ Feature: Filter - Node Name
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original name2"}                |
-    And the graph projection is fully up to date
 
     # no node name
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -60,7 +56,6 @@ Feature: Filter - Node Name
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "no node name"}                  |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
@@ -23,13 +23,11 @@ Feature: Filter - Property not empty
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /name1 (has text value set)
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -39,7 +37,6 @@ Feature: Filter - Property not empty
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original name1"}                |
-    And the graph projection is fully up to date
 
     # Node /name2 (has text value empty)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -50,7 +47,6 @@ Feature: Filter - Property not empty
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": ""}                              |
-    And the graph projection is fully up to date
 
       # no node name (has text value not set)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -60,7 +56,6 @@ Feature: Filter - Property not empty
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": null}                            |
-    And the graph projection is fully up to date
 
     # no node name (has text value not set, and null will be ignored as unset)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -70,7 +65,6 @@ Feature: Filter - Property not empty
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {}                                        |
-    And the graph projection is fully up to date
 
 
   Scenario: PropertyNotEmpty

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
@@ -24,12 +24,10 @@ Feature: Filter - Property Value
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And I am in workspace "live"
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /name1 (has text value set)
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -39,7 +37,6 @@ Feature: Filter - Property Value
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original name1"}                |
-    And the graph projection is fully up to date
 
     # Node /name2 (has text value2)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -50,7 +47,6 @@ Feature: Filter - Property Value
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "value2"}                        |
-    And the graph projection is fully up to date
 
       # no node name (has text value not set, and null will be ignored as unset)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -60,7 +56,6 @@ Feature: Filter - Property Value
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": null}                            |
-    And the graph projection is fully up to date
 
     # no node name (has text value not set)
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -70,7 +65,6 @@ Feature: Filter - Property Value
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {}                                        |
-    And the graph projection is fully up to date
 
 
   Scenario: PropertyValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
@@ -36,12 +36,10 @@ Feature: Move dimension space point
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
     And I am in workspace "live"
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -49,7 +47,6 @@ Feature: Move dimension space point
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint | {"language": "de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
 
 
   Scenario: Success Case - simple
@@ -93,7 +90,6 @@ Feature: Move dimension space point
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"language": "de"}       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
 
     # ensure the node is disabled
     When I am in workspace "live" and dimension space point {"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
@@ -29,13 +29,11 @@ Feature: Adjust node types with a node migration
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId     | "lady-eleonode-rootford"                                                   |
       | nodeTypeName                | "Neos.ContentRepository:Root"                                              |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                           | Value                                     |
@@ -43,7 +41,6 @@ Feature: Adjust node types with a node migration
       | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint     | {"language": "de"}                        |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
 
     ########################
     # Actual Test

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
@@ -27,13 +27,11 @@ Feature: Adjust node types with a node migration
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -41,7 +39,6 @@ Feature: Adjust node types with a node migration
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
 
     ########################
     # Actual Test

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
@@ -26,13 +26,11 @@ Feature: Remove Nodes
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                       |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                    |
       | nodeTypeName                | "Neos.ContentRepository:Root"                                               |
-    And the graph projection is fully up to date
     # Node /document (in "de")
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -41,7 +39,6 @@ Feature: Remove Nodes
       | originDimensionSpacePoint | {"language": "de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
     # Node /document (in "en")
     When the command CreateNodeVariant is executed with payload:
@@ -49,7 +46,6 @@ Feature: Remove Nodes
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language":"de"}        |
       | targetOrigin    | {"language":"en"}        |
-    And the graph projection is fully up to date
 
 
   Scenario: Remove nodes in a given dimension space point removes the node with all virtual specializations

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
@@ -23,13 +23,11 @@ Feature: Remove Property
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -38,7 +36,6 @@ Feature: Remove Property
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
       | initialPropertyValues     | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
@@ -26,13 +26,11 @@ Feature: Rename Node Aggregate
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                                      |
       | nodeAggregateId     | "lady-eleonode-rootford"                                                   |
       | nodeTypeName                | "Neos.ContentRepository:Root"                                              |
-    And the graph projection is fully up to date
     # Node /document (in "de")
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                           | Value                                     |
@@ -42,7 +40,6 @@ Feature: Rename Node Aggregate
       | originDimensionSpacePoint     | {"language": "de"}                        |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | initialPropertyValues         | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
     # Node /document (in "en")
     When the command CreateNodeVariant is executed with payload:
@@ -50,7 +47,6 @@ Feature: Rename Node Aggregate
       | nodeAggregateId  | "sir-david-nodenborough" |
       | sourceOrigin             | {"language":"de"}        |
       | targetOrigin             | {"language":"en"}        |
-    And the graph projection is fully up to date
 
 
   Scenario: Rename Node Aggregate

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
@@ -23,13 +23,11 @@ Feature: Rename Property
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                           | Value                                     |
@@ -38,7 +36,6 @@ Feature: Rename Property
       | originDimensionSpacePoint     | {}                                        |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | initialPropertyValues         | {"text": "Original text"}                 |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
@@ -23,13 +23,11 @@ Feature: Strip Tags on Property
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                           | Value                                     |
@@ -38,7 +36,6 @@ Feature: Strip Tags on Property
       | originDimensionSpacePoint     | {}                                        |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | initialPropertyValues         | {"text": "Original <p>text</p>"}          |
-    And the graph projection is fully up to date
 
 
   Scenario: Fixed newValue

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
@@ -15,7 +15,6 @@ Feature: Copy nodes (without dimensions)
       | workspaceTitle                 | "Live"                                 |
       | workspaceDescription           | "The live workspace"                   |
       | newContentStreamId     | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
@@ -51,7 +50,6 @@ Feature: Copy nodes (without dimensions)
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName                      | "esquire"                                 |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
 
   Scenario: Copy
     When I am in workspace "live" and dimension space point {}
@@ -65,5 +63,4 @@ Feature: Copy nodes (without dimensions)
       | targetSucceedingSiblingnodeAggregateId | null                                                              |
       | nodeAggregateIdMapping                 | {"sir-nodeward-nodington-iii": "sir-nodeward-nodington-iii-copy"} |
 
-    And the graph projection is fully up to date
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii-copy" to lead to node cs-identifier;sir-nodeward-nodington-iii-copy;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
@@ -16,13 +16,11 @@ Feature: Node Property Conversion
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: DateTime objects at Node Creation
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -33,7 +31,6 @@ Feature: Node Property Conversion
       | parentNodeAggregateId | "lady-eleonode-rootford"                           |
       | initialPropertyValues         | {"dateProperty": "Date:1997-07-16T19:20:30+05:00"} |
 
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
@@ -49,14 +46,12 @@ Feature: Node Property Conversion
       | originDimensionSpacePoint     | {}                                                 |
       | parentNodeAggregateId | "lady-eleonode-rootford"                           |
       | initialPropertyValues         | {"dateProperty": "Date:1997-07-16T19:20:30+05:00"} |
-    And the graph projection is fully up to date
 
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                              |
       | nodeAggregateId   | "nody-mc-nodeface"                                 |
       | originDimensionSpacePoint | {}                                                 |
       | propertyValues            | {"dateProperty": "Date:1997-07-19T19:20:30+05:00"} |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -23,13 +23,11 @@ Feature: Disable a node aggregate
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                     | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName            | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName            |
       | preceding-nodenborough  | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford        | preceding-document  |
@@ -41,7 +39,6 @@ Feature: Disable a node aggregate
       | sourceNodeAggregateId | "preceding-nodenborough"               |
       | referenceName                 | "references"                           |
       | references                    | [{"target": "sir-david-nodenborough"}] |
-    And the graph projection is fully up to date
 
   Scenario: Restore a hidden node by removing and recreating it
     Given the command DisableNodeAggregate is executed with payload:
@@ -54,7 +51,6 @@ Feature: Disable a node aggregate
       | nodeAggregateId              | "nody-mc-nodeface" |
       | affectedOccupiedDimensionSpacePoints | [{}]               |
       | affectedCoveredDimensionSpacePoints  | [{}]               |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                           | Value                                     |
@@ -64,7 +60,6 @@ Feature: Disable a node aggregate
       | parentNodeAggregateId | "sir-david-nodenborough"                  |
       | nodeName                      | "child-document"                          |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -19,13 +19,11 @@ Feature: Remove NodeAggregate
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "live-cs-identifier"                   |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | nodeAggregateId  | "lady-eleonode-nodesworth"             |
       | nodeTypeName             | "Neos.ContentRepository:Root"          |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes are in all dimension space points and thus cannot be varied
     # Node /document
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -34,7 +32,6 @@ Feature: Remove NodeAggregate
       | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "lady-eleonode-nodesworth"                |
       | nodeName                      | "document"                                |
-    And the graph projection is fully up to date
     # We also want to add a child node to make sure it is correctly removed when the parent is removed
     # Node /document/child-document
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -43,13 +40,11 @@ Feature: Remove NodeAggregate
       | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "nody-mc-nodeface"                        |
       | nodeName                      | "child-document"                          |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key                      | Value                |
       | nodeAggregateId  | "nody-mc-nodeface"   |
       | sourceOrigin             | {"language":"de"}    |
       | targetOrigin             | {"language":"gsw"}   |
-    And the graph projection is fully up to date
 
   ########################
   # Section: EXTRA testcases
@@ -60,7 +55,6 @@ Feature: Remove NodeAggregate
       | nodeAggregateId      | "nody-mc-nodeface"   |
       | nodeVariantSelectionStrategy | "allVariants"        |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 1 node
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -81,7 +75,6 @@ Feature: Remove NodeAggregate
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test"
 
     When the command RemoveNodeAggregate is executed with payload:
@@ -89,7 +82,6 @@ Feature: Remove NodeAggregate
       | nodeAggregateId      | "nody-mc-nodeface"   |
       | nodeVariantSelectionStrategy | "allVariants"        |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodesFromAggregate.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodesFromAggregate.wip
@@ -29,7 +29,6 @@ Feature: Remove Nodes from Aggregate
       | workspaceTitle           | "Live"                                 |
       | workspaceDescription     | "The live workspace"                   |
       | newContentStreamId  | "live-cs-identifier"                   |
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | contentStreamId  | "live-cs-identifier"                   |
@@ -65,7 +64,6 @@ Feature: Remove Nodes from Aggregate
       | originDimensionSpacePoint     | {"language":"de"}                         |
       | parentNodeAggregateId | "nodimus-prime"                           |
       | nodeName                      | "grandchild-document"                     |
-    And the graph projection is fully up to date
 
   ########################
   # Section: EXTRA testcases
@@ -96,7 +94,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier"                   |
       | nodeAggregateId | "nodasaurus-rex"                       |
       | dimensionSpacePointSet  | [{"language":"de"},{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 3 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -121,7 +118,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nodasaurus-rex"     |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -152,7 +148,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"de"}]  |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 1 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -172,7 +167,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -200,13 +194,11 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                                  |
       | contentStreamId | "user-cs-identifier"                   |
       | nodeAggregateId | "nodasaurus-rex"                        |
       | dimensionSpacePointSet  | [{"language":"de"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -255,14 +247,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                |
       | contentStreamId | "user-cs-identifier" |
       | nodeAggregateId | "nodimus-prime"      |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" to exist in the graph projection
@@ -297,14 +287,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                                  |
       | contentStreamId | "user-cs-identifier"                   |
       | nodeAggregateId | "nody-mc-nodeface"                     |
       | dimensionSpacePointSet  | [{"language":"de"},{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" not to exist in the graph projection
@@ -339,14 +327,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                |
       | contentStreamId | "user-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" to exist in the graph projection

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_BasicErrorCases.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_BasicErrorCases.feature
@@ -49,13 +49,11 @@ Feature: Change node aggregate type - basic error cases
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                   | Value                                           |
@@ -65,7 +63,6 @@ Feature: Change node aggregate type - basic error cases
       | nodeName              | "parent"                                        |
       | initialPropertyValues | {}                                              |
 
-    And the graph projection is fully up to date
 
   Scenario: Try to change the node aggregate type on a non-existing content stream
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
@@ -100,7 +97,6 @@ Feature: Change node aggregate type - basic error cases
       | parentNodeAggregateId | "sir-david-nodenborough"                   |
       | nodeName              | "parent"                                   |
       | initialPropertyValues | {}                                         |
-    And the graph projection is fully up to date
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
       | Key             | Value                                      |
       | nodeAggregateId | "nody-mc-nodeface"                         |
@@ -117,7 +113,6 @@ Feature: Change node aggregate type - basic error cases
       | nodeName                           | "parent2"                                       |
       | initialPropertyValues              | {}                                              |
       | tetheredDescendantNodeAggregateIds | {"autocreated": "autocreated-child"}            |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                      |
@@ -126,7 +121,6 @@ Feature: Change node aggregate type - basic error cases
       | originDimensionSpacePoint | {"language":"de"}                          |
       | parentNodeAggregateId     | "autocreated-child"                        |
       | initialPropertyValues     | {}                                         |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
       | Key             | Value                                      |
@@ -145,7 +139,6 @@ Feature: Change node aggregate type - basic error cases
       | nodeName                           | "parent2"                                       |
       | initialPropertyValues              | {}                                              |
       | tetheredDescendantNodeAggregateIds | {"autocreated": "nody-mc-nodeface"}             |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
       | Key             | Value                                           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_DeleteStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_DeleteStrategy.feature
@@ -65,13 +65,11 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                           |
@@ -82,7 +80,6 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | nodeName                  | "parent"                                        |
       | initialPropertyValues     | {}                                              |
 
-    And the graph projection is fully up to date
 
   Scenario: Try to change to a node type that disallows already present children with the delete conflict resolution strategy
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -91,14 +88,12 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | nodeTypeName              | "Neos.ContentRepository.Testing:NodeTypeA" |
       | originDimensionSpacePoint | {"language":"de"}                          |
       | parentNodeAggregateId     | "sir-david-nodenborough"                   |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload:
       | Key             | Value                                            |
       | nodeAggregateId | "sir-david-nodenborough"                         |
       | newNodeTypeName | "Neos.ContentRepository.Testing:ParentNodeTypeB" |
       | strategy        | "delete"                                         |
-    And the graph projection is fully up to date
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}
@@ -119,7 +114,6 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | parentNodeAggregateId              | "lady-eleonode-rootford"                        |
       | nodeName                           | "parent2"                                       |
       | tetheredDescendantNodeAggregateIds | {"autocreated": "autocreated-child"}            |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                      |
@@ -128,14 +122,12 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | originDimensionSpacePoint | {"language":"de"}                          |
       | parentNodeAggregateId     | "autocreated-child"                        |
       | initialPropertyValues     | {}                                         |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload:
       | Key             | Value                                            |
       | nodeAggregateId | "parent2-na"                                     |
       | newNodeTypeName | "Neos.ContentRepository.Testing:ParentNodeTypeB" |
       | strategy        | "delete"                                         |
-    And the graph projection is fully up to date
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}
@@ -163,14 +155,12 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | parentNodeAggregateId              | "lady-eleonode-rootford"                   |
       | initialPropertyValues              | {}                                         |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-a": "child-of-type-a-id"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "nodea-identifier-de" |
       | sourceOrigin    | {"language":"de"}     |
       | targetOrigin    | {"language":"gsw"}    |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload:
       | Key                                | Value                                      |
@@ -178,7 +168,6 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB" |
       | strategy                           | "delete"                                   |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "child-of-type-b-id"} |
-    And the graph projection is fully up to date
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}
@@ -202,14 +191,12 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | parentNodeAggregateId              | "lady-eleonode-rootford"                   |
       | initialPropertyValues              | {}                                         |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-a": "child-of-type-a-id"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "nodea-identifier-de" |
       | sourceOrigin    | {"language":"de"}     |
       | targetOrigin    | {"language":"gsw"}    |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload:
       | Key                                | Value                                      |
@@ -217,7 +204,6 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB" |
       | strategy                           | "delete"                                   |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "child-of-type-b-id"} |
-    And the graph projection is fully up to date
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRetyping/ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -58,13 +58,11 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                           |
@@ -75,7 +73,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | nodeName                  | "parent"                                        |
       | initialPropertyValues     | {}                                              |
 
-    And the graph projection is fully up to date
 
   Scenario: Try to change to a node type that disallows already present children with the HAPPYPATH conflict resolution strategy
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -84,7 +81,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | nodeTypeName              | "Neos.ContentRepository.Testing:NodeTypeA" |
       | originDimensionSpacePoint | {"language":"de"}                          |
       | parentNodeAggregateId     | "sir-david-nodenborough"                   |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
       | Key             | Value                                            |
@@ -102,7 +98,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | parentNodeAggregateId              | "lady-eleonode-rootford"                        |
       | nodeName                           | "parent2"                                       |
       | tetheredDescendantNodeAggregateIds | {"autocreated": "autocreated-child"}            |
-    And the graph projection is fully up to date
 
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                      |
@@ -111,7 +106,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | originDimensionSpacePoint | {"language":"de"}                          |
       | parentNodeAggregateId     | "autocreated-child"                        |
       | initialPropertyValues     | {}                                         |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload and exceptions are caught:
       | Key             | Value                                            |
@@ -129,14 +123,12 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | parentNodeAggregateId              | "lady-eleonode-rootford"                   |
       | initialPropertyValues              | {}                                         |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-a": "child-of-type-a-id"} |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "nodea-identifier-de" |
       | sourceOrigin    | {"language":"de"}     |
       | targetOrigin    | {"language":"gsw"}    |
-    And the graph projection is fully up to date
 
     When the command ChangeNodeAggregateType was published with payload:
       | Key                                | Value                                      |
@@ -144,7 +136,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB" |
       | strategy                           | "happypath"                                |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "child-of-type-b-id"} |
-    And the graph projection is fully up to date
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -50,13 +50,11 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -75,12 +73,10 @@ Feature: Find and count nodes using the findAncestorNodes and countAncestorNodes
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value         |
       | nodeAggregateId              | "a2b"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findAncestorNodes queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -64,13 +64,11 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues                                                                                                                                                                                | tetheredDescendantNodeAggregateIds       |
       | home            | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                                                                                                                                                                                                   | {"terms": "terms", "contact": "contact"} |
@@ -94,7 +92,6 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | Key                          | Value         |
       | nodeAggregateId              | "a2a3"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
       # Child nodes without filter

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -50,13 +50,11 @@ Feature: Find nodes using the findClosestNode query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -75,12 +73,10 @@ Feature: Find nodes using the findClosestNode query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value         |
       | nodeAggregateId              | "a2b"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findClosestNode queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
@@ -52,13 +52,11 @@ Feature: Find nodes using the countNodes query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -80,6 +78,5 @@ Feature: Find nodes using the countNodes query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a1"       |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
     # NOTE: countNodes() counts _all_ nodes, even disabled ones
     And I execute the countNodes query I expect the result to be 12

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -64,13 +64,11 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues                                                                                             | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                                                                                                                | {"terms": "terms", "contact": "contact"} |
@@ -94,7 +92,6 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -63,13 +63,11 @@ Feature: Find nodes using the findNodeById query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -85,7 +83,6 @@ Feature: Find nodes using the findNodeById query
       | Key                          | Value              |
       | nodeAggregateId              | "a2a1"             |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
 
   Scenario:
     # findNodeById queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
@@ -66,13 +66,11 @@ Feature: Find nodes using the findNodeByPath query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -89,7 +87,6 @@ Feature: Find nodes using the findNodeByPath query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # absolute paths without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
@@ -63,13 +63,11 @@ Feature: Find nodes using the findNodeByPath query with node name as path argume
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -86,7 +84,6 @@ Feature: Find nodes using the findNodeByPath query with node name as path argume
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findNodeByPath queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -63,13 +63,11 @@ Feature: Find nodes using the findParentNodes query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -85,7 +83,6 @@ Feature: Find nodes using the findParentNodes query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a"         |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findParentNode queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
@@ -23,18 +23,15 @@ Feature: Find root nodes by type
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                                 |
       | nodeAggregateId | "lady-eleonode-rootfords-evil-sister" |
       | nodeTypeName    | "Neos.ContentRepository:AnotherRoot"  |
-    And the graph projection is fully up to date
 
   Scenario:
     When I execute the findRootNodeByType query for node type "Neos.ContentRepository:Root" I expect the node "lady-eleonode-rootford" to be returned

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -52,13 +52,11 @@ Feature: Find nodes using the findSubtree query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -76,7 +74,6 @@ Feature: Find nodes using the findSubtree query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findSubtree queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
@@ -73,13 +73,11 @@ Feature: Find and count references and their target nodes using the findReferenc
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -143,7 +141,6 @@ Feature: Find and count references and their target nodes using the findReferenc
       | Key                          | Value         |
       | nodeAggregateId              | "a2a3"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findReferences queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -53,13 +53,11 @@ Feature: Find nodes using the retrieveNodePath query
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -85,7 +83,6 @@ Feature: Find nodes using the retrieveNodePath query
       | Key                          | Value         |
       | nodeAggregateId              | "b1"          |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # retrieveNodePath queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
@@ -63,13 +63,11 @@ Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedi
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -90,7 +88,6 @@ Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedi
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
-    And the graph projection is fully up to date
 
   Scenario:
     # findPrecedingSiblingNodes queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -74,13 +74,11 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | baseWorkspaceName  | "review"    |
       | newContentStreamId | "cs-user"   |
       | workspaceOwner     | "some-user" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeName | nodeTypeName                            | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
       | home            | home     | Neos.ContentRepository.Testing:Homepage | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
@@ -92,7 +90,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "a"               |
       | sourceOrigin    | {"language":"de"} |
       | targetOrigin    | {"language":"ch"} |
-    And the graph projection is fully up to date
 
   Scenario: NodePropertiesWereSet events update last modified timestamps
     When the current date and time is "2023-03-16T13:00:00+01:00"
@@ -102,7 +99,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | originDimensionSpacePoint | {"language": "ch"}  |
       | nodeAggregateId           | "a"                 |
       | propertyValues            | {"text": "Changed"} |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -120,7 +116,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | workspaceName   | "user-test" |
       | nodeAggregateId | "a"         |
       | newNodeName     | "a-renamed" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
@@ -136,18 +131,15 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "review" |
-    And the graph projection is fully up to date
     And the current date and time is "2023-03-16T14:00:00+01:00"
     And the command "ChangeNodeAggregateName" is executed with payload:
       | Key             | Value       |
       | workspaceName   | "user-test" |
       | nodeAggregateId | "a"         |
       | newNodeName     | "a-renamed" |
-    And the graph projection is fully up to date
 
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
@@ -188,7 +180,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | sourceNodeAggregateId           | "a"                |
       | referenceName                   | "ref"              |
       | references                      | [{"target": "b"}]  |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -213,7 +204,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "a"                                          |
       | newNodeTypeName | "Neos.ContentRepository.Testing:SpecialPage" |
       | strategy        | "happypath"                                  |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |
@@ -231,7 +221,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "home"            |
       | sourceOrigin    | {"language":"de"} |
       | targetOrigin    | {"language":"en"} |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -249,7 +238,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "home"             |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"mul"} |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "home" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -270,7 +258,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | relationDistributionStrategy | "gatherSpecializations" |
       | nodeAggregateId              | "a"                     |
       | newParentNodeAggregateId     | "b"                     |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -286,7 +273,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -305,7 +291,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | coveredDimensionSpacePoint   | {"language": "ch"}   |
       | nodeAggregateId              | "a"                  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect the node "a" to have the following timestamps:
@@ -324,7 +309,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | coveredDimensionSpacePoint   | {"language": "ch"}   |
       | nodeAggregateId              | "a"                  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
@@ -344,12 +328,10 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId | "a"                 |
       | propertyValues  | {"text": "Changed"} |
     And I execute the findNodeById query for node aggregate id "non-existing" I expect no node to be returned
-    And the graph projection is fully up to date
     And the current date and time is "2023-03-16T14:00:00+01:00"
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
 
     And I am in workspace "user-test"
     Then I expect the node "a" to have the following timestamps:
@@ -371,7 +353,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
     And the command PublishWorkspace is executed with payload:
       | Key           | Value    |
       | workspaceName | "review" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified        | originalLastModified |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
@@ -20,7 +20,6 @@ Feature: Run projection integrity violation detection regarding root connection
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
 
   Scenario: Create a cycle
     When the event RootNodeAggregateWithNodeWasCreated was published with payload:
@@ -50,14 +49,12 @@ Feature: Run projection integrity violation detection regarding root connection
       | parentNodeAggregateId       | "sir-david-nodenborough"                  |
       | nodeName                    | "child-document"                          |
       | nodeAggregateClassification | "regular"                                 |
-    And the graph projection is fully up to date
     And the event NodeAggregateWasMoved was published with payload:
       | Key                           | Value                                                                                                                                  |
       | contentStreamId               | "cs-identifier"                                                                                                                        |
       | nodeAggregateId               | "sir-david-nodenborough"                                                                                                               |
       | newParentNodeAggregateId      | "nody-mc-nodeface"                                                                                                                     |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId": null},{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId": null}] |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     # one error per subgraph
     Then I expect the integrity violation detection result to contain exactly 2 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
@@ -19,13 +19,11 @@ Feature: Run projection integrity violation detection to find nodes that do not 
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |
       | nodeTypeName                | "Neos.ContentRepository:Root"          |
-    And the graph projection is fully up to date
 
   Scenario: Create a node not covering its origin
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -48,7 +46,6 @@ Feature: Run projection integrity violation detection to find nodes that do not 
       | parentNodeAggregateId | "sir-david-nodenborough"                  |
       | nodeName                      | "document"                                |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 errors
     And I expect integrity violation detection result error number 1 to have code 1597828607

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
@@ -28,7 +28,6 @@ Feature: Create an intact content graph and run integrity violation detection
       | nodeTypeName                | "Neos.ContentRepository:Root"          |
       | coveredDimensionSpacePoints | [{"language":"de"},{"language":"gsw"}] |
       | nodeAggregateClassification | "root"                                 |
-    And the graph projection is fully up to date
     And the event NodeAggregateWithNodeWasCreated was published with payload:
       | Key                           | Value                                     |
       | contentStreamId       | "cs-identifier"                           |
@@ -66,6 +65,5 @@ Feature: Create an intact content graph and run integrity violation detection
       | affectedSourceOriginDimensionSpacePoints | [{"language":"de"}]                                                             |
       | referenceName                            | "referenceProperty"                                                             |
       | references                               | [{"targetNodeAggregateId":"sir-david-nodenborough", "properties":null}] |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
@@ -19,13 +19,11 @@ Feature: Create two nodes with the same node aggregate identifier in the same su
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                     |
       | nodeAggregateId     | "lady-eleonode-rootford"                  |
       | nodeTypeName                | "Neos.ContentRepository:Root"             |
-    And the graph projection is fully up to date
 
   Scenario: Create two node variants in the same subgraph
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -48,7 +46,6 @@ Feature: Create two nodes with the same node aggregate identifier in the same su
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName                      | "document"                                |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     # one error per covered dimension space point
     Then I expect the integrity violation detection result to contain exactly 2 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
@@ -19,13 +19,11 @@ Feature: Run projection integrity violation detection regarding node aggregate c
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
       | nodeAggregateId     | "lady-eleonode-rootford"               |
       | nodeTypeName                | "Neos.ContentRepository:Root"          |
-    And the graph projection is fully up to date
 
   Scenario: Create node variants of different type
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -48,7 +46,6 @@ Feature: Run projection integrity violation detection regarding node aggregate c
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName                      | "document"                                |
       | nodeAggregateClassification   | "tethered"                                |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 errors
     And I expect integrity violation detection result error number 1 to have code 1597825384

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
@@ -21,13 +21,11 @@ Feature: Run projection integrity violation detection regarding node aggregate t
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                     |
       | nodeAggregateId     | "lady-eleonode-rootford"                  |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
   Scenario: Create node variants of different type
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -50,7 +48,6 @@ Feature: Run projection integrity violation detection regarding node aggregate t
       | parentNodeAggregateId | "lady-eleonode-rootford"                   |
       | nodeName                      | "document"                                 |
       | nodeAggregateClassification   | "regular"                                  |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 errors
     And I expect integrity violation detection result error number 1 to have code 1597747062

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -19,7 +19,6 @@ Feature: Run integrity violation detection regarding reference relations
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "cs-identifier"                        |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language":"de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                                    |
@@ -34,7 +33,6 @@ Feature: Run integrity violation detection regarding reference relations
       | coveredDimensionSpacePoints   | [{"language":"de"}]                       |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
 
   Scenario: Reference a non-existing node aggregate
     When the event NodeReferencesWereSet was published with payload:
@@ -44,7 +42,6 @@ Feature: Run integrity violation detection regarding reference relations
       | affectedSourceOriginDimensionSpacePoints | [{"language":"de"}]                                                        |
       | referenceName                            | "referenceProperty"                                                        |
       | references                               | [{"targetNodeAggregateId":"anthony-destinode", "properties":null}] |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 error
     And I expect integrity violation detection result error number 1 to have code 1597919585
@@ -66,7 +63,6 @@ Feature: Run integrity violation detection regarding reference relations
       | affectedSourceOriginDimensionSpacePoints | [{"language":"de"}]                                                        |
       | referenceName                            | "referenceProperty"                                                        |
       | references                               | [{"targetNodeAggregateId":"anthony-destinode", "properties":null}] |
-    And the graph projection is fully up to date
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 error
     And I expect integrity violation detection result error number 1 to have code 1597919585

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
@@ -19,7 +19,6 @@ Feature: Update Root Node aggregate dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -39,7 +38,6 @@ Feature: Update Root Node aggregate dimensions
     And event metadata at index 1 is:
       | Key | Expected |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to be classified as "root"
     And I expect this node aggregate to be of type "Neos.ContentRepository:Root"
@@ -74,7 +72,6 @@ Feature: Update Root Node aggregate dimensions
 
 
   Scenario: Adding a dimension and updating the root node works
-    When the graph projection is fully up to date
     Given I change the content dimensions in content repository "default" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, en |                 |
@@ -98,7 +95,6 @@ Feature: Update Root Node aggregate dimensions
     And event metadata at index 1 is:
       | Key | Expected |
 
-    When the graph projection is fully up to date
     Then I expect the node aggregate "lady-eleonode-rootford" to exist
     And I expect this node aggregate to be classified as "root"
     And I expect this node aggregate to be of type "Neos.ContentRepository:Root"
@@ -138,14 +134,12 @@ Feature: Update Root Node aggregate dimensions
 
 
   Scenario: Adding a dimension updating the root node, removing dimension, updating the root node, works (dimension gone again)
-    When the graph projection is fully up to date
     Given I change the content dimensions in content repository "default" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, en |                 |
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
-    And the graph projection is fully up to date
 
     # now, the root node exists in "en"
     When I am in dimension space point {"language":"en"}
@@ -159,7 +153,6 @@ Feature: Update Root Node aggregate dimensions
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
-    And the graph projection is fully up to date
 
     # now, the root node should not exist anymore in "en"
     When I am in dimension space point {"language":"en"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
@@ -24,13 +24,11 @@ Feature: Dimension mismatch
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language": "en"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                    |
       | nodeAggregateId     | "lady-eleonode-rootford"                 |
       | nodeTypeName                | "Neos.ContentRepository:Root"            |
-    And the graph projection is fully up to date
 
   Scenario: Generalization detection
     # Node /document
@@ -40,7 +38,6 @@ Feature: Dimension mismatch
       | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint     | {"language": "en"}                        |
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
 
     When I change the content dimensions in content repository "default" to:
       | Identifier | Values | Generalizations |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
@@ -30,7 +30,6 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -59,7 +58,6 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | nodeName                      | "sub"                                        |
       | nodeAggregateClassification   | "regular"                                    |
 
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:SubDocument"
@@ -120,7 +118,6 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -149,7 +146,6 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | nodeName                      | "sub"                                        |
       | nodeAggregateClassification   | "regular"                                    |
 
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:SubDocument"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
@@ -30,13 +30,11 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | parentNodeAggregateId  | nodeTypeName                            |
       | nody-mc-nodeface | lady-eleonode-rootford | Neos.ContentRepository.Testing:Document |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
@@ -24,13 +24,11 @@ Feature: Properties
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId             | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     # Node /document
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                       | Value                                     |
@@ -38,7 +36,6 @@ Feature: Properties
       | nodeTypeName              | "Neos.ContentRepository.Testing:Document" |
       | originDimensionSpacePoint | {}                                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
@@ -103,7 +100,6 @@ Feature: Properties
       | nodeAggregateId           | "sir-david-nodenborough" |
       | originDimensionSpacePoint | {}                       |
       | propertyValues            | {"otherProp": ""}        |
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: a broken property (which cannot be deserialized) is detected and removed
@@ -124,7 +120,6 @@ Feature: Properties
       | affectedDimensionSpacePoints | [{}]                                                                        |
       | propertyValues               | {"myProp": {"value": "original value", "type": "My\\Non\\Existing\\Class"}} |
       | propertiesToUnset            | {}                                                      |
-    And the graph projection is fully up to date
     Then I expect the following structure adjustments for type "Neos.ContentRepository.Testing:Document":
       | Type                        | nodeAggregateId        |
       | NON_DESERIALIZABLE_PROPERTY | sir-david-nodenborough |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -36,7 +36,6 @@ Feature: Tethered Nodes integrity violations
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                                | Value                                               |
@@ -79,7 +78,6 @@ Feature: Tethered Nodes integrity violations
       | parentNodeAggregateId       | "nodewyn-tetherton"                           |
       | nodeName                    | "tethered-leaf"                               |
       | nodeAggregateClassification | "tethered"                                    |
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: Adjusting the schema adding a new tethered node leads to a MissingTetheredNode integrity violation

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
@@ -25,13 +25,11 @@ Feature: Tethered Nodes Reordering Structure changes
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     When I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
       | Key                                        | Value                                                                                                                                      |
       | nodeAggregateId                    | "sir-david-nodenborough"                                                                                                                   |
@@ -40,7 +38,6 @@ Feature: Tethered Nodes Reordering Structure changes
       | parentNodeAggregateId              | "lady-eleonode-rootford"                                                                                                                   |
       | nodeName                                   | "document"                                                                                                                                 |
       | tetheredDescendantNodeAggregateIds | {"tethered-node": "tethered-node-agg", "other-tethered-node": "other-tethered-node-agg", "third-tethered-node": "third-tethered-node-agg"} |
-    And the graph projection is fully up to date
 
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
@@ -17,7 +17,6 @@ Feature: Unknown node types
       | workspaceTitle             | "Live"               |
       | workspaceDescription       | "The live workspace" |
       | newContentStreamId | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -34,7 +33,6 @@ Feature: Unknown node types
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName                      | "document"                                |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: When removing "Neos.ContentRepository.Testing:Document", we find a missing node type.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -22,13 +22,11 @@ Feature: Tag subtree with dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "root"                        |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName | originDimensionSpacePoint |
       | a               | Neos.ContentRepository.Testing:Document | root                  | a        | {"language":"mul"}        |
@@ -43,7 +41,6 @@ Feature: Tag subtree with dimensions
       | nodeAggregateId | "a1"               |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"mul"} |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -63,7 +60,6 @@ Feature: Tag subtree with dimensions
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"mul"} |
 
-    And the graph projection is fully up to date
 
     When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
     """
@@ -129,26 +125,22 @@ Feature: Tag subtree with dimensions
       | workspaceName      | "user-ws"    |
       | baseWorkspaceName  | "live"       |
       | newContentStreamId | "user-cs-id" |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "a1"               |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "a1a"              |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
-    And the graph projection is fully up to date
     And the command PublishWorkspace is executed with payload:
       | Key                | Value            |
       | workspaceName      | "user-ws"        |
       | newContentStreamId | "new-user-cs-id" |
-    And the graph projection is fully up to date
 
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -156,7 +148,6 @@ Feature: Tag subtree with dimensions
       | nodeAggregateId              | "a1"                 |
       | coveredDimensionSpacePoint   | {"language":"gsw"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
@@ -172,14 +163,12 @@ Feature: Tag subtree with dimensions
       | nodeAggregateId | "a1"               |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "a1a"              |
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
-    And the graph projection is fully up to date
     And I am in workspace "user-ws" and dimension space point {"language":"gsw"}
     And I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
     """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -20,13 +20,11 @@ Feature: Tag subtree without dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "root"                        |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName |
       | a               | Neos.ContentRepository.Testing:Document | root                  | a        |
@@ -47,7 +45,6 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "a1"          |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag1"        |
-    And the graph projection is fully up to date
     Then I expect exactly 14 events to be published on stream with prefix "ContentStream:cs-identifier"
     And event at index 13 is of type "SubtreeWasTagged" with payload:
       | Key                          | Expected        |
@@ -77,7 +74,6 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "a1"          |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag1"        |
-    And the graph projection is fully up to date
     Then I expect exactly 14 events to be published on stream with prefix "ContentStream:cs-identifier"
     And event at index 13 is of type "SubtreeWasTagged" with payload:
       | Key                          | Expected        |
@@ -107,7 +103,6 @@ Feature: Tag subtree without dimensions
       | affectedDimensionSpacePoints | [[]]            |
       | tag                          | "tag1"          |
 
-    When the graph projection is fully up to date
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 12 nodes
 
@@ -137,7 +132,6 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "a1a"         |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag4"        |
-    And the graph projection is fully up to date
 
     When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
     """
@@ -161,7 +155,6 @@ Feature: Tag subtree without dimensions
       | Key                      | Value           |
       | nodeAggregateId          | "a1a"           |
       | newParentNodeAggregateId | "b1"            |
-    And the graph projection is fully up to date
     When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
     """
     a

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
@@ -29,7 +29,6 @@ Feature: Workspace discarding - complex chained functionality
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language": "de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -46,7 +45,6 @@ Feature: Workspace discarding - complex chained functionality
       | workspaceName      | "user-ws"    |
       | baseWorkspaceName  | "live"       |
       | newContentStreamId | "user-cs-id" |
-    And the graph projection is fully up to date
 
   Scenario: Vary to generalization, then delete the origin and discard parts of the result so that an exception is thrown. Ensure that the workspace recovers from this
     When the command CreateNodeVariant is executed with payload:
@@ -55,14 +53,12 @@ Feature: Workspace discarding - complex chained functionality
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language": "de"}       |
       | targetOrigin    | {"language": "en"}       |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language": "de"} |
       | targetOrigin    | {"language": "en"} |
-    And the graph projection is fully up to date
 
     And the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -70,7 +66,6 @@ Feature: Workspace discarding - complex chained functionality
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"language": "en"}       |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
-    And the graph projection is fully up to date
 
     When the command DiscardIndividualNodesFromWorkspace is executed with payload and exceptions are caught:
       | Key                | Value                                                                                                                                                                                                                                                                                                                                                   |
@@ -83,6 +78,5 @@ Feature: Workspace discarding - complex chained functionality
       | Key                | Value                                                                                                                                                                                                                                                                                                                                                   |
       | workspaceName      | "user-ws"                                                                                                                                                                                                                                                                                                                                             |
       | newContentStreamId | "user-cs-id-yet-again-rebased"                                                                                                                                                                                                                                                                                                                                |
-    And the graph projection is fully up to date
     When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id-yet-again-rebased;nody-mc-nodeface;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
@@ -29,7 +29,6 @@ Feature: Discard individual nodes (basics)
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -65,7 +64,6 @@ Feature: Discard individual nodes (basics)
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                |
       | initialPropertyValues       | {"image": {"type": "string", "value": "Initial image"}} |
       | nodeAggregateClassification | "regular"                                               |
-    And the graph projection is fully up to date
 
     # Create user workspace
     And the command CreateWorkspace is executed with payload:
@@ -73,7 +71,6 @@ Feature: Discard individual nodes (basics)
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     # modify nodes in user WS
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                    |
@@ -93,7 +90,6 @@ Feature: Discard individual nodes (basics)
       | nodeAggregateId           | "sir-nodeward-nodington-iii" |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"image": "Modified image"}  |
-    And the graph projection is fully up to date
 
   ################
   # DISCARDING
@@ -106,7 +102,6 @@ Feature: Discard individual nodes (basics)
       | nodesToDiscard     | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
       | newContentStreamId | "user-cs-identifier-new"                                                                                                |
 
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
@@ -128,7 +123,6 @@ Feature: Discard individual nodes (basics)
       | workspaceName      | "user-test"              |
       | nodesToDiscard     | []                       |
       | newContentStreamId | "user-cs-identifier-new" |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
@@ -150,7 +144,6 @@ Feature: Discard individual nodes (basics)
       | workspaceName      | "user-test"                                                                                                                                                                                                                                                                                                                                             |
       | nodesToDiscard     | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-david-nodenborough"}, {"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "nody-mc-nodeface"}, {"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
       | newContentStreamId | "user-cs-identifier-new"                                                                                                                                                                                                                                                                                                                                |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-new;sir-david-nodenborough;{}
@@ -172,7 +165,6 @@ Feature: Discard individual nodes (basics)
       | Key            | Value                                                                                                                   |
       | workspaceName  | "user-test"                                                                                                             |
       | nodesToDiscard | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
-    And the graph projection is fully up to date
 
     # live WS does not change because of a discard
     When I am in workspace "live" and dimension space point {}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
@@ -34,19 +34,16 @@ Feature: Rebasing auto-created nodes works
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
     And I am in workspace "live" and dimension space point {}
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
       | nodeAggregateId     | "lady-eleonode-rootford"      |
       | nodeTypeName                | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     And the command CreateWorkspace is executed with payload:
       | Key                        | Value                |
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
   Scenario: complex scenario (to reproduce the bug) -- see the feature description
     # USER workspace: create a new node with auto-created child nodes
@@ -58,7 +55,6 @@ Feature: Rebasing auto-created nodes works
       | nodeName                      | "mcnodeface"                             |
       | originDimensionSpacePoint     | {}                                       |
       | parentNodeAggregateId | "lady-eleonode-rootford"                 |
-    And the graph projection is fully up to date
     And I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     When I get the node at path "mcnodeface/foo"
@@ -72,11 +68,9 @@ Feature: Rebasing auto-created nodes works
       | originDimensionSpacePoint | {}                                             |
       | propertyValues            | {"text": {"value":"Modified","type":"string"}} |
       | propertiesToUnset         | {}                                             |
-    And the graph projection is fully up to date
 
     When the command RebaseWorkspace is executed with payload:
       | Key                      | Value                        |
       | workspaceName            | "user-test"                  |
-    And the graph projection is fully up to date
     # This should properly work; no error.
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -22,7 +22,6 @@ Feature: Workspace rebasing - conflicting changes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -40,14 +39,12 @@ Feature: Workspace rebasing - conflicting changes
       | propertyValues            | {"text": "Original"} |
     # we need to ensure that the projections are up to date now; otherwise a content stream is forked with an out-
     # of-date base version. This means the content stream can never be merged back, but must always be rebased.
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
       | workspaceOwner     | "owner-identifier"   |
-    And the graph projection is fully up to date
 
   Scenario: Conflicting changes lead to OUTDATED_CONFLICT which can be recovered from via forced rebase
 
@@ -57,14 +54,12 @@ Feature: Workspace rebasing - conflicting changes
       | baseWorkspaceName  | "live"                       |
       | newContentStreamId | "user-cs-one"                |
       | workspaceOwner     | "owner-identifier"           |
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                        |
       | workspaceName      | "user-ws-two"                |
       | baseWorkspaceName  | "live"                       |
       | newContentStreamId | "user-cs-two"                |
       | workspaceOwner     | "owner-identifier"           |
-    And the graph projection is fully up to date
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -72,7 +67,6 @@ Feature: Workspace rebasing - conflicting changes
       | nodeVariantSelectionStrategy | "allVariants"            |
       | coveredDimensionSpacePoint   | {}                       |
       | workspaceName              | "user-ws-one"            |
-    And the graph projection is fully up to date
 
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                        |
@@ -80,7 +74,6 @@ Feature: Workspace rebasing - conflicting changes
       | nodeAggregateId           | "nody-mc-nodeface"           |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"text": "Modified"}         |
-    And the graph projection is fully up to date
 
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                    |
@@ -89,7 +82,6 @@ Feature: Workspace rebasing - conflicting changes
       | parentNodeAggregateId       | "lady-eleonode-rootford"                 |
       | originDimensionSpacePoint   | {}                                       |
       | workspaceName               | "user-ws-two"                            |
-    And the graph projection is fully up to date
 
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                        |
@@ -97,12 +89,10 @@ Feature: Workspace rebasing - conflicting changes
       | nodeAggregateId           | "noderus-secundus"           |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"text": "The other node"}   |
-    And the graph projection is fully up to date
 
     And the command PublishWorkspace is executed with payload:
       | Key              | Value            |
       | workspaceName    | "user-ws-one"    |
-    And the graph projection is fully up to date
 
     Then workspace user-ws-two has status OUTDATED
 
@@ -111,7 +101,6 @@ Feature: Workspace rebasing - conflicting changes
       | workspaceName                  | "user-ws-two"          |
       | rebasedContentStreamId         | "user-cs-two-rebased"  |
       | rebaseErrorHandlingStrategy    | "force"                |
-    And the graph projection is fully up to date
 
     Then workspace user-ws-two has status UP_TO_DATE
     And I expect a node identified by user-cs-two-rebased;noderus-secundus;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
@@ -22,7 +22,6 @@ Feature: Workspace based content publishing
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -40,14 +39,12 @@ Feature: Workspace based content publishing
       | propertyValues            | {"text": "Original"} |
     # we need to ensure that the projections are up to date now; otherwise a content stream is forked with an out-
     # of-date base version. This means the content stream can never be merged back, but must always be rebased.
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
       | workspaceOwner     | "owner-identifier"   |
-    And the graph projection is fully up to date
 
   Scenario: Basic events are emitted
     # LIVE workspace
@@ -89,7 +86,6 @@ Feature: Workspace based content publishing
       | nodeAggregateId           | "nody-mc-nodeface"   |
       | originDimensionSpacePoint | {}                   |
       | propertyValues            | {"text": "Modified"} |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
@@ -107,7 +103,6 @@ Feature: Workspace based content publishing
     When the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
@@ -123,14 +118,12 @@ Feature: Workspace based content publishing
       | nodeAggregateId           | "nody-mc-nodeface"                     |
       | originDimensionSpacePoint | {}                                     |
       | propertyValues            | {"text": "Modified in user workspace"} |
-    And the graph projection is fully up to date
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                  |
       | workspaceName             | "live"                                 |
       | nodeAggregateId           | "nody-mc-nodeface"                     |
       | originDimensionSpacePoint | {}                                     |
       | propertyValues            | {"text": "Modified in live workspace"} |
-    And the graph projection is fully up to date
 
     # PUBLISHING without rebase: error
     When the command PublishWorkspace is executed with payload and exceptions are caught:
@@ -144,12 +137,10 @@ Feature: Workspace based content publishing
       | Key                    | Value          |
       | workspaceName          | "user-test"    |
       | rebasedContentStreamId | "rebased-cs-id" |
-    And the graph projection is fully up to date
 
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
 
@@ -167,13 +158,11 @@ Feature: Workspace based content publishing
       | originDimensionSpacePoint | {}                   |
       | propertyValues            | {"text": "Modified"} |
 
-    And the graph projection is fully up to date
 
     # PUBLISHING
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
     When I am in workspace "live" and dimension space point {}
 
     When the command SetNodeProperties is executed with payload:
@@ -183,13 +172,11 @@ Feature: Workspace based content publishing
       | originDimensionSpacePoint | {}                        |
       | propertyValues            | {"text": "Modified anew"} |
 
-    And the graph projection is fully up to date
 
     # PUBLISHING
     And the command PublishWorkspace is executed with payload:
       | Key           | Value       |
       | workspaceName | "user-test" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
@@ -29,7 +29,6 @@ Feature: Workspace publication - complex chained functionality
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"language": "de"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -46,7 +45,6 @@ Feature: Workspace publication - complex chained functionality
       | workspaceName      | "user-ws"    |
       | baseWorkspaceName  | "live"       |
       | newContentStreamId | "user-cs-id" |
-    And the graph projection is fully up to date
 
   Scenario: Vary to generalization, then publish only the child node so that an exception is thrown. Ensure that the workspace recovers from this
     When the command CreateNodeVariant is executed with payload:
@@ -55,14 +53,12 @@ Feature: Workspace publication - complex chained functionality
       | nodeAggregateId | "sir-david-nodenborough" |
       | sourceOrigin    | {"language": "de"}       |
       | targetOrigin    | {"language": "en"}       |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
       | workspaceName   | "user-ws"          |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language": "de"} |
       | targetOrigin    | {"language": "en"} |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload and exceptions are caught:
       | Key                | Value                                                                                                                                                                                                                                                                                                                                                   |
@@ -75,6 +71,5 @@ Feature: Workspace publication - complex chained functionality
       | Key                | Value                                                                                                                                                                                                                                                                                                                                                   |
       | workspaceName      | "user-ws"                                                                                                                                                                                                                                                                                                                                             |
       | newContentStreamId | "user-cs-id-yet-again-rebased"                                                                                                                                                                                                                                                                                                                                |
-    And the graph projection is fully up to date
     When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id-yet-again-rebased;nody-mc-nodeface;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
@@ -21,14 +21,12 @@ Feature: Individual node publication
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | workspaceName   | "live"                        |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And the graph projection is fully up to date
 
     # Create user workspace
     And the command CreateWorkspace is executed with payload:
@@ -36,7 +34,6 @@ Feature: Individual node publication
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
   ################
   # PUBLISHING
@@ -58,7 +55,6 @@ Feature: Individual node publication
       | nodesToPublish                  | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-david-nodenborough"}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining"                                                                           |
       | contentStreamIdForMatchingPart  | "user-cs-identifier-matching"                                                                            |
-    And the graph projection is fully up to date
 
     And I am in workspace "live"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
@@ -29,7 +29,6 @@ Feature: Publishing individual nodes (basics)
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -65,7 +64,6 @@ Feature: Publishing individual nodes (basics)
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                |
       | initialPropertyValues       | {"image": {"type": "string", "value": "Initial image"}} |
       | nodeAggregateClassification | "regular"                                               |
-    And the graph projection is fully up to date
 
     # Create user workspace
     And the command CreateWorkspace is executed with payload:
@@ -73,7 +71,6 @@ Feature: Publishing individual nodes (basics)
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     # modify nodes in user WS
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                    |
@@ -93,7 +90,6 @@ Feature: Publishing individual nodes (basics)
       | nodeAggregateId           | "sir-nodeward-nodington-iii" |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"image": "Modified image"}  |
-    And the graph projection is fully up to date
 
   ################
   # PUBLISHING
@@ -106,7 +102,6 @@ Feature: Publishing individual nodes (basics)
       | nodesToPublish                  | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining"                                                                                          |
       | contentStreamIdForMatchingPart  | "user-cs-identifier-matching"                                                                                          |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
@@ -142,7 +137,6 @@ Feature: Publishing individual nodes (basics)
       | workspaceName                   | "user-test"                    |
       | nodesToPublish                  | []                             |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
@@ -178,7 +172,6 @@ Feature: Publishing individual nodes (basics)
       | workspaceName                   | "user-test"                                                                                                                                                                                                                                                                                                                                             |
       | nodesToPublish                  | [{"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-david-nodenborough"}, {"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "nody-mc-nodeface"}, {"workspaceName": "user-test", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining"                                                                                                                                                                                                                                                                                                                          |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -38,7 +38,6 @@ Feature: Publishing hide/show scenario of nodes
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -74,7 +73,6 @@ Feature: Publishing hide/show scenario of nodes
       | parentNodeAggregateId | "lady-eleonode-rootford"                               |
       | initialPropertyValues         | {"image": {"type": "image", "value": "Initial image"}} |
       | nodeAggregateClassification   | "regular"                                              |
-    And the graph projection is fully up to date
 
   Scenario: (DisableNode) It is possible to publish hiding of a node.
     Given the command CreateWorkspace is executed with payload:
@@ -82,7 +80,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "user-test"
 
     # SETUP: hide two nodes in USER workspace
@@ -96,7 +93,6 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId      | "sir-nodeward-nodington-iii"           |
       | coveredDimensionSpacePoint   | {}                                     |
       | nodeVariantSelectionStrategy | "allVariants"                          |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                      | Value                                                                                                                               |
@@ -104,7 +100,6 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish           | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
       | contentStreamIdForRemainingPart | "remaining-cs-id"                                                                                 |
       | contentStreamIdForMatchingPart  | "matching-cs-id"                                                                                  |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
@@ -130,13 +125,11 @@ Feature: Publishing hide/show scenario of nodes
       | nodeVariantSelectionStrategy | "allVariants"                          |
     # we need to ensure that the projections are up to date now; otherwise a content stream is forked with an out-
     # of-date base version. This means the content stream can never be merged back, but must always be rebased.
-    And the graph projection is fully up to date
     Given the command CreateWorkspace is executed with payload:
       | Key                        | Value                |
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # SETUP: enable two nodes in USER workspace
     Given the command EnableNodeAggregate is executed with payload:
@@ -151,14 +144,12 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId      | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                                     | Value                                                                                                                               |
       | workspaceName                           | "user-test"                                                                                                                         |
       | nodesToPublish                          | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
@@ -219,7 +210,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # SETUP: remove two nodes in USER workspace
     When the command RemoveNodeAggregate is executed with payload:
@@ -235,14 +225,12 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId      | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                      | Value                                                                                                                               |
       | workspaceName            | "user-test"                                                                                                                         |
       | nodesToPublish           | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
@@ -261,7 +249,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # SETUP: remove two nodes in USER workspace
     When the command RemoveNodeAggregate is executed with payload:
@@ -276,13 +263,11 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId      | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                      | Value                                                                                                                               |
       | workspaceName            | "user-test"                                                                                                                         |
       | nodesToPublish           | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
@@ -301,7 +286,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # SETUP: set two node references in USER workspace
     When the command SetNodeReferences is executed with payload:
@@ -318,14 +302,12 @@ Feature: Publishing hide/show scenario of nodes
       | sourceOriginDimensionSpacePoint | {}                                        |
       | referenceName                   | "referenceProperty"                       |
       | references                      | [{"target":"sir-nodeward-nodington-iii"}] |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                                     | Value                                                                                                                               |
       | workspaceName                           | "user-test"                                                                                                                         |
       | nodesToPublish                          | [{"nodeAggregateId": "sir-david-nodenborough", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                                       |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
@@ -361,7 +343,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # SETUP: set two new nodes in USER workspace
     When the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -380,14 +361,12 @@ Feature: Publishing hide/show scenario of nodes
       | originDimensionSpacePoint     | {}                                       |
       | parentNodeAggregateId | "lady-eleonode-rootford"                 |
       | nodeName                      | "foo2"                                   |
-    And the graph projection is fully up to date
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                                     | Value                                                                                                                 |
       | workspaceName                           | "user-test"                                                                                                           |
       | nodesToPublish                          | [{"nodeAggregateId": "new1-agg", "workspaceName": "user-test", "dimensionSpacePoint": {}}] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                                         |
-    And the graph projection is fully up to date
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "new1-agg" to lead to node cs-identifier;new1-agg;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -22,7 +22,6 @@ Feature: Publishing moved nodes without dimensions
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                                  |
@@ -58,14 +57,12 @@ Feature: Publishing moved nodes without dimensions
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName                      | "esquire"                                 |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
 
     And the command CreateWorkspace is executed with payload:
       | Key                        | Value                |
       | workspaceName              | "user"               |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
   Scenario: Publish the move of a node to the end of its siblings
     When the command MoveNodeAggregate is executed with payload:
@@ -79,7 +76,6 @@ Feature: Publishing moved nodes without dimensions
       | Key                      | Value                                                                                                                               |
       | workspaceName            | "user"                                                                                                                              |
       | nodesToPublish           | [{"workspaceName": "user", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-david-nodenborough"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -119,7 +115,6 @@ Feature: Publishing moved nodes without dimensions
       | Key                      | Value                                                                                                                                   |
       | workspaceName            | "user"                                                                                                                                  |
       | nodesToPublish           | [{"workspaceName": "user", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-nodeward-nodington-iii"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -158,7 +153,6 @@ Feature: Publishing moved nodes without dimensions
       | parentNodeAggregateId | "sir-nodeward-nodington-iii"              |
       | nodeName                      | "other-document"                          |
       | nodeAggregateClassification   | "regular"                                 |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload:
       | Key                              | Value                        |
       | workspaceName              | "user"               |
@@ -169,7 +163,6 @@ Feature: Publishing moved nodes without dimensions
       | Key                      | Value                                                                                                                               |
       | workspaceName            | "user"                                                                                                                              |
       | nodesToPublish           | [{"workspaceName": "user", "dimensionSpacePoint": {}, "nodeAggregateId": "sir-david-nodenborough"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -215,7 +208,6 @@ Feature: Publishing moved nodes without dimensions
       | workspaceName            | "user"                                                                                                                        |
       | nodesToPublish           | [{"workspaceName": "user", "dimensionSpacePoint": {}, "nodeAggregateId": "nody-mc-nodeface"}] |
 
-    When the graph projection is fully up to date
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
@@ -22,7 +22,6 @@ Feature: Workspace discarding - basic functionality
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -40,14 +39,12 @@ Feature: Workspace discarding - basic functionality
       | propertyValues            | {"text": "Original"} |
     # we need to ensure that the projections are up to date now; otherwise a content stream is forked with an out-
     # of-date base version. This means the content stream can never be merged back, but must always be rebased.
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
       | workspaceOwner     | "owner-identifier"   |
-    And the graph projection is fully up to date
 
   Scenario: Discarding a full workspace works
     When the command SetNodeProperties is executed with payload:
@@ -56,7 +53,6 @@ Feature: Workspace discarding - basic functionality
       | nodeAggregateId           | "nody-mc-nodeface"   |
       | originDimensionSpacePoint | {}                   |
       | propertyValues            | {"text": "Modified"} |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
@@ -69,7 +65,6 @@ Feature: Workspace discarding - basic functionality
       | Key                | Value                         |
       | workspaceName      | "user-test"                   |
       | newContentStreamId | "user-cs-identifier-modified" |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
@@ -84,7 +79,6 @@ Feature: Workspace discarding - basic functionality
       | nodeAggregateId           | "nody-mc-nodeface"   |
       | originDimensionSpacePoint | {}                   |
       | propertyValues            | {"text": "Modified"} |
-    And the graph projection is fully up to date
 
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                  |
@@ -92,14 +86,12 @@ Feature: Workspace discarding - basic functionality
       | nodeAggregateId           | "nody-mc-nodeface"                     |
       | originDimensionSpacePoint | {}                                     |
       | propertyValues            | {"text": "Modified in live workspace"} |
-    And the graph projection is fully up to date
 
     # Discarding
     When the command DiscardWorkspace is executed with payload:
       | Key                | Value                         |
       | workspaceName      | "user-test"                   |
       | newContentStreamId | "user-cs-identifier-modified" |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
@@ -115,14 +107,12 @@ Feature: Workspace discarding - basic functionality
       | baseWorkspaceName  | "live"                       |
       | newContentStreamId | "user-cs-one"                |
       | workspaceOwner     | "owner-identifier"           |
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                        |
       | workspaceName      | "user-ws-two"                |
       | baseWorkspaceName  | "live"                       |
       | newContentStreamId | "user-cs-two"                |
       | workspaceOwner     | "owner-identifier"           |
-    And the graph projection is fully up to date
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -130,7 +120,6 @@ Feature: Workspace discarding - basic functionality
       | nodeAggregateId              | "nody-mc-nodeface"       |
       | nodeVariantSelectionStrategy | "allVariants"            |
       | coveredDimensionSpacePoint   | {}                       |
-    And the graph projection is fully up to date
 
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                        |
@@ -138,12 +127,10 @@ Feature: Workspace discarding - basic functionality
       | nodeAggregateId           | "nody-mc-nodeface"           |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"text": "Modified"}         |
-    And the graph projection is fully up to date
 
     And the command PublishWorkspace is executed with payload:
       | Key              | Value            |
       | workspaceName    | "user-ws-one"    |
-    And the graph projection is fully up to date
 
     Then workspace user-ws-two has status OUTDATED
 
@@ -158,7 +145,6 @@ Feature: Workspace discarding - basic functionality
       | Key                | Value                     |
       | workspaceName      | "user-ws-two"             |
       | newContentStreamId | "user-cs-two-discarded"   |
-    And the graph projection is fully up to date
 
     Then workspace user-ws-two has status OUTDATED
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
@@ -16,7 +16,6 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -42,19 +41,16 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | parentNodeAggregateId | "nody-mc-nodeface"                       |
       | nodeName                      | "pet"                                    |
       | nodeAggregateClassification   | "regular"                                |
-    And the graph projection is fully up to date
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                        |
       | nodeAggregateId   | "nody-mc-nodeface"           |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"text": "Original"}         |
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                        | Value                |
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
   Scenario: Set property of a node
     Given the command SetNodeProperties is executed with payload:
@@ -72,7 +68,6 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | originDimensionSpacePoint | []                           |
       | propertyValues.text.value | "Changed"                    |
 
-    When the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -13,13 +13,11 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | nodeAggregateId  | "root-node"                            |
       | nodeTypeName             | "Neos.ContentRepository:Root"          |
-    And the graph projection is fully up to date
 
   Scenario: content streams are marked as IN_USE_BY_WORKSPACE properly after creation
     Then the content stream "cs-identifier" has state "IN_USE_BY_WORKSPACE"
@@ -31,7 +29,6 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     Then the content stream "user-cs-identifier" has state "IN_USE_BY_WORKSPACE"
 
@@ -41,11 +38,9 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     When the command RebaseWorkspace is executed with payload:
       | Key                      | Value                        |
       | workspaceName            | "user-test"                  |
-    And the graph projection is fully up to date
 
     When I am in workspace "user-test" and dimension space point {}
     Then the current content stream has state "IN_USE_BY_WORKSPACE"
@@ -58,16 +53,13 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     When the command RebaseWorkspace is executed with payload:
       | Key                            | Value                        |
       | workspaceName                  | "user-test"                  |
       | rebasedContentStreamId | "user-cs-identifier-rebased" |
-    And the graph projection is fully up to date
     # now, we have one unused content stream (the old content stream of the user-test workspace)
 
     When I prune unused content streams
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {}
     Then I expect node aggregate identifier "root-node" to lead to no node
@@ -82,15 +74,12 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "live"               |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
     When the command RebaseWorkspace is executed with payload:
       | Key                      | Value                        |
       | workspaceName            | "user-test"                  |
-    And the graph projection is fully up to date
     # now, we have one unused content stream (the old content stream of the user-test workspace)
 
     When I prune unused content streams
-    And the graph projection is fully up to date
     And I prune removed content streams from the event stream
 
     Then I expect exactly 0 events to be published on stream "ContentStream:user-cs-identifier"
@@ -103,13 +92,11 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName              | "review"               |
       | baseWorkspaceName          | "live"                 |
       | newContentStreamId | "review-cs-identifier" |
-    And the graph projection is fully up to date
     And the command CreateWorkspace is executed with payload:
       | Key                        | Value                |
       | workspaceName              | "user-test"          |
       | baseWorkspaceName          | "review"             |
       | newContentStreamId | "user-cs-identifier" |
-    And the graph projection is fully up to date
 
     # now, we rebase the "review" workspace, effectively marking the "review-cs-identifier" content stream as NO_LONGER_IN_USE.
     # however, we are not allowed to drop the content stream from the event store yet, because the "user-cs-identifier" is based
@@ -117,10 +104,8 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     When the command RebaseWorkspace is executed with payload:
       | Key                      | Value                        |
       | workspaceName            | "review"                     |
-    And the graph projection is fully up to date
 
     When I prune unused content streams
-    And the graph projection is fully up to date
     And I prune removed content streams from the event stream
 
     # the events should still exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodeAggregateWithDimensions.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodeAggregateWithDimensions.wip
@@ -18,13 +18,11 @@ Feature: Remove NodeAggregate
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
       | newContentStreamId | "live-cs-identifier"                   |
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | contentStreamId  | "live-cs-identifier"                   |
       | nodeAggregateId  | "lady-eleonode-nodesworth"             |
       | nodeTypeName             | "Neos.ContentRepository:Root"          |
-    And the graph projection is fully up to date
     # We have to add another node since root nodes are in all dimension space points and thus cannot be varied
     # Node /document
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -35,7 +33,6 @@ Feature: Remove NodeAggregate
       | originDimensionSpacePoint     | {"language":"de"}                         |
       | parentNodeAggregateId | "lady-eleonode-nodesworth"                |
       | nodeName                      | "document"                                |
-    And the graph projection is fully up to date
     # We also want to add a child node to make sure it is correctly removed when the parent is removed
     # Node /document/child-document
     And the command CreateNodeAggregateWithNodeAndSerializedProperties is executed with payload:
@@ -46,14 +43,12 @@ Feature: Remove NodeAggregate
       | originDimensionSpacePoint     | {"language":"de"}                         |
       | parentNodeAggregateId | "nody-mc-nodeface"                        |
       | nodeName                      | "child-document"                          |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key                      | Value                |
       | contentStreamId  | "live-cs-identifier" |
       | nodeAggregateId  | "nody-mc-nodeface"   |
       | sourceOrigin             | {"language":"de"}    |
       | targetOrigin             | {"language":"gsw"}   |
-    And the graph projection is fully up to date
 
   ########################
   # Section: EXTRA testcases
@@ -65,7 +60,6 @@ Feature: Remove NodeAggregate
       | nodeAggregateId      | "nody-mc-nodeface"   |
       | nodeVariantSelectionStrategy | "allVariants"        |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 1 node
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -84,7 +78,6 @@ Feature: Remove NodeAggregate
       | Key                           | Value                        |
       | contentStreamId       | "user-cs-identifier"         |
       | sourceContentStreamId | "live-cs-identifier"         |
-    And the graph projection is fully up to date
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -92,7 +85,6 @@ Feature: Remove NodeAggregate
       | nodeAggregateId      | "nody-mc-nodeface"   |
       | nodeVariantSelectionStrategy | "allVariants"        |
       | coveredDimensionSpacePoint   | {"language":"de"}    |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodesFromAggregate.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodesFromAggregate.wip
@@ -29,7 +29,6 @@ Feature: Remove Nodes from Aggregate
       | workspaceTitle           | "Live"                                 |
       | workspaceDescription     | "The live workspace"                   |
       | newContentStreamId  | "live-cs-identifier"                   |
-    And the graph projection is fully up to date
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                      | Value                                  |
       | contentStreamId  | "live-cs-identifier"                   |
@@ -65,7 +64,6 @@ Feature: Remove Nodes from Aggregate
       | originDimensionSpacePoint     | {"language":"de"}                         |
       | parentNodeAggregateId | "nodimus-prime"                           |
       | nodeName                      | "grandchild-document"                     |
-    And the graph projection is fully up to date
 
   ########################
   # Section: EXTRA testcases
@@ -96,7 +94,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier"                   |
       | nodeAggregateId | "nodasaurus-rex"                       |
       | dimensionSpacePointSet  | [{"language":"de"},{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 3 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -121,7 +118,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nodasaurus-rex"     |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -152,7 +148,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"de"}]  |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 1 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -172,7 +167,6 @@ Feature: Remove Nodes from Aggregate
       | contentStreamId | "live-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -200,13 +194,11 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                                  |
       | contentStreamId | "user-cs-identifier"                   |
       | nodeAggregateId | "nodasaurus-rex"                        |
       | dimensionSpacePointSet  | [{"language":"de"}] |
-    And the graph projection is fully up to date
 
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by live-cs-identifier;lady-eleonode-nodesworth;{} to exist in the content graph
@@ -255,14 +247,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                |
       | contentStreamId | "user-cs-identifier" |
       | nodeAggregateId | "nodimus-prime"      |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" to exist in the graph projection
@@ -297,14 +287,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                                  |
       | contentStreamId | "user-cs-identifier"                   |
       | nodeAggregateId | "nody-mc-nodeface"                     |
       | dimensionSpacePointSet  | [{"language":"de"},{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" not to exist in the graph projection
@@ -339,14 +327,12 @@ Feature: Remove Nodes from Aggregate
       | Key                           | Value                |
       | contentStreamId       | "user-cs-identifier" |
       | sourceContentStreamId | "live-cs-identifier" |
-    And the graph projection is fully up to date
 
     When the command RemoveNodesFromAggregate was published with payload:
       | Key                     | Value                |
       | contentStreamId | "user-cs-identifier" |
       | nodeAggregateId | "nody-mc-nodeface"   |
       | dimensionSpacePointSet  | [{"language":"gsw"}] |
-    And the graph projection is fully up to date
 
     When I am in content stream "user-cs-identifier" and dimension space point {"language":"de"}
     Then I expect a node "doc-identifier-de" to exist in the graph projection

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
@@ -18,7 +18,6 @@ Feature: Single Node operations on live workspace
       | Key                        | Value           |
       | workspaceName              | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key                         | Value                         |
@@ -34,7 +33,6 @@ Feature: Single Node operations on live workspace
       | parentNodeAggregateId | "lady-eleonode-rootford"                 |
       | nodeName                      | "child"                                  |
       | nodeAggregateClassification   | "regular"                                |
-    And the graph projection is fully up to date
 
   Scenario: Set property of a node
     Given the command SetNodeProperties is executed with payload:
@@ -50,7 +48,6 @@ Feature: Single Node operations on live workspace
       | originDimensionSpacePoint | []                           |
       | propertyValues.text.value | "Hello"                      |
 
-    When the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php
@@ -111,12 +111,12 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
             new WorkspaceTitle('Live'),
             new WorkspaceDescription('The live workspace'),
             ContentStreamId::fromString('live-cs-id')
-        ))->block();
+        ));
         $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
             WorkspaceName::forLive(),
             NodeAggregateId::fromString('lady-eleonode-rootford'),
             NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
-        ))->block();
+        ));
         $contentRepository->handle(CreateNodeAggregateWithNode::create(
             WorkspaceName::forLive(),
             NodeAggregateId::fromString('nody-mc-nodeface'),
@@ -126,14 +126,14 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
             initialPropertyValues: PropertyValuesToWrite::fromArray([
                 'title' => 'title'
             ])
-        ))->block();
+        ));
         $contentRepository->handle(CreateWorkspace::create(
             WorkspaceName::fromString('user-test'),
             WorkspaceName::forLive(),
             new WorkspaceTitle('User'),
             new WorkspaceDescription('The user workspace'),
             ContentStreamId::fromString('user-cs-id')
-        ))->block();
+        ));
         for ($i = 0; $i <= 1000; $i++) {
             $contentRepository->handle(CreateNodeAggregateWithNode::create(
                 WorkspaceName::forLive(),
@@ -144,7 +144,7 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
                 initialPropertyValues: PropertyValuesToWrite::fromArray([
                     'title' => 'title'
                 ])
-            ))->block();
+            ));
             // give the database lock some time to recover
             usleep(5000);
         }
@@ -166,7 +166,7 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
         try {
             $this->contentRepository->handle(RebaseWorkspace::create(
                 $workspaceName,
-            )->withRebasedContentStreamId(ContentStreamId::fromString('user-test-rebased')))->block();
+            )->withRebasedContentStreamId(ContentStreamId::fromString('user-test-rebased')));
         } catch (\RuntimeException $runtimeException) {
             $exception = $runtimeException;
         }
@@ -194,7 +194,7 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
                 PropertyValuesToWrite::fromArray([
                     'title' => 'title47b'
                 ])
-            ))->block();
+            ));
         } catch (\Exception $thrownException) {
             $exceptionIsThrownAsExpected
                 = $thrownException instanceof ContentStreamIsClosed || $thrownException instanceof ConcurrencyException;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Feature/WorkspacePublication/WorkspaceWritingDuringPublication.php
@@ -42,7 +42,6 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceTitle;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteTrait;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\ContentRepositoryRegistry\Factory\ProjectionCatchUpTrigger\CatchUpTriggerWithSynchronousOption;
 use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\Flow\Tests\FunctionalTestCase;
 use PHPUnit\Framework\Assert;
@@ -66,7 +65,6 @@ class WorkspaceWritingDuringPublication extends FunctionalTestCase
     public function setUp(): void
     {
         parent::setUp();
-        CatchUpTriggerWithSynchronousOption::enableSynchronicityForSpeedingUpTesting();
         GherkinTableNodeBasedContentDimensionSourceFactory::$contentDimensionsToUse = new class implements ContentDimensionSourceInterface
         {
             public function getDimension(ContentDimensionId $dimensionId): ?ContentDimension

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -144,7 +144,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->newContentStreamId,
                 $baseWorkspaceContentGraph->getContentStreamId(),
             )
-        )->block();
+        );
 
         $events = Events::with(
             new WorkspaceWasCreated(
@@ -205,7 +205,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             CreateContentStream::create(
                 $newContentStreamId,
             )
-        )->block();
+        );
 
         $events = Events::with(
             new RootWorkspaceWasCreated(
@@ -242,7 +242,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         $this->publishContentStream(
             $workspace->currentContentStreamId,
             $baseWorkspace->currentContentStreamId
-        )?->block();
+        );
 
         // After publishing a workspace, we need to again fork from Base.
         $commandHandlingDependencies->handle(
@@ -250,7 +250,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->newContentStreamId,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         $streamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
         $events = Events::with(
@@ -363,7 +363,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         // 0) close old content stream
         $commandHandlingDependencies->handle(
             CloseContentStream::create($oldWorkspaceContentStreamId)
-        )->block();
+        );
 
         // 1) fork a new content stream
         $rebasedContentStreamId = $command->rebasedContentStreamId;
@@ -372,7 +372,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->rebasedContentStreamId,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
         $workspaceContentStreamName = ContentStreamEventStreamName::fromContentStreamId(
@@ -389,7 +389,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 foreach ($originalCommands as $sequenceNumber => $originalCommand) {
                     // We no longer need to adjust commands as the workspace stays the same
                     try {
-                        $commandHandlingDependencies->handle($originalCommand)->block();
+                        $commandHandlingDependencies->handle($originalCommand);
                         // if we came this far, we know the command was applied successfully.
                     } catch (\Exception $e) {
                         $commandsThatFailed = $commandsThatFailed->add(
@@ -427,12 +427,12 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $oldWorkspaceContentStreamId,
                 $oldWorkspaceContentStreamIdState,
             )
-        )->block();
+        );
 
         // ... remove the newly created one...
         $commandHandlingDependencies->handle(RemoveContentStream::create(
             $rebasedContentStreamId
-        ))->block();
+        ));
 
         // ...and throw an exception that contains all the information about what exactly failed
         throw new WorkspaceRebaseFailed($commandsThatFailed, 'Rebase failed', 1711713880);
@@ -513,7 +513,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->contentStreamIdForMatchingPart,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         try {
             // 4) using the new content stream, apply the matching commands
@@ -531,7 +531,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
                         $commandHandlingDependencies->handle($matchingCommand->createCopyForWorkspace(
                             $baseWorkspace->workspaceName,
-                        ))->block();
+                        ));
                     }
                 }
             );
@@ -540,7 +540,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $this->publishContentStream(
                 $command->contentStreamIdForMatchingPart,
                 $baseWorkspace->currentContentStreamId
-            )?->block();
+            );
 
             // 6) fork a new content stream, based on the base WS, and apply REST
             $commandHandlingDependencies->handle(
@@ -548,7 +548,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->contentStreamIdForRemainingPart,
                     $baseWorkspace->currentContentStreamId
                 )
-            )->block();
+            );
 
 
             // 7) apply REMAINING commands to the workspace's new content stream
@@ -557,7 +557,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->contentStreamIdForRemainingPart,
                 function () use ($commandHandlingDependencies, $remainingCommands) {
                     foreach ($remainingCommands as $remainingCommand) {
-                        $commandHandlingDependencies->handle($remainingCommand)->block();
+                        $commandHandlingDependencies->handle($remainingCommand);
                     }
                 }
             );
@@ -568,16 +568,16 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $oldWorkspaceContentStreamId,
                     $oldWorkspaceContentStreamIdState,
                 )
-            )->block();
+            );
 
             $commandHandlingDependencies->handle(RemoveContentStream::create(
                 $command->contentStreamIdForMatchingPart
-            ))->block();
+            ));
 
             try {
                 $commandHandlingDependencies->handle(RemoveContentStream::create(
                     $command->contentStreamIdForRemainingPart
-                ))->block();
+                ));
             } catch (ContentStreamDoesNotExistYet $contentStreamDoesNotExistYet) {
                 // in case the exception was thrown before 6), this does not exist
             }
@@ -637,7 +637,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         // 1) close old content stream
         $commandHandlingDependencies->handle(
             CloseContentStream::create($oldWorkspaceContentStreamId)
-        )->block();
+        );
 
         // 2) filter commands, only keeping the ones NOT MATCHING the nodes from the command
         // (i.e. the modifications we want to keep)
@@ -653,7 +653,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->newContentStreamId,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         // 4) using the new content stream, apply the commands to keep
         try {
@@ -671,7 +671,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
                         $commandHandlingDependencies->handle($matchingCommand->createCopyForWorkspace(
                             $baseWorkspace->workspaceName,
-                        ))->block();
+                        ));
                     }
                 }
             );
@@ -682,11 +682,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $oldWorkspaceContentStreamId,
                     $oldWorkspaceContentStreamIdState,
                 )
-            )->block();
+            );
 
             $commandHandlingDependencies->handle(RemoveContentStream::create(
                 $command->newContentStreamId
-            ))->block();
+            ));
 
             throw $exception;
         }
@@ -694,7 +694,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         // 5) If everything worked, to avoid dangling content streams, we need to remove the old content stream
         $commandHandlingDependencies->handle(RemoveContentStream::create(
             $oldWorkspaceContentStreamId
-        ))->block();
+        ));
 
         $streamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
 
@@ -779,7 +779,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $newContentStream,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         // if we got so far without an Exception, we can switch the Workspace's active Content stream.
         $streamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
@@ -824,7 +824,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->newContentStreamId,
                 $baseWorkspace->currentContentStreamId,
             )
-        )->block();
+        );
 
         $streamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
         $events = Events::with(
@@ -855,7 +855,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             RemoveContentStream::create(
                 $workspace->currentContentStreamId
             )
-        )->block();
+        );
 
         $events = Events::with(
             new WorkspaceWasRemoved(

--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryBootstrapper.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryBootstrapper.php
@@ -52,7 +52,7 @@ final readonly class ContentRepositoryBootstrapper
                 WorkspaceDescription::fromString('Public live workspace'),
                 ContentStreamId::create()
             )
-        )->block();
+        );
         $liveWorkspace = $this->contentRepository->getWorkspaceFinder()->findOneByName($liveWorkspaceName);
         if (!$liveWorkspace) {
             throw new \Exception('Live workspace creation failed', 1699002435);
@@ -81,7 +81,7 @@ final readonly class ContentRepositoryBootstrapper
                 $workspace->workspaceName,
                 $rootNodeAggregateId,
                 $rootNodeTypeName,
-            ))->block();
+            ));
             return $rootNodeAggregateId;
         }
     }

--- a/Neos.ContentRepository.Core/Classes/Service/WorkspaceMaintenanceService.php
+++ b/Neos.ContentRepository.Core/Classes/Service/WorkspaceMaintenanceService.php
@@ -41,7 +41,7 @@ class WorkspaceMaintenanceService implements ContentRepositoryServiceInterface
             if ($strategy) {
                 $rebaseCommand = $rebaseCommand->withErrorHandlingStrategy($strategy);
             }
-            $this->contentRepository->handle($rebaseCommand)->block();
+            $this->contentRepository->handle($rebaseCommand);
         }
 
         return $outdatedWorkspaces;

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -44,7 +44,6 @@ class FeatureContext implements BehatContext
         self::bootstrapFlow();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
 
-        $this->setupCRTestSuiteTrait();
         $this->setupCrImportExportTrait();
     }
 

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/Export/Export.feature
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/Export/Export.feature
@@ -17,7 +17,6 @@ Feature: As a user of the CR I want to export the event stream
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -33,7 +32,6 @@ Feature: As a user of the CR I want to export the event stream
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                 |
       | nodeName                    | "child-document"                                         |
       | nodeAggregateClassification | "regular"                                                |
-    And the graph projection is fully up to date
 
   Scenario: Export the event stream
     Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-identifier"

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -79,7 +79,6 @@ class FeatureContext implements Context
 
         $this->mockFilesystemAdapter = new InMemoryFilesystemAdapter();
         $this->mockFilesystem = new Filesystem($this->mockFilesystemAdapter);
-        $this->setupCRTestSuiteTrait();
     }
 
     /**

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
@@ -78,7 +78,7 @@ readonly class NodeMigrationService implements ContentRepositoryServiceInterface
                     WorkspaceDescription::fromString(''),
                     $contentStreamForWriting,
                 )
-            )->block();
+            );
             /** array $migrationDescription */
             $this->executeSubMigrationAndBlock(
                 $migrationDescription,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
@@ -94,7 +94,7 @@ final class Transformations
         WorkspaceName $workspaceNameForWriting,
     ): void {
         foreach ($this->globalTransformations as $globalTransformation) {
-            $globalTransformation->execute($workspaceNameForWriting)->block();
+            $globalTransformation->execute($workspaceNameForWriting);
         }
     }
 
@@ -104,7 +104,7 @@ final class Transformations
         ContentStreamId $contentStreamForWriting
     ): void {
         foreach ($this->nodeAggregateBasedTransformations as $nodeAggregateBasedTransformation) {
-            $nodeAggregateBasedTransformation->execute($nodeAggregate, $workspaceNameForWriting, $contentStreamForWriting)->block();
+            $nodeAggregateBasedTransformation->execute($nodeAggregate, $workspaceNameForWriting, $contentStreamForWriting);
         }
     }
 
@@ -115,7 +115,7 @@ final class Transformations
         ContentStreamId $contentStreamForWriting
     ): void {
         foreach ($this->nodeBasedTransformations as $nodeBasedTransformation) {
-            $nodeBasedTransformation->execute($node, $coveredDimensionSpacePoints, $workspaceNameForWriting, $contentStreamForWriting)?->block();
+            $nodeBasedTransformation->execute($node, $coveredDimensionSpacePoints, $workspaceNameForWriting, $contentStreamForWriting);
         }
     }
 }

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -95,7 +95,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
             $remediation = $adjustment->remediation;
             $eventsToPublish = $remediation();
             assert($eventsToPublish instanceof EventsToPublish);
-            $this->eventPersister->publishEvents($eventsToPublish)->block();
+            $this->eventPersister->publishEvents($eventsToPublish);
         }
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandResult;
 use Neos\ContentRepository\Core\ContentGraphFinder;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -47,8 +46,6 @@ trait CRTestSuiteRuntimeVariables
     protected ?VisibilityConstraints $currentVisibilityConstraints = null;
 
     protected ?NodeAggregateId $currentRootNodeAggregateId = null;
-
-    protected ?CommandResult $lastCommandOrEventResult = null;
 
     protected ?\Exception $lastCommandException = null;
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -49,7 +49,6 @@ use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features\Subtre
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features\WorkspaceCreation;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features\WorkspaceDiscarding;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features\WorkspacePublishing;
-use Neos\ContentRepositoryRegistry\Factory\ProjectionCatchUpTrigger\CatchUpTriggerWithSynchronousOption;
 use Neos\EventStore\EventStoreInterface;
 use PHPUnit\Framework\Assert;
 
@@ -84,13 +83,6 @@ trait CRTestSuiteTrait
     use WorkspaceCreation;
     use WorkspaceDiscarding;
     use WorkspacePublishing;
-
-    protected function setupCRTestSuiteTrait(): void
-    {
-        if (getenv('CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION')) {
-            CatchUpTriggerWithSynchronousOption::enableSynchronicityForSpeedingUpTesting();
-        }
-    }
 
     /**
      * @BeforeScenario
@@ -137,18 +129,6 @@ trait CRTestSuiteTrait
         }
 
         return $eventPayload;
-    }
-
-    /**
-     * @When /^the graph projection is fully up to date$/
-     */
-    public function theGraphProjectionIsFullyUpToDate(): void
-    {
-        if ($this->lastCommandOrEventResult === null) {
-            throw new \RuntimeException('lastCommandOrEventResult not filled; so I cannot block!');
-        }
-        $this->lastCommandOrEventResult->block();
-        $this->lastCommandOrEventResult = null;
     }
 
     /**
@@ -304,7 +284,6 @@ trait CRTestSuiteTrait
         /** @var ContentStreamPruner $contentStreamPruner */
         $contentStreamPruner = $this->getContentRepositoryService(new ContentStreamPrunerFactory());
         $contentStreamPruner->prune();
-        $this->lastCommandOrEventResult = $contentStreamPruner->getLastCommandResult();
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamClosing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamClosing.php
@@ -37,7 +37,7 @@ trait ContentStreamClosing
         $commandArguments = $this->readPayloadTable($payloadTable);
         $command = CloseContentStream::create(ContentStreamId::fromString($commandArguments['contentStreamId']));
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamForking.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/ContentStreamForking.php
@@ -41,7 +41,7 @@ trait ContentStreamForking
             ContentStreamId::fromString($commandArguments['sourceContentStreamId']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCopying.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCopying.php
@@ -67,6 +67,6 @@ trait NodeCopying
         );
         $command = $command->withNodeAggregateIdMapping(NodeAggregateIdMapping::fromArray($commandArguments['nodeAggregateIdMapping']));
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
@@ -69,7 +69,7 @@ trait NodeCreation
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
         $this->currentRootNodeAggregateId = $nodeAggregateId;
     }
 
@@ -121,7 +121,7 @@ trait NodeCreation
             $nodeAggregateId,
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
         $this->currentRootNodeAggregateId = $nodeAggregateId;
     }
 
@@ -158,7 +158,7 @@ trait NodeCreation
         if (isset($commandArguments['tetheredDescendantNodeAggregateIds'])) {
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
         }
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**
@@ -208,8 +208,7 @@ trait NodeCreation
             if (isset($row['tetheredDescendantNodeAggregateIds'])) {
                 $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromJsonString($row['tetheredDescendantNodeAggregateIds']));
             }
-            $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
-            $this->theGraphProjectionIsFullyUpToDate();
+            $this->currentContentRepository->handle($command);
         }
     }
 
@@ -254,7 +253,7 @@ trait NodeCreation
         if (isset($commandArguments['tetheredDescendantNodeAggregateIds'])) {
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
         }
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeDisabling.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeDisabling.php
@@ -57,7 +57,7 @@ trait NodeDisabling
             NodeVariantSelectionStrategy::from($commandArguments['nodeVariantSelectionStrategy']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**
@@ -95,7 +95,7 @@ trait NodeDisabling
             NodeVariantSelectionStrategy::from($commandArguments['nodeVariantSelectionStrategy']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeModification.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeModification.php
@@ -61,7 +61,7 @@ trait NodeModification
             $this->deserializeProperties($commandArguments['propertyValues']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeMove.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeMove.php
@@ -73,7 +73,7 @@ trait NodeMove
             $newSucceedingSiblingNodeAggregateId,
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeReferencing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeReferencing.php
@@ -75,7 +75,7 @@ trait NodeReferencing
             $references,
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRemoval.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRemoval.php
@@ -61,7 +61,7 @@ trait NodeRemoval
             $command = $command->withRemovalAttachmentPoint(NodeAggregateId::fromString($commandArguments['removalAttachmentPoint']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRenaming.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRenaming.php
@@ -47,7 +47,7 @@ trait NodeRenaming
             NodeName::fromString($commandArguments['newNodeName']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeTypeChange.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeTypeChange.php
@@ -53,7 +53,7 @@ trait NodeTypeChange
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeVariation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeVariation.php
@@ -51,7 +51,7 @@ trait NodeVariation
             OriginDimensionSpacePoint::fromArray($commandArguments['sourceOrigin']),
             OriginDimensionSpacePoint::fromArray($commandArguments['targetOrigin']),
         );
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/SubtreeTagging.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/SubtreeTagging.php
@@ -61,7 +61,7 @@ trait SubtreeTagging
             SubtreeTag::fromString($commandArguments['tag']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**
@@ -132,7 +132,7 @@ trait SubtreeTagging
             SubtreeTag::fromString($commandArguments['tag']),
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceCreation.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features;
 
 use Behat\Gherkin\Node\TableNode;
+use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Command\CreateContentStream;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
@@ -40,6 +41,22 @@ trait WorkspaceCreation
     abstract protected function publishEvent(string $eventType, StreamName $streamName, array $eventPayload): void;
 
     /**
+     * @When /^the command CreateContentStream is executed with payload:$/
+     * @param TableNode $payloadTable
+     * @throws \Exception
+     */
+    public function theCommandCreateContentStreamIsExecutedWithPayload(TableNode $payloadTable)
+    {
+        $commandArguments = $this->readPayloadTable($payloadTable);
+
+        $command = CreateContentStream::create(
+            ContentStreamId::fromString($commandArguments['contentStreamId']),
+        );
+
+        $this->currentContentRepository->handle($command);
+    }
+
+    /**
      * @When /^the command CreateRootWorkspace is executed with payload:$/
      * @param TableNode $payloadTable
      * @throws \Exception
@@ -55,7 +72,7 @@ trait WorkspaceCreation
             ContentStreamId::fromString($commandArguments['newContentStreamId'])
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
     /**
      * @Given /^the event RootWorkspaceWasCreated was published with payload:$/
@@ -88,7 +105,7 @@ trait WorkspaceCreation
             isset($commandArguments['workspaceOwner']) ? UserId::fromString($commandArguments['workspaceOwner']) : null
         );
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
 
@@ -110,7 +127,7 @@ trait WorkspaceCreation
             $command = $command->withErrorHandlingStrategy(RebaseErrorHandlingStrategy::from($commandArguments['rebaseErrorHandlingStrategy']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceDiscarding.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspaceDiscarding.php
@@ -46,7 +46,7 @@ trait WorkspaceDiscarding
             $command = $command->withNewContentStreamId(ContentStreamId::fromString($commandArguments['newContentStreamId']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
 
@@ -67,7 +67,7 @@ trait WorkspaceDiscarding
             $command = $command->withNewContentStreamId(ContentStreamId::fromString($commandArguments['newContentStreamId']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
@@ -53,7 +53,7 @@ trait WorkspacePublishing
             $command = $command->withContentStreamIdForRemainingPart(ContentStreamId::fromString($commandArguments['contentStreamIdForRemainingPart']));
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**
@@ -85,7 +85,7 @@ trait WorkspacePublishing
             );
         }
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -81,7 +81,7 @@ trait GenericCommandExecutionAndEventPublication
 
         $command = $commandClassName::fromArray($commandArguments);
 
-        $this->lastCommandOrEventResult = $this->currentContentRepository->handle($command);
+        $this->currentContentRepository->handle($command);
     }
 
     /**
@@ -140,7 +140,7 @@ trait GenericCommandExecutionAndEventPublication
             ->getValue($eventPersister);
         $event = $eventNormalizer->denormalize($artificiallyConstructedEvent);
 
-        $this->lastCommandOrEventResult = $eventPersister->publishEvents(new EventsToPublish(
+        $eventPersister->publishEvents(new EventsToPublish(
             $streamName,
             Events::with($event),
             ExpectedVersion::ANY()

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
@@ -28,7 +28,6 @@ use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\ContentRepositoryRegistry\Factory\ProjectionCatchUpTrigger\CatchUpTriggerWithSynchronousOption;
 use Neos\Flow\Cli\CommandController;
 
 final class ContentCommandController extends CommandController
@@ -75,7 +74,7 @@ final class ContentCommandController extends CommandController
                     $workspaceInstance->workspaceName,
                     $rootNodeAggregate->nodeAggregateId
                 )
-            )->block();
+            );
         }
         $this->outputLine('<success>Done!</success>');
     }
@@ -118,7 +117,7 @@ final class ContentCommandController extends CommandController
                 $sourceDimensionSpacePoint,
                 $targetDimensionSpacePoint
             )
-        )->block();
+        );
         $this->outputLine('<success>Done!</success>');
     }
 
@@ -163,15 +162,13 @@ final class ContentCommandController extends CommandController
 
 
         foreach ($rootNodeAggregates as $rootNodeAggregate) {
-            CatchUpTriggerWithSynchronousOption::synchronously(fn() =>
-                $this->createVariantRecursivelyInternal(
-                    0,
-                    $rootNodeAggregate->nodeAggregateId,
-                    $sourceSubgraph,
-                    $targetSpacePoint,
-                    $workspaceName,
-                    $contentRepositoryInstance,
-                )
+            $this->createVariantRecursivelyInternal(
+                0,
+                $rootNodeAggregate->nodeAggregateId,
+                $sourceSubgraph,
+                $targetSpacePoint,
+                $workspaceName,
+                $contentRepositoryInstance,
             );
         }
 
@@ -201,7 +198,7 @@ final class ContentCommandController extends CommandController
                         $childNode->nodeAggregateId,
                         $childNode->originDimensionSpacePoint,
                         $target
-                    ))->block();
+                    ));
                 } catch (DimensionSpacePointIsAlreadyOccupied $e) {
                     if ($childNodeType?->isOfType('Neos.Neos:Document')) {
                         $this->output("%s  (already exists)\n", [

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -153,7 +153,7 @@ class WorkspaceCommandController extends CommandController
             WorkspaceTitle::fromString($name),
             WorkspaceDescription::fromString($name),
             ContentStreamId::create()
-        ))->block();
+        ));
     }
 
     /**
@@ -199,7 +199,7 @@ class WorkspaceCommandController extends CommandController
                 WorkspaceDescription::fromString($description ?: $workspace),
                 ContentStreamId::create(),
                 $workspaceOwnerUserId
-            ))->block();
+            ));
         } catch (WorkspaceAlreadyExists $workspaceAlreadyExists) {
             $this->outputLine('Workspace "%s" already exists', [$workspace]);
             $this->quit(1);
@@ -309,7 +309,7 @@ class WorkspaceCommandController extends CommandController
             DeleteWorkspace::create(
                 $workspaceName
             )
-        )->block();
+        );
         $this->outputLine('Deleted workspace "%s"', [$workspaceName->value]);
     }
 

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -240,7 +240,7 @@ class WorkspacesController extends AbstractModuleController
                     ContentStreamId::create(),
                     $visibility === 'private' ? $currentUserIdentifier : null
                 )
-            )->block();
+            );
         } catch (WorkspaceAlreadyExists $exception) {
             $this->addFlashMessage(
                 $this->getModuleLabel('workspaces.workspaceWithThisTitleAlreadyExists'),
@@ -319,7 +319,7 @@ class WorkspacesController extends AbstractModuleController
                     $title,
                     $description
                 )
-            )->block();
+            );
         }
 
         if ($workspace->workspaceOwner !== $workspaceOwner) {
@@ -328,7 +328,7 @@ class WorkspacesController extends AbstractModuleController
                     $workspaceName,
                     $workspaceOwner ?: null,
                 )
-            )->block();
+            );
         }
 
         $this->addFlashMessage($this->translator->translateById(
@@ -428,7 +428,7 @@ class WorkspacesController extends AbstractModuleController
             DeleteWorkspace::create(
                 $workspaceName,
             )
-        )->block();
+        );
 
         $this->addFlashMessage($this->translator->translateById(
             'workspaces.workspaceHasBeenRemoved',
@@ -531,7 +531,7 @@ class WorkspacesController extends AbstractModuleController
             ),
         );
         $contentRepository->handle($command)
-            ->block();
+            ;
 
         $this->addFlashMessage($this->translator->translateById(
             'workspaces.selectedChangeHasBeenPublished',
@@ -568,7 +568,7 @@ class WorkspacesController extends AbstractModuleController
             ),
         );
         $contentRepository->handle($command)
-            ->block();
+            ;
 
         $this->addFlashMessage($this->translator->translateById(
             'workspaces.selectedChangeHasBeenDiscarded',
@@ -611,7 +611,7 @@ class WorkspacesController extends AbstractModuleController
                     NodeIdsToPublishOrDiscard::create(...$nodesToPublishOrDiscard),
                 );
                 $contentRepository->handle($command)
-                    ->block();
+                    ;
                 $this->addFlashMessage($this->translator->translateById(
                     'workspaces.selectedChangesHaveBeenPublished',
                     [],
@@ -627,7 +627,7 @@ class WorkspacesController extends AbstractModuleController
                     NodeIdsToPublishOrDiscard::create(...$nodesToPublishOrDiscard),
                 );
                 $contentRepository->handle($command)
-                    ->block();
+                    ;
                 $this->addFlashMessage($this->translator->translateById(
                     'workspaces.selectedChangesHaveBeenDiscarded',
                     [],

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -26,12 +26,9 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNod
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\ContentRepositoryRegistry\Factory\ProjectionCatchUpTrigger\CatchUpTriggerWithSynchronousOption;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Property\PropertyMapper;
@@ -279,16 +276,15 @@ class NodesController extends ActionController
             );
 
         if ($mode === 'adoptFromAnotherDimension' || $mode === 'adoptFromAnotherDimensionAndCopyContent') {
-            CatchUpTriggerWithSynchronousOption::synchronously(fn() =>
-                $this->adoptNodeAndParents(
-                    $workspaceName,
-                    $nodeAggregateId,
-                    $sourceSubgraph,
-                    $targetSubgraph,
-                    $targetDimensionSpacePoint,
-                    $contentRepository,
-                    $mode === 'adoptFromAnotherDimensionAndCopyContent'
-                ));
+            $this->adoptNodeAndParents(
+                $workspaceName,
+                $nodeAggregateId,
+                $sourceSubgraph,
+                $targetSubgraph,
+                $targetDimensionSpacePoint,
+                $contentRepository,
+                $mode === 'adoptFromAnotherDimensionAndCopyContent'
+            );
 
             $this->redirect('show', null, null, [
                 'identifier' => $nodeAggregateId->value,
@@ -413,7 +409,7 @@ class NodesController extends ActionController
                     $sourceNode->originDimensionSpacePoint,
                     OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
                 )
-            )->block();
+            );
 
             if ($copyContent === true) {
                 $contentNodeConstraint = NodeTypeCriteria::fromFilterString('!' . NodeTypeNameFactory::NAME_DOCUMENT);
@@ -455,7 +451,7 @@ class NodesController extends ActionController
                         $childNode->originDimensionSpacePoint,
                         OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
                     )
-                )->block();
+                );
             }
 
             $this->createNodeVariantsForChildNodes(

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -120,7 +120,7 @@ readonly class SiteServiceInternals implements ContentRepositoryServiceInterface
             PropertyValuesToWrite::fromArray([
                 'title' => $site->getName()
             ])
-        ))->block();
+        ));
 
         // Handle remaining root dimension space points by creating peer variants
         foreach ($rootDimensionSpacePoints as $rootDimensionSpacePoint) {
@@ -129,7 +129,7 @@ readonly class SiteServiceInternals implements ContentRepositoryServiceInterface
                 $siteNodeAggregateId,
                 OriginDimensionSpacePoint::fromDimensionSpacePoint($arbitraryRootDimensionSpacePoint),
                 OriginDimensionSpacePoint::fromDimensionSpacePoint($rootDimensionSpacePoint),
-            ))->block();
+            ));
         }
     }
 }

--- a/Neos.Neos/Classes/Domain/Workspace/Workspace.php
+++ b/Neos.Neos/Classes/Domain/Workspace/Workspace.php
@@ -241,7 +241,7 @@ final class Workspace
             $this->name
         )->withErrorHandlingStrategy($rebaseErrorHandlingStrategy);
 
-        $this->contentRepository->handle($rebaseCommand)->block();
+        $this->contentRepository->handle($rebaseCommand);
 
         $this->updateCurrentState();
     }
@@ -253,7 +253,7 @@ final class Workspace
                 $this->name,
                 $baseWorkspaceName
             )
-        )->block();
+        );
 
         $this->updateCurrentState();
     }
@@ -290,7 +290,7 @@ final class Workspace
             PublishWorkspace::create(
                 $this->name,
             )
-        )->block();
+        );
 
         $this->updateCurrentState();
     }
@@ -306,14 +306,14 @@ final class Workspace
             RebaseWorkspace::create(
                 $this->name
             )
-        )->block();
+        );
 
         $this->contentRepository->handle(
             PublishIndividualNodesFromWorkspace::create(
                 $this->name,
                 $nodeIdsToPublish
             )
-        )->block();
+        );
 
         $this->updateCurrentState();
     }
@@ -324,7 +324,7 @@ final class Workspace
             DiscardWorkspace::create(
                 $this->name,
             )
-        )->block();
+        );
 
         $this->updateCurrentState();
     }
@@ -340,14 +340,14 @@ final class Workspace
             RebaseWorkspace::create(
                 $this->name
             )
-        )->block();
+        );
 
         $this->contentRepository->handle(
             DiscardIndividualNodesFromWorkspace::create(
                 $this->name,
                 $nodeIdsToDiscard
             )
-        )->block();
+        );
 
         $this->updateCurrentState();
     }

--- a/Neos.Neos/Classes/Service/EditorContentStreamZookeeper.php
+++ b/Neos.Neos/Classes/Service/EditorContentStreamZookeeper.php
@@ -136,6 +136,6 @@ final class EditorContentStreamZookeeper
                 $editorsNewContentStreamId,
                 UserId::fromString($this->persistenceManager->getIdentifierByObject($user))
             )
-        )->block();
+        );
     }
 }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -56,7 +56,6 @@ class FeatureContext implements BehatContext
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
         $this->persistenceManager = $this->getObject(PersistenceManagerInterface::class);
 
-        $this->setupCRTestSuiteTrait();
     }
 
     /*

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -165,18 +165,6 @@ trait RoutingTrait
     }
 
     /**
-     * @When The documenturipath projection is up to date
-     */
-    public function theDocumenturipathProjectionIsUpToDate(): void
-    {
-        if ($this->lastCommandOrEventResult === null) {
-            // we just blocked in "The graph projection is up to date"
-            return;
-        }
-        $this->lastCommandOrEventResult->block();
-    }
-
-    /**
      * @When I am on URL :url
      */
     public function iAmOnUrl(string $url): void

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
@@ -58,7 +58,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                                                                       | nodeName |
       | a               | root                  | Neos.Neos:Site               | {}                                                                                          | site     |

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
@@ -41,7 +41,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                        | nodeName |
       | a               | root                  | Neos.Neos:Site               | {}                                           | a        |
@@ -118,8 +117,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
       | contentStreamId | "cs-identifier"              |
       | nodeAggregateId | "a1"                         |
       | propertyValues  | {"uriPathSegment": "a1-new"} |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     And the Fusion context node is a2
     And I execute the following Fusion code:
@@ -155,8 +152,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
       | contentStreamId | "cs-identifier"              |
       | nodeAggregateId | "a1"                         |
       | propertyValues  | {"uriPathSegment": "a1-new"} |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
@@ -38,7 +38,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                            | nodeName |
       | a               | root                  | Neos.Neos:Site               | {}                                               | site     |
@@ -133,7 +132,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a1"                     |
       | propertyValues  | {"title": "Node a1 new"} |
-    And the graph projection is fully up to date
 
     And the Fusion context node is a1
     And I execute the following Fusion code:
@@ -167,7 +165,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a2"                     |
       | propertyValues  | {"title": "Node a2 new"} |
-    And the graph projection is fully up to date
 
     And the Fusion context node is a1
     And I execute the following Fusion code:
@@ -202,7 +199,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a3"                     |
       | propertyValues  | {"title": "Node a3 new"} |
-    And the graph projection is fully up to date
 
     And the Fusion context node is a1
     And I execute the following Fusion code:
@@ -236,7 +232,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a1"                     |
       | propertyValues  | {"title": "Node a1 new"} |
-    And the graph projection is fully up to date
 
     And the Fusion context node is a2
     And I execute the following Fusion code:
@@ -269,7 +264,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"            |
       | nodeAggregateId | "a1-1"                     |
       | propertyValues  | {"title": "Node a1-1 new"} |
-    And the graph projection is fully up to date
 
     And the Fusion context node is "a1"
     And I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
@@ -43,7 +43,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                            | nodeName |
       | a               | root                  | Neos.Neos:Site               | {}                                               | site     |
@@ -141,7 +140,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a1"                     |
       | propertyValues  | {"title": "Node a1 new"} |
-    And the graph projection is fully up to date
 
     And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
@@ -177,7 +175,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a2"                     |
       | propertyValues  | {"title": "Node a2 new"} |
-    And the graph projection is fully up to date
 
     And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a1
@@ -213,7 +210,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a1"                     |
       | propertyValues  | {"title": "Node a1 new"} |
-    And the graph projection is fully up to date
 
     And I am in workspace "live" and dimension space point {}
     And the Fusion context node is a2
@@ -249,7 +245,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"          |
       | nodeAggregateId | "a1-1"                     |
       | propertyValues  | {"title": "Node a1-1 new"} |
-    And the graph projection is fully up to date
 
     And I am in workspace "live" and dimension space point {}
     And the Fusion context node is "a1"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
@@ -36,7 +36,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
       | nodeTypeName                | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     # lady-eleonode-rootford
     #   shernode-homes
@@ -66,7 +65,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   Scenario: Match homepage URL
     When I am on URL "/"
@@ -94,7 +92,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | nodeAggregateId           | "sir-david-nodenborough"                         |
       | originDimensionSpacePoint | {}                                               |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated"} |
-    And The documenturipath projection is up to date
     And I am on URL "/"
     Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated"
     And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated/earl-document"
@@ -105,13 +102,11 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | nodeAggregateId           | "sir-david-nodenborough"                           |
       | originDimensionSpacePoint | {}                                                 |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated-a"} |
-    And The documenturipath projection is up to date
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                              |
       | nodeAggregateId           | "sir-david-nodenborough"                           |
       | originDimensionSpacePoint | {}                                                 |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated-b"} |
-    And The documenturipath projection is up to date
 
     And I am on URL "/"
     Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated-b"
@@ -131,7 +126,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "shernode-homes"        |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
     And I am on URL "/earl-document"
     Then the matched node should be "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}"
     And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/earl-document"
@@ -143,7 +137,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "earl-o-documentbourgh" |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
     And I am on URL "/david-nodenborough/earl-document/nody"
     Then the matched node should be "nody-mc-nodeface" in content stream "cs-identifier" and dimension "{}"
     And the node "nody-mc-nodeface" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/earl-document/nody"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
@@ -48,7 +48,6 @@ Feature: Routing functionality with multiple content dimensions
       | Key                         | Value                                                                                                                                                                                                     |
       | nodeAggregateId             | "lady-eleonode-rootford"                                                                                                                                                                                  |
       | nodeTypeName                | "Neos.Neos:Sites"                                                                                                                                                                                         |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                | initialPropertyValues           | nodeName |
       | sir-david-nodenborough | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "ignore-me"} | node1    |
@@ -59,7 +58,6 @@ Feature: Routing functionality with multiple content dimensions
       | nodeAggregateId | "carl-destinode"                 |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"de"} |
-    And the graph projection is fully up to date
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                            |
       | nodeAggregateId           | "carl-destinode"                 |
@@ -93,9 +91,6 @@ Feature: Routing functionality with multiple content dimensions
                       dimensionValueMapping:
                         DE: ''
     """
-
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
   Scenario: Resolve homepage URL in multiple dimensions
     When I am on URL "/"
@@ -207,8 +202,6 @@ Feature: Routing functionality with multiple content dimensions
     When the command PublishWorkspace is executed with payload:
       | Key           | Value          |
       | workspaceName | "migration-cs" |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     When I am on URL "/"
     Then the node "carl-destinode" in content stream "cs-identifier" and dimension '{"market":"CH", "language":"en"}' should resolve to URL "/nody/carl"
@@ -278,8 +271,6 @@ Feature: Routing functionality with multiple content dimensions
     When the command PublishWorkspace is executed with payload:
       | Key           | Value          |
       | workspaceName | "migration-cs" |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     When I am on URL "/"
     And the node "carl-destinode" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"de"}' should resolve to URL "/de/nody/karl-de"
@@ -292,7 +283,6 @@ Feature: Routing functionality with multiple content dimensions
       | nodeAggregateId           | "carl-destinode"                        |
       | originDimensionSpacePoint | {"market":"DE", "language":"de"}        |
       | propertyValues            | {"uriPathSegment": "karl-aktualisiert"} |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     And the node "carl-destinode" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"de"}' should resolve to URL "/de/nody/karl-aktualisiert"
     # testcase for #4256
@@ -333,28 +323,22 @@ Feature: Routing functionality with multiple content dimensions
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
-    And the graph projection is fully up to date
     # create variant for fr and sites node
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
       | nodeAggregateId | "nody-mc-nodeface"               |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |
-
-    And the graph projection is fully up to date
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                            |
       | nodeAggregateId           | "nody-mc-nodeface"               |
       | originDimensionSpacePoint | {"market":"DE", "language":"fr"} |
       | propertyValues            | {"uriPathSegment": "nody-fr"}    |
-
-    And the graph projection is fully up to date
 
     When I am on URL "/"
     Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"fr"}' should resolve to URL "/fr/"
@@ -395,28 +379,23 @@ Feature: Routing functionality with multiple content dimensions
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
-    And the graph projection is fully up to date
     # create variant for fr and sites node
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
       | nodeAggregateId | "sir-david-nodenborough"         |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |
-    And the graph projection is fully up to date
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                            |
       | nodeAggregateId | "nody-mc-nodeface"               |
       | sourceOrigin    | {"market":"DE", "language":"en"} |
       | targetOrigin    | {"market":"DE", "language":"fr"} |
 
-    And the graph projection is fully up to date
-
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                            |
       | nodeAggregateId           | "nody-mc-nodeface"               |
       | originDimensionSpacePoint | {"market":"DE", "language":"fr"} |
       | propertyValues            | {"uriPathSegment": "nody-fr"}    |
-    And the graph projection is fully up to date
 
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                            |
@@ -425,9 +404,6 @@ Feature: Routing functionality with multiple content dimensions
       | newParentNodeAggregateId            | "lady-eleonode-rootford"         |
       | newSucceedingSiblingNodeAggregateId | null                             |
       | relationDistributionStrategy        | "scatter"                        |
-    And The documenturipath projection is up to date
-
-    And the graph projection is fully up to date
 
     When I am on URL "/"
     Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"en"}' should resolve to URL "/"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -35,7 +35,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     # lady-eleonode-rootford
     #   shernode-homes
@@ -67,15 +66,12 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
 
-    And The documenturipath projection is up to date
-
   Scenario: Disable leaf node
     When the command DisableNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "leaf-mc-node"  |
       | coveredDimensionSpacePoint   | {}              |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough/earl-document/leaf"
     And The node "leaf-mc-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/earl-document/leaf"
 
@@ -85,7 +81,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -102,8 +97,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "earl-o-documentbourgh" |
       | coveredDimensionSpacePoint   | {}                      |
       | nodeVariantSelectionStrategy | "allVariants"           |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -113,8 +106,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     When I am on URL "/david-nodenborough"
     Then the matched node should be "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}"
     And No node should match URL "/david-nodenborough/earl-document"
@@ -132,8 +123,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "earl-o-documentbourgh" |
       | coveredDimensionSpacePoint   | {}                      |
       | nodeVariantSelectionStrategy | "allVariants"           |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -143,8 +132,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "earl-o-documentbourgh" |
       | coveredDimensionSpacePoint   | {}                      |
       | nodeVariantSelectionStrategy | "allVariants"           |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -162,8 +149,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | affectedDimensionSpacePoints | [{}]                     |
       | tag                          | "disabled"               |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -173,8 +158,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     When I am on URL "/david-nodenborough"
     Then the matched node should be "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -192,8 +175,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "earl-o-documentbourgh" |
       | affectedDimensionSpacePoints | [{}]                    |
       | tag                          | "disabled"              |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -209,8 +190,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | affectedDimensionSpacePoints | [{}]                     |
       | tag                          | "disabled"               |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     When I am on URL "/david-nodenborough"
     Then the matched node should be "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}"
     And The node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough"
@@ -222,14 +201,12 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
       | nodeAggregateId                     | "earl-o-documentbourgh" |
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "nody-mc-nodeface"      |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
     When I am on URL "/nody/earl-document"
     Then the matched node should be "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}"
 
@@ -239,14 +216,12 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "earl-o-documentbourgh" |
       | coveredDimensionSpacePoint   | {}                      |
       | nodeVariantSelectionStrategy | "allVariants"           |
-    And the graph projection is fully up to date
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                   |
       | nodeAggregateId                     | "earl-o-documentbourgh" |
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "nody-mc-nodeface"      |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
     Then No node should match URL "/nody/earl-document"
     And The node "leaf-mc-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/nody/earl-document/leaf"
 
@@ -256,11 +231,9 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       | nodeAggregateId              | "nody-mc-nodeface" |
       | coveredDimensionSpacePoint   | {}                 |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId | nodeTypeName                | initialPropertyValues            |
       | nody-mc-nodeface-child | nody-mc-nodeface      | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "nody-child"} |
-    And The documenturipath projection is up to date
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId              | "nody-mc-nodeface" |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
@@ -44,7 +44,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
       | nodeTypeName                | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId  | nodeTypeName                | initialPropertyValues           | nodeName |
@@ -53,7 +52,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | b               | shernode-homes         | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "b"}         | b        |
       | c               | shernode-homes         | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "c"}         | c        |
     And A site exists for node name "site"
-    And The documenturipath projection is up to date
 
   Scenario: initial state
     Then I expect the documenturipath table to contain exactly:
@@ -71,7 +69,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -87,7 +84,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | "b"             |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -103,7 +99,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | "a"             |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -119,7 +114,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | "c"             |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -135,7 +129,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -151,14 +144,12 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | "a"             |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
       | nodeAggregateId                     | "c"             |
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | null            |
       | newSucceedingSiblingNodeAggregateId | "a"             |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -174,7 +165,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "a"             |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                         | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                    | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -192,14 +182,12 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | parentNodeAggregateId            | "b"                           |
       | initialPropertyValues            | {"uriPathSegment": "b1"}      |
       | succeedingSiblingNodeAggregateId | null                          |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
       | nodeAggregateId                     | "b"             |
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "a"             |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath  | nodeaggregateidpath                            | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""       | "lady-eleonode-rootford"                       | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -218,14 +206,12 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | parentNodeAggregateId            | "b"                           |
       | initialPropertyValues            | {"uriPathSegment": "b1"}      |
       | succeedingSiblingNodeAggregateId | null                          |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
       | nodeAggregateId                     | "b1"            |
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "a"             |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                          | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""      | "lady-eleonode-rootford"                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -248,7 +234,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "a"             |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath    | nodeaggregateidpath                              | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""         | "lady-eleonode-rootford"                         | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -273,7 +258,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "b"             |
       | newSucceedingSiblingNodeAggregateId | "b2"            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath    | nodeaggregateidpath                              | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""         | "lady-eleonode-rootford"                         | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |
@@ -291,7 +275,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | nodeAggregateId | "c"                                    |
       | newNodeTypeName | "Neos.Neos:Test.Routing.SomeOtherPage" |
       | strategy        | "happypath"                            |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath | nodeaggregateidpath                       | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                           |
       | ""      | "lady-eleonode-rootford"                  | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"                      |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
@@ -44,7 +44,6 @@ Feature: Linking between multiple websites
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
       | nodeTypeName                | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     # lady-eleonode-rootford
     #   shernode-homes
@@ -78,7 +77,6 @@ Feature: Linking between multiple websites
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   Scenario: Resolve foreign website homepage node
     When I am on URL "http://domain1.tld/"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
@@ -27,20 +27,17 @@ Feature: Test cases for node creation edge cases
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                    |
       | nodeAggregateId           | "shernode-homes"         |
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's prepare some siblings to check orderings. Also, everything gets better with siblings.
@@ -53,7 +50,6 @@ Feature: Test cases for node creation edge cases
       | nodeAggregateId              | "younger-mc-nodeface" |
       | coveredDimensionSpacePoint   | {"example":"spec"}    |
       | nodeVariantSelectionStrategy | "allSpecializations"  |
-    And the graph projection is fully up to date
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | nodeName | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues      |
       | nody-mc-nodeface | document | shernode-homes        | younger-mc-nodeface              | Neos.Neos:Document | {"uriPathSegment": "nody"} |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -27,26 +27,22 @@ Feature: Test cases for node variation edge cases
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                    |
       | nodeAggregateId           | "shernode-homes"         |
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | nodeAggregateId | "shernode-homes"     |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | originDimensionSpacePoint | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Set up our test subject document
@@ -61,13 +57,11 @@ Feature: Test cases for node variation edge cases
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | nodeAggregateId | "elder-mc-nodeface"  |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"peer"}   |
-    And the graph projection is fully up to date
     # Complete the sibling set with a node in the target DSP between the middle and last node
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                         |
@@ -77,13 +71,11 @@ Feature: Test cases for node variation edge cases
       | originDimensionSpacePoint | {"example":"peer"}            |
       | nodeName                  | "younger-document"            |
       | initialPropertyValues     | {"uriPathSegment": "younger"} |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                  |
       | nodeAggregateId | "youngest-mc-nodeface" |
       | sourceOrigin    | {"example":"source"}   |
       | targetOrigin    | {"example":"peer"}     |
-    And the graph projection is fully up to date
 
     Then I expect the documenturipath table to contain exactly:
       # source: 65901ded4f068dac14ad0dce4f459b29
@@ -136,20 +128,17 @@ Feature: Test cases for node variation edge cases
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                     |
       | nodeAggregateId           | "shernode-homes"          |
       | nodeTypeName              | "Neos.Neos:Site"          |
       | parentNodeAggregateId     | "lady-eleonode-rootford"  |
       | originDimensionSpacePoint | {"example":"rootGeneral"} |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | originDimensionSpacePoint | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's create some siblings, both in source and target, to check ordering
@@ -164,19 +153,16 @@ Feature: Test cases for node variation edge cases
       | nodeAggregateId | "nody-mc-nodeface"    |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "elder-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"}  |
       | targetOrigin    | {"example":"general"} |
-    And the graph projection is fully up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                  |
       | nodeAggregateId | "youngest-mc-nodeface" |
       | sourceOrigin    | {"example":"source"}   |
       | targetOrigin    | {"example":"general"}  |
-    And the graph projection is fully up to date
 
     Then I expect the documenturipath table to contain exactly:
       # general: 033e5de7b423f45bb4f5a09f73af839e
@@ -234,20 +220,17 @@ Feature: Test cases for node variation edge cases
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
-    And the graph projection is fully up to date
     And I am in workspace "live" and dimension space point {"example":"source"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                    |
       | nodeAggregateId           | "shernode-homes"         |
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's create our test subject...
@@ -262,7 +245,6 @@ Feature: Test cases for node variation edge cases
       | nodeAggregateId              | "nody-mc-nodeface"   |
       | coveredDimensionSpacePoint   | {"example":"spec"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
@@ -270,7 +252,6 @@ Feature: Test cases for node variation edge cases
       | nodeAggregateId | "nody-mc-nodeface"   |
       | sourceOrigin    | {"example":"source"} |
       | targetOrigin    | {"example":"spec"}   |
-    And the graph projection is fully up to date
 
     Then I expect the documenturipath table to contain exactly:
       # source: 65901ded4f068dac14ad0dce4f459b29

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
@@ -35,7 +35,6 @@ Feature: Route cache invalidation
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     # lady-eleonode-rootford
     #   shernode-homes
@@ -65,7 +64,6 @@ Feature: Route cache invalidation
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   Scenario: Change uri path segment invalidates route cache
     When I am on URL "/"
@@ -76,7 +74,6 @@ Feature: Route cache invalidation
       | nodeAggregateId           | "sir-david-nodenborough"                         |
       | originDimensionSpacePoint | {}                                               |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated"} |
-    And The documenturipath projection is up to date
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
 
@@ -90,13 +87,11 @@ Feature: Route cache invalidation
       | nodeAggregateId           | "sir-david-nodenborough"                           |
       | originDimensionSpacePoint | {}                                                 |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated-a"} |
-    And The documenturipath projection is up to date
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                              |
       | nodeAggregateId           | "sir-david-nodenborough"                           |
       | originDimensionSpacePoint | {}                                                 |
       | propertyValues            | {"uriPathSegment": "david-nodenborough-updated-b"} |
-    And The documenturipath projection is up to date
 
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
@@ -115,7 +110,6 @@ Feature: Route cache invalidation
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "shernode-homes"        |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
 
     Then No node should match URL "/david-nodenborough/earl-document"
 
@@ -129,7 +123,6 @@ Feature: Route cache invalidation
       | dimensionSpacePoint                 | {}                      |
       | newParentNodeAggregateId            | "earl-o-documentbourgh" |
       | newSucceedingSiblingNodeAggregateId | null                    |
-    And The documenturipath projection is up to date
 
     Then No node should match URL "/nody"
 
@@ -143,7 +136,6 @@ Feature: Route cache invalidation
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And The documenturipath projection is up to date
 
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"
@@ -159,7 +151,6 @@ Feature: Route cache invalidation
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And The documenturipath projection is up to date
 
     Then No node should match URL "/david-nodenborough"
     And No node should match URL "/david-nodenborough/earl-document"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
@@ -52,7 +52,6 @@ Feature: Routing behavior of shortcut nodes
       | Key                         | Value                    |
       | nodeAggregateId             | "lady-eleonode-rootford" |
       | nodeTypeName                | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
     # lady-eleonode-rootford
     #   shernode-homes
@@ -94,7 +93,6 @@ Feature: Routing behavior of shortcut nodes
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   Scenario: Shortcut parent node
     When I am on URL "/"
@@ -119,7 +117,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-external-url"          |
       | originDimensionSpacePoint | {}                               |
       | propertyValues            | {"target": "/some/relative/url"} |
-    And The documenturipath projection is up to date
     When I am on URL "https://current.host/"
     Then the node "shortcut-external-url" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/some/relative/url"
 
@@ -129,7 +126,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-external-url"                                                               |
       | originDimensionSpacePoint | {}                                                                                    |
       | propertyValues            | {"target": "https://www.some-domain.tld:1234/some/url/path?some=query#some-fragment"} |
-    And The documenturipath projection is up to date
     When I am on URL "http://current.host/"
     Then the node "shortcut-external-url" in content stream "cs-identifier" and dimension "{}" should resolve to URL "https://www.some-domain.tld:1234/some/url/path?some=query#some-fragment"
 
@@ -146,7 +142,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId            | "shortcut-first-child-node"                          |
       | initialPropertyValues            | {"uriPathSegment": "new-child-node"}                 |
       | succeedingSiblingNodeAggregateId | "first-child-node"                                   |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/new-child-node"
 
@@ -157,7 +152,6 @@ Feature: Routing behavior of shortcut nodes
       | dimensionSpacePoint                 | {}                           |
       | newParentNodeAggregateId            | "shortcut-first-child-node"  |
       | newSucceedingSiblingNodeAggregateId | "first-child-node"           |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/nodeward-3"
 
@@ -168,7 +162,6 @@ Feature: Routing behavior of shortcut nodes
       | dimensionSpacePoint                 | {}                  |
       | newParentNodeAggregateId            | null                |
       | newSucceedingSiblingNodeAggregateId | "first-child-node"  |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/second-child-node"
 
@@ -179,7 +172,6 @@ Feature: Routing behavior of shortcut nodes
       | dimensionSpacePoint                 | {}                           |
       | newParentNodeAggregateId            | "shortcut-first-child-node"  |
       | newSucceedingSiblingNodeAggregateId | "second-child-node"          |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/first-child-node"
 
@@ -192,14 +184,12 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId            | "shortcut-first-child-node"                          |
       | initialPropertyValues            | {"uriPathSegment": "new-child-node"}                 |
       | succeedingSiblingNodeAggregateId | "second-child-node"                                  |
-    And the graph projection is fully up to date
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value             |
       | nodeAggregateId                     | "nody-mc-newface" |
       | dimensionSpacePoint                 | {}                |
       | newParentNodeAggregateId            | null              |
       | newSucceedingSiblingNodeAggregateId | null              |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/first-child-node"
 
@@ -209,7 +199,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId | "sir-david-nodenborough-ii" |
       | newNodeTypeName | "Neos.Neos:Shortcut"        |
       | strategy        | "happypath"                 |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "sir-david-nodenborough-ii" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-2/nodeward-3"
 
@@ -219,7 +208,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId | "shortcut-first-child-node"                          |
       | newNodeTypeName | "Neos.Neos:Test.Routing.Page" |
       | strategy        | "happypath"                                          |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child"
 
@@ -229,7 +217,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-first-child-node"  |
       | originDimensionSpacePoint | {}                           |
       | propertyValues            | {"targetMode": "parentNode"} |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts"
 
@@ -239,7 +226,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-first-child-node"                                      |
       | originDimensionSpacePoint | {}                                                               |
       | propertyValues            | {"targetMode": "selectedTarget", "target": "http://www.neos.io"} |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "http://www.neos.io/"
 
@@ -253,7 +239,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-parent-node"           |
       | originDimensionSpacePoint | {}                               |
       | propertyValues            | {"targetMode": "firstChildNode"} |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-parent-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-parent-node/new-child"
 
@@ -263,7 +248,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId           | "shortcut-parent-node"                                         |
       | originDimensionSpacePoint | {}                                                             |
       | propertyValues            | {"targetMode": "selectedTarget", "target": "https://neos.io/"} |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "shortcut-parent-node" in content stream "cs-identifier" and dimension "{}" should resolve to URL "https://neos.io/"
 
@@ -276,7 +260,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId     | "shortcuts"                                                            |
       | initialPropertyValues     | {"uriPathSegment": "invalid-target-mode", "targetMode": "invalidMode"} |
       | nodeName                  | "some-node-name"                                                       |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "invalid-target-mode" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
@@ -289,7 +272,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId     | "shortcuts"                                                                  |
       | initialPropertyValues     | {"uriPathSegment": "invalid-missing-target", "targetMode": "selectedTarget"} |
       | nodeName                  | "some-node-name"                                                             |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "invalid-missing-target" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
@@ -302,7 +284,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId     | "shortcuts"                                                                        |
       | initialPropertyValues     | {"uriPathSegment": "invalid-shortcut-first-child", "targetMode": "firstChildNode"} |
       | nodeName                  | "some-node-name"                                                                   |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "invalid-shortcut-first-child-node" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
@@ -315,7 +296,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId     | "shortcuts"                                                                                                                |
       | initialPropertyValues     | {"uriPathSegment": "invalid-shortcut-selected-node", "targetMode": "selectedTarget", "target": "node://non-existing-node"} |
       | nodeName                  | "some-node-name"                                                                                                           |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "invalid-shortcut-selected-node" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
@@ -328,7 +308,6 @@ Feature: Routing behavior of shortcut nodes
       | parentNodeAggregateId     | "shortcuts"                                                                                               |
       | initialPropertyValues     | {"uriPathSegment": "invalid-shortcut-selected-node", "targetMode": "selectedTarget", "target": "node://"} |
       | nodeName                  | "some-node-name"                                                                                          |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "invalid-shortcut-selected-node" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL
 
@@ -338,7 +317,6 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName       | initialPropertyValues                                                                                      | nodeName |
       | level-1         | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "level1", "targetMode": "selectedTarget", "target": "node://level-2"}                   | level1   |
       | level-2         | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "level2", "targetMode": "selectedTarget", "target": "node://shortcut-first-child-node"} | level2   |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then the node "level-1" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/first-child-node"
     Then the node "level-2" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough/shortcuts/shortcut-first-child/first-child-node"
@@ -349,6 +327,5 @@ Feature: Routing behavior of shortcut nodes
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName       | initialPropertyValues                                                              | nodeName |
       | node-a          | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "a", "targetMode": "selectedTarget", "target": "node://node-b"} | node-a   |
       | node-b          | shortcuts             | Neos.Neos:Shortcut | {"uriPathSegment": "b", "targetMode": "selectedTarget", "target": "node://node-a"} | node-b   |
-    And The documenturipath projection is up to date
     When I am on URL "/"
     Then The node "node-a" in content stream "cs-identifier" and dimension "{}" should not resolve to an URL

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
@@ -35,7 +35,6 @@ Feature: Tests for site node child documents. These are special in that they hav
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
     # We explicitly create a site node with a tethered child document without uriPathSegment, so its uriPath is empty, exactly as the site node's
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId  | nodeTypeName                | initialPropertyValues | nodeName |
@@ -53,7 +52,6 @@ Feature: Tests for site node child documents. These are special in that they hav
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   Scenario: Set tethered child uriPathSegment
     When I remember NodeAggregateId of node "shernode-homes"s child "notFound" as "notFoundId"
@@ -61,8 +59,6 @@ Feature: Tests for site node child documents. These are special in that they hav
       | Key             | Value                           |
       | nodeAggregateId | "$notFoundId"                   |
       | propertyValues  | {"uriPathSegment": "not-found"} |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
     And I am on URL "/"
     Then the matched node should be "shernode-homes" in content stream "cs-identifier" and dimension "{}"
     And the node "$notFoundId" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/not-found"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -29,7 +29,6 @@ Feature: Basic routing functionality (match & resolve nodes with unknown types)
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
   Scenario:
     When the event NodeAggregateWithNodeWasCreated was published with payload:
@@ -55,7 +54,6 @@ Feature: Basic routing functionality (match & resolve nodes with unknown types)
       | parentNodeAggregateId       | "shernode-homes"                                                |
       | nodeAggregateClassification | "regular"                                                       |
       | initialPropertyValues       | {"uriPathSegment": {"type": "string", "value": "non-existing"}} |
-    And The documenturipath projection is up to date
     Then I expect the documenturipath table to contain exactly:
       | uripath              | nodeaggregateidpath                                            | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename                  |
       | ""                   | "lady-eleonode-rootford"                                       | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"             |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
@@ -38,7 +38,6 @@ Feature: Tests for the "Neos.Neos:ContentCase" Fusion prototype
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  |
       | a               | root                  | Neos.Neos:Site                |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
@@ -46,7 +46,6 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName   |
       | a               | root                  | Neos.Neos:Site |
@@ -117,7 +116,6 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
       | parentNodeAggregateId              | "a"                           |
       | initialPropertyValues              | {}                            |
       | tetheredDescendantNodeAggregateIds | { "main": "a1-main"}          |
-    And the graph projection is fully up to date
     When the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName               |
       | content1        | a1-main               | Neos.Neos:Test.ContentType |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -35,7 +35,6 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                |initialPropertyValues                              | nodeName |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -51,7 +51,6 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  | initialPropertyValues                                                  | nodeName |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -51,7 +51,6 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  | initialPropertyValues                                                  | nodeName |
       | a               | root                  | Neos.Neos:Site                | {"title": "Node a"}                                                    | a        |

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -38,8 +38,6 @@ class FeatureContext implements Context
     {
         self::bootstrapFlow();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
-
-        $this->setupCRTestSuiteTrait();
     }
 
     /**

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -31,14 +31,12 @@ Feature: Simple handling of nodes with exceeded enableAfter and disableAfter dat
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And the graph projection is fully up to date
     And I am in workspace "live"
     And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                    |
       | nodeAggregateId | "lady-eleonode-rootford" |
       | nodeTypeName    | "Neos.Neos:Sites"        |
-    And the graph projection is fully up to date
 
 
   # <===========================|now|===========================>

--- a/Readme.rst
+++ b/Readme.rst
@@ -188,13 +188,6 @@ we use the right versions etc).
        cd Packages/Neos
        composer test:behavioral
 
-Running all tests can take a long time, depending on the hardware.
-To speed up the process, Behat tests can be executed in a "synchronous" mode:
-
-   .. code-block:: bash
-
-       composer test:behavioral:sync
-
 Alternatively, if you want to reproduce errors as they happen inside the CI system, but you
 develop on Mac OS, you might want to run the Behat tests in a Docker container (= a linux environment)
 as well. We have seen cases where they behave differently, i.e. where they run without race

--- a/composer.json
+++ b/composer.json
@@ -130,10 +130,6 @@
             "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
             "@test:behat-cli -c Neos.Neos/Tests/Behavior/behat.yml"
         ],
-        "test:behavioral:sync": [
-            "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
-            "@test:behavioral"
-        ],
         "test:behavioral:stop-on-failure": [
             "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentRepository.BehavioralTests/Tests/Behavior/behat.yml.dist",
             "@test:behat-cli -vvv --stop-on-failure -c Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/behat.yml.dist",
@@ -142,10 +138,6 @@
             "@test:behat-cli -vvv --stop-on-failure -c Neos.TimeableNodeVisibility/Tests/Behavior/behat.yml.dist",
             "../../flow doctrine:migrate --quiet; ../../flow cr:setup",
             "@test:behat-cli -vvv --stop-on-failure -c Neos.Neos/Tests/Behavior/behat.yml"
-        ],
-        "test:behavioral:stop-on-failure:sync": [
-            "@putenv CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1",
-            "@test:behavioral:stop-on-failure"
         ],
         "test": [
             "@test:unit",


### PR DESCRIPTION
This change was partially ported from https://github.com/neos/neos-development-collection/pull/4988

Following things have been adjusted:

- Removal of the step: The graph projection is fully up to date
  - remove lastCommandOrEventResult
- Removal of the step: The documenturipath projection is up to date
- Remove `CommandResult::block` in php


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
