### PR TITLE
!!! TASK: Remove concepts `addQueryString` and `argumentsToBeExcludedFromQueryString` in Neos

### DIFF
--- a/Neos.Fusion/Classes/FusionObjects/ActionUriImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/ActionUriImplementation.php
@@ -28,8 +28,6 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
  *  * format
  *  * section
  *  * additionalParams
- *  * addQueryString
- *  * argumentsToBeExcludedFromQueryString
  *  * absolute
  *  * request
  *
@@ -127,26 +125,6 @@ class ActionUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * Arguments to be removed from the URI. Only active if addQueryString = true
-     *
-     * @return array|null
-     */
-    public function getArgumentsToBeExcludedFromQueryString(): ?array
-    {
-        return $this->fusionValue('argumentsToBeExcludedFromQueryString');
-    }
-
-    /**
-     * If true, the current query parameters will be kept in the URI
-     *
-     * @return boolean
-     */
-    public function isAddQueryString(): bool
-    {
-        return (boolean)$this->fusionValue('addQueryString');
-    }
-
-    /**
      * If true, an absolute URI is rendered
      *
      * @return boolean
@@ -174,11 +152,6 @@ class ActionUriImplementation extends AbstractFusionObject
             $uriBuilder->setArguments($additionalParams);
         }
 
-        $argumentsToBeExcludedFromQueryString = $this->getArgumentsToBeExcludedFromQueryString();
-        if ($argumentsToBeExcludedFromQueryString !== null) {
-            $uriBuilder->setArgumentsToBeExcludedFromQueryString($argumentsToBeExcludedFromQueryString);
-        }
-
         $absolute = $this->isAbsolute();
         if ($absolute === true) {
             $uriBuilder->setCreateAbsoluteUri(true);
@@ -187,11 +160,6 @@ class ActionUriImplementation extends AbstractFusionObject
         $section = $this->getSection();
         if ($section !== null) {
             $uriBuilder->setSection($section);
-        }
-
-        $addQueryString = $this->isAddQueryString();
-        if ($addQueryString === true) {
-            $uriBuilder->setAddQueryString(true);
         }
 
         try {

--- a/Neos.Fusion/Classes/FusionObjects/UriBuilderImplementation.php
+++ b/Neos.Fusion/Classes/FusionObjects/UriBuilderImplementation.php
@@ -27,8 +27,6 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
  *  * format
  *  * section
  *  * additionalParams
- *  * addQueryString
- *  * argumentsToBeExcludedFromQueryString
  *  * absolute
  *
  * See respective getters for descriptions
@@ -119,26 +117,6 @@ class UriBuilderImplementation extends AbstractFusionObject
     }
 
     /**
-     * Arguments to be removed from the URI. Only active if addQueryString = true
-     *
-     * @return array
-     */
-    public function getArgumentsToBeExcludedFromQueryString()
-    {
-        return $this->fusionValue('argumentsToBeExcludedFromQueryString');
-    }
-
-    /**
-     * If true, the current query parameters will be kept in the URI
-     *
-     * @return boolean
-     */
-    public function isAddQueryString()
-    {
-        return (boolean)$this->fusionValue('addQueryString');
-    }
-
-    /**
      * If true, an absolute URI is rendered
      *
      * @return boolean
@@ -177,11 +155,6 @@ class UriBuilderImplementation extends AbstractFusionObject
             $uriBuilder->setArguments($additionalParams);
         }
 
-        $argumentsToBeExcludedFromQueryString = $this->getArgumentsToBeExcludedFromQueryString();
-        if ($argumentsToBeExcludedFromQueryString !== null) {
-            $uriBuilder->setArgumentsToBeExcludedFromQueryString($argumentsToBeExcludedFromQueryString);
-        }
-
         $absolute = $this->isAbsolute();
         if ($absolute === true) {
             $uriBuilder->setCreateAbsoluteUri(true);
@@ -190,11 +163,6 @@ class UriBuilderImplementation extends AbstractFusionObject
         $section = $this->getSection();
         if ($section !== null) {
             $uriBuilder->setSection($section);
-        }
-
-        $addQueryString = $this->isAddQueryString();
-        if ($addQueryString === true) {
-            $uriBuilder->setAddQueryString(true);
         }
 
         try {

--- a/Neos.Fusion/Resources/Private/Fusion/Deprecated/UriBuilder.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Deprecated/UriBuilder.fusion
@@ -18,11 +18,9 @@ prototype(Neos.Fusion:UriBuilder) {
   additionalParams = Neos.Fusion:DataStructure {
     @sortProperties = false
   }
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure {
     @sortProperties = false
   }
-  addQueryString = false
   absolute = false
 
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'

--- a/Neos.Fusion/Resources/Private/Fusion/Prototypes/ActionUri.fusion
+++ b/Neos.Fusion/Resources/Private/Fusion/Prototypes/ActionUri.fusion
@@ -18,8 +18,6 @@ prototype(Neos.Fusion:ActionUri) {
   section = null
   additionalParams = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
-  addQueryString = false
   absolute = false
 
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'

--- a/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
+++ b/Neos.Neos/Classes/Fusion/NodeUriImplementation.php
@@ -83,26 +83,6 @@ class NodeUriImplementation extends AbstractFusionObject
     }
 
     /**
-     * Arguments to be removed from the URI. Only active if addQueryString = true
-     *
-     * @return array<int,string>
-     */
-    public function getArgumentsToBeExcludedFromQueryString(): array
-    {
-        return $this->fusionValue('argumentsToBeExcludedFromQueryString');
-    }
-
-    /**
-     * If true, the current query parameters will be kept in the URI
-     *
-     * @return boolean
-     */
-    public function getAddQueryString()
-    {
-        return (bool)$this->fusionValue('addQueryString');
-    }
-
-    /**
      * If true, an absolute URI is rendered
      *
      * @return boolean
@@ -177,9 +157,7 @@ class NodeUriImplementation extends AbstractFusionObject
             ->setFormat($this->getFormat())
             ->setCreateAbsoluteUri($this->isAbsolute())
             ->setArguments($this->getAdditionalParams())
-            ->setSection($this->getSection())
-            ->setAddQueryString($this->getAddQueryString())
-            ->setArgumentsToBeExcludedFromQueryString($this->getArgumentsToBeExcludedFromQueryString());
+            ->setSection($this->getSection());
 
         try {
             return (string)NodeUriBuilder::fromUriBuilder($uriBuilder)->uriFor($nodeAddress);

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -34,7 +34,6 @@ use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Exception as NeosException;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\FrontendRouting\NodeShortcutResolver;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
@@ -87,12 +86,6 @@ class LinkingService
      * @var ResourceManager
      */
     protected $resourceManager;
