### PR TITLE
WIP: TASK: Make Subgraph filter optional

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -25,22 +25,8 @@ use Neos\ContentRepository\Core\Infrastructure\DbalClientInterface;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
-use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphIdentity;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountBackReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountChildNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\ExpandedNodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\OrderingDirection;
@@ -124,7 +110,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $this->visibilityConstraints;
     }
 
-    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, FindChildNodesFilter $filter): Nodes
+    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\FindChildNodesFilter $filter = null): Nodes
     {
         $queryBuilder = $this->buildChildNodesQuery($parentNodeAggregateId, $filter);
         if ($filter->pagination !== null) {
@@ -137,30 +123,30 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $this->fetchNodes($queryBuilder);
     }
 
-    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, CountChildNodesFilter $filter): int
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\CountChildNodesFilter $filter = null): int
     {
         $queryBuilder = $this->buildChildNodesQuery($parentNodeAggregateId, $filter);
         return $this->fetchCount($queryBuilder);
     }
 
-    public function findReferences(NodeAggregateId $nodeAggregateId, FindReferencesFilter $filter): References
+    public function findReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindReferencesFilter $filter = null): References
     {
         $queryBuilder = $this->buildReferencesQuery(false, $nodeAggregateId, $filter);
         return $this->fetchReferences($queryBuilder);
     }
 
-    public function countReferences(NodeAggregateId $nodeAggregateId, CountReferencesFilter $filter): int
+    public function countReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountReferencesFilter $filter = null): int
     {
         return $this->fetchCount($this->buildReferencesQuery(false, $nodeAggregateId, $filter));
     }
 
-    public function findBackReferences(NodeAggregateId $nodeAggregateId, FindBackReferencesFilter $filter): References
+    public function findBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindBackReferencesFilter $filter = null): References
     {
         $queryBuilder = $this->buildReferencesQuery(true, $nodeAggregateId, $filter);
         return $this->fetchReferences($queryBuilder);
     }
 
-    public function countBackReferences(NodeAggregateId $nodeAggregateId, CountBackReferencesFilter $filter): int
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountBackReferencesFilter $filter = null): int
     {
         return $this->fetchCount($this->buildReferencesQuery(true, $nodeAggregateId, $filter));
     }
@@ -222,13 +208,13 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $this->fetchNode($queryBuilder);
     }
 
-    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, FindSucceedingSiblingNodesFilter $filter): Nodes
+    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindSucceedingSiblingNodesFilter $filter = null): Nodes
     {
         $queryBuilder = $this->buildSiblingsQuery(false, $siblingNodeAggregateId, $filter);
         return $this->fetchNodes($queryBuilder);
     }
 
-    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, FindPrecedingSiblingNodesFilter $filter): Nodes
+    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindPrecedingSiblingNodesFilter $filter = null): Nodes
     {
         $queryBuilder = $this->buildSiblingsQuery(true, $siblingNodeAggregateId, $filter);
         return $this->fetchNodes($queryBuilder);
@@ -243,7 +229,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
                 1687513836
             );
         }
-        $ancestors = $this->findAncestorNodes($leafNode->nodeAggregateId, FindAncestorNodesFilter::create())
+        $ancestors = $this->findAncestorNodes($leafNode->nodeAggregateId, Filter\FindAncestorNodesFilter::create())
             ->reverse();
 
         try {
@@ -257,7 +243,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
     }
 
-    public function findSubtree(NodeAggregateId $entryNodeAggregateId, FindSubtreeFilter $filter): ?Subtree
+    public function findSubtree(NodeAggregateId $entryNodeAggregateId, ?Filter\FindSubtreeFilter $filter = null): ?Subtree
     {
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
@@ -276,10 +262,10 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->innerJoin('p', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = h.childnodeanchor')
             ->where('h.contentstreamid = :contentStreamId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
-        if ($filter->maximumLevels !== null) {
+        if ($filter?->maximumLevels !== null) {
             $queryBuilderRecursive->andWhere('p.level < :maximumLevels')->setParameter('maximumLevels', $filter->maximumLevels);
         }
-        if ($filter->nodeTypes !== null) {
+        if ($filter?->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderRecursive, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'c');
         }
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
@@ -318,7 +304,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return null;
     }
 
-    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter $filter): Nodes
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindAncestorNodesFilter $filter = null): Nodes
     {
         [
             'queryBuilderInitial' => $queryBuilderInitial,
@@ -341,7 +327,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         );
     }
 
-    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, CountAncestorNodesFilter $filter): int
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountAncestorNodesFilter $filter = null): int
     {
         [
             'queryBuilderInitial' => $queryBuilderInitial,
@@ -357,7 +343,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         );
     }
 
