### PR TITLE
WIP: TAKS: Improve node address serialisation

### DIFF
--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
@@ -93,6 +93,11 @@ final class DimensionSpacePoint extends AbstractDimensionSpacePoint
         return self::instance(json_decode(base64_decode($encoded), true));
     }
 
+    final public function toUriRepresentation(): string
+    {
+        return base64_encode(json_encode($this->coordinates, JSON_THROW_ON_ERROR));
+    }
+
     /**
      * Varies a dimension space point in a single coordinate
      */

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
@@ -90,13 +90,13 @@ final class DimensionSpacePoint extends AbstractDimensionSpacePoint
 
     final public static function fromUriRepresentation(string $encoded): self
     {
-        parse_str(base64_decode($encoded), $parsed);
+        parse_str(base64_decode(str_replace( '~', '=', $encoded)), $parsed);
         return self::instance($parsed);
     }
 
     final public function toUriRepresentation(): string
     {
-        return base64_encode(http_build_query($this->coordinates));
+        return str_replace('=', '~', base64_encode(http_build_query($this->coordinates)));
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePoint.php
@@ -90,12 +90,13 @@ final class DimensionSpacePoint extends AbstractDimensionSpacePoint
 
     final public static function fromUriRepresentation(string $encoded): self
     {
-        return self::instance(json_decode(base64_decode($encoded), true));
+        parse_str(base64_decode($encoded), $parsed);
+        return self::instance($parsed);
     }
 
     final public function toUriRepresentation(): string
     {
-        return base64_encode(json_encode($this->coordinates, JSON_THROW_ON_ERROR));
+        return base64_encode(http_build_query($this->coordinates));
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -99,6 +99,31 @@ final readonly class NodeAddress implements \JsonSerializable
         }
     }
 
+    public static function fromUriString(string $encoded): self
+    {
+        $parts = explode('__', $encoded);
+        if (count($parts) !== 4) {
+            throw new \RuntimeException(sprintf('Failed to decode NodeAddress from uri string: %s', $encoded), 1716051847);
+        }
+        return new self(
+            ContentRepositoryId::fromString($parts[0]),
+            WorkspaceName::fromString($parts[1]),
+            DimensionSpacePoint::fromUriRepresentation($parts[2]),
+            NodeAggregateId::fromString($parts[3])
+        );
+    }
+
+    public function toUriString(): string
+    {
+        return sprintf(
+            '%s__%s__%s__%s',
+            $this->contentRepositoryId->value,
+            $this->workspaceName->value,
+            $this->dimensionSpacePoint->toUriRepresentation(),
+            $this->aggregateId->value
+        );
+    }
+
     public function jsonSerialize(): mixed
     {
         return get_object_vars($this);

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAddress.php
@@ -101,7 +101,7 @@ final readonly class NodeAddress implements \JsonSerializable
 
     public static function fromUriString(string $encoded): self
     {
-        $parts = explode('__', $encoded);
+        $parts = explode('/', $encoded);
         if (count($parts) !== 4) {
             throw new \RuntimeException(sprintf('Failed to decode NodeAddress from uri string: %s', $encoded), 1716051847);
         }
@@ -116,7 +116,7 @@ final readonly class NodeAddress implements \JsonSerializable
     public function toUriString(): string
     {
         return sprintf(
-            '%s__%s__%s__%s',
+            '%s/%s/%s/%s',
             $this->contentRepositoryId->value,
             $this->workspaceName->value,
             $this->dimensionSpacePoint->toUriRepresentation(),

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\Node;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use PHPUnit\Framework\TestCase;
+
+class NodeAddressTest extends TestCase
+{
+    public static function urlCompatibleSerialization(): iterable
+    {
+        yield 'no dimensions' => [
+            'nodeAddress' => NodeAddress::create(
+                ContentRepositoryId::fromString('default'),
+                WorkspaceName::forLive(),
+                DimensionSpacePoint::createWithoutDimensions(),
+                NodeAggregateId::fromString('marcus-heinrichus')
+            ),
+            'serialized' => 'default__live__W10=__marcus-heinrichus'
+        ];
+
+        yield 'one dimension' => [
+            'nodeAddress' => NodeAddress::create(
+                ContentRepositoryId::fromString('default'),
+                WorkspaceName::fromString('user-mh'),
+                DimensionSpacePoint::fromArray(['language' => 'de']),
+                NodeAggregateId::fromString('79e69d1c-b079-4535-8c8a-37e76736c445')
+            ),
+            'serialized' => 'default__user-mh__eyJsYW5ndWFnZSI6ImRlIn0=__79e69d1c-b079-4535-8c8a-37e76736c445'
+        ];
+
+        yield 'two dimensions' => [
+            'nodeAddress' => NodeAddress::create(
+                ContentRepositoryId::fromString('second'),
+                WorkspaceName::fromString('user-mh'),
+                DimensionSpacePoint::fromArray(['language' => 'en_US', 'audience' => 'nice people']),
+                NodeAggregateId::fromString('my-node-id')
+            ),
+            'serialized' => 'second__user-mh__eyJsYW5ndWFnZSI6ImVuX1VTIiwiYXVkaWVuY2UiOiJuaWNlIHBlb3BsZSJ9__my-node-id'
+        ];
+    }
+
+    /**
+     * @dataProvider urlCompatibleSerialization
+     */
+    public function testUrlCompatibleSerialization(NodeAddress $nodeAddress, string $expected): void
+    {
+        self::assertEquals($expected, $nodeAddress->toUriString());
+    }
+
+    /**
+     * @dataProvider urlCompatibleSerialization
+     */
+    public function testUrlCompatibleDeserialization(NodeAddress $expectedNodeAddress, string $encoded): void
+    {
+        $nodeAddress = NodeAddress::fromUriString($encoded);
+        self::assertInstanceOf(NodeAddress::class, $nodeAddress);
+        self::assertTrue($expectedNodeAddress->equals($nodeAddress));
+    }
+}

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
@@ -32,7 +32,7 @@ class NodeAddressTest extends TestCase
                 DimensionSpacePoint::createWithoutDimensions(),
                 NodeAggregateId::fromString('marcus-heinrichus')
             ),
-            'serialized' => 'default__live__W10=__marcus-heinrichus'
+            'serialized' => 'default/live//marcus-heinrichus'
         ];
 
         yield 'one dimension' => [
@@ -42,7 +42,7 @@ class NodeAddressTest extends TestCase
                 DimensionSpacePoint::fromArray(['language' => 'de']),
                 NodeAggregateId::fromString('79e69d1c-b079-4535-8c8a-37e76736c445')
             ),
-            'serialized' => 'default__user-mh__eyJsYW5ndWFnZSI6ImRlIn0=__79e69d1c-b079-4535-8c8a-37e76736c445'
+            'serialized' => 'default/user-mh/bGFuZ3VhZ2U9ZGU=/79e69d1c-b079-4535-8c8a-37e76736c445'
         ];
 
         yield 'two dimensions' => [
@@ -52,7 +52,7 @@ class NodeAddressTest extends TestCase
                 DimensionSpacePoint::fromArray(['language' => 'en_US', 'audience' => 'nice people']),
                 NodeAggregateId::fromString('my-node-id')
             ),
-            'serialized' => 'second__user-mh__eyJsYW5ndWFnZSI6ImVuX1VTIiwiYXVkaWVuY2UiOiJuaWNlIHBlb3BsZSJ9__my-node-id'
+            'serialized' => 'second/user-mh/bGFuZ3VhZ2U9ZW5fVVMmYXVkaWVuY2U9bmljZStwZW9wbGU=/my-node-id'
         ];
     }
 

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAddressTest.php
@@ -42,7 +42,7 @@ class NodeAddressTest extends TestCase
                 DimensionSpacePoint::fromArray(['language' => 'de']),
                 NodeAggregateId::fromString('79e69d1c-b079-4535-8c8a-37e76736c445')
             ),