-
-    /**
-     * @Flow\Inject
-     * @var NodeShortcutResolver
-     */
-    protected $nodeShortcutResolver;
 
     /**
      * @Flow\Inject

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -35,6 +35,7 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Exception as NeosException;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
+use Neos\Utility\Arrays;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 
@@ -253,9 +254,9 @@ class LinkingService
      * @param array<string,mixed> $arguments Additional arguments to be passed to the UriBuilder
      *                                       (e.g. pagination parameters)
      * @param string $section
-     * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
+     * @param boolean $addQueryString If set, the current query parameters will be kept in the URI @deprecated see https://github.com/neos/neos-development-collection/issues/5076
      * @param array<int,string> $argumentsToBeExcludedFromQueryString arguments to be removed from the URI.
-     *                                                    Only active if $addQueryString = true
+     *                                                    Only active if $addQueryString = true @deprecated see https://github.com/neos/neos-development-collection/issues/5076
      * @param boolean $resolveShortcuts @deprecated With Neos 7.0 this argument is no longer evaluated
      *                                  and log a message if set to FALSE
      * @return string The rendered URI
@@ -348,18 +349,27 @@ class LinkingService
         $workspace = $contentRepository->getWorkspaceFinder()->findOneByName(
             $node->workspaceName
         );
-        $request = $controllerContext->getRequest()->getMainRequest();
+        $mainRequest = $controllerContext->getRequest()->getMainRequest();
         $uriBuilder = clone $controllerContext->getUriBuilder();
-        $uriBuilder->setRequest($request);
+        $uriBuilder->setRequest($mainRequest);
         $action = $workspace && $workspace->isPublicWorkspace() && $node->tags->contain(SubtreeTag::disabled()) ? 'show' : 'preview';
+
+        if ($addQueryString === true) {
+            // legacy feature see https://github.com/neos/neos-development-collection/issues/5076
+            $requestArguments = $mainRequest->getArguments();
+            foreach ($argumentsToBeExcludedFromQueryString as $argumentToBeExcluded) {
+                unset($requestArguments[$argumentToBeExcluded]);
+            }
+            if ($requestArguments !== []) {
+                $arguments = Arrays::arrayMergeRecursiveOverrule($requestArguments, $arguments);
+            }
+        }
 
         return $uriBuilder
             ->reset()
             ->setSection($section)
             ->setArguments($arguments)
-            ->setAddQueryString($addQueryString)
-            ->setArgumentsToBeExcludedFromQueryString($argumentsToBeExcludedFromQueryString)
-            ->setFormat($format ?: $request->getFormat())
+            ->setFormat($format ?: $mainRequest->getFormat())
             ->setCreateAbsoluteUri($absolute)
             ->uriFor($action, ['node' => $node], 'Frontend\Node', 'Neos.Neos');
     }

--- a/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/ModuleViewHelper.php
@@ -79,14 +79,14 @@ class ModuleViewHelper extends AbstractTagBasedViewHelper
         $this->registerArgument(
             'addQueryString',
             'boolean',
-            'If set, the current query parameters will be kept in the URI',
+            'Deprecated with Neos 9. If set, the current query parameters will be kept in the URI',
             false,
             false
         );
         $this->registerArgument(
             'argumentsToBeExcludedFromQueryString',
             'array',
-            'arguments to be removed from the URI. Only active if $addQueryString = true',
+            'Deprecated with Neos 9. arguments to be removed from the URI. Only active if $addQueryString = true',
             false,
             []
         );

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -218,20 +218,6 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
             ''
         );
         $this->registerArgument(
-            'addQueryString',
-            'boolean',
-            'If set, the current query parameters will be kept in the URI',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'argumentsToBeExcludedFromQueryString',
-            'array',
-            'arguments to be removed from the URI. Only active if $addQueryString = true',
-            false,
-            []
-        );
-        $this->registerArgument(
             'baseNodeName',
             'string',
             'The name of the base node inside the Fusion context to use for the ContentContext'
@@ -322,9 +308,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
         $uriBuilder->setFormat($this->arguments['format'])
             ->setCreateAbsoluteUri($this->arguments['absolute'])
             ->setArguments($this->arguments['arguments'])
-            ->setSection($this->arguments['section'])
-            ->setAddQueryString($this->arguments['addQueryString'])
-            ->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString']);
+            ->setSection($this->arguments['section']);
 
         $uri = '';
         try {

--- a/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/ModuleViewHelper.php
@@ -66,14 +66,14 @@ class ModuleViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'addQueryString',
             'string',
-            'If set, the current query parameters will be kept in the URI',
+            'Deprecated with Neos 9. If set, the current query parameters will be kept in the URI',
             false,
             false
         );
         $this->registerArgument(
             'argumentsToBeExcludedFromQueryString',
             'string',
-            'arguments to be removed from the URI. Only active if $addQueryString = true',
+            'Deprecated with Neos 9. arguments to be removed from the URI. Only active if $addQueryString = true',
             false,
             []
         );

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -158,20 +158,6 @@ class NodeViewHelper extends AbstractViewHelper
             ''
         );
         $this->registerArgument(
-            'addQueryString',
-            'boolean',
-            'If set, the current query parameters will be kept in the URI',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'argumentsToBeExcludedFromQueryString',
-            'array',
-            'arguments to be removed from the URI. Only active if $addQueryString = true',
-            false,
-            []
-        );
-        $this->registerArgument(
             'baseNodeName',
             'string',
             'The name of the base node inside the Fusion context to use for the ContentContext'
@@ -227,9 +213,7 @@ class NodeViewHelper extends AbstractViewHelper
         $uriBuilder->setFormat($this->arguments['format'])
             ->setCreateAbsoluteUri($this->arguments['absolute'])
             ->setArguments($this->arguments['arguments'])
-            ->setSection($this->arguments['section'])
-            ->setAddQueryString($this->arguments['addQueryString'])
-            ->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString']);
+            ->setSection($this->arguments['section']);
 
         $uri = '';
         if (!$nodeAddress) {

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -570,8 +570,6 @@ Built a URI to a controller action
 :format: (string) An optional request format (e.g. ``'html'``)
 :section: (string) An optional fragment (hash) for the URI
 :additionalParams: (array) Additional URI query parameters by named key
-:addQueryString: (boolean) Whether to keep the query parameters of the current URI
-:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
 :absolute: (boolean) Whether to create an absolute URI
 
 Example::
@@ -1181,8 +1179,6 @@ Build a URI to a node. Accepts the same arguments as the node link/uri view help
 :format: (string) An optional request format (e.g. ``'html'``)
 :section: (string) An optional fragment (hash) for the URI
 :additionalParams: (array) Additional URI query parameters.
-:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
-:addQueryString: (boolean) Whether to keep current query parameters, defaults to ``FALSE``
 :absolute: (boolean) Whether to create an absolute URI, defaults to ``FALSE``
 :baseNodeName: (string) Base node context variable name (for relative paths), defaults to ``'documentNode'``
 
@@ -1355,8 +1351,6 @@ Built a URI to a controller action
 :format: (string) An optional request format (e.g. ``'html'``)
 :section: (string) An optional fragment (hash) for the URI
 :additionalParams: (array) Additional URI query parameters by named key
-:addQueryString: (boolean) Whether to keep the query parameters of the current URI
-:argumentsToBeExcludedFromQueryString: (array) Query parameters to exclude for ``addQueryString``
 :absolute: (boolean) Whether to create an absolute URI
 
 .. note:: The use of ``Neos.Fusion:UriBuilder`` is deprecated. Use :ref:`Neos_Fusion__ActionUri` instead.

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -5,8 +5,6 @@ prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
   node = null
   additionalParams = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
-  addQueryString = false
   absolute = false
   baseNodeName = 'documentNode'
 
@@ -14,8 +12,6 @@ prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
     node = ${this.node}
     additionalParams = ${this.additionalParams}
     arguments = ${this.arguments}
-    argumentsToBeExcludedFromQueryString = ${this.argumentsToBeExcludedFromQueryString}
-    addQueryString = ${this.addQueryString}
     absolute = ${this.absolute}
     baseNodeName = ${this.baseNodeName}
   }
@@ -26,8 +22,6 @@ prototype(Neos.Neos:NodeLink) < prototype(Neos.Fusion:Tag) {
       node = ${node}
       additionalParams = ${additionalParams}
       arguments = ${arguments}
-      argumentsToBeExcludedFromQueryString = ${argumentsToBeExcludedFromQueryString}
-      addQueryString = ${addQueryString}
       absolute = ${absolute}
       baseNodeName = ${baseNodeName}
     }

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/NodeUri.fusion
@@ -4,6 +4,5 @@ prototype(Neos.Neos:NodeUri) {
   @class = 'Neos\\Neos\\Fusion\\NodeUriImplementation'
   additionalParams = Neos.Fusion:DataStructure
   arguments = Neos.Fusion:DataStructure
-  argumentsToBeExcludedFromQueryString = Neos.Fusion:DataStructure
   @exceptionHandler = 'Neos\\Fusion\\Core\\ExceptionHandlers\\AbsorbingHandler'
 }


### PR DESCRIPTION
Resolves: #5076


**Upgrade instructions**

The options `addQueryString` and `argumentsToBeExcludedFromQueryString` have been removed from Fluid and Fusions Node Uri-Building API.
Please consider using Flows actual routing or reimplement this feature yourself:

```diff
- root = Neos.Fusion:NodeUri {
-    addQueryString = true
-    argumentsToBeExcludedFromQueryString = ${['bar']}
- }
+ root = Neos.Fusion:NodeUri {
+    additionalParams = ${request.arguments.filter((value, key) => key != 'bar')}
+ }
```

Affected Fusion prototypes:
- `Neos.Fusion:ActionUri`
  - and its usages like `Neos.Fusion:Link.Action`'s href 
- `Neos.Fusion:UriBuilder`
- `Neos.Neos:NodeLink`
- `Neos.Neos:NodeUri`

Fluid view helpers with now removed `addQueryString`
- `<neos:link.node />`
- `<neos:uri.node />`

Fluid view helpers with now deprecated `addQueryString`
- `<neos:uri.module />`
- `<neos:link.module />`

Affected PHP APIs:
- `LinkingService::createNodeUri`
  - the parameters no. 8 & 9 are deprecated.

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
