### PR TITLE
TASK: Remove references to deprecate node read model properties

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -243,7 +243,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
                 1687513836
             );
         }
-        $ancestors = $this->findAncestorNodes($leafNode->nodeAggregateId, FindAncestorNodesFilter::create())
+        $ancestors = $this->findAncestorNodes($leafNode->aggregateId, FindAncestorNodesFilter::create())
             ->reverse();
 
         try {
@@ -457,7 +457,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         $currentNode = $startingNode;
 
         foreach ($path->getParts() as $edgeName) {
-            $currentNode = $this->findChildNodeConnectedThroughEdgeName($currentNode->nodeAggregateId, $edgeName);
+            $currentNode = $this->findChildNodeConnectedThroughEdgeName($currentNode->aggregateId, $edgeName);
             if ($currentNode === null) {
                 return null;
             }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentSubhypergraph.php
@@ -533,7 +533,7 @@ final readonly class ContentSubhypergraph implements ContentSubgraphInterface
         $currentNode = $startingNode;
         foreach ($path->getParts() as $edgeName) {
             // id exists here :)
-            $currentNode = $this->findChildNodeConnectedThroughEdgeName($currentNode->nodeAggregateId, $edgeName);
+            $currentNode = $this->findChildNodeConnectedThroughEdgeName($currentNode->aggregateId, $edgeName);
             if ($currentNode === null) {
                 return null;
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeCreationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeCreationInternals.php
@@ -59,21 +59,21 @@ trait NodeCreationInternals
                 // a) happy path, the explicitly requested succeeding sibling also exists in this dimension space point
                 $interdimensionalSiblings[] = new InterdimensionalSibling(
                     $coveredDimensionSpacePoint,
-                    $variantSucceedingSibling->nodeAggregateId,
+                    $variantSucceedingSibling->aggregateId,
                 );
                 continue;
             }
 
             // check the other siblings succeeding in the origin dimension space point
             foreach ($originAlternativeSucceedingSiblings as $originSibling) {
-                $alternativeVariantSucceedingSibling = $subGraph->findNodeById($originSibling->nodeAggregateId);
+                $alternativeVariantSucceedingSibling = $subGraph->findNodeById($originSibling->aggregateId);
                 if (!$alternativeVariantSucceedingSibling) {
                     continue;
                 }
                 // b) one of the further succeeding sibling exists in this dimension space point
                 $interdimensionalSiblings[] = new InterdimensionalSibling(
                     $coveredDimensionSpacePoint,
-                    $alternativeVariantSucceedingSibling->nodeAggregateId,
+                    $alternativeVariantSucceedingSibling->aggregateId,
                 );
                 continue 2;
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -282,14 +282,14 @@ trait NodeVariationInternals
         foreach ($variantCoverage as $variantDimensionSpacePoint) {
             // check the siblings succeeding in the origin dimension space point
             foreach ($originSiblings as $originSibling) {
-                $variantSibling = $contentGraph->getSubgraph($variantDimensionSpacePoint, VisibilityConstraints::withoutRestrictions())->findNodeById($originSibling->nodeAggregateId);
+                $variantSibling = $contentGraph->getSubgraph($variantDimensionSpacePoint, VisibilityConstraints::withoutRestrictions())->findNodeById($originSibling->aggregateId);
                 if (!$variantSibling) {
                     continue;
                 }
                 // a) one of the further succeeding sibling exists in this dimension space point
                 $interdimensionalSiblings[] = new InterdimensionalSibling(
                     $variantDimensionSpacePoint,
-                    $variantSibling->nodeAggregateId,
+                    $variantSibling->aggregateId,
                 );
                 continue 2;
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeSubtreeSnapshot.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeSubtreeSnapshot.php
@@ -46,20 +46,20 @@ final readonly class NodeSubtreeSnapshot implements \JsonSerializable
     {
         $childNodes = [];
         foreach (
-            $subgraph->findChildNodes($sourceNode->nodeAggregateId, FindChildNodesFilter::create()) as $sourceChildNode
+            $subgraph->findChildNodes($sourceNode->aggregateId, FindChildNodesFilter::create()) as $sourceChildNode
         ) {
             $childNodes[] = self::fromSubgraphAndStartNode($subgraph, $sourceChildNode);
         }
         $properties = $sourceNode->properties;
 
         return new self(
-            $sourceNode->nodeAggregateId,
+            $sourceNode->aggregateId,
             $sourceNode->nodeTypeName,
             $sourceNode->nodeName,
             $sourceNode->classification,
             $properties->serialized(),
             NodeReferencesSnapshot::fromReferences(
-                $subgraph->findReferences($sourceNode->nodeAggregateId, FindReferencesFilter::create())
+                $subgraph->findReferences($sourceNode->aggregateId, FindReferencesFilter::create())
             ),
             $childNodes
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeSubtreeSnapshot.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeSubtreeSnapshot.php
@@ -55,7 +55,7 @@ final readonly class NodeSubtreeSnapshot implements \JsonSerializable
         return new self(
             $sourceNode->aggregateId,
             $sourceNode->nodeTypeName,
-            $sourceNode->nodeName,
+            $sourceNode->name,
             $sourceNode->classification,
             $properties->serialized(),
             NodeReferencesSnapshot::fromReferences(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
@@ -273,13 +273,13 @@ trait NodeMove
             );
             if ($succeedingSiblingId) {
                 $variantSucceedingSibling = $variantSubgraph->findNodeById($succeedingSiblingId);
-                $variantParentId = $parentNodeAggregateId ?: $variantSubgraph->findParentNode($nodeAggregateId)?->nodeAggregateId;
+                $variantParentId = $parentNodeAggregateId ?: $variantSubgraph->findParentNode($nodeAggregateId)?->aggregateId;
                 $siblingParent = $variantSubgraph->findParentNode($succeedingSiblingId);
-                if ($variantSucceedingSibling && $siblingParent && $variantParentId?->equals($siblingParent->nodeAggregateId)) {
+                if ($variantSucceedingSibling && $siblingParent && $variantParentId?->equals($siblingParent->aggregateId)) {
                     // a) happy path, the explicitly requested succeeding sibling also exists in this dimension space point
                     $interdimensionalSiblings[] = new InterdimensionalSibling(
                         $dimensionSpacePoint,
-                        $variantSucceedingSibling->nodeAggregateId,
+                        $variantSucceedingSibling->aggregateId,
                     );
                     continue;
                 }
@@ -295,13 +295,13 @@ trait NodeMove
                         continue;
                     }
                     $siblingParent = $variantSubgraph->findParentNode($alternativeSucceedingSiblingId);
-                    if (!$siblingParent || !$variantParentId?->equals($siblingParent->nodeAggregateId)) {
+                    if (!$siblingParent || !$variantParentId?->equals($siblingParent->aggregateId)) {
                         continue;
                     }
                     // b) one of the further succeeding sibling exists in this dimension space point
                     $interdimensionalSiblings[] = new InterdimensionalSibling(
                         $dimensionSpacePoint,
-                        $alternativeVariantSucceedingSibling->nodeAggregateId,
+                        $alternativeVariantSucceedingSibling->aggregateId,
                     );
                     continue 2;
                 }
@@ -310,9 +310,9 @@ trait NodeMove
             if ($precedingSiblingId) {
                 $variantPrecedingSiblingId = null;
                 $variantPrecedingSibling = $variantSubgraph->findNodeById($precedingSiblingId);
-                $variantParentId = $parentNodeAggregateId ?: $variantSubgraph->findParentNode($nodeAggregateId)?->nodeAggregateId;
+                $variantParentId = $parentNodeAggregateId ?: $variantSubgraph->findParentNode($nodeAggregateId)?->aggregateId;
                 $siblingParent = $variantSubgraph->findParentNode($precedingSiblingId);
-                if ($variantPrecedingSibling && $siblingParent && $variantParentId?->equals($siblingParent->nodeAggregateId)) {
+                if ($variantPrecedingSibling && $siblingParent && $variantParentId?->equals($siblingParent->aggregateId)) {
                     // c) happy path, the explicitly requested preceding sibling also exists in this dimension space point
                     $variantPrecedingSiblingId = $precedingSiblingId;
                 } elseif ($alternativePrecedingSiblingIds) {
@@ -323,7 +323,7 @@ trait NodeMove
                             continue;
                         }
                         $siblingParent = $variantSubgraph->findParentNode($alternativePrecedingSiblingId);
-                        if (!$siblingParent || !$variantParentId?->equals($siblingParent->nodeAggregateId)) {
+                        if (!$siblingParent || !$variantParentId?->equals($siblingParent->aggregateId)) {
                             continue;
                         }
                         $alternativeVariantSucceedingSibling = $variantSubgraph->findNodeById($alternativePrecedingSiblingId);

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -188,7 +188,7 @@ trait NodeTypeChange
                     VisibilityConstraints::withoutRestrictions()
                 )->findNodeByPath(
                     $tetheredNodeTypeDefinition->name,
-                    $node->nodeAggregateId,
+                    $node->aggregateId,
                 );
 
                 if ($tetheredNode === null) {
@@ -404,7 +404,7 @@ trait NodeTypeChange
             );
             if (
                 $parentNode
-                && $parentNode->nodeAggregateId->equals($parentNodeAggregate->nodeAggregateId)
+                && $parentNode->aggregateId->equals($parentNodeAggregate->nodeAggregateId)
             ) {
                 $points[] = $coveredDimensionSpacePoint;
             }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
@@ -86,14 +86,14 @@ final readonly class AbsoluteNodePath implements \JsonSerializable
             if ($ancestor->classification->isRoot()) {
                 continue;
             }
-            if (!$ancestor->nodeName) {
+            if (!$ancestor->name) {
                 throw new \InvalidArgumentException(
                     'Could not resolve node path for node ' . $leafNode->aggregateId->value
                     . ', ancestor ' . $ancestor->aggregateId->value . ' is unnamed.',
                     1687509348
                 );
             }
-            $nodeNames[] = $ancestor->nodeName;
+            $nodeNames[] = $ancestor->name;
         }
 
         return new self(

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
@@ -88,8 +88,8 @@ final readonly class AbsoluteNodePath implements \JsonSerializable
             }
             if (!$ancestor->nodeName) {
                 throw new \InvalidArgumentException(
-                    'Could not resolve node path for node ' . $leafNode->nodeAggregateId->value
-                    . ', ancestor ' . $ancestor->nodeAggregateId->value . ' is unnamed.',
+                    'Could not resolve node path for node ' . $leafNode->aggregateId->value
+                    . ', ancestor ' . $ancestor->aggregateId->value . ' is unnamed.',
                     1687509348
                 );
             }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -90,7 +90,7 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         }
         $childNodes = $this->wrappedContentSubgraph->findChildNodes($parentNodeAggregateId, $filter);
         foreach ($childNodes as $node) {
-            $namedChildNodeCache->add($parentNodeAggregateId, $node->nodeName, $node);
+            $namedChildNodeCache->add($parentNodeAggregateId, $node->name, $node);
             $parentNodeIdCache->add($node->aggregateId, $parentNodeAggregateId);
             $nodeByIdCache->add($node->aggregateId, $node);
         }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphWithRuntimeCaches/ContentSubgraphWithRuntimeCaches.php
@@ -91,8 +91,8 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
         $childNodes = $this->wrappedContentSubgraph->findChildNodes($parentNodeAggregateId, $filter);
         foreach ($childNodes as $node) {
             $namedChildNodeCache->add($parentNodeAggregateId, $node->nodeName, $node);
-            $parentNodeIdCache->add($node->nodeAggregateId, $parentNodeAggregateId);
-            $nodeByIdCache->add($node->nodeAggregateId, $node);
+            $parentNodeIdCache->add($node->aggregateId, $parentNodeAggregateId);
+            $nodeByIdCache->add($node->aggregateId, $node);
         }
         $childNodesCache->add($parentNodeAggregateId, $filter->nodeTypes, $childNodes);
         return $childNodes;
@@ -174,10 +174,10 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
             $parentNodeIdCache->rememberNonExistingParentNode($childNodeAggregateId);
             return null;
         }
-        $parentNodeIdCache->add($childNodeAggregateId, $parentNode->nodeAggregateId);
+        $parentNodeIdCache->add($childNodeAggregateId, $parentNode->aggregateId);
         // we also add the parent node to the NodeAggregateId => Node cache;
         // as this might improve cache hit rates as well.
-        $this->inMemoryCache->getNodeByNodeAggregateIdCache()->add($parentNode->nodeAggregateId, $parentNode);
+        $this->inMemoryCache->getNodeByNodeAggregateIdCache()->add($parentNode->aggregateId, $parentNode);
         return $parentNode;
     }
 

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentSubgraphIdentity.php
@@ -15,7 +15,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  * - {@see visibilityConstraints}
  *
  * In addition to the above subgraph identity, a Node's read model identity is further described
- * by {@see Node::$nodeAggregateId}.
+ * by {@see Node::$aggregateId}.
  *
  * With the above information, you can fetch a Subgraph directly by using
  * {@see \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry::subgraphForNode()}.

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -147,7 +147,7 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
         }
         throw new \InvalidArgumentException(sprintf(
             'The node %s does not exist in this set',
-            $subject->nodeAggregateId->value
+            $subject->aggregateId->value
         ), 1542901216);
     }
 
@@ -210,7 +210,7 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
     public function toNodeAggregateIds(): NodeAggregateIds
     {
         return NodeAggregateIds::create(...$this->map(
-            fn (Node $node): NodeAggregateId => $node->nodeAggregateId,
+            fn (Node $node): NodeAggregateId => $node->aggregateId,
         ));
     }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -55,7 +55,7 @@ final readonly class NodeAddress implements \JsonSerializable
             $node->contentRepositoryId,
             $node->workspaceName,
             $node->dimensionSpacePoint,
-            $node->nodeAggregateId
+            $node->aggregateId
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -71,7 +71,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \JsonSerializable
     public static function fromNodes(Nodes $nodes): self
     {
         return self::fromArray(
-            array_map(fn(Node $node) => $node->nodeAggregateId, iterator_to_array($nodes))
+            array_map(fn(Node $node) => $node->aggregateId, iterator_to_array($nodes))
         );
     }
 

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferenceNodesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferenceNodesOperation.php
@@ -73,7 +73,7 @@ final class BackReferenceNodesOperation implements OperationInterface
         /** @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
-            $output[] = iterator_to_array($subgraph->findBackReferences($contextNode->nodeAggregateId, $filter));
+            $output[] = iterator_to_array($subgraph->findBackReferences($contextNode->aggregateId, $filter));
         }
         $flowQuery->setContext(array_map(fn(Reference $reference) => $reference->node, array_merge(...$output)));
     }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferencesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferencesOperation.php
@@ -79,7 +79,7 @@ final class BackReferencesOperation implements OperationInterface
         /** @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
-            $output[] = iterator_to_array($subgraph->findBackReferences($contextNode->nodeAggregateId, $filter));
+            $output[] = iterator_to_array($subgraph->findBackReferences($contextNode->aggregateId, $filter));
         }
         $flowQuery->setContext(array_merge(...$output));
     }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ChildrenOperation.php
@@ -83,11 +83,11 @@ class ChildrenOperation extends AbstractOperation
         /** @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
             $childNodes = $this->contentRepositoryRegistry->subgraphForNode($contextNode)
-                ->findChildNodes($contextNode->nodeAggregateId, FindChildNodesFilter::create());
+                ->findChildNodes($contextNode->aggregateId, FindChildNodesFilter::create());
             foreach ($childNodes as $childNode) {
-                if (!isset($outputNodeAggregateIds[$childNode->nodeAggregateId->value])) {
+                if (!isset($outputNodeAggregateIds[$childNode->aggregateId->value])) {
                     $output[] = $childNode;
-                    $outputNodeAggregateIds[$childNode->nodeAggregateId->value] = true;
+                    $outputNodeAggregateIds[$childNode->aggregateId->value] = true;
                 }
             }
         }
@@ -142,14 +142,14 @@ class ChildrenOperation extends AbstractOperation
                         $resolvedNode = $this->contentRepositoryRegistry->subgraphForNode($contextNode)
                             ->findNodeByPath(
                                 NodePath::fromString($nodePath),
-                                $contextNode->nodeAggregateId,
+                                $contextNode->aggregateId,
                             );
 
                         if (!is_null($resolvedNode) && !isset($filteredOutputNodeIdentifiers[
-                            $resolvedNode->nodeAggregateId->value
+                            $resolvedNode->aggregateId->value
                         ])) {
                             $filteredOutput[] = $resolvedNode;
-                            $filteredOutputNodeIdentifiers[$resolvedNode->nodeAggregateId->value] = true;
+                            $filteredOutputNodeIdentifiers[$resolvedNode->aggregateId->value] = true;
                         }
                     }
                 } elseif (count($instanceOfFilters) > 0) {
@@ -161,7 +161,7 @@ class ChildrenOperation extends AbstractOperation
                     foreach ($flowQuery->getContext() as $contextNode) {
                         $childNodes = $this->contentRepositoryRegistry->subgraphForNode($contextNode)
                             ->findChildNodes(
-                            $contextNode->nodeAggregateId,
+                            $contextNode->aggregateId,
                             FindChildNodesFilter::create(
                                 nodeTypes: NodeTypeCriteria::create(
                                     NodeTypeNames::fromStringArray($allowedNodeTypes),
@@ -172,10 +172,10 @@ class ChildrenOperation extends AbstractOperation
 
                         foreach ($childNodes as $childNode) {
                             if (!isset($filteredOutputNodeIdentifiers[
-                                $childNode->nodeAggregateId->value
+                                $childNode->aggregateId->value
                             ])) {
                                 $filteredOutput[] = $childNode;
-                                $filteredOutputNodeIdentifiers[$childNode->nodeAggregateId->value] = true;
+                                $filteredOutputNodeIdentifiers[$childNode->aggregateId->value] = true;
                             }
                         }
                     }
@@ -198,7 +198,7 @@ class ChildrenOperation extends AbstractOperation
                 /** @var Node $filteredNode */
                 foreach ($filteredOutput as $filteredNode) {
                     /** @phpstan-ignore-next-line undefined behaviour https://github.com/neos/neos-development-collection/issues/4507#issuecomment-1784123143 */
-                    if (!isset($outputNodeAggregateIds[$filteredNode->nodeAggregateId->value])) {
+                    if (!isset($outputNodeAggregateIds[$filteredNode->aggregateId->value])) {
                         $output[] = $filteredNode;
                     }
                 }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ClosestOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ClosestOperation.php
@@ -75,7 +75,7 @@ class ClosestOperation extends AbstractOperation
 
             foreach ($contextNodeQuery as $result) {
                 /* @var Node $result */
-                $output[$result->nodeAggregateId->value] = $result;
+                $output[$result->aggregateId->value] = $result;
             }
         }
 

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/CreateNodeHashTrait.php
@@ -20,7 +20,7 @@ trait CreateNodeHashTrait
             implode(
                 ':',
                 [
-                    $node->nodeAggregateId->value,
+                    $node->aggregateId->value,
                     $node->contentRepositoryId->value,
                     $node->workspaceName->value,
                     $node->dimensionSpacePoint->hash,

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
@@ -95,7 +95,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
     protected function matchesPropertyNameFilter($element, $propertyNameFilter)
     {
         assert($element instanceof Node);
-        return $element->nodeName?->value === $propertyNameFilter;
+        return $element->name?->value === $propertyNameFilter;
     }
 
     /**

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
@@ -107,7 +107,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
      */
     protected function matchesIdentifierFilter($element, $identifier)
     {
-        return (strtolower($element->nodeAggregateId->value) === strtolower($identifier));
+        return (strtolower($element->aggregateId->value) === strtolower($identifier));
     }
 
     /**
@@ -121,7 +121,7 @@ class FilterOperation extends \Neos\Eel\FlowQuery\Operations\Object\FilterOperat
     {
         if ($propertyPath === '_identifier') {
             // TODO: deprecated (Neos <9 case)
-            return $element->nodeAggregateId->value;
+            return $element->aggregateId->value;
         } elseif ($propertyPath[0] === '_') {
             return ObjectAccess::getPropertyPath($element, substr($propertyPath, 1));
         } else {

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
@@ -252,7 +252,7 @@ class FindOperation extends AbstractOperation
                 if ($nodePath instanceof AbsoluteNodePath) {
                     $nodeByPath = $subgraph->findNodeByAbsolutePath($nodePath);
                 } else {
-                    $nodeByPath = $subgraph->findNodeByPath($nodePath, $node->nodeAggregateId);
+                    $nodeByPath = $subgraph->findNodeByPath($nodePath, $node->aggregateId);
                 }
                 if (isset($nodeByPath)) {
                     $result[] = $nodeByPath;
@@ -277,7 +277,7 @@ class FindOperation extends AbstractOperation
 
             /** @var Node $node */
             foreach ($entryPoint['nodes'] as $node) {
-                foreach ($subgraph->findDescendantNodes($node->nodeAggregateId, FindDescendantNodesFilter::create(nodeTypes: $nodeTypeFilter)) as $descendant) {
+                foreach ($subgraph->findDescendantNodes($node->aggregateId, FindDescendantNodesFilter::create(nodeTypes: $nodeTypeFilter)) as $descendant) {
                     $result[] = $descendant;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/HasOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/HasOperation.php
@@ -100,7 +100,7 @@ class HasOperation extends AbstractOperation
             foreach ($elements as $element) {
                 if ($element instanceof Node) {
                     $parent = $this->contentRepositoryRegistry->subgraphForNode($element)
-                        ->findParentNode($element->nodeAggregateId);
+                        ->findParentNode($element->aggregateId);
                     if (!is_null($parent)) {
                         foreach ($context as $contextElement) {
                             /** @var Node $contextElement */

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/IdOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/IdOperation.php
@@ -74,6 +74,6 @@ class IdOperation extends AbstractOperation
         if (!$node instanceof Node) {
             return null;
         }
-        return $node->nodeAggregateId->value;
+        return $node->aggregateId->value;
     }
 }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextAllOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextAllOperation.php
@@ -74,8 +74,8 @@ class NextAllOperation extends AbstractOperation
                     FindSucceedingSiblingNodesFilter::create()
                 );
             foreach ($nextNodes as $nextNode) {
-                if ($nextNode !== null && !isset($outputNodePaths[$nextNode->nodeAggregateId->value])) {
-                    $outputNodePaths[$nextNode->nodeAggregateId->value] = true;
+                if ($nextNode !== null && !isset($outputNodePaths[$nextNode->aggregateId->value])) {
+                    $outputNodePaths[$nextNode->aggregateId->value] = true;
                     $output[] = $nextNode;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextOperation.php
@@ -74,8 +74,8 @@ class NextOperation extends AbstractOperation
                     $contextNode->nodeAggregateId,
                     FindSucceedingSiblingNodesFilter::create()
                 )->first();
-            if ($nextNode !== null && !isset($outputNodePaths[$nextNode->nodeAggregateId->value])) {
-                $outputNodePaths[$nextNode->nodeAggregateId->value] = true;
+            if ($nextNode !== null && !isset($outputNodePaths[$nextNode->aggregateId->value])) {
+                $outputNodePaths[$nextNode->aggregateId->value] = true;
                 $output[] = $nextNode;
             }
         }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextUntilOperation.php
@@ -87,8 +87,8 @@ class NextUntilOperation extends AbstractOperation
             }
             foreach ($nextNodes as $nextNode) {
                 if ($nextNode !== null
-                    && !isset($outputNodeIdentifiers[$nextNode->nodeAggregateId->value])) {
-                    $outputNodeIdentifiers[$nextNode->nodeAggregateId->value] = true;
+                    && !isset($outputNodeIdentifiers[$nextNode->aggregateId->value])) {
+                    $outputNodeIdentifiers[$nextNode->aggregateId->value] = true;
                     $output[] = $nextNode;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentOperation.php
@@ -69,14 +69,14 @@ class ParentOperation extends AbstractOperation
         foreach ($flowQuery->getContext() as $contextNode) {
             /* @var $contextNode Node */
             $parentNode = $this->contentRepositoryRegistry->subgraphForNode($contextNode)
-                ->findParentNode($contextNode->nodeAggregateId);
+                ->findParentNode($contextNode->aggregateId);
             if ($parentNode === null) {
                 continue;
             }
 
-            if (!isset($outputNodeAggregateIds[$parentNode->nodeAggregateId->value])) {
+            if (!isset($outputNodeAggregateIds[$parentNode->aggregateId->value])) {
                 $output[] = $parentNode;
-                $outputNodeAggregateIds[$parentNode->nodeAggregateId->value] = true;
+                $outputNodeAggregateIds[$parentNode->aggregateId->value] = true;
             }
         }
 

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -80,7 +80,7 @@ class ParentsOperation extends AbstractOperation
             $ancestorNodes = $this->contentRepositoryRegistry
                 ->subgraphForNode($contextNode)
                 ->findAncestorNodes(
-                    $contextNode->nodeAggregateId,
+                    $contextNode->aggregateId,
                     $findAncestorNodesFilter
                 );
             $parents = $parents->merge($ancestorNodes);

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsUntilOperation.php
@@ -92,8 +92,8 @@ class ParentsUntilOperation extends AbstractOperation
             }
             foreach ($parentNodes as $parentNode) {
                 if ($parentNode !== null
-                    && !isset($outputNodeAggregateIds[$parentNode->nodeAggregateId->value])) {
-                    $outputNodeAggregateIds[$parentNode->nodeAggregateId->value] = true;
+                    && !isset($outputNodeAggregateIds[$parentNode->aggregateId->value])) {
+                    $outputNodeAggregateIds[$parentNode->aggregateId->value] = true;
                     $output[] = $parentNode;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevAllOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevAllOperation.php
@@ -75,9 +75,9 @@ class PrevAllOperation extends AbstractOperation
                 )->reverse();
             foreach ($prevNodes as $prevNode) {
                 if ($prevNode !== null
-                    && !isset($outputNodeAggregateIds[$prevNode->nodeAggregateId->value])
+                    && !isset($outputNodeAggregateIds[$prevNode->aggregateId->value])
                 ) {
-                    $outputNodeAggregateIds[$prevNode->nodeAggregateId->value] = true;
+                    $outputNodeAggregateIds[$prevNode->aggregateId->value] = true;
                     $output[] = $prevNode;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevOperation.php
@@ -73,8 +73,8 @@ class PrevOperation extends AbstractOperation
                     $contextNode->nodeAggregateId,
                     FindPrecedingSiblingNodesFilter::create()
                 )->first();
-            if ($previousNode !== null && !isset($outputNodePaths[$previousNode->nodeAggregateId->value])) {
-                $outputNodePaths[$previousNode->nodeAggregateId->value] = true;
+            if ($previousNode !== null && !isset($outputNodePaths[$previousNode->aggregateId->value])) {
+                $outputNodePaths[$previousNode->aggregateId->value] = true;
                 $output[] = $previousNode;
             }
         }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevUntilOperation.php
@@ -87,8 +87,8 @@ class PrevUntilOperation extends AbstractOperation
             }
             foreach ($prevNodes as $prevNode) {
                 if ($prevNode !== null &&
-                    !isset($outputNodeIdentifiers[$prevNode->nodeAggregateId->value])) {
-                    $outputNodeIdentifiers[$prevNode->nodeAggregateId->value] = true;
+                    !isset($outputNodeIdentifiers[$prevNode->aggregateId->value])) {
+                    $outputNodeIdentifiers[$prevNode->aggregateId->value] = true;
                     $output[] = $prevNode;
                 }
             }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
@@ -96,7 +96,7 @@ class PropertyOperation extends AbstractOperation
         if ($propertyName === '_path') {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($element);
             $ancestors = $subgraph->findAncestorNodes(
-                $element->nodeAggregateId,
+                $element->aggregateId,
                 FindAncestorNodesFilter::create()
             )->reverse();
 
@@ -104,7 +104,7 @@ class PropertyOperation extends AbstractOperation
         }
         if ($propertyName === '_identifier') {
             // TODO: deprecated (Neos <9 case)
-            return $element->nodeAggregateId->value;
+            return $element->aggregateId->value;
         }
 
         if ($propertyName[0] === '_') {
@@ -118,7 +118,7 @@ class PropertyOperation extends AbstractOperation
             // legacy access layer for references
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($element);
             $references = $subgraph->findReferences(
-                $element->nodeAggregateId,
+                $element->aggregateId,
                 FindReferencesFilter::create(referenceName: $propertyName)
             )->getNodes();
 

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
@@ -111,7 +111,7 @@ class PropertyOperation extends AbstractOperation
             return ObjectAccess::getPropertyPath($element, substr($propertyName, 1));
         }
 
-        $contentRepository = $this->contentRepositoryRegistry->get($element->subgraphIdentity->contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get($element->contentRepositoryId);
         $nodeTypeManager = $contentRepository->getNodeTypeManager();
 
         if ($nodeTypeManager->getNodeType($element->nodeTypeName)?->hasReference($propertyName)) {

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferenceNodesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferenceNodesOperation.php
@@ -72,7 +72,7 @@ final class ReferenceNodesOperation implements OperationInterface
         /** @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
-            $output[] = iterator_to_array($subgraph->findReferences($contextNode->nodeAggregateId, $filter));
+            $output[] = iterator_to_array($subgraph->findReferences($contextNode->aggregateId, $filter));
         }
         $flowQuery->setContext(array_map(fn(Reference $reference) => $reference->node, array_merge(...$output)));
     }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencesOperation.php
@@ -77,7 +77,7 @@ final class ReferencesOperation implements OperationInterface
         /** @var Node $contextNode */
         foreach ($flowQuery->getContext() as $contextNode) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
-            $output[] = iterator_to_array($subgraph->findReferences($contextNode->nodeAggregateId, $filter));
+            $output[] = iterator_to_array($subgraph->findReferences($contextNode->aggregateId, $filter));
         }
         $flowQuery->setContext(array_merge(...$output));
     }

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/SiblingsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/SiblingsOperation.php
@@ -68,24 +68,24 @@ class SiblingsOperation extends AbstractOperation
         $outputNodeAggregateIds = [];
         foreach ($flowQuery->getContext() as $contextNode) {
             /** @var Node $contextNode */
-            $outputNodeAggregateIds[$contextNode->nodeAggregateId->value] = true;
+            $outputNodeAggregateIds[$contextNode->aggregateId->value] = true;
         }
 
         foreach ($flowQuery->getContext() as $contextNode) {
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($contextNode);
 
-            $parentNode = $subgraph->findParentNode($contextNode->nodeAggregateId);
+            $parentNode = $subgraph->findParentNode($contextNode->aggregateId);
             if ($parentNode === null) {
                 // no parent found
                 continue;
             }
 
             foreach (
-                $subgraph->findChildNodes($parentNode->nodeAggregateId, FindChildNodesFilter::create()) as $childNode
+                $subgraph->findChildNodes($parentNode->aggregateId, FindChildNodesFilter::create()) as $childNode
             ) {
-                if (!isset($outputNodeAggregateIds[$childNode->nodeAggregateId->value])) {
+                if (!isset($outputNodeAggregateIds[$childNode->aggregateId->value])) {
                     $output[] = $childNode;
-                    $outputNodeAggregateIds[$childNode->nodeAggregateId->value] = true;
+                    $outputNodeAggregateIds[$childNode->aggregateId->value] = true;
                 }
             }
         }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyTransformationFactory.php
@@ -69,7 +69,7 @@ class AddNewPropertyTransformationFactory implements TransformationFactoryInterf
                     return $this->contentRepository->handle(
                         SetSerializedNodeProperties::create(
                             $workspaceNameForWriting,
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             $node->originDimensionSpacePoint,
                             SerializedPropertyValues::fromArray([
                                 $this->newPropertyName => SerializedPropertyValue::create(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueTransformationFactory.php
@@ -131,7 +131,7 @@ class ChangePropertyValueTransformationFactory implements TransformationFactoryI
                     return $this->contentRepository->handle(
                         SetSerializedNodeProperties::create(
                             $workspaceNameForWriting,
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             $node->originDimensionSpacePoint,
                             SerializedPropertyValues::fromArray([
                                 $this->propertyName => SerializedPropertyValue::create(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
@@ -89,7 +89,7 @@ class RemoveNodeTransformationFactory implements TransformationFactoryInterface
 
                 return $this->contentRepository->handle(RemoveNodeAggregate::create(
                     $workspaceNameForWriting,
-                    $node->nodeAggregateId,
+                    $node->aggregateId,
                     $coveredDimensionSpacePoint,
                     $this->strategy,
                 ));

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
@@ -59,7 +59,7 @@ class RemovePropertyTransformationFactory implements TransformationFactoryInterf
                     return $this->contentRepository->handle(
                         SetSerializedNodeProperties::create(
                             $workspaceNameForWriting,
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             $node->originDimensionSpacePoint,
                             SerializedPropertyValues::createEmpty(),
                             PropertyNames::fromArray([$this->propertyName])

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
@@ -68,7 +68,7 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
                     return $this->contentRepository->handle(
                         SetSerializedNodeProperties::create(
                             $workspaceNameForWriting,
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             $node->originDimensionSpacePoint,
                             SerializedPropertyValues::fromArray([
                                 $this->to => $serializedPropertyValue

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
@@ -69,7 +69,7 @@ class StripTagsOnPropertyTransformationFactory implements TransformationFactoryI
                     return $this->contentRepository->handle(
                         SetSerializedNodeProperties::create(
                             $workspaceNameForWriting,
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             $node->originDimensionSpacePoint,
                             SerializedPropertyValues::fromArray([
                                 $this->propertyName => SerializedPropertyValue::create(

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
@@ -57,7 +57,7 @@ class DisallowedChildNodeAdjustment
 
                 $parentNode = $subgraph->findParentNode($nodeAggregate->nodeAggregateId);
                 $grandparentNode = $parentNode !== null
-                    ? $subgraph->findParentNode($parentNode->nodeAggregateId)
+                    ? $subgraph->findParentNode($parentNode->aggregateId)
                     : null;
 
                 $allowedByParent = true;

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
@@ -115,7 +115,7 @@ class PropertyAdjustment
         $events = Events::with(
             new NodePropertiesWereSet(
                 $node->subgraphIdentity->contentStreamId,
-                $node->nodeAggregateId,
+                $node->aggregateId,
                 $node->originDimensionSpacePoint,
                 $nodeAggregate->getCoverageByOccupant($node->originDimensionSpacePoint),
                 $serializedPropertyValues,

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -127,8 +127,8 @@ class TetheredNodeAdjustments
                     $actualTetheredChildNodes = [];
                     foreach ($childNodes as $childNode) {
                         if ($childNode->classification->isTethered()) {
-                            assert($childNode->nodeName !== null); // it's tethered!
-                            $actualTetheredChildNodes[$childNode->nodeName->value] = $childNode;
+                            assert($childNode->name !== null); // it's tethered!
+                            $actualTetheredChildNodes[$childNode->name->value] = $childNode;
                         }
                     }
 

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -219,13 +219,13 @@ class TetheredNodeAdjustments
             foreach ($coverageByOrigin as $coveredDimensionSpacePoint) {
                 $succeedingSiblingsForCoverage[] = new InterdimensionalSibling(
                     $coveredDimensionSpacePoint,
-                    $succeedingNode->nodeAggregateId
+                    $succeedingNode->aggregateId
                 );
             }
 
             $events[] = new NodeAggregateWasMoved(
                 $contentStreamId,
-                $nodeToMove->nodeAggregateId,
+                $nodeToMove->aggregateId,
                 null,
                 new InterdimensionalSiblings(...$succeedingSiblingsForCoverage),
             );

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -170,12 +170,12 @@ trait CRTestSuiteRuntimeVariables
         $this->rememberedNodeAggregateIds[$indexName] = $this->getCurrentSubgraph()->findNodeByPath(
             NodePath::fromString($childNodeName),
             NodeAggregateId::fromString($parentNodeAggregateId),
-        )->nodeAggregateId;
+        )->aggregateId;
     }
 
     protected function getCurrentNodeAggregateId(): NodeAggregateId
     {
         assert($this->currentNode instanceof Node);
-        return $this->currentNode->nodeAggregateId;
+        return $this->currentNode->aggregateId;
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -208,7 +208,7 @@ trait CRTestSuiteTrait
             $actualLevel = $flattenedSubtree[$i]->level;
             Assert::assertSame($expectedLevel, $actualLevel, 'Level does not match in index ' . $i . ', expected: ' . $expectedLevel . ', actual: ' . $actualLevel);
             $expectedNodeAggregateId = NodeAggregateId::fromString($expectedRow['nodeAggregateId']);
-            $actualNodeAggregateId = $flattenedSubtree[$i]->node->nodeAggregateId;
+            $actualNodeAggregateId = $flattenedSubtree[$i]->node->aggregateId;
             Assert::assertTrue(
                 $expectedNodeAggregateId->equals($actualNodeAggregateId),
                 'NodeAggregateId does not match in index ' . $i . ', expected: "' . $expectedNodeAggregateId->value . '", actual: "' . $actualNodeAggregateId->value . '"'

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRenaming.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeRenaming.php
@@ -72,6 +72,6 @@ trait NodeRenaming
     public function iExpectTheNodeToHaveTheName(string $nodeAggregateId, string $nodeName)
     {
         $node = $this->getCurrentSubgraph()->findNodeById(NodeAggregateId::fromString($nodeAggregateId));
-        Assert::assertEquals($nodeName, $node->nodeName->value, 'Node Names do not match');
+        Assert::assertEquals($nodeName, $node->name->value, 'Node Names do not match');
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
@@ -51,7 +51,7 @@ final readonly class NodeDiscriminator implements \JsonSerializable
     {
         return new self(
             $node->subgraphIdentity->contentStreamId,
-            $node->nodeAggregateId,
+            $node->aggregateId,
             $node->originDimensionSpacePoint
         );
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -58,7 +58,7 @@ trait NodeTraversalTrait
         $filter = FindChildNodesFilter::create(...$filterValues);
         $subgraph = $this->getCurrentSubgraph();
 
-        $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findChildNodes($parentNodeAggregateId, $filter)));
+        $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findChildNodes($parentNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findChildNodes returned an unexpected result');
         $actualCount = $subgraph->countChildNodes($parentNodeAggregateId, CountChildNodesFilter::fromFindChildNodesFilter($filter));
         Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countChildNodes returned an unexpected result');
@@ -76,7 +76,7 @@ trait NodeTraversalTrait
         $subgraph = $this->getCurrentSubgraph();
 
         $actualReferences = array_map(static fn(Reference $reference) => [
-            'nodeAggregateId' => $reference->node->nodeAggregateId->value,
+            'nodeAggregateId' => $reference->node->aggregateId->value,
             'name' => $reference->name->value,
             'properties' => json_decode(json_encode($reference->properties?->serialized(), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR)
         ], iterator_to_array($subgraph->findReferences($nodeAggregateId, $filter)));
@@ -95,7 +95,7 @@ trait NodeTraversalTrait
         $filter = FindBackReferencesFilter::create(...$filterValues);
         $subgraph = $this->getCurrentSubgraph();
         $actualReferences = array_map(static fn(Reference $reference) => [
-            'nodeAggregateId' => $reference->node->nodeAggregateId->value,
+            'nodeAggregateId' => $reference->node->aggregateId->value,
             'name' => $reference->name->value,
             'properties' => json_decode(json_encode($reference->properties?->serialized(), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR)
         ], iterator_to_array($subgraph->findBackReferences($nodeAggregateId, $filter)));
@@ -113,7 +113,7 @@ trait NodeTraversalTrait
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
         $actualNode = $this->getCurrentSubgraph()->findNodeById($nodeAggregateId);
-        Assert::assertSame($actualNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
     /**
@@ -126,7 +126,7 @@ trait NodeTraversalTrait
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
         $actualParentNode = $this->getCurrentSubgraph()->findParentNode($nodeAggregateId);
-        Assert::assertSame($actualParentNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualParentNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
     /**
@@ -140,7 +140,7 @@ trait NodeTraversalTrait
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
         $actualNode = $this->getCurrentSubgraph()->findNodeByPath($path, $startingNodeAggregateId);
-        Assert::assertSame($actualNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
     /**
@@ -153,7 +153,7 @@ trait NodeTraversalTrait
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
         $actualNode = $this->getCurrentSubgraph()->findNodeByAbsolutePath($path);
-        Assert::assertSame($actualNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
     /**
@@ -167,7 +167,7 @@ trait NodeTraversalTrait
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
         $actualNode = $this->getCurrentSubgraph()->findNodeByPath($edgeName, $parentNodeAggregateId);
-        Assert::assertSame($actualNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
     /**
@@ -181,7 +181,7 @@ trait NodeTraversalTrait
         $filter = FindSucceedingSiblingNodesFilter::create(...$filterValues);
 
         $actualNodeIds = array_map(
-            static fn(Node $node) => $node->nodeAggregateId->value,
+            static fn(Node $node) => $node->aggregateId->value,
             iterator_to_array($this->getCurrentSubgraph()->findSucceedingSiblingNodes($siblingNodeAggregateId, $filter))
         );
         Assert::assertSame($expectedNodeIds, $actualNodeIds);
@@ -198,7 +198,7 @@ trait NodeTraversalTrait
         $filter = FindPrecedingSiblingNodesFilter::create(...$filterValues);
 
         $actualNodeIds = array_map(
-            static fn(Node $node) => $node->nodeAggregateId->value,
+            static fn(Node $node) => $node->aggregateId->value,
             iterator_to_array($this->getCurrentSubgraph()->findPrecedingSiblingNodes($siblingNodeAggregateId, $filter))
         );
         Assert::assertSame($expectedNodeIds, $actualNodeIds);
@@ -254,7 +254,7 @@ trait NodeTraversalTrait
                 sort($inheritedTags);
                 $tags = [...array_map(static fn(string $tag) => $tag . '*', $explicitTags), ...$inheritedTags];
             }
-            $result[] = str_repeat(' ', $subtree->level) . $subtree->node->nodeAggregateId->value . ($tags !== [] ? ' (' . implode(',', $tags) . ')' : '');
+            $result[] = str_repeat(' ', $subtree->level) . $subtree->node->aggregateId->value . ($tags !== [] ? ' (' . implode(',', $tags) . ')' : '');
             $subtreeStack = [...$subtree->children, ...$subtreeStack];
         }
         Assert::assertSame($expectedTree?->getRaw() ?? '', implode(chr(10), $result));
@@ -271,7 +271,7 @@ trait NodeTraversalTrait
         $filter = FindDescendantNodesFilter::create(...$filterValues);
         $subgraph = $this->getCurrentSubgraph();
 
-        $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findDescendantNodes($entryNodeAggregateId, $filter)));
+        $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findDescendantNodes($entryNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
         $actualCount = $subgraph->countDescendantNodes($entryNodeAggregateId, CountDescendantNodesFilter::fromFindDescendantNodesFilter($filter));
         Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countDescendantNodes returned an unexpected result');
@@ -287,7 +287,7 @@ trait NodeTraversalTrait
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindAncestorNodesFilter::create(...$filterValues);
         $subgraph = $this->getCurrentSubgraph();
-        $actualNodeIds = array_map(static fn(Node $node) => $node->nodeAggregateId->value, iterator_to_array($subgraph->findAncestorNodes($entryNodeAggregateId, $filter)));
+        $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findAncestorNodes($entryNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findAncestorNodes returned an unexpected result');
         $actualCount = $subgraph->countAncestorNodes($entryNodeAggregateId, CountAncestorNodesFilter::fromFindAncestorNodesFilter($filter));
         Assert::assertSame($expectedTotalCount ?? count($expectedNodeIds), $actualCount, 'countAncestorNodes returned an unexpected result');
@@ -302,7 +302,7 @@ trait NodeTraversalTrait
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindClosestNodeFilter::create(...$filterValues);
         $subgraph = $this->getCurrentSubgraph();
-        $actualNodeId = $subgraph->findClosestNode($entryNodeAggregateId, $filter)?->nodeAggregateId->value;
+        $actualNodeId = $subgraph->findClosestNode($entryNodeAggregateId, $filter)?->aggregateId->value;
         Assert::assertSame($expectedNodeId, $actualNodeId, 'findClosestNode returned an unexpected result');
     }
 
@@ -347,6 +347,6 @@ trait NodeTraversalTrait
             : null;
 
         $actualNode = $this->getCurrentSubgraph()->findRootNodeByType(NodeTypeName::fromString($serializedNodeTypeName));
-        Assert::assertSame($actualNode?->nodeAggregateId->value, $expectedNodeAggregateId?->value);
+        Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -430,7 +430,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedReferences) {
             $actualReferences = $this->getCurrentSubgraph()
-                ->findReferences($currentNode->nodeAggregateId, FindReferencesFilter::create());
+                ->findReferences($currentNode->aggregateId, FindReferencesFilter::create());
 
             $this->assertReferencesMatch($expectedReferences, $actualReferences);
         });
@@ -444,7 +444,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
             $references = $this->getCurrentSubgraph()
-                ->findReferences($currentNode->nodeAggregateId, FindReferencesFilter::create());
+                ->findReferences($currentNode->aggregateId, FindReferencesFilter::create());
 
             Assert::assertCount(0, $references, 'No references were expected.');
         });
@@ -458,7 +458,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedReferences) {
             $actualReferences = $this->getCurrentSubgraph()
-                ->findBackReferences($currentNode->nodeAggregateId, FindBackReferencesFilter::create());
+                ->findBackReferences($currentNode->aggregateId, FindBackReferencesFilter::create());
 
             $this->assertReferencesMatch($expectedReferences, $actualReferences);
         });
@@ -537,7 +537,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
             $originNodes = $this->getCurrentSubgraph()
-                ->findBackReferences($currentNode->nodeAggregateId, FindBackReferencesFilter::create());
+                ->findBackReferences($currentNode->aggregateId, FindBackReferencesFilter::create());
             Assert::assertCount(0, $originNodes, 'No referencing nodes were expected.');
         });
     }
@@ -552,13 +552,13 @@ trait ProjectedNodeTrait
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedParentDiscriminator) {
             $subgraph = $this->getCurrentSubgraph();
 
-            $parent = $subgraph->findParentNode($currentNode->nodeAggregateId);
+            $parent = $subgraph->findParentNode($currentNode->aggregateId);
             Assert::assertInstanceOf(Node::class, $parent, 'Parent not found.');
             $actualParentDiscriminator = NodeDiscriminator::fromNode($parent);
             Assert::assertTrue($expectedParentDiscriminator->equals($actualParentDiscriminator), 'Parent discriminator does not match. Expected was ' . json_encode($expectedParentDiscriminator) . ', given was ' . json_encode($actualParentDiscriminator));
 
             $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode);
-            $child = $subgraph->findNodeByPath($currentNode->nodeName, $parent->nodeAggregateId);
+            $child = $subgraph->findNodeByPath($currentNode->nodeName, $parent->aggregateId);
             $actualChildDiscriminator = NodeDiscriminator::fromNode($child);
             Assert::assertTrue($expectedChildDiscriminator->equals($actualChildDiscriminator), 'Child discriminator does not match. Expected was ' . json_encode($expectedChildDiscriminator) . ', given was ' . json_encode($actualChildDiscriminator));
         });
@@ -570,8 +570,8 @@ trait ProjectedNodeTrait
     public function iExpectThisNodeToHaveNoParentNode(): void
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
-            $parentNode = $this->getCurrentSubgraph()->findParentNode($currentNode->nodeAggregateId);
-            $unexpectedNodeAggregateId = $parentNode ? $parentNode->nodeAggregateId : '';
+            $parentNode = $this->getCurrentSubgraph()->findParentNode($currentNode->aggregateId);
+            $unexpectedNodeAggregateId = $parentNode ? $parentNode->aggregateId : '';
             Assert::assertNull($parentNode, 'Parent node ' . $unexpectedNodeAggregateId . ' was found, but none was expected.');
         });
     }
@@ -585,7 +585,7 @@ trait ProjectedNodeTrait
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedChildNodesTable) {
             $subgraph = $this->getCurrentSubgraph();
             $actualChildNodes = [];
-            foreach ($subgraph->findChildNodes($currentNode->nodeAggregateId, FindChildNodesFilter::create()) as $actualChildNode) {
+            foreach ($subgraph->findChildNodes($currentNode->aggregateId, FindChildNodesFilter::create()) as $actualChildNode) {
                 $actualChildNodes[] = $actualChildNode;
             }
 
@@ -611,7 +611,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
             $subgraph = $this->getCurrentSubgraph();
-            $actualChildNodes = $subgraph->findChildNodes($currentNode->nodeAggregateId, FindChildNodesFilter::create());
+            $actualChildNodes = $subgraph->findChildNodes($currentNode->aggregateId, FindChildNodesFilter::create());
 
             Assert::assertEquals(0, count($actualChildNodes), 'ContentSubgraph::findChildNodes returned present child nodes.');
         });
@@ -627,7 +627,7 @@ trait ProjectedNodeTrait
             $actualSiblings = [];
             foreach (
                 $this->getCurrentSubgraph()->findPrecedingSiblingNodes(
-                    $currentNode->nodeAggregateId,
+                    $currentNode->aggregateId,
                     FindPrecedingSiblingNodesFilter::create()
                 ) as $actualSibling
             ) {
@@ -649,7 +649,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
             $actualSiblings = $this->getCurrentSubgraph()
-                ->findPrecedingSiblingNodes($currentNode->nodeAggregateId, FindPrecedingSiblingNodesFilter::create());
+                ->findPrecedingSiblingNodes($currentNode->aggregateId, FindPrecedingSiblingNodesFilter::create());
             Assert::assertCount(0, $actualSiblings, 'ContentSubgraph::findPrecedingSiblingNodes: No siblings were expected');
         });
     }
@@ -664,7 +664,7 @@ trait ProjectedNodeTrait
             $actualSiblings = [];
             foreach (
                 $this->getCurrentSubgraph()->findSucceedingSiblingNodes(
-                    $currentNode->nodeAggregateId,
+                    $currentNode->aggregateId,
                     FindSucceedingSiblingNodesFilter::create()
                 ) as $actualSibling
             ) {
@@ -686,7 +686,7 @@ trait ProjectedNodeTrait
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
             $actualSiblings = $this->getCurrentSubgraph()
-                ->findSucceedingSiblingNodes($currentNode->nodeAggregateId, FindSucceedingSiblingNodesFilter::create());
+                ->findSucceedingSiblingNodes($currentNode->aggregateId, FindSucceedingSiblingNodesFilter::create());
             Assert::assertCount(0, $actualSiblings, 'ContentSubgraph::findSucceedingSiblingNodes: No siblings were expected');
         });
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -315,7 +315,7 @@ trait ProjectedNodeTrait
     {
         $expectedNodeName = NodeName::fromString($serializedExpectedNodeName);
         $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedNodeName) {
-            $actualNodeName = $currentNode->nodeName;
+            $actualNodeName = $currentNode->name;
             Assert::assertSame($expectedNodeName->value, $actualNodeName->value, 'Actual node name "' . $actualNodeName->value . '" does not match expected "' . $expectedNodeName->value . '"');
         });
     }
@@ -326,7 +326,7 @@ trait ProjectedNodeTrait
     public function iExpectThisNodeToBeUnnamed(): void
     {
         $this->assertOnCurrentNode(function (Node $currentNode) {
-            Assert::assertNull($currentNode->nodeName, 'Node was not expected to be named');
+            Assert::assertNull($currentNode->name, 'Node was not expected to be named');
         });
     }
 
@@ -558,7 +558,7 @@ trait ProjectedNodeTrait
             Assert::assertTrue($expectedParentDiscriminator->equals($actualParentDiscriminator), 'Parent discriminator does not match. Expected was ' . json_encode($expectedParentDiscriminator) . ', given was ' . json_encode($actualParentDiscriminator));
 
             $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode);
-            $child = $subgraph->findNodeByPath($currentNode->nodeName, $parent->aggregateId);
+            $child = $subgraph->findNodeByPath($currentNode->name, $parent->aggregateId);
             $actualChildDiscriminator = NodeDiscriminator::fromNode($child);
             Assert::assertTrue($expectedChildDiscriminator->equals($actualChildDiscriminator), 'Child discriminator does not match. Expected was ' . json_encode($expectedChildDiscriminator) . ', given was ' . json_encode($actualChildDiscriminator));
         });
@@ -593,7 +593,7 @@ trait ProjectedNodeTrait
 
             foreach ($expectedChildNodesTable->getHash() as $index => $row) {
                 $expectedNodeName = NodeName::fromString($row['Name']);
-                $actualNodeName = $actualChildNodes[$index]->nodeName;
+                $actualNodeName = $actualChildNodes[$index]->name;
                 Assert::assertTrue($expectedNodeName->equals($actualNodeName), 'ContentSubgraph::findChildNodes: Node name in index ' . $index . ' does not match. Expected: "' . $expectedNodeName->value . '" Actual: "' . $actualNodeName->value . '"');
                 if (isset($row['NodeDiscriminator'])) {
                     $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
@@ -188,14 +188,14 @@ final class ContentCommandController extends CommandController
                 if ($childNodeType?->isOfType('Neos.Neos:Document')) {
                     $this->output("%s- %s\n", [
                         str_repeat('  ', $level),
-                        $childNode->getProperty('uriPathSegment') ?? $childNode->nodeAggregateId->value
+                        $childNode->getProperty('uriPathSegment') ?? $childNode->aggregateId->value
                     ]);
                 }
                 try {
                     // Tethered nodes' variants are automatically created when the parent is translated.
                     $contentRepository->handle(CreateNodeVariant::create(
                         $workspaceName,
-                        $childNode->nodeAggregateId,
+                        $childNode->aggregateId,
                         $childNode->originDimensionSpacePoint,
                         $target
                     ));
@@ -210,7 +210,7 @@ final class ContentCommandController extends CommandController
 
             $this->createVariantRecursivelyInternal(
                 $level + 1,
-                $childNode->nodeAggregateId,
+                $childNode->aggregateId,
                 $sourceSubgraph,
                 $target,
                 $workspaceName,

--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -152,7 +152,7 @@ class UsageController extends ActionController
             }
             foreach ($existingSites as $existingSite) {
                 /** @var Site $existingSite * */
-                if ($siteNode->nodeName->equals($existingSite->getNodeName()->toNodeName())) {
+                if ($siteNode->name->equals($existingSite->getNodeName()->toNodeName())) {
                     $site = $existingSite;
                 }
             }

--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -137,14 +137,14 @@ class UsageController extends ActionController
                 continue;
             }
 
-            $documentNode = $subgraph->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
+            $documentNode = $subgraph->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
             // this should actually never happen, too.
             if (!$documentNode) {
                 $inaccessibleRelations[] = $inaccessibleRelation;
                 continue;
             }
 
-            $siteNode = $subgraph->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
+            $siteNode = $subgraph->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
             // this should actually never happen, too. :D
             if (!$siteNode) {
                 $inaccessibleRelations[] = $inaccessibleRelation;

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -341,10 +341,10 @@ class NodeController extends ActionController
             = $inMemoryCache->getParentNodeIdByChildNodeIdCache();
         $namedChildNodeByNodeIdentifierCache = $inMemoryCache->getNamedChildNodeByNodeIdCache();
         $allChildNodesByNodeIdentifierCache = $inMemoryCache->getAllChildNodesByNodeIdCache();
-        if ($node->nodeName !== null) {
+        if ($node->name !== null) {
             $namedChildNodeByNodeIdentifierCache->add(
                 $parentNode->aggregateId,
-                $node->nodeName,
+                $node->name,
                 $node
             );
         } else {

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -343,7 +343,7 @@ class NodeController extends ActionController
         $allChildNodesByNodeIdentifierCache = $inMemoryCache->getAllChildNodesByNodeIdCache();
         if ($node->nodeName !== null) {
             $namedChildNodeByNodeIdentifierCache->add(
-                $parentNode->nodeAggregateId,
+                $parentNode->aggregateId,
                 $node->nodeName,
                 $node
             );
@@ -352,8 +352,8 @@ class NodeController extends ActionController
         }
 
         $parentNodeIdentifierByChildNodeIdentifierCache->add(
-            $node->nodeAggregateId,
-            $parentNode->nodeAggregateId
+            $node->aggregateId,
+            $parentNode->aggregateId
         );
 
         $allChildNodes = [];
@@ -364,7 +364,7 @@ class NodeController extends ActionController
         }
         // TODO Explain why this is safe (Content can not contain other documents)
         $allChildNodesByNodeIdentifierCache->add(
-            $node->nodeAggregateId,
+            $node->aggregateId,
             null,
             Nodes::fromArray($allChildNodes)
         );

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -778,7 +778,7 @@ class WorkspacesController extends AbstractModuleController
                 $nodePathSegments = [];
                 $documentPathSegments = [];
                 foreach ($ancestors as $ancestor) {
-                    $pathSegment = $ancestor->nodeName ?: NodeName::fromString($ancestor->aggregateId->value);
+                    $pathSegment = $ancestor->name ?: NodeName::fromString($ancestor->aggregateId->value);
                     // Don't include `sites` path as they are not needed
                     // by the HTML/JS magic and won't be included as `$documentPathSegments`
                     if (!$this->getNodeType($ancestor)->isOfType(NodeTypeNameFactory::NAME_SITES)) {
@@ -797,8 +797,8 @@ class WorkspacesController extends AbstractModuleController
 
                 // Neither $documentNode, $siteNode or its cannot really be null, this is just for type checks;
                 // We should probably throw an exception though
-                if ($documentNode !== null && $siteNode !== null && $siteNode->nodeName) {
-                    $siteNodeName = $siteNode->nodeName->value;
+                if ($documentNode !== null && $siteNode !== null && $siteNode->name) {
+                    $siteNodeName = $siteNode->name->value;
                     // Reverse `$documentPathSegments` to start with the site node.
                     // The paths are used for grouping the nodes and for selecting a tree of nodes.
                     $documentPath = implode('/', array_reverse(array_map(

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -481,7 +481,7 @@ class WorkspacesController extends AbstractModuleController
 
         $targetNodeAddressInPersonalWorkspace = new NodeAddress(
             $personalWorkspace->currentContentStreamId,
-            $targetNode->subgraphIdentity->dimensionSpacePoint,
+            $targetNode->dimensionSpacePoint,
             $targetNode->nodeAggregateId,
             $personalWorkspace->workspaceName
         );
@@ -874,7 +874,7 @@ class WorkspacesController extends AbstractModuleController
         ContentRepository $contentRepository,
     ): ?Node {
         $baseSubgraph = $contentRepository->getContentGraph($baseWorkspaceName)->getSubgraph(
-            $modifiedNode->subgraphIdentity->dimensionSpacePoint,
+            $modifiedNode->dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );
         return $baseSubgraph->findNodeById($modifiedNode->nodeAggregateId);

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -482,7 +482,7 @@ class WorkspacesController extends AbstractModuleController
         $targetNodeAddressInPersonalWorkspace = new NodeAddress(
             $personalWorkspace->currentContentStreamId,
             $targetNode->dimensionSpacePoint,
-            $targetNode->nodeAggregateId,
+            $targetNode->aggregateId,
             $personalWorkspace->workspaceName
         );
 
@@ -770,7 +770,7 @@ class WorkspacesController extends AbstractModuleController
                 $documentNode = null;
                 $siteNode = null;
                 $ancestors = $subgraph->findAncestorNodes(
-                    $node->nodeAggregateId,
+                    $node->aggregateId,
                     FindAncestorNodesFilter::create()
                 );
                 $ancestors = Nodes::fromArray([$node])->merge($ancestors);
@@ -778,7 +778,7 @@ class WorkspacesController extends AbstractModuleController
                 $nodePathSegments = [];
                 $documentPathSegments = [];
                 foreach ($ancestors as $ancestor) {
-                    $pathSegment = $ancestor->nodeName ?: NodeName::fromString($ancestor->nodeAggregateId->value);
+                    $pathSegment = $ancestor->nodeName ?: NodeName::fromString($ancestor->aggregateId->value);
                     // Don't include `sites` path as they are not needed
                     // by the HTML/JS magic and won't be included as `$documentPathSegments`
                     if (!$this->getNodeType($ancestor)->isOfType(NodeTypeNameFactory::NAME_SITES)) {
@@ -877,7 +877,7 @@ class WorkspacesController extends AbstractModuleController
             $modifiedNode->dimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions()
         );
-        return $baseSubgraph->findNodeById($modifiedNode->nodeAggregateId);
+        return $baseSubgraph->findNodeById($modifiedNode->aggregateId);
     }
 
     /**

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -148,7 +148,7 @@ class NodesController extends ActionController
             }
 
             $nodes = !is_null($entryNode) ? $subgraph->findDescendantNodes(
-                $entryNode->nodeAggregateId,
+                $entryNode->aggregateId,
                 FindDescendantNodesFilter::create(
                     nodeTypes: NodeTypeCriteria::create(
                         NodeTypeNames::fromStringArray($nodeTypes),
@@ -386,7 +386,7 @@ class NodesController extends ActionController
         ) {
             $identifiersFromRootlineToTranslate[] = $nodeAggregateId;
             $nodeAggregateId = $sourceSubgraph->findParentNode($nodeAggregateId)
-                ?->nodeAggregateId;
+                ?->aggregateId;
         }
         // $identifiersFromRootlineToTranslate is now bottom-to-top; so we need to reverse
         // them to know what we need to create.
@@ -447,7 +447,7 @@ class NodesController extends ActionController
                 $contentRepository->handle(
                     CreateNodeVariant::create(
                         $workspaceName,
-                        $childNode->nodeAggregateId,
+                        $childNode->aggregateId,
                         $childNode->originDimensionSpacePoint,
                         OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
                     )
@@ -456,7 +456,7 @@ class NodesController extends ActionController
 
             $this->createNodeVariantsForChildNodes(
                 $workspaceName,
-                $childNode->nodeAggregateId,
+                $childNode->aggregateId,
                 $constraints,
                 $sourceSubgraph,
                 $targetSubgraph,

--- a/Neos.Neos/Classes/Domain/Model/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Domain/Model/NodeCacheEntryIdentifier.php
@@ -33,7 +33,7 @@ final class NodeCacheEntryIdentifier implements CacheAwareInterface
     public static function fromNode(Node $node): self
     {
         return new self('Node_' . $node->subgraphIdentity->contentStreamId->value
-            . '_' . $node->subgraphIdentity->dimensionSpacePoint->hash
+            . '_' . $node->dimensionSpacePoint->hash
             . '_' .  $node->nodeAggregateId->value);
     }
 

--- a/Neos.Neos/Classes/Domain/Model/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Domain/Model/NodeCacheEntryIdentifier.php
@@ -34,7 +34,7 @@ final class NodeCacheEntryIdentifier implements CacheAwareInterface
     {
         return new self('Node_' . $node->subgraphIdentity->contentStreamId->value
             . '_' . $node->dimensionSpacePoint->hash
-            . '_' .  $node->nodeAggregateId->value);
+            . '_' .  $node->aggregateId->value);
     }
 
     public function getCacheEntryIdentifier(): string

--- a/Neos.Neos/Classes/Domain/Repository/SiteRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/SiteRepository.php
@@ -122,10 +122,10 @@ class SiteRepository extends Repository
     public function findSiteBySiteNode(Node $siteNode): Site
     {
         if (!$this->getNodeType($siteNode)->isOfType(NodeTypeNameFactory::NAME_SITE)) {
-            throw new \Neos\Neos\Domain\Exception(sprintf('Node %s is not a site node. Site nodes must be of type "%s".', $siteNode->nodeAggregateId->value, NodeTypeNameFactory::NAME_SITE), 1697108987);
+            throw new \Neos\Neos\Domain\Exception(sprintf('Node %s is not a site node. Site nodes must be of type "%s".', $siteNode->aggregateId->value, NodeTypeNameFactory::NAME_SITE), 1697108987);
         }
         if ($siteNode->nodeName === null) {
-            throw new \Neos\Neos\Domain\Exception(sprintf('Site node "%s" is unnamed', $siteNode->nodeAggregateId->value), 1681286146);
+            throw new \Neos\Neos\Domain\Exception(sprintf('Site node "%s" is unnamed', $siteNode->aggregateId->value), 1681286146);
         }
         return $this->findOneByNodeName(SiteNodeName::fromNodeName($siteNode->nodeName))
             ?? throw new \Neos\Neos\Domain\Exception(sprintf('No site found for nodeNodeName "%s"', $siteNode->nodeName->value), 1677245517);

--- a/Neos.Neos/Classes/Domain/Repository/SiteRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/SiteRepository.php
@@ -124,11 +124,11 @@ class SiteRepository extends Repository
         if (!$this->getNodeType($siteNode)->isOfType(NodeTypeNameFactory::NAME_SITE)) {
             throw new \Neos\Neos\Domain\Exception(sprintf('Node %s is not a site node. Site nodes must be of type "%s".', $siteNode->aggregateId->value, NodeTypeNameFactory::NAME_SITE), 1697108987);
         }
-        if ($siteNode->nodeName === null) {
+        if ($siteNode->name === null) {
             throw new \Neos\Neos\Domain\Exception(sprintf('Site node "%s" is unnamed', $siteNode->aggregateId->value), 1681286146);
         }
-        return $this->findOneByNodeName(SiteNodeName::fromNodeName($siteNode->nodeName))
-            ?? throw new \Neos\Neos\Domain\Exception(sprintf('No site found for nodeNodeName "%s"', $siteNode->nodeName->value), 1677245517);
+        return $this->findOneByNodeName(SiteNodeName::fromNodeName($siteNode->name))
+            ?? throw new \Neos\Neos\Domain\Exception(sprintf('No site found for nodeNodeName "%s"', $siteNode->name->value), 1677245517);
     }
 
     /**

--- a/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteNodeUtility.php
@@ -72,7 +72,7 @@ final class SiteNodeUtility
 
         $siteNode = $subgraph->findNodeByPath(
             $site->getNodeName()->toNodeName(),
-            $rootNode->nodeAggregateId
+            $rootNode->aggregateId
         );
 
         if (!$siteNode) {
@@ -82,7 +82,7 @@ final class SiteNodeUtility
         if (!$this->getNodeType($siteNode)->isOfType(NodeTypeNameFactory::NAME_SITE)) {
             throw new \RuntimeException(sprintf(
                 'The site node "%s" (type: "%s") must be of type "%s"',
-                $siteNode->nodeAggregateId->value,
+                $siteNode->aggregateId->value,
                 $siteNode->nodeTypeName->value,
                 NodeTypeNameFactory::NAME_SITE
             ), 1697140367);

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -123,7 +123,7 @@ class SiteService
     public function assignUploadedAssetToSiteAssetCollection(Asset $asset, Node $node, string $propertyName)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
-        $siteNode = $subgraph->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
+        $siteNode = $subgraph->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
         if (!$siteNode) {
             // should not happen
             return;

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -128,10 +128,10 @@ class SiteService
             // should not happen
             return;
         }
-        if ($siteNode->nodeName === null) {
+        if ($siteNode->name === null) {
             return;
         }
-        $site = $this->siteRepository->findOneByNodeName($siteNode->nodeName->value);
+        $site = $this->siteRepository->findOneByNodeName($siteNode->name->value);
         if ($site === null) {
             return;
         }

--- a/Neos.Neos/Classes/Domain/Workspace/Workspace.php
+++ b/Neos.Neos/Classes/Domain/Workspace/Workspace.php
@@ -410,7 +410,7 @@ final class Workspace
             FindClosestNodeFilter::create(nodeTypes: $ancestorNodeTypeName->value)
         );
 
-        return $actualAncestorNode?->nodeAggregateId->equals($ancestorId) ?? false;
+        return $actualAncestorNode?->aggregateId->equals($ancestorId) ?? false;
     }
 
     /**

--- a/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
+++ b/Neos.Neos/Classes/Eel/FlowQueryOperations/SortOperation.php
@@ -123,8 +123,8 @@ class SortOperation extends AbstractOperation
                 $propertyValue = $propertyValue->getTimestamp();
             }
 
-            $sortSequence[$node->nodeAggregateId->value] = $propertyValue;
-            $nodesByIdentifier[$node->nodeAggregateId->value] = $node;
+            $sortSequence[$node->aggregateId->value] = $propertyValue;
+            $nodesByIdentifier[$node->aggregateId->value] = $node;
         }
 
         // Create the sort sequence

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
@@ -64,7 +64,7 @@ class NodeAddressFactory
         return $this->createFromContentStreamIdAndDimensionSpacePointAndNodeAggregateId(
             $node->subgraphIdentity->contentStreamId,
             $node->dimensionSpacePoint,
-            $node->nodeAggregateId,
+            $node->aggregateId,
         );
     }
 

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
@@ -63,7 +63,7 @@ class NodeAddressFactory
     {
         return $this->createFromContentStreamIdAndDimensionSpacePointAndNodeAggregateId(
             $node->subgraphIdentity->contentStreamId,
-            $node->subgraphIdentity->dimensionSpacePoint,
+            $node->dimensionSpacePoint,
             $node->nodeAggregateId,
         );
     }

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -47,7 +47,7 @@ class CacheTag
         return self::forNodeAggregate(
             $node->contentRepositoryId,
             $node->workspaceName,
-            $node->nodeAggregateId
+            $node->aggregateId
         );
     }
 

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -82,14 +82,14 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                             $dimensionSpacePoint,
                             $currentNode->visibilityConstraints,
                         )
-                        ->findNodeById($currentNode->nodeAggregateId);
+                        ->findNodeById($currentNode->aggregateId);
                 }
 
                 if (!$variant && $this->includeGeneralizations() && $contentDimensionIdentifierToLimitTo) {
                     $variant = $this->findClosestGeneralizationMatchingDimensionValue(
                         $dimensionSpacePoint,
                         $contentDimensionIdentifierToLimitTo,
-                        $currentNode->nodeAggregateId,
+                        $currentNode->aggregateId,
                         $dimensionMenuItemsImplementationInternals,
                         $contentGraph
                     );

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -51,7 +51,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         $menuItems = [];
         $currentNode = $this->getCurrentNode();
 
-        $contentRepositoryId = $currentNode->subgraphIdentity->contentRepositoryId;
+        $contentRepositoryId = $currentNode->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get(
             $contentRepositoryId,
         );
@@ -63,7 +63,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         assert($dimensionMenuItemsImplementationInternals instanceof DimensionsMenuItemsImplementationInternals);
 
         $interDimensionalVariationGraph = $dimensionMenuItemsImplementationInternals->interDimensionalVariationGraph;
-        $currentDimensionSpacePoint = $currentNode->subgraphIdentity->dimensionSpacePoint;
+        $currentDimensionSpacePoint = $currentNode->dimensionSpacePoint;
         $contentDimensionIdentifierToLimitTo = $this->getContentDimensionIdentifierToLimitTo();
         try {
             $contentGraph = $contentRepository->getContentGraph($currentNode->workspaceName);
@@ -80,7 +80,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                     $variant = $contentGraph
                         ->getSubgraph(
                             $dimensionSpacePoint,
-                            $currentNode->subgraphIdentity->visibilityConstraints,
+                            $currentNode->visibilityConstraints,
                         )
                         ->findNodeById($currentNode->nodeAggregateId);
                 }
@@ -119,9 +119,9 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                 $order,
                 $contentDimensionIdentifierToLimitTo
             ) {
-                return (int)$order[$menuItemA->node?->subgraphIdentity->dimensionSpacePoint->getCoordinate(
+                return (int)$order[$menuItemA->node?->dimensionSpacePoint->getCoordinate(
                     $contentDimensionIdentifierToLimitTo
-                )] <=> (int)$order[$menuItemB->node?->subgraphIdentity->dimensionSpacePoint->getCoordinate(
+                )] <=> (int)$order[$menuItemB->node?->dimensionSpacePoint->getCoordinate(
                     $contentDimensionIdentifierToLimitTo
                 )];
             });
@@ -138,11 +138,11 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
     {
         return !$this->getContentDimensionIdentifierToLimitTo() // no limit to one dimension, so all DSPs are relevant
             // always include the current variant
-            || $dimensionSpacePoint->equals($this->currentNode->subgraphIdentity->dimensionSpacePoint)
+            || $dimensionSpacePoint->equals($this->currentNode->dimensionSpacePoint)
             // include all direct variants in the dimension we're limited to unless their values
             // in that dimension are missing in the specified list
             || $dimensionSpacePoint->isDirectVariantInDimension(
-                $this->currentNode->subgraphIdentity->dimensionSpacePoint,
+                $this->currentNode->dimensionSpacePoint,
                 $this->getContentDimensionIdentifierToLimitTo()
             )
             && (
@@ -172,7 +172,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                 $variant = $contentGraph
                     ->getSubgraph(
                         $generalization,
-                        $this->getCurrentNode()->subgraphIdentity->visibilityConstraints,
+                        $this->getCurrentNode()->visibilityConstraints,
                     )
                     ->findNodeById($nodeAggregateId);
                 if ($variant) {

--- a/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/DimensionHelper.php
@@ -52,7 +52,7 @@ final class DimensionHelper implements ProtectedContextAwareInterface
     public function currentValue(Node $node, ContentDimensionId|string $dimensionName): ?ContentDimensionValue
     {
         $contentDimensionId = is_string($dimensionName) ? new ContentDimensionId($dimensionName) : $dimensionName;
-        $currentDimensionValueAsString = $node->subgraphIdentity->dimensionSpacePoint->getCoordinate($contentDimensionId);
+        $currentDimensionValueAsString = $node->dimensionSpacePoint->getCoordinate($contentDimensionId);
 
         if (is_string($currentDimensionValueAsString)) {
             return $this->allDimensionValues($node, $contentDimensionId)?->getValue($currentDimensionValueAsString);
@@ -97,7 +97,7 @@ final class DimensionHelper implements ProtectedContextAwareInterface
      */
     public function all(ContentRepositoryId|Node $subject): array
     {
-        $contentRepositoryId = $subject instanceof Node ? $subject->subgraphIdentity->contentRepositoryId : $subject;
+        $contentRepositoryId = $subject instanceof Node ? $subject->contentRepositoryId : $subject;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         return $contentRepository->getContentDimensionSource()->getContentDimensionsOrderedByPriority();
@@ -118,7 +118,7 @@ final class DimensionHelper implements ProtectedContextAwareInterface
      */
     public function allDimensionValues(ContentRepositoryId|Node $subject, ContentDimensionId|string $dimensionName): ?ContentDimensionValues
     {
-        $contentRepositoryId = $subject instanceof Node ? $subject->subgraphIdentity->contentRepositoryId : $subject;
+        $contentRepositoryId = $subject instanceof Node ? $subject->contentRepositoryId : $subject;
         $contentDimensionId = is_string($dimensionName) ? new ContentDimensionId($dimensionName) : $dimensionName;
 
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);

--- a/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
@@ -106,7 +106,7 @@ class LinkHelper implements ProtectedContextAwareInterface
             return null;
         }
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $targetNode->subgraphIdentity->contentRepositoryId
+            $targetNode->contentRepositoryId
         );
         $targetNodeAddress = NodeAddressFactory::create($contentRepository)->createFromNode($targetNode);
         try {

--- a/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
@@ -119,7 +119,7 @@ class LinkHelper implements ProtectedContextAwareInterface
         ) {
             $this->systemLogger->info(sprintf(
                 'Failed to build URI for node "%s": %e',
-                $targetNode->nodeAggregateId->value,
+                $targetNode->aggregateId->value,
                 $e->getMessage()
             ), LogEnvironment::fromMethodName(__METHOD__));
             return null;

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -149,14 +149,14 @@ class NodeHelper implements ProtectedContextAwareInterface
 
     public function isNodeTypeExistent(Node $node): bool
     {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
         return $contentRepository->getNodeTypeManager()->hasNodeType($node->nodeTypeName);
     }
 
     public function serializedNodeAddress(Node $node): string
     {
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
+            $node->contentRepositoryId
         );
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
         return $nodeAddressFactory->createFromNode($node)->serializeForUri();

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -70,7 +70,7 @@ class NodeHelper implements ProtectedContextAwareInterface
 
             $subNode = $nodePath instanceof AbsoluteNodePath
                 ? $subgraph->findNodeByAbsolutePath($nodePath)
-                : $subgraph->findNodeByPath($nodePath, $node->nodeAggregateId);
+                : $subgraph->findNodeByPath($nodePath, $node->aggregateId);
 
             if ($subNode !== null && $this->isOfType($subNode, $contentCollectionType)) {
                 return $subNode;
@@ -79,7 +79,7 @@ class NodeHelper implements ProtectedContextAwareInterface
                     $node,
                     $this->contentRepositoryRegistry->subgraphForNode($node)
                         ->findAncestorNodes(
-                            $node->nodeAggregateId,
+                            $node->aggregateId,
                             FindAncestorNodesFilter::create()
                         )
                 );
@@ -116,7 +116,7 @@ class NodeHelper implements ProtectedContextAwareInterface
     public function depth(Node $node): int
     {
         return $this->contentRepositoryRegistry->subgraphForNode($node)
-            ->countAncestorNodes($node->nodeAggregateId, CountAncestorNodesFilter::create());
+            ->countAncestorNodes($node->aggregateId, CountAncestorNodesFilter::create());
     }
 
     /**
@@ -126,7 +126,7 @@ class NodeHelper implements ProtectedContextAwareInterface
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         $ancestors = $subgraph->findAncestorNodes(
-            $node->nodeAggregateId,
+            $node->aggregateId,
             FindAncestorNodesFilter::create()
         )->reverse();
 

--- a/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
@@ -152,8 +152,8 @@ class NodeLabelToken implements ProtectedContextAwareInterface
             $this->label = $this->node->nodeTypeName->value;
         }
 
-        if (empty($this->postfix) && $this->node->nodeName !== null && $this->node->classification->isTethered()) {
-            $this->postfix =  ' (' . $this->node->nodeName->value . ')';
+        if (empty($this->postfix) && $this->node->name !== null && $this->node->classification->isTethered()) {
+            $this->postfix =  ' (' . $this->node->name->value . ')';
         }
     }
 

--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -158,7 +158,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
             foreach ($this->getItemCollection() as $node) {
                 if ($this->getMaximumLevels() > 0) {
                     $childSubtree = $subgraph->findSubtree(
-                        $node->nodeAggregateId,
+                        $node->aggregateId,
                         FindSubtreeFilter::create(nodeTypes: $this->getNodeTypeCriteria(), maximumLevels: $this->getMaximumLevels() - 1)
                     );
                     if ($childSubtree === null) {
@@ -273,7 +273,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
         }
 
         if ($this->getEntryLevel() === 0) {
-            return $traversalStartingPoint->nodeAggregateId;
+            return $traversalStartingPoint->aggregateId;
         } elseif ($this->getEntryLevel() < 0) {
             $ancestorNodeAggregateIds = $this->getCurrentNodeRootlineAggregateIds();
             $ancestorNodeAggregateIdArray = array_values(iterator_to_array($ancestorNodeAggregateIds));
@@ -300,7 +300,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
         }
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($this->getCurrentNode());
         $currentNodeAncestors = $subgraph->findAncestorNodes(
-            $this->currentNode->nodeAggregateId,
+            $this->currentNode->aggregateId,
             FindAncestorNodesFilter::create(
                 NodeTypeCriteria::createWithAllowedNodeTypeNames(
                     NodeTypeNames::with(
@@ -310,7 +310,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
             )
         );
 
-        $this->currentNodeRootlineAggregateIds = NodeAggregateIds::create($this->currentNode->nodeAggregateId)
+        $this->currentNodeRootlineAggregateIds = NodeAggregateIds::create($this->currentNode->aggregateId)
             ->merge(NodeAggregateIds::fromNodes($currentNodeAncestors));
 
         return $this->currentNodeRootlineAggregateIds;
@@ -318,10 +318,10 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
 
     protected function calculateItemState(Node $node): MenuItemState
     {
-        if ($node->nodeAggregateId->equals($this->getCurrentNode()->nodeAggregateId)) {
+        if ($node->aggregateId->equals($this->getCurrentNode()->aggregateId)) {
             return MenuItemState::CURRENT;
         }
-        if ($this->getCurrentNodeRootlineAggregateIds()->contain($node->nodeAggregateId)) {
+        if ($this->getCurrentNodeRootlineAggregateIds()->contain($node->aggregateId)) {
             return MenuItemState::ACTIVE;
         }
         return MenuItemState::NORMAL;

--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -184,7 +184,7 @@ class NodeUriImplementation extends AbstractFusionObject
         try {
             return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);
         } catch (NoMatchingRouteException) {
-            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri. Arguments: %s', $node->nodeAggregateId->value, json_encode($uriBuilder->getLastArguments())), LogEnvironment::fromMethodName(__METHOD__));
+            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri. Arguments: %s', $node->aggregateId->value, json_encode($uriBuilder->getLastArguments())), LogEnvironment::fromMethodName(__METHOD__));
         }
         return '';
     }

--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -141,7 +141,7 @@ class NodeUriImplementation extends AbstractFusionObject
         $node = $this->getNode();
         if ($node instanceof Node) {
             $contentRepository = $this->contentRepositoryRegistry->get(
-                $node->subgraphIdentity->contentRepositoryId
+                $node->contentRepositoryId
             );
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($node);

--- a/Neos.Neos/Classes/Presentation/VisualNodePath.php
+++ b/Neos.Neos/Classes/Presentation/VisualNodePath.php
@@ -31,7 +31,7 @@ final readonly class VisualNodePath
     {
         $pathSegments = [];
         foreach ($ancestors->reverse() as $ancestor) {
-            $pathSegments[] = $ancestor->nodeName?->value ?: '[' . $ancestor->aggregateId->value . ']';
+            $pathSegments[] = $ancestor->name?->value ?: '[' . $ancestor->aggregateId->value . ']';
         }
 
         return new self('/' . implode('/', $pathSegments));

--- a/Neos.Neos/Classes/Presentation/VisualNodePath.php
+++ b/Neos.Neos/Classes/Presentation/VisualNodePath.php
@@ -31,7 +31,7 @@ final readonly class VisualNodePath
     {
         $pathSegments = [];
         foreach ($ancestors->reverse() as $ancestor) {
-            $pathSegments[] = $ancestor->nodeName?->value ?: '[' . $ancestor->nodeAggregateId->value . ']';
+            $pathSegments[] = $ancestor->nodeName?->value ?: '[' . $ancestor->aggregateId->value . ']';
         }
 
         return new self('/' . implode('/', $pathSegments));

--- a/Neos.Neos/Classes/Routing/Cache/RouteCacheFlusher.php
+++ b/Neos.Neos/Classes/Routing/Cache/RouteCacheFlusher.php
@@ -54,7 +54,7 @@ class RouteCacheFlusher
      */
     public function registerNodeChange(Node $node)
     {
-        $identifier = $node->nodeAggregateId->value;
+        $identifier = $node->aggregateId->value;
         if (in_array($identifier, $this->tagsToFlush)) {
             return;
         }

--- a/Neos.Neos/Classes/Routing/NodeIdentityConverterAspect.php
+++ b/Neos.Neos/Classes/Routing/NodeIdentityConverterAspect.php
@@ -48,7 +48,7 @@ class NodeIdentityConverterAspect
         $objectArgument = $joinPoint->getMethodArgument('object');
         if ($objectArgument instanceof Node) {
             $contentRepository = $this->contentRepositoryRegistry->get(
-                $objectArgument->subgraphIdentity->contentRepositoryId
+                $objectArgument->contentRepositoryId
             );
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($objectArgument);

--- a/Neos.Neos/Classes/Service/ContentElementEditableService.php
+++ b/Neos.Neos/Classes/Service/ContentElementEditableService.php
@@ -51,7 +51,7 @@ class ContentElementEditableService
     public function wrapContentProperty(Node $node, string $property, string $content): string
     {
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
+            $node->contentRepositoryId
         );
 
         // TODO: permissions

--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -81,7 +81,7 @@ class ContentElementWrappingService
         array $additionalAttributes = []
     ): ?string {
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->subgraphIdentity->contentRepositoryId
+            $node->contentRepositoryId
         );
 
         // TODO: reenable permissions
@@ -121,7 +121,7 @@ class ContentElementWrappingService
     protected function addCssClasses(array $attributes, Node $node, array $initialClasses = []): array
     {
         $classNames = $initialClasses;
-        if (!$node->subgraphIdentity->dimensionSpacePoint->equals($node->originDimensionSpacePoint)) {
+        if (!$node->dimensionSpacePoint->equals($node->originDimensionSpacePoint)) {
             $classNames[] = 'neos-contentelement-shine-through';
         }
 

--- a/Neos.Neos/Classes/Service/ImageVariantGarbageCollector.php
+++ b/Neos.Neos/Classes/Service/ImageVariantGarbageCollector.php
@@ -79,7 +79,7 @@ class ImageVariantGarbageCollector
                     $usageItem instanceof AssetUsageReference
                     && $usageItem->getContentStreamId()->equals($node->subgraphIdentity->contentStreamId)
                     && $usageItem->getOriginDimensionSpacePoint()->equals($node->originDimensionSpacePoint)
-                    && $usageItem->getNodeAggregateId()->equals($node->nodeAggregateId)
+                    && $usageItem->getNodeAggregateId()->equals($node->aggregateId)
                 ) {
                     $this->assetRepository->remove($oldValue);
                 }

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -329,7 +329,7 @@ class LinkingService
                     );
                 }
                 $node = $this->contentRepositoryRegistry->subgraphForNode($baseNode)
-                    ->findNodeByPath(NodePath::fromString($nodeString), $baseNode->nodeAggregateId);
+                    ->findNodeByPath(NodePath::fromString($nodeString), $baseNode->aggregateId);
             }
             if (!$node instanceof Node) {
                 throw new NeosException(sprintf(

--- a/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
@@ -65,7 +65,7 @@ class NodeToNodeAddressStringConverter extends AbstractTypeConverter
         PropertyMappingConfigurationInterface $configuration = null
     ) {
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $source->subgraphIdentity->contentRepositoryId
+            $source->contentRepositoryId
         );
         return NodeAddressFactory::create($contentRepository)->createFromNode($source)->serializeForUri();
     }

--- a/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
+++ b/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
@@ -19,7 +19,7 @@ trait NodeTypeWithFallbackProvider
 {
     protected function getNodeType(Node $node): NodeType
     {
-        $nodeTypeManager = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId)->getNodeTypeManager();
+        $nodeTypeManager = $this->contentRepositoryRegistry->get($node->contentRepositoryId)->getNodeTypeManager();
 
         return $nodeTypeManager->getNodeType($node->nodeTypeName)
             ?? $nodeTypeManager->getNodeType(NodeTypeNameFactory::forFallback())

--- a/Neos.Neos/Classes/Utility/NodeUriPathSegmentGenerator.php
+++ b/Neos.Neos/Classes/Utility/NodeUriPathSegmentGenerator.php
@@ -44,7 +44,7 @@ class NodeUriPathSegmentGenerator
     {
         $language = null;
         if ($node) {
-            $text = $text ?: $this->nodeLabelGenerator->getLabel($node) ?: ($node->nodeName?->value ?? '');
+            $text = $text ?: $this->nodeLabelGenerator->getLabel($node) ?: ($node->name?->value ?? '');
             $languageDimensionValue = $node->originDimensionSpacePoint->coordinates['language'] ?? null;
             if (!is_null($languageDimensionValue)) {
                 $locale = new Locale($languageDimensionValue);

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -81,7 +81,7 @@ class FusionView extends AbstractView
 
         $fusionRuntime = $this->getFusionRuntime($currentSiteNode);
 
-        $this->setFallbackRuleFromDimension($currentNode->subgraphIdentity->dimensionSpacePoint);
+        $this->setFallbackRuleFromDimension($currentNode->dimensionSpacePoint);
 
         return $fusionRuntime->renderEntryPathWithContext($this->fusionPath, [
             'node' => $currentNode,

--- a/Neos.Neos/Classes/View/FusionView.php
+++ b/Neos.Neos/Classes/View/FusionView.php
@@ -73,7 +73,7 @@ class FusionView extends AbstractView
         $currentNode = $this->getCurrentNode();
 
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($currentNode);
-        $currentSiteNode = $subgraph->findClosestNode($currentNode->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
+        $currentSiteNode = $subgraph->findClosestNode($currentNode->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
 
         if (!$currentSiteNode) {
             throw new \RuntimeException('No site node found!', 1697053346);
@@ -166,7 +166,7 @@ class FusionView extends AbstractView
     protected function getClosestDocumentNode(Node $node): ?Node
     {
         return $this->contentRepositoryRegistry->subgraphForNode($node)
-            ->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
+            ->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
     }
 
     /**

--- a/Neos.Neos/Classes/ViewHelpers/Backend/DocumentBreadcrumbPathViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Backend/DocumentBreadcrumbPathViewHelper.php
@@ -54,7 +54,7 @@ class DocumentBreadcrumbPathViewHelper extends AbstractViewHelper
             if ($this->getNodeType($currentNode)->isOfType(NodeTypeNameFactory::NAME_DOCUMENT)) {
                 $documentNodes[] = $currentNode;
             }
-            $currentNode = $subgraph->findParentNode($currentNode->nodeAggregateId);
+            $currentNode = $subgraph->findParentNode($currentNode->aggregateId);
         }
         $documentNodes = array_reverse($documentNodes);
         $this->templateVariableContainer->add('documentNodes', $documentNodes);

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -263,7 +263,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
 
         if ($node instanceof Node) {
             $contentRepository = $this->contentRepositoryRegistry->get(
-                $node->subgraphIdentity->contentRepositoryId
+                $node->contentRepositoryId
             );
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($node);
@@ -271,7 +271,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             $documentNode = $this->getContextVariable('documentNode');
             assert($documentNode instanceof Node);
             $contentRepository = $this->contentRepositoryRegistry->get(
-                $documentNode->subgraphIdentity->contentRepositoryId
+                $documentNode->contentRepositoryId
             );
             $nodeAddress = $this->resolveNodeAddressFromString($node, $documentNode, $contentRepository);
             $node = $documentNode;
@@ -287,7 +287,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
         $subgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)
             ->getSubgraph(
                 $nodeAddress->dimensionSpacePoint,
-                $node->subgraphIdentity->visibilityConstraints
+                $node->visibilityConstraints
             );
 
         $resolvedNode = $subgraph->findNodeById($nodeAddress->nodeAggregateId);

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -311,7 +311,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             } catch (NodeNotFoundException | InvalidShortcutException $e) {
                 $this->throwableStorage->logThrowable(new ViewHelperException(sprintf(
                     'Failed to resolve shortcut node "%s" on subgraph "%s"',
-                    $resolvedNode->nodeAggregateId->value,
+                    $resolvedNode->aggregateId->value,
                     json_encode($subgraph, JSON_PARTIAL_OUTPUT_ON_ERROR)
                 ), 1601370239, $e));
             }
@@ -394,13 +394,13 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             } else {
                 $targetNode = $subgraph->findNodeByPath(
                     NodePath::fromString(substr($path, 1)),
-                    $siteNode->nodeAggregateId
+                    $siteNode->aggregateId
                 );
             }
         } else {
             $targetNode = $subgraph->findNodeByPath(
                 NodePath::fromString($path),
-                $documentNode->nodeAggregateId
+                $documentNode->aggregateId
             );
         }
         if ($targetNode === null) {
@@ -411,6 +411,6 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
                 json_encode($subgraph, JSON_PARTIAL_OUTPUT_ON_ERROR)
             ), 1601311789);
         }
-        return $documentNodeAddress->withNodeAggregateId($targetNode->nodeAggregateId);
+        return $documentNodeAddress->withNodeAggregateId($targetNode->aggregateId);
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Node/ClosestDocumentViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Node/ClosestDocumentViewHelper.php
@@ -41,6 +41,6 @@ class ClosestDocumentViewHelper extends AbstractViewHelper
         $node = $this->arguments['node'];
 
         return $this->contentRepositoryRegistry->subgraphForNode($node)
-            ->findClosestNode($node->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
+            ->findClosestNode($node->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_DOCUMENT));
     }
 }

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -208,7 +208,7 @@ class NodeViewHelper extends AbstractViewHelper
 
         if ($node instanceof Node) {
             $contentRepository = $this->contentRepositoryRegistry->get(
-                $node->subgraphIdentity->contentRepositoryId
+                $node->contentRepositoryId
             );
             $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
             $nodeAddress = $nodeAddressFactory->createFromNode($node);
@@ -264,7 +264,7 @@ class NodeViewHelper extends AbstractViewHelper
         /* @var Node $documentNode */
         $documentNode = $this->getContextVariable('documentNode');
         $contentRepository = $this->contentRepositoryRegistry->get(
-            $documentNode->subgraphIdentity->contentRepositoryId
+            $documentNode->contentRepositoryId
         );
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
         $documentNodeAddress = $nodeAddressFactory->createFromNode($documentNode);

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -291,13 +291,13 @@ class NodeViewHelper extends AbstractViewHelper
             } else {
                 $targetNode = $subgraph->findNodeByPath(
                     NodePath::fromString(substr($path, 1)),
-                    $siteNode->nodeAggregateId
+                    $siteNode->aggregateId
                 );
             }
         } else {
             $targetNode = $subgraph->findNodeByPath(
                 NodePath::fromString($path),
-                $documentNode->nodeAggregateId
+                $documentNode->aggregateId
             );
         }
         if ($targetNode === null) {
@@ -309,6 +309,6 @@ class NodeViewHelper extends AbstractViewHelper
             ), 1601311789));
             return null;
         }
-        return $documentNodeAddress->withNodeAggregateId($targetNode->nodeAggregateId);
+        return $documentNodeAddress->withNodeAggregateId($targetNode->aggregateId);
     }
 }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
@@ -144,7 +144,7 @@ trait BrowserTrait
         $this->currentNodeAddresses[$alias] = new NodeAddress(
             $this->currentContentStreamId,
             $this->currentDimensionSpacePoint,
-            $node->nodeAggregateId,
+            $node->aggregateId,
             $this->currentWorkspaceName,
         );
     }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -93,7 +93,7 @@ trait FusionTrait
         if ($this->fusionContext['documentNode'] === null) {
             throw new \RuntimeException(sprintf('Failed to find closest document node for node with aggregate id "%s"', $nodeAggregateId), 1697790940);
         }
-        $this->fusionContext['site'] = $subgraph->findClosestNode($this->fusionContext['documentNode']->nodeAggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
+        $this->fusionContext['site'] = $subgraph->findClosestNode($this->fusionContext['documentNode']->aggregateId, FindClosestNodeFilter::create(nodeTypes: NodeTypeNameFactory::NAME_SITE));
         if ($this->fusionContext['site'] === null) {
             throw new \RuntimeException(sprintf('Failed to resolve site node for node with aggregate id "%s"', $nodeAggregateId), 1697790963);
         }

--- a/Neos.TimeableNodeVisibility/Classes/Command/TimeableNodeVisibilityCommandController.php
+++ b/Neos.TimeableNodeVisibility/Classes/Command/TimeableNodeVisibilityCommandController.php
@@ -29,7 +29,7 @@ class TimeableNodeVisibilityCommandController extends CommandController
             foreach ($handlingResult->getByType(ChangedVisibilityType::NODE_WAS_ENABLED) as $result) {
                 $this->output->outputLine(sprintf(
                         '- NodeAggregateId: %s, DimensionSpacePoint: %s',
-                        $result->node->nodeAggregateId->value,
+                        $result->node->aggregateId->value,
                         join(',', $result->node->originDimensionSpacePoint->coordinates)
                     )
                 );
@@ -39,7 +39,7 @@ class TimeableNodeVisibilityCommandController extends CommandController
             foreach ($handlingResult->getByType(ChangedVisibilityType::NODE_WAS_DISABLED) as $result) {
                 $this->output->outputLine(sprintf(
                         '- NodeAggregateId: %s, DimensionSpacePoint: %s',
-                        $result->node->nodeAggregateId->value,
+                        $result->node->aggregateId->value,
                         join(',', $result->node->originDimensionSpacePoint->coordinates)
                     )
                 );

--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -55,7 +55,7 @@ class TimeableNodeVisibilityService
                     EnableNodeAggregate::create(
                         $workspaceName,
                         $node->nodeAggregateId,
-                        $node->subgraphIdentity->dimensionSpacePoint,
+                        $node->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                     )
                 );
@@ -69,7 +69,7 @@ class TimeableNodeVisibilityService
                     DisableNodeAggregate::create(
                         $workspaceName,
                         $node->nodeAggregateId,
-                        $node->subgraphIdentity->dimensionSpacePoint,
+                        $node->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                     )
                 );

--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -54,7 +54,7 @@ class TimeableNodeVisibilityService
                 $contentRepository->handle(
                     EnableNodeAggregate::create(
                         $workspaceName,
-                        $node->nodeAggregateId,
+                        $node->aggregateId,
                         $node->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                     )
@@ -68,7 +68,7 @@ class TimeableNodeVisibilityService
                 $contentRepository->handle(
                     DisableNodeAggregate::create(
                         $workspaceName,
-                        $node->nodeAggregateId,
+                        $node->aggregateId,
                         $node->dimensionSpacePoint,
                         NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
                     )
@@ -105,7 +105,7 @@ class TimeableNodeVisibilityService
             }
 
             $nodes = $subgraph->findDescendantNodes(
-                $rootNode->nodeAggregateId,
+                $rootNode->aggregateId,
                 FindDescendantNodesFilter::create(
                     nodeTypes: NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::fromStringArray(['Neos.TimeableNodeVisibility:Timeable'])),
                     propertyValue: OrCriteria::create(
@@ -159,7 +159,7 @@ class TimeableNodeVisibilityService
         $this->logger->info(
             sprintf('Timed node visibility: %s node [NodeAggregateId: %s, DimensionSpacePoints: %s]',
                 $result->type->value,
-                $result->node->nodeAggregateId->value,
+                $result->node->aggregateId->value,
                 implode(',', $result->node->originDimensionSpacePoint->coordinates)
             )
         );

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -62,9 +62,9 @@ class FeatureContext implements Context
             $this->currentDimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions(),
         );
-        $currentNode = $subgraph->findNodeById($this->currentNode->nodeAggregateId);
-        Assert::assertNotNull($currentNode, sprintf('Failed to find node with id "%s" in subgraph %s', $this->currentNode->nodeAggregateId->value, json_encode($subgraph)));
-        Assert::assertFalse($currentNode->tags->contain(SubtreeTag::disabled()), sprintf('Node "%s" was expected to be enabled, but it is not', $this->currentNode->nodeAggregateId->value));
+        $currentNode = $subgraph->findNodeById($this->currentNode->aggregateId);
+        Assert::assertNotNull($currentNode, sprintf('Failed to find node with id "%s" in subgraph %s', $this->currentNode->aggregateId->value, json_encode($subgraph)));
+        Assert::assertFalse($currentNode->tags->contain(SubtreeTag::disabled()), sprintf('Node "%s" was expected to be enabled, but it is not', $this->currentNode->aggregateId->value));
     }
 
     /**
@@ -77,9 +77,9 @@ class FeatureContext implements Context
             $this->currentDimensionSpacePoint,
             VisibilityConstraints::withoutRestrictions(),
         );
-        $currentNode = $subgraph->findNodeById($this->currentNode->nodeAggregateId);
-        Assert::assertNotNull($currentNode, sprintf('Failed to find node with id "%s" in subgraph %s', $this->currentNode->nodeAggregateId->value, json_encode($subgraph)));
-        Assert::assertTrue($currentNode->tags->contain(SubtreeTag::disabled()), sprintf('Node "%s" was expected to be disabled, but it is not', $this->currentNode->nodeAggregateId->value));
+        $currentNode = $subgraph->findNodeById($this->currentNode->aggregateId);
+        Assert::assertNotNull($currentNode, sprintf('Failed to find node with id "%s" in subgraph %s', $this->currentNode->aggregateId->value, json_encode($subgraph)));
+        Assert::assertTrue($currentNode->tags->contain(SubtreeTag::disabled()), sprintf('Node "%s" was expected to be disabled, but it is not', $this->currentNode->aggregateId->value));
     }
 
     protected function getContentRepositoryService(


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

See https://discuss.neos.io/t/neos-9-beta-10-release/6578

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

I did a phpstorm rename of the properties aggregate id and name. For the subgraph identity i replaced them via an explict search:

```
->subgraphIdentity->visibilityConstraints
to:
->visibilityConstraints
```

this works perfect and phpstan doesnt complain.

No other changes have been made. All usages of `->subgraphIdentity->contentStreamId` will be removed separately or even need other things to happen first. See https://github.com/neos/neos-development-collection/issues/5043

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
