### PR TITLE
BUGFIX: Properly convert legacy MoveNodeMappings

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Event/NodeAggregateWasMoved.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Event/NodeAggregateWasMoved.php
@@ -92,15 +92,22 @@ final readonly class NodeAggregateWasMoved implements
             foreach ($values['nodeMoveMappings'] as $nodeMoveMapping) {
                 // we don't care about origins anymore
                 foreach ($nodeMoveMapping['newLocations'] as $newLocation) {
-                    if (array_key_exists('newParent', $newLocation)) {
-                        $newParentNodeAggregateId = NodeAggregateId::fromString($newLocation['newParent']);
+                    $dimensionSpacePoint = DimensionSpacePoint::fromArray($newLocation['coveredDimensionSpacePoint']);
+                    if (array_key_exists('newSucceedingSibling', $newLocation)) {
+                        $succeedingSiblings[] = new InterdimensionalSibling(
+                            $dimensionSpacePoint,
+                            NodeAggregateId::fromString($newLocation['newSucceedingSibling']['nodeAggregateId'])
+                        );
+                        if (array_key_exists('parentNodeAggregateId', $newLocation['newSucceedingSibling'])) {
+                            $newParentNodeAggregateId = NodeAggregateId::fromString($newLocation['newSucceedingSibling']['parentNodeAggregateId']);
+                        }
+                    } elseif (array_key_exists('newParent', $newLocation)) {
+                        $newParentNodeAggregateId = NodeAggregateId::fromString($newLocation['newParent']['nodeAggregateId']);
+                        $succeedingSiblings[] = new InterdimensionalSibling(
+                            $dimensionSpacePoint,
+                            null
+                        );
                     }
-                    $succeedingSiblings[] = new InterdimensionalSibling(
-                        DimensionSpacePoint::fromArray($newLocation['coveredDimensionSpacePoint']),
-                        ($newLocation['newSucceedingSibling'] ?? null)
-                            ? NodeAggregateId::fromString($newLocation['newSucceedingSibling'])
-                            : null
-                    );
                 }
             }
             $succeedingSiblingsForCoverage = new InterdimensionalSiblings(...$succeedingSiblings);

--- a/Neos.ContentRepository.Core/Tests/Unit/Feature/NodeMove/Event/NodeAggregateWasMovedTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Feature/NodeMove/Event/NodeAggregateWasMovedTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.Core package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\Feature\NodeMove\Event;
+
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSibling;
+use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
+use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use PHPUnit\Framework\TestCase;
+
+
+class NodeAggregateWasMovedTest extends TestCase
+{
+    /**
+     * @param array<string,mixed> $payload
+     * @dataProvider eventPayloadProvider
+     */
+    public function testFromArray(array $payload, NodeAggregateWasMoved $expectedEvent): void
+    {
+        self::assertEquals($expectedEvent, NodeAggregateWasMoved::fromArray($payload));
+    }
+
+    /**
+     * @return \Traversable<string,array<string,mixed>>
+     */
+    public static function eventPayloadProvider(): \Traversable
+    {
+        yield 'singleNodeMoveMappingWithSibling' => [
+            'payload' => [
+                 'contentStreamId' => '90bcfbf8-c444-48f8-9911-ba0954ac795a',
+                 'nodeAggregateId' => '30ef3082-e37f-4346-83cf-45ed0249381f',
+                 'nodeMoveMappings' => [
+                     [
+                         'movedNodeOrigin' => [
+                             'language' => 'pl'
+                         ],
+                         'newLocations' => [
+                             [
+                                 'coveredDimensionSpacePoint' => [
+                                     'language' => 'pl'
+                                 ],
+                                 'newSucceedingSibling' => [
+                                     'nodeAggregateId' => '7db24575-1227-4c7c-87ff-7aaa98532a94',
+                                     'originDimensionSpacePoint' => [
+                                         'language' => 'pl'
+                                     ],
+                                     'parentNodeAggregateId' => '6b6e1251-4346-494f-ac56-526a30a5741d',
+                                     'parentOriginDimensionSpacePoint' => [
+                                         'language' => 'pl'
+                                     ]
+                                 ]
+                             ]
+                         ]
+                     ],
+                 ],
+                'workspaceName' => 'user-soee'
+            ],
+            'expectedEvent' => new NodeAggregateWasMoved(
+                WorkspaceName::fromString('user-soee'),
+                ContentStreamId::fromString('90bcfbf8-c444-48f8-9911-ba0954ac795a'),
+                NodeAggregateId::fromString('30ef3082-e37f-4346-83cf-45ed0249381f'),
+                NodeAggregateId::fromString('6b6e1251-4346-494f-ac56-526a30a5741d'),
+                new InterdimensionalSiblings(
+                    new InterdimensionalSibling(
+                        DimensionSpacePoint::fromArray([
+                            'language' => 'pl'
+                        ]),
+                        NodeAggregateId::fromString('7db24575-1227-4c7c-87ff-7aaa98532a94')
+                    )
+                )
+            )
+        ];
+
+        yield 'singleNodeMoveMappingWithParent' => [
+            'payload' => [
+                 'contentStreamId' => '516b9125-ccd4-4f73-ba49-05cb2c04d9f1',
+                 'nodeAggregateId' => 'b894d0d3-f941-415b-ad1e-33054582bf00',
+                 'nodeMoveMappings' => [
+                     [
+                         'movedNodeOrigin' => [
+                             'language' => 'pl'
+                         ],
+                         'newLocations' => [
+                             [
+                                 'coveredDimensionSpacePoint' => [
+                                     'language' => 'pl'
+                                 ],
+                                 'newParent' => [
+                                     'nodeAggregateId' => '46e2139a-32e3-457d-bc1e-4e583c5c5530',
+                                     'originDimensionSpacePoint' => [
+                                         'language' => 'pl'
+                                     ],
+                                 ]
+                             ]
+                         ]
+                     ],
+                 ],
+                'workspaceName' => 'user-soee'
+            ],
+            'expectedEvent' => new NodeAggregateWasMoved(
+                WorkspaceName::fromString('user-soee'),
+                ContentStreamId::fromString('516b9125-ccd4-4f73-ba49-05cb2c04d9f1'),
+                NodeAggregateId::fromString('b894d0d3-f941-415b-ad1e-33054582bf00'),
+                NodeAggregateId::fromString('46e2139a-32e3-457d-bc1e-4e583c5c5530'),
+                new InterdimensionalSiblings(
+                    new InterdimensionalSibling(
+                        DimensionSpacePoint::fromArray([
+                            'language' => 'pl'
+                        ]),
+                        null
+                    )
+                )
+            )
+        ];
+
+
+        yield 'mulitpleNodeMoveMappingWithSibling' => [
+            'payload' => [
+                'contentStreamId' => 'd742c335-b733-47d6-aebe-c809a3afc972',
+                'nodeAggregateId' => 'eebf6ea3-a69b-48c0-af16-d0e14c0bb646',
+                'nodeMoveMappings' => [
+                    [
+                        'movedNodeOrigin' => [
+                            'language' => 'en'
+                        ],
+                        'newLocations' => [
+                            [
+                                'coveredDimensionSpacePoint' => [
+                                    'language' => 'en'
+                                ],
+                                'newSucceedingSibling' => [
+                                    'nodeAggregateId' => 'eebf6ea3-a69b-48c0-af16-d0e14c0bb646',
+                                    'originDimensionSpacePoint' => [
+                                        'language' => 'en'
+                                    ],
+                                    'parentNodeAggregateId' => '6b6e1251-4346-494f-ac56-526a30a5741d',
+                                    'parentOriginDimensionSpacePoint' => [
+                                        'language' => 'en'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    [
+                        'movedNodeOrigin' => [
+                            'language' => 'pl'
+                        ],
+                        'newLocations' => [
+                            [
+                                'coveredDimensionSpacePoint' => [
+                                    'language' => 'pl'
+                                ],
+                                'newSucceedingSibling' => [
+                                    'nodeAggregateId' => '37342037-b69b-476b-bf7b-9383f33efa1b',
+                                    'originDimensionSpacePoint' => [
+                                        'language' => 'pl'
+                                    ],
+                                    'parentNodeAggregateId' => '6b6e1251-4346-494f-ac56-526a30a5741d',
+                                    'parentOriginDimensionSpacePoint' => [
+                                        'language' => 'pl'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                ],
+                'workspaceName' => 'user-soee'
+            ],
+            'expectedEvent' => new NodeAggregateWasMoved(
+                WorkspaceName::fromString('user-soee'),
+                ContentStreamId::fromString('d742c335-b733-47d6-aebe-c809a3afc972'),
+                NodeAggregateId::fromString('eebf6ea3-a69b-48c0-af16-d0e14c0bb646'),
+                NodeAggregateId::fromString('6b6e1251-4346-494f-ac56-526a30a5741d'),
+                new InterdimensionalSiblings(
+                    new InterdimensionalSibling(
+                        DimensionSpacePoint::fromArray([
+                            'language' => 'en'
+                        ]),
+                        NodeAggregateId::fromString('eebf6ea3-a69b-48c0-af16-d0e14c0bb646')
+                    ),
+                    new InterdimensionalSibling(
+                        DimensionSpacePoint::fromArray([
+                            'language' => 'pl'
+                        ]),
+                        NodeAggregateId::fromString('37342037-b69b-476b-bf7b-9383f33efa1b')
+                    )
+                )
+            )
+        ];
+    }
+}


### PR DESCRIPTION
…to InterdimensionalSiblings

resolves #5056

This solves the regression introduced in https://github.com/neos/neos-development-collection/pull/4993 by properly evaluating the legacy MoveNodeMappings payload array. Respective tests have been added.

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