-    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, FindClosestNodeFilter $filter): ?Node
+    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, ?Filter\FindClosestNodeFilter $filter = null): ?Node
     {
         $queryBuilderInitial = $this->createQueryBuilder()
             ->select('n.*, ph.subtreetags, ph.parentnodeanchor')
@@ -397,7 +383,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         )->first();
     }
 
-    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter $filter): Nodes
+    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindDescendantNodesFilter $filter = null): Nodes
     {
         ['queryBuilderInitial' => $queryBuilderInitial, 'queryBuilderRecursive' => $queryBuilderRecursive, 'queryBuilderCte' => $queryBuilderCte] = $this->buildDescendantNodesQueries($entryNodeAggregateId, $filter);
         if ($filter->ordering !== null) {
@@ -417,7 +403,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         );
     }
 
-    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, CountDescendantNodesFilter $filter): int
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountDescendantNodesFilter $filter = null): int
     {
         ['queryBuilderInitial' => $queryBuilderInitial, 'queryBuilderRecursive' => $queryBuilderRecursive, 'queryBuilderCte' => $queryBuilderCte] = $this->buildDescendantNodesQueries($entryNodeAggregateId, $filter);
         return $this->fetchCteCountResult($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
@@ -480,7 +466,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
     }
 
-    private function buildChildNodesQuery(NodeAggregateId $parentNodeAggregateId, FindChildNodesFilter|CountChildNodesFilter $filter): QueryBuilder
+    private function buildChildNodesQuery(NodeAggregateId $parentNodeAggregateId, Filter\FindChildNodesFilter|Filter\CountChildNodesFilter $filter): QueryBuilder
     {
         $queryBuilder = $this->nodeQueryBuilder->buildBasicChildNodesQuery($parentNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
         if ($filter->nodeTypes !== null) {
@@ -496,7 +482,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $queryBuilder;
     }
 
-    private function buildReferencesQuery(bool $backReferences, NodeAggregateId $nodeAggregateId, FindReferencesFilter|FindBackReferencesFilter|CountReferencesFilter|CountBackReferencesFilter $filter): QueryBuilder
+    private function buildReferencesQuery(bool $backReferences, NodeAggregateId $nodeAggregateId, Filter\FindReferencesFilter|Filter\FindBackReferencesFilter|Filter\CountReferencesFilter|Filter\CountBackReferencesFilter $filter): QueryBuilder
     {
         $sourceTablePrefix = $backReferences ? 'd' : 's';
         $destinationTablePrefix = $backReferences ? 's' : 'd';
@@ -532,7 +518,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         if ($filter->referenceName !== null) {
             $queryBuilder->andWhere('r.name = :referenceName')->setParameter('referenceName', $filter->referenceName->value);
         }
-        if ($filter instanceof FindReferencesFilter || $filter instanceof FindBackReferencesFilter) {
+        if ($filter instanceof Filter\FindReferencesFilter || $filter instanceof Filter\FindBackReferencesFilter) {
             if ($filter->ordering !== null) {
                 $this->applyOrdering($queryBuilder, $filter->ordering, "{$destinationTablePrefix}n");
             } elseif ($filter->referenceName === null) {
@@ -547,7 +533,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         return $queryBuilder;
     }
 
-    private function buildSiblingsQuery(bool $preceding, NodeAggregateId $siblingNodeAggregateId, FindPrecedingSiblingNodesFilter|FindSucceedingSiblingNodesFilter $filter): QueryBuilder
+    private function buildSiblingsQuery(bool $preceding, NodeAggregateId $siblingNodeAggregateId, Filter\FindPrecedingSiblingNodesFilter|Filter\FindSucceedingSiblingNodesFilter $filter): QueryBuilder
     {
         $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeSiblingsQuery($preceding, $siblingNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
 
@@ -570,7 +556,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     /**
      * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
      */
-    private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter|FindClosestNodeFilter $filter): array
+    private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, Filter\FindAncestorNodesFilter|Filter\CountAncestorNodesFilter|Filter\FindClosestNodeFilter|null $filter): array
     {
         $queryBuilderInitial = $this->createQueryBuilder()
             ->select('n.*, ph.subtreetags, ph.parentnodeanchor')
@@ -597,7 +583,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
         $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
-        if ($filter->nodeTypes !== null) {
+        if ($filter?->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
         }
         return compact('queryBuilderInitial', 'queryBuilderRecursive', 'queryBuilderCte');
@@ -606,7 +592,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     /**
      * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
      */
-    private function buildDescendantNodesQueries(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter|CountDescendantNodesFilter $filter): array
+    private function buildDescendantNodesQueries(NodeAggregateId $entryNodeAggregateId, Filter\FindDescendantNodesFilter|Filter\CountDescendantNodesFilter $filter): array
     {
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -19,16 +19,6 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountBackReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountChildNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
@@ -76,7 +66,7 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $this->wrappedContentSubgraph->getVisibilityConstraints();
     }
 
-    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, FindChildNodesFilter $filter): Nodes
+    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\FindChildNodesFilter $filter = null): Nodes
     {
         if (!self::isFilterEmpty($filter)) {
             return $this->wrappedContentSubgraph->findChildNodes($parentNodeAggregateId, $filter);
@@ -98,7 +88,7 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $childNodes;
     }
 
-    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, CountChildNodesFilter $filter): int
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\CountChildNodesFilter $filter = null): int
     {
         if (!self::isFilterEmpty($filter)) {
             return $this->wrappedContentSubgraph->countChildNodes($parentNodeAggregateId, $filter);
@@ -110,25 +100,25 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $this->wrappedContentSubgraph->countChildNodes($parentNodeAggregateId, $filter);
     }
 
-    public function findReferences(NodeAggregateId $nodeAggregateId, FindReferencesFilter $filter): References
+    public function findReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindReferencesFilter $filter = null): References
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findReferences($nodeAggregateId, $filter);
     }
 
-    public function countReferences(NodeAggregateId $nodeAggregateId, CountReferencesFilter $filter): int
+    public function countReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountReferencesFilter $filter = null): int
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->countReferences($nodeAggregateId, $filter);
     }
 
-    public function findBackReferences(NodeAggregateId $nodeAggregateId, FindBackReferencesFilter $filter): References
+    public function findBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindBackReferencesFilter $filter = null): References
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findBackReferences($nodeAggregateId, $filter);
     }
 
