### PR TITLE
TASK: Remove transaction closures from projections

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -511,7 +511,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
         usort(
             $hierarchyRelations,
             fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int
-            => $relationA->position <=> $relationB->position
+                => $relationA->position <=> $relationB->position
         );
 
         foreach ($hierarchyRelations as $relation) {

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -220,34 +220,32 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenRootNodeAggregateWithNodeWasCreated(RootNodeAggregateWithNodeWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            $originDimensionSpacePoint = OriginDimensionSpacePoint::createWithoutDimensions();
-            $node = NodeRecord::createNewInDatabase(
-                $this->getDatabaseConnection(),
-                $this->tableNames,
-                $event->nodeAggregateId,
-                $originDimensionSpacePoint->coordinates,
-                $originDimensionSpacePoint->hash,
-                SerializedPropertyValues::createEmpty(),
-                $event->nodeTypeName,
-                $event->nodeAggregateClassification,
+        $originDimensionSpacePoint = OriginDimensionSpacePoint::createWithoutDimensions();
+        $node = NodeRecord::createNewInDatabase(
+            $this->getDatabaseConnection(),
+            $this->tableNames,
+            $event->nodeAggregateId,
+            $originDimensionSpacePoint->coordinates,
+            $originDimensionSpacePoint->hash,
+            SerializedPropertyValues::createEmpty(),
+            $event->nodeTypeName,
+            $event->nodeAggregateClassification,
+            null,
+            Timestamps::create(
+                $eventEnvelope->recordedAt,
+                self::initiatingDateTime($eventEnvelope),
                 null,
-                Timestamps::create(
-                    $eventEnvelope->recordedAt,
-                    self::initiatingDateTime($eventEnvelope),
-                    null,
-                    null,
-                ),
-            );
+                null,
+            ),
+        );
 
-            $this->connectHierarchy(
-                $event->contentStreamId,
-                NodeRelationAnchorPoint::forRootEdge(),
-                $node->relationAnchorPoint,
-                $event->coveredDimensionSpacePoints,
-                null
-            );
-        });
+        $this->connectHierarchy(
+            $event->contentStreamId,
+            NodeRelationAnchorPoint::forRootEdge(),
+            $node->relationAnchorPoint,
+            $event->coveredDimensionSpacePoints,
+            null
+        );
     }
 
     /**
@@ -267,28 +265,26 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
             return;
         }
 
-        $this->transactional(function () use ($rootNodeAnchorPoint, $event) {
-            // delete all hierarchy edges of the root node
-            $this->getDatabaseConnection()->executeUpdate('
+        // delete all hierarchy edges of the root node
+        $this->getDatabaseConnection()->executeUpdate('
                 DELETE FROM ' . $this->tableNames->hierarchyRelation() . '
                 WHERE
                     parentnodeanchor = :parentNodeAnchor
                     AND childnodeanchor = :childNodeAnchor
                     AND contentstreamid = :contentStreamId
             ', [
-                'parentNodeAnchor' => NodeRelationAnchorPoint::forRootEdge()->value,
-                'childNodeAnchor' => $rootNodeAnchorPoint->value,
-                'contentStreamId' => $event->contentStreamId->value,
-            ]);
-            // recreate hierarchy edges for the root node
-            $this->connectHierarchy(
-                $event->contentStreamId,
-                NodeRelationAnchorPoint::forRootEdge(),
-                $rootNodeAnchorPoint,
-                $event->coveredDimensionSpacePoints,
-                null
-            );
-        });
+            'parentNodeAnchor' => NodeRelationAnchorPoint::forRootEdge()->value,
+            'childNodeAnchor' => $rootNodeAnchorPoint->value,
+            'contentStreamId' => $event->contentStreamId->value,
+        ]);
+        // recreate hierarchy edges for the root node
+        $this->connectHierarchy(
+            $event->contentStreamId,
+            NodeRelationAnchorPoint::forRootEdge(),
+            $rootNodeAnchorPoint,
+            $event->coveredDimensionSpacePoints,
+            null
+        );
     }
 
     /**
@@ -296,20 +292,18 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenNodeAggregateWithNodeWasCreated(NodeAggregateWithNodeWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            $this->createNodeWithHierarchy(
-                $event->contentStreamId,
-                $event->nodeAggregateId,
-                $event->nodeTypeName,
-                $event->parentNodeAggregateId,
-                $event->originDimensionSpacePoint,
-                $event->succeedingSiblingsForCoverage,
-                $event->initialPropertyValues,
-                $event->nodeAggregateClassification,
-                $event->nodeName,
-                $eventEnvelope,
-            );
-        });
+        $this->createNodeWithHierarchy(
+            $event->contentStreamId,
+            $event->nodeAggregateId,
+            $event->nodeTypeName,
+            $event->parentNodeAggregateId,
+            $event->originDimensionSpacePoint,
+            $event->succeedingSiblingsForCoverage,
+            $event->initialPropertyValues,
+            $event->nodeAggregateClassification,
+            $event->nodeName,
+            $eventEnvelope,
+        );
     }
 
     /**
@@ -317,26 +311,24 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenNodeAggregateNameWasChanged(NodeAggregateNameWasChanged $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            foreach (
-                $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream(
-                    $event->nodeAggregateId,
-                    $event->contentStreamId,
-                ) as $anchorPoint
-            ) {
-                $this->updateNodeRecordWithCopyOnWrite(
-                    $event->contentStreamId,
-                    $anchorPoint,
-                    function (NodeRecord $node) use ($event, $eventEnvelope) {
-                        $node->nodeName = $event->newNodeName;
-                        $node->timestamps = $node->timestamps->with(
-                            lastModified: $eventEnvelope->recordedAt,
-                            originalLastModified: self::initiatingDateTime($eventEnvelope)
-                        );
-                    }
-                );
-            }
-        });
+        foreach (
+            $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream(
+                $event->nodeAggregateId,
+                $event->contentStreamId,
+            ) as $anchorPoint
+        ) {
+            $this->updateNodeRecordWithCopyOnWrite(
+                $event->contentStreamId,
+                $anchorPoint,
+                function (NodeRecord $node) use ($event, $eventEnvelope) {
+                    $node->nodeName = $event->newNodeName;
+                    $node->timestamps = $node->timestamps->with(
+                        lastModified: $eventEnvelope->recordedAt,
+                        originalLastModified: self::initiatingDateTime($eventEnvelope)
+                    );
+                }
+            );
+        }
     }
 
     /**
@@ -519,7 +511,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
         usort(
             $hierarchyRelations,
             fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int
-                => $relationA->position <=> $relationB->position
+            => $relationA->position <=> $relationB->position
         );
 
         foreach ($hierarchyRelations as $relation) {
@@ -542,74 +534,68 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenContentStreamWasForked(ContentStreamWasForked $event): void
     {
-        $this->transactional(function () use ($event) {
+        //
+        // 1) Copy HIERARCHY RELATIONS (this is the MAIN OPERATION here)
+        //
+        $this->getDatabaseConnection()->executeUpdate('
+            INSERT INTO ' . $this->tableNames->hierarchyRelation() . ' (
+              parentnodeanchor,
+              childnodeanchor,
+              position,
+              dimensionspacepointhash,
+              subtreetags,
+              contentstreamid
+            )
+            SELECT
+              h.parentnodeanchor,
+              h.childnodeanchor,
+              h.position,
+              h.dimensionspacepointhash,
+              h.subtreetags,
+              "' . $event->newContentStreamId->value . '" AS contentstreamid
+            FROM
+                ' . $this->tableNames->hierarchyRelation() . ' h
+                WHERE h.contentstreamid = :sourceContentStreamId
+        ', [
+            'sourceContentStreamId' => $event->sourceContentStreamId->value
+        ]);
 
-            //
-            // 1) Copy HIERARCHY RELATIONS (this is the MAIN OPERATION here)
-            //
-            $this->getDatabaseConnection()->executeUpdate('
-                INSERT INTO ' . $this->tableNames->hierarchyRelation() . ' (
-                  parentnodeanchor,
-                  childnodeanchor,
-                  position,
-                  dimensionspacepointhash,
-                  subtreetags,
-                  contentstreamid
-                )
-                SELECT
-                  h.parentnodeanchor,
-                  h.childnodeanchor,
-                  h.position,
-                  h.dimensionspacepointhash,
-                  h.subtreetags,
-                  "' . $event->newContentStreamId->value . '" AS contentstreamid
-                FROM
-                    ' . $this->tableNames->hierarchyRelation() . ' h
-                    WHERE h.contentstreamid = :sourceContentStreamId
-            ', [
-                'sourceContentStreamId' => $event->sourceContentStreamId->value
-            ]);
-
-            // NOTE: as reference edges are attached to Relation Anchor Points (and they are lazily copy-on-written),
-            // we do not need to copy reference edges here (but we need to do it during copy on write).
-        });
+        // NOTE: as reference edges are attached to Relation Anchor Points (and they are lazily copy-on-written),
+        // we do not need to copy reference edges here (but we need to do it during copy on write).
     }
 
     private function whenContentStreamWasRemoved(ContentStreamWasRemoved $event): void
     {
-        $this->transactional(function () use ($event) {
+        // Drop hierarchy relations
+        $this->getDatabaseConnection()->executeUpdate('
+            DELETE FROM ' . $this->tableNames->hierarchyRelation() . '
+            WHERE
+                contentstreamid = :contentStreamId
+        ', [
+            'contentStreamId' => $event->contentStreamId->value
+        ]);
 
-            // Drop hierarchy relations
-            $this->getDatabaseConnection()->executeUpdate('
-                DELETE FROM ' . $this->tableNames->hierarchyRelation() . '
-                WHERE
-                    contentstreamid = :contentStreamId
-            ', [
-                'contentStreamId' => $event->contentStreamId->value
-            ]);
+        // Drop non-referenced nodes (which do not have a hierarchy relation anymore)
+        $this->getDatabaseConnection()->executeUpdate('
+            DELETE FROM ' . $this->tableNames->node() . '
+            WHERE NOT EXISTS
+                (
+                    SELECT 1 FROM ' . $this->tableNames->hierarchyRelation() . '
+                    WHERE ' . $this->tableNames->hierarchyRelation() . '.childnodeanchor
+                              = ' . $this->tableNames->node() . '.relationanchorpoint
+                )
+        ');
 
-            // Drop non-referenced nodes (which do not have a hierarchy relation anymore)
-            $this->getDatabaseConnection()->executeUpdate('
-                DELETE FROM ' . $this->tableNames->node() . '
-                WHERE NOT EXISTS
-                    (
-                        SELECT 1 FROM ' . $this->tableNames->hierarchyRelation() . '
-                        WHERE ' . $this->tableNames->hierarchyRelation() . '.childnodeanchor
-                                  = ' . $this->tableNames->node() . '.relationanchorpoint
-                    )
-            ');
-
-            // Drop non-referenced reference relations (i.e. because the referenced nodes are gone by now)
-            $this->getDatabaseConnection()->executeUpdate('
-                DELETE FROM ' . $this->tableNames->referenceRelation() . '
-                WHERE NOT EXISTS
-                    (
-                        SELECT 1 FROM ' . $this->tableNames->node() . '
-                        WHERE ' . $this->tableNames->node() . '.relationanchorpoint
-                                  = ' . $this->tableNames->referenceRelation() . '.nodeanchorpoint
-                    )
-            ');
-        });
+        // Drop non-referenced reference relations (i.e. because the referenced nodes are gone by now)
+        $this->getDatabaseConnection()->executeUpdate('
+            DELETE FROM ' . $this->tableNames->referenceRelation() . '
+            WHERE NOT EXISTS
+                (
+                    SELECT 1 FROM ' . $this->tableNames->node() . '
+                    WHERE ' . $this->tableNames->node() . '.relationanchorpoint
+                              = ' . $this->tableNames->referenceRelation() . '.nodeanchorpoint
+                )
+        ');
     }
 
     /**
@@ -617,35 +603,33 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenNodePropertiesWereSet(NodePropertiesWereSet $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            $anchorPoint = $this->projectionContentGraph
-                ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
-                    $event->getNodeAggregateId(),
-                    $event->getOriginDimensionSpacePoint(),
-                    $event->getContentStreamId()
-                );
-            if (is_null($anchorPoint)) {
-                throw new \InvalidArgumentException(
-                    'Cannot update node with copy on write since no anchor point could be resolved for node '
-                    . $event->getNodeAggregateId()->value . ' in content stream '
-                    . $event->getContentStreamId()->value,
-                    1645303332
+        $anchorPoint = $this->projectionContentGraph
+            ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
+                $event->getNodeAggregateId(),
+                $event->getOriginDimensionSpacePoint(),
+                $event->getContentStreamId()
+            );
+        if (is_null($anchorPoint)) {
+            throw new \InvalidArgumentException(
+                'Cannot update node with copy on write since no anchor point could be resolved for node '
+                . $event->getNodeAggregateId()->value . ' in content stream '
+                . $event->getContentStreamId()->value,
+                1645303332
+            );
+        }
+        $this->updateNodeRecordWithCopyOnWrite(
+            $event->getContentStreamId(),
+            $anchorPoint,
+            function (NodeRecord $node) use ($event, $eventEnvelope) {
+                $node->properties = $node->properties
+                    ->merge($event->propertyValues)
+                    ->unsetProperties($event->propertiesToUnset);
+                $node->timestamps = $node->timestamps->with(
+                    lastModified: $eventEnvelope->recordedAt,
+                    originalLastModified: self::initiatingDateTime($eventEnvelope)
                 );
             }
-            $this->updateNodeRecordWithCopyOnWrite(
-                $event->getContentStreamId(),
-                $anchorPoint,
-                function (NodeRecord $node) use ($event, $eventEnvelope) {
-                    $node->properties = $node->properties
-                        ->merge($event->propertyValues)
-                        ->unsetProperties($event->propertiesToUnset);
-                    $node->timestamps = $node->timestamps->with(
-                        lastModified: $eventEnvelope->recordedAt,
-                        originalLastModified: self::initiatingDateTime($eventEnvelope)
-                    );
-                }
-            );
-        });
+        );
     }
 
     /**
@@ -653,66 +637,64 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
      */
     private function whenNodeReferencesWereSet(NodeReferencesWereSet $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            foreach ($event->affectedSourceOriginDimensionSpacePoints as $originDimensionSpacePoint) {
-                $nodeAnchorPoint = $this->projectionContentGraph
-                    ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
-                        $event->sourceNodeAggregateId,
-                        $originDimensionSpacePoint,
-                        $event->contentStreamId
-                    );
-
-                if (is_null($nodeAnchorPoint)) {
-                    throw new \InvalidArgumentException(
-                        'Could not apply event of type "' . get_class($event)
-                        . '" since no anchor point could be resolved for node '
-                        . $event->getNodeAggregateId()->value . ' in content stream '
-                        . $event->getContentStreamId()->value,
-                        1658580583
-                    );
-                }
-
-                $this->updateNodeRecordWithCopyOnWrite(
-                    $event->contentStreamId,
-                    $nodeAnchorPoint,
-                    function (NodeRecord $node) use ($eventEnvelope) {
-                        $node->timestamps = $node->timestamps->with(
-                            lastModified: $eventEnvelope->recordedAt,
-                            originalLastModified: self::initiatingDateTime($eventEnvelope)
-                        );
-                    }
+        foreach ($event->affectedSourceOriginDimensionSpacePoints as $originDimensionSpacePoint) {
+            $nodeAnchorPoint = $this->projectionContentGraph
+                ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
+                    $event->sourceNodeAggregateId,
+                    $originDimensionSpacePoint,
+                    $event->contentStreamId
                 );
 
-                $nodeAnchorPoint = $this->projectionContentGraph
-                    ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
-                        $event->sourceNodeAggregateId,
-                        $originDimensionSpacePoint,
-                        $event->contentStreamId
-                    );
-
-                // remove old
-                $this->getDatabaseConnection()->delete($this->tableNames->referenceRelation(), [
-                    'nodeanchorpoint' => $nodeAnchorPoint?->value,
-                    'name' => $event->referenceName->value
-                ]);
-
-                // set new
-                $position = 0;
-                /** @var SerializedNodeReference $reference */
-                foreach ($event->references as $reference) {
-                    $this->getDatabaseConnection()->insert($this->tableNames->referenceRelation(), [
-                        'name' => $event->referenceName->value,
-                        'position' => $position,
-                        'nodeanchorpoint' => $nodeAnchorPoint?->value,
-                        'destinationnodeaggregateid' => $reference->targetNodeAggregateId->value,
-                        'properties' => $reference->properties
-                            ? \json_encode($reference->properties, JSON_THROW_ON_ERROR & JSON_FORCE_OBJECT)
-                            : null
-                    ]);
-                    $position++;
-                }
+            if (is_null($nodeAnchorPoint)) {
+                throw new \InvalidArgumentException(
+                    'Could not apply event of type "' . get_class($event)
+                    . '" since no anchor point could be resolved for node '
+                    . $event->getNodeAggregateId()->value . ' in content stream '
+                    . $event->getContentStreamId()->value,
+                    1658580583
+                );
             }
-        });
+
+            $this->updateNodeRecordWithCopyOnWrite(
+                $event->contentStreamId,
+                $nodeAnchorPoint,
+                function (NodeRecord $node) use ($eventEnvelope) {
+                    $node->timestamps = $node->timestamps->with(
+                        lastModified: $eventEnvelope->recordedAt,
+                        originalLastModified: self::initiatingDateTime($eventEnvelope)
+                    );
+                }
+            );
+
+            $nodeAnchorPoint = $this->projectionContentGraph
+                ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
+                    $event->sourceNodeAggregateId,
+                    $originDimensionSpacePoint,
+                    $event->contentStreamId
+                );
+
+            // remove old
+            $this->getDatabaseConnection()->delete($this->tableNames->referenceRelation(), [
+                'nodeanchorpoint' => $nodeAnchorPoint?->value,
+                'name' => $event->referenceName->value
+            ]);
+
+            // set new
+            $position = 0;
+            /** @var SerializedNodeReference $reference */
+            foreach ($event->references as $reference) {
+                $this->getDatabaseConnection()->insert($this->tableNames->referenceRelation(), [
+                    'name' => $event->referenceName->value,
+                    'position' => $position,
+                    'nodeanchorpoint' => $nodeAnchorPoint?->value,
+                    'destinationnodeaggregateid' => $reference->targetNodeAggregateId->value,
+                    'properties' => $reference->properties
+                        ? \json_encode($reference->properties, JSON_THROW_ON_ERROR & JSON_FORCE_OBJECT)
+                        : null
+                ]);
+                $position++;
+            }
+        }
     }
 
     /**
@@ -777,22 +759,20 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
 
     private function whenNodeAggregateTypeWasChanged(NodeAggregateTypeWasChanged $event, EventEnvelope $eventEnvelope): void
     {
-        $this->transactional(function () use ($event, $eventEnvelope) {
-            $anchorPoints = $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream($event->nodeAggregateId, $event->contentStreamId);
-            foreach ($anchorPoints as $anchorPoint) {
-                $this->updateNodeRecordWithCopyOnWrite(
-                    $event->contentStreamId,
-                    $anchorPoint,
-                    function (NodeRecord $node) use ($event, $eventEnvelope) {
-                        $node->nodeTypeName = $event->newNodeTypeName;
-                        $node->timestamps = $node->timestamps->with(
-                            lastModified: $eventEnvelope->recordedAt,
-                            originalLastModified: self::initiatingDateTime($eventEnvelope)
-                        );
-                    }
-                );
-            }
-        });
+        $anchorPoints = $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream($event->nodeAggregateId, $event->contentStreamId);
+        foreach ($anchorPoints as $anchorPoint) {
+            $this->updateNodeRecordWithCopyOnWrite(
+                $event->contentStreamId,
+                $anchorPoint,
+                function (NodeRecord $node) use ($event, $eventEnvelope) {
+                    $node->nodeTypeName = $event->newNodeTypeName;
+                    $node->timestamps = $node->timestamps->with(
+                        lastModified: $eventEnvelope->recordedAt,
+                        originalLastModified: self::initiatingDateTime($eventEnvelope)
+                    );
+                }
+            );
+        }
     }
 
     private function updateNodeRecordWithCopyOnWrite(
@@ -884,103 +864,91 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
 
     private function whenDimensionSpacePointWasMoved(DimensionSpacePointWasMoved $event): void
     {
-        $this->transactional(function () use ($event) {
-            $this->dimensionSpacePointsRepository->insertDimensionSpacePoint($event->target);
+        $this->dimensionSpacePointsRepository->insertDimensionSpacePoint($event->target);
 
-            // the ordering is important - we first update the OriginDimensionSpacePoints, as we need the
-            // hierarchy relations for this query. Then, we update the Hierarchy Relations.
+        // the ordering is important - we first update the OriginDimensionSpacePoints, as we need the
+        // hierarchy relations for this query. Then, we update the Hierarchy Relations.
 
-            // 1) originDimensionSpacePoint on Node
-            $rel = $this->getDatabaseConnection()->executeQuery(
-                'SELECT n.relationanchorpoint, n.origindimensionspacepointhash
-                     FROM ' . $this->tableNames->node() . ' n
-                     INNER JOIN ' . $this->tableNames->hierarchyRelation() . ' h
-                        ON h.childnodeanchor = n.relationanchorpoint
+        // 1) originDimensionSpacePoint on Node
+        $rel = $this->getDatabaseConnection()->executeQuery(
+            'SELECT n.relationanchorpoint, n.origindimensionspacepointhash
+                 FROM ' . $this->tableNames->node() . ' n
+                 INNER JOIN ' . $this->tableNames->hierarchyRelation() . ' h
+                    ON h.childnodeanchor = n.relationanchorpoint
 
-                     AND h.contentstreamid = :contentStreamId
-                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
-                     -- find only nodes which have their ORIGIN at the source DimensionSpacePoint,
-                     -- as we need to rewrite these origins (using copy on write)
-                     AND n.origindimensionspacepointhash = :dimensionSpacePointHash
-                ',
-                [
-                    'dimensionSpacePointHash' => $event->source->hash,
-                    'contentStreamId' => $event->contentStreamId->value
-                ]
+                 AND h.contentstreamid = :contentStreamId
+                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
+                 -- find only nodes which have their ORIGIN at the source DimensionSpacePoint,
+                 -- as we need to rewrite these origins (using copy on write)
+                 AND n.origindimensionspacepointhash = :dimensionSpacePointHash
+            ',
+            [
+                'dimensionSpacePointHash' => $event->source->hash,
+                'contentStreamId' => $event->contentStreamId->value
+            ]
+        );
+        while ($res = $rel->fetchAssociative()) {
+            $relationAnchorPoint = NodeRelationAnchorPoint::fromInteger($res['relationanchorpoint']);
+            $this->updateNodeRecordWithCopyOnWrite(
+                $event->contentStreamId,
+                $relationAnchorPoint,
+                function (NodeRecord $nodeRecord) use ($event) {
+                    $nodeRecord->originDimensionSpacePoint = $event->target->coordinates;
+                    $nodeRecord->originDimensionSpacePointHash = $event->target->hash;
+                }
             );
-            while ($res = $rel->fetchAssociative()) {
-                $relationAnchorPoint = NodeRelationAnchorPoint::fromInteger($res['relationanchorpoint']);
-                $this->updateNodeRecordWithCopyOnWrite(
-                    $event->contentStreamId,
-                    $relationAnchorPoint,
-                    function (NodeRecord $nodeRecord) use ($event) {
-                        $nodeRecord->originDimensionSpacePoint = $event->target->coordinates;
-                        $nodeRecord->originDimensionSpacePointHash = $event->target->hash;
-                    }
-                );
-            }
+        }
 
-            // 2) hierarchy relations
-            $this->getDatabaseConnection()->executeStatement(
-                '
-                UPDATE ' . $this->tableNames->hierarchyRelation() . ' h
-                    SET
-                        h.dimensionspacepointhash = :newDimensionSpacePointHash
-                    WHERE
-                      h.dimensionspacepointhash = :originalDimensionSpacePointHash
-                      AND h.contentstreamid = :contentStreamId
-                      ',
-                [
-                    'originalDimensionSpacePointHash' => $event->source->hash,
-                    'newDimensionSpacePointHash' => $event->target->hash,
-                    'contentStreamId' => $event->contentStreamId->value
-                ]
-            );
-        });
+        // 2) hierarchy relations
+        $this->getDatabaseConnection()->executeStatement(
+            '
+            UPDATE ' . $this->tableNames->hierarchyRelation() . ' h
+                SET
+                    h.dimensionspacepointhash = :newDimensionSpacePointHash
+                WHERE
+                  h.dimensionspacepointhash = :originalDimensionSpacePointHash
+                  AND h.contentstreamid = :contentStreamId
+                  ',
+            [
+                'originalDimensionSpacePointHash' => $event->source->hash,
+                'newDimensionSpacePointHash' => $event->target->hash,
+                'contentStreamId' => $event->contentStreamId->value
+            ]
+        );
     }
 
     private function whenDimensionShineThroughWasAdded(DimensionShineThroughWasAdded $event): void
     {
-        $this->transactional(function () use ($event) {
-            $this->dimensionSpacePointsRepository->insertDimensionSpacePoint($event->target);
+        $this->dimensionSpacePointsRepository->insertDimensionSpacePoint($event->target);
 
-            // 1) hierarchy relations
-            $this->getDatabaseConnection()->executeStatement(
-                '
-                INSERT INTO ' . $this->tableNames->hierarchyRelation() . ' (
-                  parentnodeanchor,
-                  childnodeanchor,
-                  position,
-                  subtreetags,
-                  dimensionspacepointhash,
-                  contentstreamid
-                )
-                SELECT
-                  h.parentnodeanchor,
-                  h.childnodeanchor,
-                  h.position,
-                  h.subtreetags,
-                 :newDimensionSpacePointHash AS dimensionspacepointhash,
-                  h.contentstreamid
-                FROM
-                    ' . $this->tableNames->hierarchyRelation() . ' h
-                    WHERE h.contentstreamid = :contentStreamId
-                    AND h.dimensionspacepointhash = :sourceDimensionSpacePointHash',
-                [
-                    'contentStreamId' => $event->contentStreamId->value,
-                    'sourceDimensionSpacePointHash' => $event->source->hash,
-                    'newDimensionSpacePointHash' => $event->target->hash,
-                ]
-            );
-        });
-    }
-
-    /**
-     * @throws \Throwable
-     */
-    private function transactional(\Closure $operations): void
-    {
-        $this->getDatabaseConnection()->transactional($operations);
+        // 1) hierarchy relations
+        $this->getDatabaseConnection()->executeStatement(
+            '
+            INSERT INTO ' . $this->tableNames->hierarchyRelation() . ' (
+              parentnodeanchor,
+              childnodeanchor,
+              position,
+              subtreetags,
+              dimensionspacepointhash,
+              contentstreamid
+            )
+            SELECT
+              h.parentnodeanchor,
+              h.childnodeanchor,
+              h.position,
+              h.subtreetags,
+             :newDimensionSpacePointHash AS dimensionspacepointhash,
+              h.contentstreamid
+            FROM
+                ' . $this->tableNames->hierarchyRelation() . ' h
+                WHERE h.contentstreamid = :contentStreamId
+                AND h.dimensionspacepointhash = :sourceDimensionSpacePointHash',
+            [
+                'contentStreamId' => $event->contentStreamId->value,
+                'sourceDimensionSpacePointHash' => $event->source->hash,
+                'newDimensionSpacePointHash' => $event->target->hash,
+            ]
+        );
     }
 
     private function getDatabaseConnection(): Connection

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
@@ -29,17 +29,15 @@ trait NodeRemoval
     {
         // the focus here is to be correct; that's why the method is not overly performant (for now at least). We might
         // lateron find tricks to improve performance
-        $this->transactional(function () use ($event) {
-            $ingoingRelations = $this->getProjectionContentGraph()->findIngoingHierarchyRelationsForNodeAggregate(
-                $event->contentStreamId,
-                $event->nodeAggregateId,
-                $event->affectedCoveredDimensionSpacePoints
-            );
+        $ingoingRelations = $this->getProjectionContentGraph()->findIngoingHierarchyRelationsForNodeAggregate(
+            $event->contentStreamId,
+            $event->nodeAggregateId,
+            $event->affectedCoveredDimensionSpacePoints
+        );
 
-            foreach ($ingoingRelations as $ingoingRelation) {
-                $this->removeRelationRecursivelyFromDatabaseIncludingNonReferencedNodes($ingoingRelation);
-            }
-        });
+        foreach ($ingoingRelations as $ingoingRelation) {
+            $this->removeRelationRecursivelyFromDatabaseIncludingNonReferencedNodes($ingoingRelation);
+        }
     }
 
     /**
@@ -83,6 +81,4 @@ trait NodeRemoval
     }
 
     abstract protected function getDatabaseConnection(): Connection;
-
-    abstract protected function transactional(\Closure $operations): void;
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
@@ -44,21 +44,17 @@ final readonly class HierarchyRelation
      */
     public function addToDatabase(Connection $databaseConnection, ContentGraphTableNames $tableNames): void
     {
-        $databaseConnection->transactional(function ($databaseConnection) use (
-            $tableNames
-        ) {
-            $dimensionSpacePoints = new DimensionSpacePointsRepository($databaseConnection, $tableNames);
-            $dimensionSpacePoints->insertDimensionSpacePoint($this->dimensionSpacePoint);
+        $dimensionSpacePoints = new DimensionSpacePointsRepository($databaseConnection, $tableNames);
+        $dimensionSpacePoints->insertDimensionSpacePoint($this->dimensionSpacePoint);
 
-            $databaseConnection->insert($tableNames->hierarchyRelation(), [
-                'parentnodeanchor' => $this->parentNodeAnchor->value,
-                'childnodeanchor' => $this->childNodeAnchor->value,
-                'contentstreamid' => $this->contentStreamId->value,
-                'dimensionspacepointhash' => $this->dimensionSpacePointHash,
-                'position' => $this->position,
-                'subtreetags' => json_encode($this->subtreeTags, JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT),
-            ]);
-        });
+        $databaseConnection->insert($tableNames->hierarchyRelation(), [
+            'parentnodeanchor' => $this->parentNodeAnchor->value,
+            'childnodeanchor' => $this->childNodeAnchor->value,
+            'contentstreamid' => $this->contentStreamId->value,
+            'dimensionspacepointhash' => $this->dimensionSpacePointHash,
+            'position' => $this->position,
+            'subtreetags' => json_encode($this->subtreeTags, JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT),
+        ]);
     }
 
     /**

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/NodeRecord.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/NodeRecord.php
@@ -116,40 +116,28 @@ final class NodeRecord
         ?NodeName $nodeName,
         Timestamps $timestamps,
     ): self {
-        $relationAnchorPoint = $databaseConnection->transactional(function ($databaseConnection) use (
-            $tableNames,
-            $nodeAggregateId,
-            $originDimensionSpacePoint,
-            $originDimensionSpacePointHash,
-            $properties,
-            $nodeTypeName,
-            $nodeName,
-            $classification,
-            $timestamps
-        ) {
-            $dimensionSpacePoints = new DimensionSpacePointsRepository($databaseConnection, $tableNames);
-            $dimensionSpacePoints->insertDimensionSpacePointByHashAndCoordinates($originDimensionSpacePointHash, $originDimensionSpacePoint);
+        $dimensionSpacePoints = new DimensionSpacePointsRepository($databaseConnection, $tableNames);
+        $dimensionSpacePoints->insertDimensionSpacePointByHashAndCoordinates($originDimensionSpacePointHash, $originDimensionSpacePoint);
 
-            $databaseConnection->insert($tableNames->node(), [
-                'nodeaggregateid' => $nodeAggregateId->value,
-                'origindimensionspacepointhash' => $originDimensionSpacePointHash,
-                'properties' => json_encode($properties),
-                'nodetypename' => $nodeTypeName->value,
-                'name' => $nodeName?->value,
-                'classification' => $classification->value,
-                'created' => $timestamps->created,
-                'originalcreated' => $timestamps->originalCreated,
-                'lastmodified' => $timestamps->lastModified,
-                'originallastmodified' => $timestamps->originalLastModified,
-            ], [
-                'created' => Types::DATETIME_IMMUTABLE,
-                'originalcreated' => Types::DATETIME_IMMUTABLE,
-                'lastmodified' => Types::DATETIME_IMMUTABLE,
-                'originallastmodified' => Types::DATETIME_IMMUTABLE,
-            ]);
+        $databaseConnection->insert($tableNames->node(), [
+            'nodeaggregateid' => $nodeAggregateId->value,
+            'origindimensionspacepointhash' => $originDimensionSpacePointHash,
+            'properties' => json_encode($properties),
+            'nodetypename' => $nodeTypeName->value,
+            'name' => $nodeName?->value,
+            'classification' => $classification->value,
+            'created' => $timestamps->created,
+            'originalcreated' => $timestamps->originalCreated,
+            'lastmodified' => $timestamps->lastModified,
+            'originallastmodified' => $timestamps->originalLastModified,
+        ], [
+            'created' => Types::DATETIME_IMMUTABLE,
+            'originalcreated' => Types::DATETIME_IMMUTABLE,
+            'lastmodified' => Types::DATETIME_IMMUTABLE,
+            'originallastmodified' => Types::DATETIME_IMMUTABLE,
+        ]);
 
-            return NodeRelationAnchorPoint::fromInteger((int)$databaseConnection->lastInsertId());
-        });
+        $relationAnchorPoint = NodeRelationAnchorPoint::fromInteger((int)$databaseConnection->lastInsertId());
 
         return new self(
             $relationAnchorPoint,

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/ContentStreamForking.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/ContentStreamForking.php
@@ -29,40 +29,33 @@ trait ContentStreamForking
      */
     private function whenContentStreamWasForked(ContentStreamWasForked $event): void
     {
-        $this->transactional(function () use ($event) {
-            $parameters = [
-                'sourceContentStreamId' => $event->sourceContentStreamId->value,
-                'targetContentStreamId' => $event->newContentStreamId->value
-            ];
+        $parameters = [
+            'sourceContentStreamId' => $event->sourceContentStreamId->value,
+            'targetContentStreamId' => $event->newContentStreamId->value
+        ];
 
-            $this->getDatabaseConnection()->executeQuery(/** @lang PostgreSQL */
-                'INSERT INTO ' . $this->tableNamePrefix . '_hierarchyhyperrelation
-                    (contentstreamid, parentnodeanchor,
-                     dimensionspacepoint, dimensionspacepointhash, childnodeanchors)
-                SELECT :targetContentStreamId, parentnodeanchor,
-                    dimensionspacepoint, dimensionspacepointhash, childnodeanchors
-                FROM ' . $this->tableNamePrefix . '_hierarchyhyperrelation source
-                WHERE source.contentstreamid = :sourceContentStreamId',
-                $parameters
-            );
+        $this->getDatabaseConnection()->executeQuery(/** @lang PostgreSQL */
+            'INSERT INTO ' . $this->tableNamePrefix . '_hierarchyhyperrelation
+                (contentstreamid, parentnodeanchor,
+                 dimensionspacepoint, dimensionspacepointhash, childnodeanchors)
+            SELECT :targetContentStreamId, parentnodeanchor,
+                dimensionspacepoint, dimensionspacepointhash, childnodeanchors
+            FROM ' . $this->tableNamePrefix . '_hierarchyhyperrelation source
+            WHERE source.contentstreamid = :sourceContentStreamId',
+            $parameters
+        );
 
-            $this->getDatabaseConnection()->executeQuery(/** @lang PostgreSQL */
-                'INSERT INTO ' . $this->tableNamePrefix . '_restrictionhyperrelation
-                    (contentstreamid, dimensionspacepointhash,
-                     originnodeaggregateid, affectednodeaggregateids)
-                SELECT :targetContentStreamId, dimensionspacepointhash,
-                    originnodeaggregateid, affectednodeaggregateids
-                FROM ' . $this->tableNamePrefix . '_restrictionhyperrelation source
-                WHERE source.contentstreamid = :sourceContentStreamId',
-                $parameters
-            );
-        });
+        $this->getDatabaseConnection()->executeQuery(/** @lang PostgreSQL */
+            'INSERT INTO ' . $this->tableNamePrefix . '_restrictionhyperrelation
+                (contentstreamid, dimensionspacepointhash,
+                 originnodeaggregateid, affectednodeaggregateids)
+            SELECT :targetContentStreamId, dimensionspacepointhash,
+                originnodeaggregateid, affectednodeaggregateids
+            FROM ' . $this->tableNamePrefix . '_restrictionhyperrelation source
+            WHERE source.contentstreamid = :sourceContentStreamId',
+            $parameters
+        );
     }
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/CopyOnWrite.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/CopyOnWrite.php
@@ -136,10 +136,5 @@ trait CopyOnWrite
 
     abstract protected function getProjectionHypergraph(): ProjectionHypergraph;
 
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
-
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeModification.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeModification.php
@@ -34,33 +34,26 @@ trait NodeModification
      */
     private function whenNodePropertiesWereSet(NodePropertiesWereSet $event): void
     {
-        $this->transactional(function () use ($event) {
-            $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByOrigin(
-                $event->contentStreamId,
-                $event->originDimensionSpacePoint,
-                $event->nodeAggregateId
-            );
-            if (is_null($nodeRecord)) {
-                throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
+        $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByOrigin(
+            $event->contentStreamId,
+            $event->originDimensionSpacePoint,
+            $event->nodeAggregateId
+        );
+        if (is_null($nodeRecord)) {
+            throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
+        }
+        $this->copyOnWrite(
+            $event->contentStreamId,
+            $nodeRecord,
+            function (NodeRecord $node) use ($event) {
+                $node->properties = $node->properties
+                    ->merge($event->propertyValues)
+                    ->unsetProperties($event->propertiesToUnset);
             }
-            $this->copyOnWrite(
-                $event->contentStreamId,
-                $nodeRecord,
-                function (NodeRecord $node) use ($event) {
-                    $node->properties = $node->properties
-                        ->merge($event->propertyValues)
-                        ->unsetProperties($event->propertiesToUnset);
-                }
-            );
-        });
+        );
     }
 
     abstract protected function getProjectionHypergraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeReferencing.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeReferencing.php
@@ -35,54 +35,47 @@ trait NodeReferencing
      */
     private function whenNodeReferencesWereSet(NodeReferencesWereSet $event): void
     {
-        $this->transactional(function () use ($event) {
-            foreach ($event->affectedSourceOriginDimensionSpacePoints as $originDimensionSpacePoint) {
-                $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByOrigin(
+        foreach ($event->affectedSourceOriginDimensionSpacePoints as $originDimensionSpacePoint) {
+            $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByOrigin(
+                $event->contentStreamId,
+                $originDimensionSpacePoint,
+                $event->sourceNodeAggregateId
+            );
+
+            if ($nodeRecord) {
+                $anchorPoint = $this->copyOnWrite(
                     $event->contentStreamId,
-                    $originDimensionSpacePoint,
-                    $event->sourceNodeAggregateId
+                    $nodeRecord,
+                    function (NodeRecord $node) {
+                    }
                 );
 
-                if ($nodeRecord) {
-                    $anchorPoint = $this->copyOnWrite(
-                        $event->contentStreamId,
-                        $nodeRecord,
-                        function (NodeRecord $node) {
-                        }
+                // remove old
+                $this->getDatabaseConnection()->delete($this->tableNamePrefix . '_referencerelation', [
+                    'sourcenodeanchor' => $anchorPoint->value,
+                    'name' => $event->referenceName->value
+                ]);
+
+                // set new
+                $position = 0;
+                foreach ($event->references as $reference) {
+                    $referenceRecord = new ReferenceRelationRecord(
+                        $anchorPoint,
+                        $event->referenceName,
+                        $position,
+                        $reference->properties,
+                        $reference->targetNodeAggregateId
                     );
-
-                    // remove old
-                    $this->getDatabaseConnection()->delete($this->tableNamePrefix . '_referencerelation', [
-                        'sourcenodeanchor' => $anchorPoint->value,
-                        'name' => $event->referenceName->value
-                    ]);
-
-                    // set new
-                    $position = 0;
-                    foreach ($event->references as $reference) {
-                        $referenceRecord = new ReferenceRelationRecord(
-                            $anchorPoint,
-                            $event->referenceName,
-                            $position,
-                            $reference->properties,
-                            $reference->targetNodeAggregateId
-                        );
-                        $referenceRecord->addToDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
-                        $position++;
-                    }
-                } else {
-                    throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
+                    $referenceRecord->addToDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
+                    $position++;
                 }
+            } else {
+                throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
             }
-        });
+        }
     }
 
     abstract protected function getProjectionHypergraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeRemoval.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeRemoval.php
@@ -38,73 +38,71 @@ trait NodeRemoval
      */
     private function whenNodeAggregateWasRemoved(NodeAggregateWasRemoved $event): void
     {
-        $this->transactional(function () use ($event) {
-            $affectedRelationAnchorPoints = [];
-            // first step: remove hierarchy relations
-            foreach ($event->affectedCoveredDimensionSpacePoints as $dimensionSpacePoint) {
-                $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByCoverage(
-                    $event->getContentStreamId(),
-                    $dimensionSpacePoint,
-                    $event->getNodeAggregateId()
-                );
-                if (is_null($nodeRecord)) {
-                    throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
-                }
-
-                /** @var HierarchyHyperrelationRecord $ingoingHierarchyRelation */
-                $ingoingHierarchyRelation = $this->getProjectionHypergraph()
-                    ->findHierarchyHyperrelationRecordByChildNodeAnchor(
-                        $event->getContentStreamId(),
-                        $dimensionSpacePoint,
-                        $nodeRecord->relationAnchorPoint
-                    );
-                $ingoingHierarchyRelation->removeChildNodeAnchor(
-                    $nodeRecord->relationAnchorPoint,
-                    $this->getDatabaseConnection(),
-                    $this->tableNamePrefix
-                );
-                $this->removeFromRestrictions(
-                    $event->getContentStreamId(),
-                    $dimensionSpacePoint,
-                    $event->getNodeAggregateId()
-                );
-
-                $affectedRelationAnchorPoints[] = $nodeRecord->relationAnchorPoint;
-
-                $this->cascadeHierarchy(
-                    $event->getContentStreamId(),
-                    $dimensionSpacePoint,
-                    $nodeRecord->relationAnchorPoint,
-                    $affectedRelationAnchorPoints
-                );
+        $affectedRelationAnchorPoints = [];
+        // first step: remove hierarchy relations
+        foreach ($event->affectedCoveredDimensionSpacePoints as $dimensionSpacePoint) {
+            $nodeRecord = $this->getProjectionHypergraph()->findNodeRecordByCoverage(
+                $event->getContentStreamId(),
+                $dimensionSpacePoint,
+                $event->getNodeAggregateId()
+            );
+            if (is_null($nodeRecord)) {
+                throw EventCouldNotBeAppliedToContentGraph::becauseTheSourceNodeIsMissing(get_class($event));
             }
 
-            // second step: remove orphaned nodes
-            $this->getDatabaseConnection()->executeStatement(
-                /** @lang PostgreSQL */
-                '
-                WITH deletedNodes AS (
-                    DELETE FROM ' . $this->tableNamePrefix . '_node n
-                    WHERE n.relationanchorpoint IN (
-                        SELECT relationanchorpoint FROM ' . $this->tableNamePrefix . '_node
-                            LEFT JOIN ' . $this->tableNamePrefix . '_hierarchyhyperrelation h
-                                ON n.relationanchorpoint = ANY(h.childnodeanchors)
-                        WHERE n.relationanchorpoint IN (:affectedRelationAnchorPoints)
-                            AND h.contentstreamid IS NULL
-                    )
-                    RETURNING relationanchorpoint
-                )
-                DELETE FROM ' . $this->tableNamePrefix . '_referencerelation r
-                    WHERE sourcenodeanchor IN (SELECT relationanchorpoint FROM deletedNodes)
-                ',
-                [
-                    'affectedRelationAnchorPoints' => $affectedRelationAnchorPoints
-                ],
-                [
-                    'affectedRelationAnchorPoints' => Connection::PARAM_STR_ARRAY
-                ]
+            /** @var HierarchyHyperrelationRecord $ingoingHierarchyRelation */
+            $ingoingHierarchyRelation = $this->getProjectionHypergraph()
+                ->findHierarchyHyperrelationRecordByChildNodeAnchor(
+                    $event->getContentStreamId(),
+                    $dimensionSpacePoint,
+                    $nodeRecord->relationAnchorPoint
+                );
+            $ingoingHierarchyRelation->removeChildNodeAnchor(
+                $nodeRecord->relationAnchorPoint,
+                $this->getDatabaseConnection(),
+                $this->tableNamePrefix
             );
-        });
+            $this->removeFromRestrictions(
+                $event->getContentStreamId(),
+                $dimensionSpacePoint,
+                $event->getNodeAggregateId()
+            );
+
+            $affectedRelationAnchorPoints[] = $nodeRecord->relationAnchorPoint;
+
+            $this->cascadeHierarchy(
+                $event->getContentStreamId(),
+                $dimensionSpacePoint,
+                $nodeRecord->relationAnchorPoint,
+                $affectedRelationAnchorPoints
+            );
+        }
+
+        // second step: remove orphaned nodes
+        $this->getDatabaseConnection()->executeStatement(
+            /** @lang PostgreSQL */
+            '
+            WITH deletedNodes AS (
+                DELETE FROM ' . $this->tableNamePrefix . '_node n
+                WHERE n.relationanchorpoint IN (
+                    SELECT relationanchorpoint FROM ' . $this->tableNamePrefix . '_node
+                        LEFT JOIN ' . $this->tableNamePrefix . '_hierarchyhyperrelation h
+                            ON n.relationanchorpoint = ANY(h.childnodeanchors)
+                    WHERE n.relationanchorpoint IN (:affectedRelationAnchorPoints)
+                        AND h.contentstreamid IS NULL
+                )
+                RETURNING relationanchorpoint
+            )
+            DELETE FROM ' . $this->tableNamePrefix . '_referencerelation r
+                WHERE sourcenodeanchor IN (SELECT relationanchorpoint FROM deletedNodes)
+            ',
+            [
+                'affectedRelationAnchorPoints' => $affectedRelationAnchorPoints
+            ],
+            [
+                'affectedRelationAnchorPoints' => Connection::PARAM_STR_ARRAY
+            ]
+        );
     }
 
     /**
@@ -183,11 +181,6 @@ trait NodeRemoval
     }
 
     abstract protected function getProjectionHypergraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeRenaming.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeRenaming.php
@@ -33,30 +33,23 @@ trait NodeRenaming
      */
     private function whenNodeAggregateNameWasChanged(NodeAggregateNameWasChanged $event): void
     {
-        $this->transactional(function () use ($event) {
-            foreach (
-                $this->getProjectionHyperGraph()->findNodeRecordsForNodeAggregate(
-                    $event->contentStreamId,
-                    $event->nodeAggregateId
-                ) as $originNode
-            ) {
-                $this->copyOnWrite(
-                    $event->contentStreamId,
-                    $originNode,
-                    function (NodeRecord $nodeRecord) use ($event) {
-                        $nodeRecord->nodeName = $event->newNodeName;
-                    }
-                );
-            }
-        });
+        foreach (
+            $this->getProjectionHyperGraph()->findNodeRecordsForNodeAggregate(
+                $event->contentStreamId,
+                $event->nodeAggregateId
+            ) as $originNode
+        ) {
+            $this->copyOnWrite(
+                $event->contentStreamId,
+                $originNode,
+                function (NodeRecord $nodeRecord) use ($event) {
+                    $nodeRecord->nodeName = $event->newNodeName;
+                }
+            );
+        }
     }
 
     abstract protected function getProjectionHyperGraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeTypeChange.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/NodeTypeChange.php
@@ -33,30 +33,23 @@ trait NodeTypeChange
      */
     private function whenNodeAggregateTypeWasChanged(NodeAggregateTypeWasChanged $event): void
     {
-        $this->transactional(function () use ($event) {
-            foreach (
-                $this->getProjectionHyperGraph()->findNodeRecordsForNodeAggregate(
-                    $event->contentStreamId,
-                    $event->nodeAggregateId
-                ) as $originNode
-            ) {
-                $this->copyOnWrite(
-                    $event->contentStreamId,
-                    $originNode,
-                    function (NodeRecord $nodeRecord) use ($event) {
-                        $nodeRecord->nodeTypeName = $event->newNodeTypeName;
-                    }
-                );
-            }
-        });
+        foreach (
+            $this->getProjectionHyperGraph()->findNodeRecordsForNodeAggregate(
+                $event->contentStreamId,
+                $event->nodeAggregateId
+            ) as $originNode
+        ) {
+            $this->copyOnWrite(
+                $event->contentStreamId,
+                $originNode,
+                function (NodeRecord $nodeRecord) use ($event) {
+                    $nodeRecord->nodeTypeName = $event->newNodeTypeName;
+                }
+            );
+        }
     }
 
     abstract protected function getProjectionHyperGraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -32,27 +32,25 @@ trait SubtreeTagging
      */
     private function whenSubtreeWasTagged(SubtreeWasTagged $event): void
     {
-        $this->transactional(function () use ($event) {
-            $descendantNodeAggregateIdsByAffectedDimensionSpacePoint
-                = $this->getProjectionHypergraph()->findDescendantNodeAggregateIds(
-                    $event->contentStreamId,
-                    $event->affectedDimensionSpacePoints,
-                    $event->nodeAggregateId
-                );
+        $descendantNodeAggregateIdsByAffectedDimensionSpacePoint
+            = $this->getProjectionHypergraph()->findDescendantNodeAggregateIds(
+                $event->contentStreamId,
+                $event->affectedDimensionSpacePoints,
+                $event->nodeAggregateId
+            );
 
-            /** @codingStandardsIgnoreStart */
-            foreach ($descendantNodeAggregateIdsByAffectedDimensionSpacePoint as $dimensionSpacePointHash => $descendantNodeAggregateIds) {
-            /** @codingStandardsIgnoreEnd */
-                $restrictionRelation = new RestrictionHyperrelationRecord(
-                    $event->contentStreamId,
-                    $dimensionSpacePointHash,
-                    $event->nodeAggregateId,
-                    $descendantNodeAggregateIds
-                );
+        /** @codingStandardsIgnoreStart */
+        foreach ($descendantNodeAggregateIdsByAffectedDimensionSpacePoint as $dimensionSpacePointHash => $descendantNodeAggregateIds) {
+        /** @codingStandardsIgnoreEnd */
+            $restrictionRelation = new RestrictionHyperrelationRecord(
+                $event->contentStreamId,
+                $dimensionSpacePointHash,
+                $event->nodeAggregateId,
+                $descendantNodeAggregateIds
+            );
 
-                $restrictionRelation->addToDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
-            }
-        });
+            $restrictionRelation->addToDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
+        }
     }
 
     /**
@@ -60,24 +58,17 @@ trait SubtreeTagging
      */
     private function whenSubtreeWasUntagged(SubtreeWasUntagged $event): void
     {
-        $this->transactional(function () use ($event) {
-            $restrictionRelations = $this->getProjectionHypergraph()->findOutgoingRestrictionRelations(
-                $event->contentStreamId,
-                $event->affectedDimensionSpacePoints,
-                $event->nodeAggregateId,
-            );
-            foreach ($restrictionRelations as $restrictionRelation) {
-                $restrictionRelation->removeFromDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
-            }
-        });
+        $restrictionRelations = $this->getProjectionHypergraph()->findOutgoingRestrictionRelations(
+            $event->contentStreamId,
+            $event->affectedDimensionSpacePoints,
+            $event->nodeAggregateId,
+        );
+        foreach ($restrictionRelations as $restrictionRelation) {
+            $restrictionRelation->removeFromDatabase($this->getDatabaseConnection(), $this->tableNamePrefix);
+        }
     }
 
     abstract protected function getProjectionHypergraph(): ProjectionHypergraph;
-
-    /**
-     * @throws \Throwable
-     */
-    abstract protected function transactional(\Closure $operations): void;
 
     abstract protected function getDatabaseConnection(): Connection;
 }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/HypergraphProjection.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/HypergraphProjection.php
@@ -234,14 +234,6 @@ final class HypergraphProjection implements ProjectionInterface
         return $this->projectionHypergraph;
     }
 
-    /**
-     * @throws \Throwable
-     */
-    protected function transactional(\Closure $operations): void
-    {
-        $this->getDatabaseConnection()->transactional($operations);
-    }
-
     protected function getDatabaseConnection(): Connection
     {
         return $this->dbal;


### PR DESCRIPTION
Removes the many `transactional` closures from our projections that made the code harder to read and especially made exceptions much harder to debug.

Due to our current architecture (see #4746) all `Projection::apply()` calls are wrapped in a transaction anyways

Related: #3854