### PR TITLE
!!! TASK: Refactor `Node` property mapper to use new NodeAddress

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -150,14 +150,15 @@ class ContentController extends ActionController
         $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())
             ->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-        $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($nodeAddressString);
+        // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
+        $nodeAddress = NodeAddressFactory::create($contentRepository)->createCoreNodeAddressFromLegacyUriString($nodeAddressString);
 
         $node = $contentRepository->getContentGraph($nodeAddress->workspaceName)
             ->getSubgraph(
                 $nodeAddress->dimensionSpacePoint,
                 VisibilityConstraints::withoutRestrictions()
             )
-            ->findNodeById($nodeAddress->nodeAggregateId);
+            ->findNodeById($nodeAddress->aggregateId);
 
 
         $this->response->setContentType('application/json');

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -121,8 +121,9 @@ class NodesController extends ActionController
             : null;
         $nodeAddress = null;
         if (!$nodePath) {
+            // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
             $nodeAddress = $contextNode
-                ? NodeAddressFactory::create($contentRepository)->createFromUriString($contextNode)
+                ? NodeAddressFactory::create($contentRepository)->createCoreNodeAddressFromLegacyUriString($contextNode)
                 : null;
         }
 
@@ -141,7 +142,7 @@ class NodesController extends ActionController
 
         if ($nodeIds === [] && (!is_null($nodeAddress) || !is_null($nodePath))) {
             if (!is_null($nodeAddress)) {
-                $entryNode = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
+                $entryNode = $subgraph->findNodeById($nodeAddress->aggregateId);
             } else {
                 /** @var AbsoluteNodePath $nodePath */
                 $entryNode = $subgraph->findNodeByAbsolutePath($nodePath);

--- a/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeAddress.php
@@ -22,16 +22,6 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * A persistent, external "address" of a node; used to link to it.
- *
- * Describes the intention of the user making the current request:
- * Show me
- *  node $nodeAggregateId
- *  in dimensions $dimensionSpacePoint
- *  in contentStreamId $contentStreamId
- *
- * It is used in Neos Routing to build a URI to a node.
- *
  * @deprecated will be removed before Final 9.0
  * The NodeAddress was added 6 years ago without the concept of multiple crs
  * Its usages will be replaced by the new node attached node address
@@ -42,8 +32,9 @@ final readonly class NodeAddress
     /**
      * @internal use NodeAddressFactory, if you want to create a NodeAddress
      */
+    /** @phpstan-ignore-next-line its all just temporary */
     public function __construct(
-        public ContentStreamId $contentStreamId,
+        ?ContentStreamId $_contentStreamId,
         public DimensionSpacePoint $dimensionSpacePoint,
         public NodeAggregateId $nodeAggregateId,
         public WorkspaceName $workspaceName
@@ -59,16 +50,10 @@ final readonly class NodeAddress
             . '__' . $this->nodeAggregateId->value;
     }
 
-    public function isInLiveWorkspace(): bool
-    {
-        return $this->workspaceName->isLive();
-    }
-
     public function __toString(): string
     {
         return sprintf(
-            'NodeAddress[contentStream=%s, dimensionSpacePoint=%s, nodeAggregateId=%s, workspaceName=%s]',
-            $this->contentStreamId->value,
+            'NodeAddress[dimensionSpacePoint=%s, nodeAggregateId=%s, workspaceName=%s]',
             $this->dimensionSpacePoint->toJson(),
             $this->nodeAggregateId->value,
             $this->workspaceName->value

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -21,13 +21,12 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNode
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
-use Neos\ContentRepository\Core\Projection\NodeHiddenState\NodeHiddenStateFinder;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Exception;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\Presentation\VisualNodePath;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 
@@ -155,11 +154,7 @@ class NodeHelper implements ProtectedContextAwareInterface
 
     public function serializedNodeAddress(Node $node): string
     {
-        $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->contentRepositoryId
-        );
-        $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        return $nodeAddressFactory->createFromNode($node)->serializeForUri();
+        return NodeAddress::fromNode($node)->toJson();
     }
 
     public function subgraphForNode(Node $node): ContentSubgraphInterface

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -36,7 +36,6 @@ use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Exception as NeosException;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Utility\Arrays;
 use Psr\Http\Message\UriInterface;
@@ -309,7 +308,7 @@ class LinkingService
                     $controllerContext->getRequest()->getHttpRequest()
                 )->contentRepositoryId;
                 $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-                $nodeAddress = NodeAddressFactory::create($contentRepository)->createFromUriString($node);
+                $nodeAddress = NodeAddress::fromJsonString($nodeString);
                 $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($nodeAddress->workspaceName);
                 $subgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)->getSubgraph(
                     $nodeAddress->dimensionSpacePoint,
@@ -317,7 +316,7 @@ class LinkingService
                         ? VisibilityConstraints::withoutRestrictions()
                         : VisibilityConstraints::frontend()
                 );
-                $node = $subgraph->findNodeById($nodeAddress->nodeAggregateId);
+                $node = $subgraph->findNodeById($nodeAddress->aggregateId);
             } catch (\Throwable $exception) {
                 if ($baseNode === null) {
                     throw new NeosException(

--- a/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
@@ -15,27 +15,19 @@ declare(strict_types=1);
 namespace Neos\Neos\TypeConverter;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
-use Neos\Neos\FrontendRouting\NodeAddressFactory;
 
 /**
- * To be removed legacy fragment for property mapping nodes in controllers.
- * MUST not be used and MUST be removed before Neos 9 release.
- * See issue: https://github.com/neos/neos-development-collection/issues/4873
- *
  * @Flow\Scope("singleton")
- * @deprecated must be removed before Neos 9 release!!!
  */
 class NodeToNodeAddressStringConverter extends AbstractTypeConverter
 {
-    /**
-     * @Flow\Inject
-     * @var ContentRepositoryRegistry
-     */
-    protected $contentRepositoryRegistry;
+    #[Flow\Inject]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
     /**
      * @var array<int,string>
@@ -64,9 +56,6 @@ class NodeToNodeAddressStringConverter extends AbstractTypeConverter
         array $subProperties = [],
         PropertyMappingConfigurationInterface $configuration = null
     ) {
-        $contentRepository = $this->contentRepositoryRegistry->get(
-            $source->contentRepositoryId
-        );
-        return NodeAddressFactory::create($contentRepository)->createFromNode($source)->serializeForUri();
+        return NodeAddress::fromNode($source)->toJson();
     }
 }

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -493,7 +493,7 @@ class WorkspaceController extends AbstractModuleController
         if ($this->packageManager->isPackageAvailable('Neos.Neos.Ui')) {
             // todo remove me legacy
             $legacyTargetNodeAddressInPersonalWorkspace = new LegacyNodeAddress(
-                $personalWorkspace->currentContentStreamId,
+                null,
                 $targetNodeAddressInPersonalWorkspace->dimensionSpacePoint,
                 $targetNodeAddressInPersonalWorkspace->aggregateId,
                 $targetNodeAddressInPersonalWorkspace->workspaceName
@@ -839,7 +839,7 @@ class WorkspaceController extends AbstractModuleController
                     // we can't create `serializedNodeAddress` from the node.
                     // Instead, we use the original stored values.
                     $nodeAddress = new LegacyNodeAddress(
-                        $change->contentStreamId,
+                        null,
                         $change->originDimensionSpacePoint->toDimensionSpacePoint(),
                         $change->nodeAggregateId,
                         $selectedWorkspace->workspaceName

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -447,11 +447,13 @@ class WorkspaceController extends AbstractModuleController
      * Rebase the current users personal workspace onto the given $targetWorkspace and then
      * redirects to the $targetNode in the content module.
      */
-    public function rebaseAndRedirectAction(Node $targetNode, Workspace $targetWorkspace): void
+    public function rebaseAndRedirectAction(string $targetNode, Workspace $targetWorkspace): void
     {
         $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())
             ->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
+        $targetNodeAddress = NodeAddressFactory::create($contentRepository)->createCoreNodeAddressFromLegacyUriString($targetNode);
 
         /** @var ?Account $currentAccount */
         $currentAccount = $this->securityContext->getAccount();
@@ -482,10 +484,10 @@ class WorkspaceController extends AbstractModuleController
          */
 
         $targetNodeAddressInPersonalWorkspace = NodeAddress::create(
-            $targetNode->contentRepositoryId,
+            $targetNodeAddress->contentRepositoryId,
             $personalWorkspace->workspaceName,
-            $targetNode->dimensionSpacePoint,
-            $targetNode->aggregateId
+            $targetNodeAddress->dimensionSpacePoint,
+            $targetNodeAddress->aggregateId
         );
 
         if ($this->packageManager->isPackageAvailable('Neos.Neos.Ui')) {
@@ -526,13 +528,14 @@ class WorkspaceController extends AbstractModuleController
             ->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        $nodeAddress = $nodeAddressFactory->createFromUriString($nodeAddress);
+        // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
+        $nodeAddress = $nodeAddressFactory->createCoreNodeAddressFromLegacyUriString($nodeAddress);
 
         $command = PublishIndividualNodesFromWorkspace::create(
             $selectedWorkspace,
             NodeIdsToPublishOrDiscard::create(
                 new NodeIdToPublishOrDiscard(
-                    $nodeAddress->nodeAggregateId,
+                    $nodeAddress->aggregateId,
                     $nodeAddress->dimensionSpacePoint
                 )
             ),
@@ -563,13 +566,14 @@ class WorkspaceController extends AbstractModuleController
             ->contentRepositoryId;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $nodeAddressFactory = NodeAddressFactory::create($contentRepository);
-        $nodeAddress = $nodeAddressFactory->createFromUriString($nodeAddress);
+        // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
+        $nodeAddress = $nodeAddressFactory->createCoreNodeAddressFromLegacyUriString($nodeAddress);
 
         $command = DiscardIndividualNodesFromWorkspace::create(
             $selectedWorkspace,
             NodeIdsToPublishOrDiscard::create(
                 new NodeIdToPublishOrDiscard(
-                    $nodeAddress->nodeAggregateId,
+                    $nodeAddress->aggregateId,
                     $nodeAddress->dimensionSpacePoint
                 )
             ),
@@ -604,9 +608,10 @@ class WorkspaceController extends AbstractModuleController
 
         $nodesToPublishOrDiscard = [];
         foreach ($nodes as $node) {
-            $nodeAddress = $nodeAddressFactory->createFromUriString($node);
+            // todo legacy uri node address notation used. Should be refactored to use json encoded NodeAddress
+            $nodeAddress = $nodeAddressFactory->createCoreNodeAddressFromLegacyUriString($node);
             $nodesToPublishOrDiscard[] = new NodeIdToPublishOrDiscard(
-                $nodeAddress->nodeAggregateId,
+                $nodeAddress->aggregateId,
                 $nodeAddress->dimensionSpacePoint
             );
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,7 @@ parameters:
         - Neos.ContentRepository.TestSuite/Classes
         - Neos.ContentRepositoryRegistry/Classes
         - Neos.Neos/Classes
+        - Neos.Workspace.Ui/Classes
         - Neos.TimeableNodeVisibility/Classes
         - Neos.NodeTypes.Form/Classes
         # todo lint whole fusion package


### PR DESCRIPTION
Solves: https://github.com/neos/neos-development-collection/issues/4873

This is an intermediate step after [!!! FEATURE: Overhaul node uri building](https://github.com/neos/neos-development-collection/pull/4892) before we fully move to the new node address serialisation in the Neos Ui.
Everything was refactored here that does not require adjustments in the Neos Ui (and the workspace module was also not really touched).

- avoid using the legacy node address instance in the code. The `NodeAddressFactory` is only used at the places where we still depend on the legacy format, but we create already new node address instances via `createCoreNodeAddressFromLegacyUriString`
- removed the $contentStreamId field from the legacy NodeAddress already (as we can otherwise not transform a new node address to this one). Also this prevents the $contentStreamId field from accidentally being used again in the migration time.
- removed the the unused legacy node address `isInLiveWorkspace` method.
- The currently unused method `Neos.Node.serializedNodeAddress(node)` will return the new node address format
- where previously `Node $node` was used to trigger property mapping (`DataSourceController` and `WorkspaceController`) we now pass the node as `string` and use the legacy node address factory to handle the legacy format manually. A followup will adjust everything to work with the new node address.
- the unused linkinservice will use the new node address string format if a string is passed as `$node`
- the Node property mappers were adjusted to use the new node address and not depend on the global active request handler
- lint `Neos.Workspace.Ui/Classes` with phpstan


**Upgrade instructions**

This change is breaking for existing Neos 9 users as the node being property mapped will require a new serialised input.

```php
public function someAction(Node $node): {}
```

In Neos 8.3 you could call this action with the node like

```
?node=/sites/neosdemo/features/multiple-columns@user-admin;language=en_US
```

in Neos9-dev it was

```
?node=user-admin__eyJsYW5ndWFnZSI6ImVuX1VTIn0%3D__995c9174-ddd6-4d5c-cfc0-1ffc82184677
```

and now it must be the node address in  json `NodeAddress::toJson()`

```
?node=%7B%22contentRepositoryId%22%3A%22default%22%2C%22workspaceName%22%3A%22live%22%2C%22dimensionSpacePoint%22%3A%7B%22language%22%3A%22es%22%2C%22country%22%3A%22ar%22%7D%2C%22aggregateId%22%3A%22node-1%22%7D
```

to build such a uri you can simply use:

```php
$myActionUri = new Uri($this->uriBuilder->uriFor(...));
$myActionUriWithNode = UriHelper::uriWithAdditionalQueryParameters(
    $myActionUri,
    ['node' => NodeAddress::fromNode($node)->toJson()]
);
```


<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