-    public function countBackReferences(NodeAggregateId $nodeAggregateId, CountBackReferencesFilter $filter): int
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountBackReferencesFilter $filter = null): int
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->countBackReferences($nodeAggregateId, $filter);
@@ -193,13 +183,13 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $this->wrappedContentSubgraph->findNodeByAbsolutePath($path);
     }
 
-    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, FindSucceedingSiblingNodesFilter $filter): Nodes
+    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindSucceedingSiblingNodesFilter $filter = null): Nodes
     {
         // TODO implement runtime caches
         return $this->wrappedContentSubgraph->findSucceedingSiblingNodes($siblingNodeAggregateId, $filter);
     }
 
-    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, FindPrecedingSiblingNodesFilter $filter): Nodes
+    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindPrecedingSiblingNodesFilter $filter = null): Nodes
     {
         // TODO implement runtime caches
         return $this->wrappedContentSubgraph->findPrecedingSiblingNodes($siblingNodeAggregateId, $filter);
@@ -217,38 +207,38 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $nodePath;
     }
 
-    public function findSubtree(NodeAggregateId $entryNodeAggregateId, FindSubtreeFilter $filter): ?Subtree
+    public function findSubtree(NodeAggregateId $entryNodeAggregateId, ?Filter\FindSubtreeFilter $filter = null): ?Subtree
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findSubtree($entryNodeAggregateId, $filter);
         // TODO populate NodeByNodeAggregateIdCache and ParentNodeIdByChildNodeIdCache from result
     }
 