-            'serialized' => 'default/user-mh/bGFuZ3VhZ2U9ZGU=/79e69d1c-b079-4535-8c8a-37e76736c445'
+            'serialized' => 'default/user-mh/bGFuZ3VhZ2U9ZGU~/79e69d1c-b079-4535-8c8a-37e76736c445'
         ];
 
         yield 'two dimensions' => [
@@ -52,7 +52,7 @@ class NodeAddressTest extends TestCase
                 DimensionSpacePoint::fromArray(['language' => 'en_US', 'audience' => 'nice people']),
                 NodeAggregateId::fromString('my-node-id')
             ),
-            'serialized' => 'second/user-mh/bGFuZ3VhZ2U9ZW5fVVMmYXVkaWVuY2U9bmljZStwZW9wbGU=/my-node-id'
+            'serialized' => 'second/user-mh/bGFuZ3VhZ2U9ZW5fVVMmYXVkaWVuY2U9bmljZStwZW9wbGU~/my-node-id'
         ];
     }
 

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddressFactory.php
@@ -76,7 +76,7 @@ class NodeAddressFactory
         list($workspaceNameSerialized, $dimensionSpacePointSerialized, $nodeAggregateIdSerialized)
             = explode('__', $serializedNodeAddress);
         $workspaceName = WorkspaceName::fromString($workspaceNameSerialized);
-        $dimensionSpacePoint = DimensionSpacePoint::fromUriRepresentation($dimensionSpacePointSerialized);
+        $dimensionSpacePoint = DimensionSpacePoint::fromArray(json_decode(base64_decode($dimensionSpacePointSerialized), true));
         $nodeAggregateId = NodeAggregateId::fromString($nodeAggregateIdSerialized);
 
         $contentStreamId = $this->contentRepository->getWorkspaceFinder()->findOneByName($workspaceName)


### PR DESCRIPTION
Followup to https://github.com/neos/neos-development-collection/pull/4892 with the intent to optimise the `NodeAddress` uri serialisation. 

Currently using base64 + json produces bigger output for dsps and also the default case (empty) is not particular pretty.
Additionally base64 as used currently is actually not safe due the `=` padding. Which could produce problems when used as query parameter.

See also https://github.com/neos/neos-development-collection/issues/4564#issuecomment-1999514362 for the discussion

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