-    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindAncestorNodesFilter $filter): Nodes
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindAncestorNodesFilter $filter = null): Nodes
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findAncestorNodes($entryNodeAggregateId, $filter);
     }
 
-    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountAncestorNodesFilter $filter): int
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountAncestorNodesFilter $filter = null): int
     {
         // TODO: Implement countAncestorNodes() method.
         return $this->wrappedContentSubgraph->countAncestorNodes($entryNodeAggregateId, $filter);
     }
 
-    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, Filter\FindClosestNodeFilter $filter): ?Node
+    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, ?Filter\FindClosestNodeFilter $filter = null): ?Node
     {
         // TODO: Implement findClosestNode() method.
         return $this->wrappedContentSubgraph->findClosestNode($entryNodeAggregateId, $filter);
     }
 
-    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter $filter): Nodes
+    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindDescendantNodesFilter $filter = null): Nodes
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->findDescendantNodes($entryNodeAggregateId, $filter);
     }
 
-    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountDescendantNodesFilter $filter = null): int
     {
         // TODO: implement runtime caches
         return $this->wrappedContentSubgraph->countDescendantNodes($entryNodeAggregateId, $filter);
@@ -260,8 +250,14 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         return $this->wrappedContentSubgraph->countNodes();
     }
 
-    private static function isFilterEmpty(object $filter): bool
+    /**
+     * @phpstan-assert-if-true !null $filter
+     */
+    private static function isFilterEmpty(?object $filter): bool
     {
+        if ($filter === null) {
+            return true;
+        }
         return array_filter(get_object_vars($filter), static fn ($value) => $value !== null) === [];
     }
 

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphInterface.php
@@ -75,13 +75,13 @@ interface ContentSubgraphInterface extends \JsonSerializable
     /**
      * Find direct child nodes of the specified parent node that match the given $filter
      */
-    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\FindChildNodesFilter $filter): Nodes;
+    public function findChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\FindChildNodesFilter $filter = null): Nodes;
 
     /**
      * Count direct child nodes of the specified parent node that match the given $filter
      * @see findChildNodes
      */
-    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, Filter\CountChildNodesFilter $filter): int;
+    public function countChildNodes(NodeAggregateId $parentNodeAggregateId, ?Filter\CountChildNodesFilter $filter = null): int;
 
     /**
      * Find the direct parent of a node specified by its aggregate id
@@ -93,23 +93,23 @@ interface ContentSubgraphInterface extends \JsonSerializable
     /**
      * Find all nodes that are positioned _behind_ the specified sibling and match the specified $filter
      */
-    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, Filter\FindSucceedingSiblingNodesFilter $filter): Nodes;
+    public function findSucceedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindSucceedingSiblingNodesFilter $filter = null): Nodes;
 
     /**
      * Find all nodes that are positioned _before_ the specified sibling and match the specified $filter
      */
-    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, Filter\FindPrecedingSiblingNodesFilter $filter): Nodes;
+    public function findPrecedingSiblingNodes(NodeAggregateId $siblingNodeAggregateId, ?Filter\FindPrecedingSiblingNodesFilter $filter = null): Nodes;
 
     /**
      * Recursively find all nodes above the $entryNodeAggregateId that match the specified $filter and return them as a flat list
      */
-    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindAncestorNodesFilter $filter): Nodes;
+    public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindAncestorNodesFilter $filter = null): Nodes;
 
     /**
      * Count all nodes above the $entryNodeAggregateId that match the specified $filter
      * @see findAncestorNodes
      */
-    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountAncestorNodesFilter $filter): int;
+    public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountAncestorNodesFilter $filter = null): int;
 
     /**
      * Find the closest matching node, the entry node itself or the first ancestors of the $entryNodeAggregateId, that match the specified $filter and return it
@@ -117,20 +117,20 @@ interface ContentSubgraphInterface extends \JsonSerializable
      *
      * @return Node|null the closest node that matches the given $filter, or NULL if no matching node was found
      */
-    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, Filter\FindClosestNodeFilter $filter): ?Node;
+    public function findClosestNode(NodeAggregateId $entryNodeAggregateId, ?Filter\FindClosestNodeFilter $filter = null): ?Node;
 
     /**
      * Recursively find all nodes underneath the $entryNodeAggregateId that match the specified $filter and return them as a flat list
      *
      * Note: This is basically a set-based view of descendant nodes; so the ordering should not be relied upon
      */
-    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\FindDescendantNodesFilter $filter): Nodes;
+    public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\FindDescendantNodesFilter $filter = null): Nodes;
 
     /**
      * Count all nodes underneath the $entryNodeAggregateId that match the specified $filter
      * @see findDescendantNodes
      */
-    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, Filter\CountDescendantNodesFilter $filter): int;
+    public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, ?Filter\CountDescendantNodesFilter $filter = null): int;
 
     /**
      * Recursively find all nodes underneath the $entryNodeAggregateId that match the specified $filter and return them as a tree
@@ -139,7 +139,7 @@ interface ContentSubgraphInterface extends \JsonSerializable
      *
      * @return Subtree|null the recursive tree of all matching nodes, or NULL if the entry node is not accessible
      */
-    public function findSubtree(NodeAggregateId $entryNodeAggregateId, Filter\FindSubtreeFilter $filter): ?Subtree;
+    public function findSubtree(NodeAggregateId $entryNodeAggregateId, ?Filter\FindSubtreeFilter $filter = null): ?Subtree;
 
     /**
      * Find all "outgoing" references of a given node that match the specified $filter
@@ -148,13 +148,13 @@ interface ContentSubgraphInterface extends \JsonSerializable
      * directly, but a collection of references {@see References}.
      * The corresponding nodes can be retrieved via {@see References::getNodes()}
      */
-    public function findReferences(NodeAggregateId $nodeAggregateId, Filter\FindReferencesFilter $filter): References;
+    public function findReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindReferencesFilter $filter = null): References;
 
     /**
      * Count all "outgoing" references of a given node that match the specified $filter
      * @see findReferences
      */
-    public function countReferences(NodeAggregateId $nodeAggregateId, Filter\CountReferencesFilter $filter): int;
+    public function countReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountReferencesFilter $filter = null): int;
 
     /**
      * Find all "incoming" references of a given node that match the specified $filter
@@ -162,13 +162,13 @@ interface ContentSubgraphInterface extends \JsonSerializable
      *
      * @see findReferences
      */
-    public function findBackReferences(NodeAggregateId $nodeAggregateId, Filter\FindBackReferencesFilter $filter): References;
+    public function findBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\FindBackReferencesFilter $filter = null): References;
 
     /**
      * Count all "incoming" references of a given node that match the specified $filter
      * @see findBackReferences
      */
-    public function countBackReferences(NodeAggregateId $nodeAggregateId, Filter\CountBackReferencesFilter $filter): int;
+    public function countBackReferences(NodeAggregateId $nodeAggregateId, ?Filter\CountBackReferencesFilter $filter = null): int;
 
     /**
      * Find a single node underneath $startingNodeAggregateId that matches the specified $path


### PR DESCRIPTION
related: https://github.com/neos/neos-development-collection/issues/5065

with this change (https://github.com/neos/neos-development-collection/commit/f25e44940f6629eb162783c622e7bf53878a9397#diff-35872d162c44bc083ae30164f7e89b289a61df55723ee599916b6372995612af) the filters where introduced for the subgraph. But the nullability got lost:

```php
    public function findChildNodes(
         NodeAggregateId $parentNodeAggregateId,
         NodeTypeConstraints $nodeTypeConstraints = null,
         int $limit = null,
         int $offset = null
     ): Nodes;
```

changed to.

```php
    public function findChildNodes(
         NodeAggregateId $parentNodeAggregateId,
         Filter\FindChildNodesFilter $filter
     ): Nodes;
```

Meaning an empty `FindChildNodesFilter` f.e. has always to be instantiated:

```php
return $this->contentRepositoryRegistry->subgraphForNode($node)
    ->findChildNodes($node->aggregateId, FindChildNodesFilter::create());
```

though we should consider if it wouldnt be easier to make this param optional:

```php
return $this->contentRepositoryRegistry->subgraphForNode($node)
    ->findChildNodes($node->aggregateId);
```

as it increases readability and usability.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
