### PR TITLE
!!! TASK: Deprecate setting NodeNames via cr commands

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNode.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNode.php
@@ -65,12 +65,11 @@ final readonly class CreateNodeAggregateWithNode implements CommandInterface
      * @param OriginDimensionSpacePoint $originDimensionSpacePoint Origin of the new node in the dimension space. Will also be used to calculate a set of dimension points where the new node will cover from the configured specializations.
      * @param NodeAggregateId $parentNodeAggregateId The id of the node aggregate underneath which the new node is added
      * @param NodeAggregateId|null $succeedingSiblingNodeAggregateId Node aggregate id of the node's succeeding sibling (optional). If not given, the node will be added as the parent's first child
-     * @param NodeName|null $nodeName The node's optional name. Set if there is a meaningful relation to its parent that should be named.
      * @param PropertyValuesToWrite|null $initialPropertyValues The node's initial property values. Will be merged over the node type's default property values
      */
-    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $nodeTypeName, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, ?NodeAggregateId $succeedingSiblingNodeAggregateId = null, ?NodeName $nodeName = null, ?PropertyValuesToWrite $initialPropertyValues = null): self
+    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $nodeTypeName, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, ?NodeAggregateId $succeedingSiblingNodeAggregateId = null, ?PropertyValuesToWrite $initialPropertyValues = null): self
     {
-        return new self($workspaceName, $nodeAggregateId, $nodeTypeName, $originDimensionSpacePoint, $parentNodeAggregateId, $initialPropertyValues ?: PropertyValuesToWrite::createEmpty(), $succeedingSiblingNodeAggregateId, $nodeName, NodeAggregateIdsByNodePaths::createEmpty());
+        return new self($workspaceName, $nodeAggregateId, $nodeTypeName, $originDimensionSpacePoint, $parentNodeAggregateId, $initialPropertyValues ?: PropertyValuesToWrite::createEmpty(), $succeedingSiblingNodeAggregateId, null, NodeAggregateIdsByNodePaths::createEmpty());
     }
 
     public function withInitialPropertyValues(PropertyValuesToWrite $newInitialPropertyValues): self
@@ -128,6 +127,27 @@ final readonly class CreateNodeAggregateWithNode implements CommandInterface
             $this->succeedingSiblingNodeAggregateId,
             $this->nodeName,
             $tetheredDescendantNodeAggregateIds,
+        );
+    }
+
+    /**
+     * The node's optional name.
+     * Set if there is a meaningful relation to its parent that should be named.
+     *
+     * @deprecated the concept regarding node-names for non-tethered nodes is outdated.
+     */
+    public function withNodeName(NodeName $nodeName): self
+    {
+        return new self(
+            $this->workspaceName,
+            $this->nodeAggregateId,
+            $this->nodeTypeName,
+            $this->originDimensionSpacePoint,
+            $this->parentNodeAggregateId,
+            $this->initialPropertyValues,
+            $this->succeedingSiblingNodeAggregateId,
+            $nodeName,
+            $this->tetheredDescendantNodeAggregateIds,
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -83,7 +83,6 @@ trait NodeCreation
             $command->originDimensionSpacePoint,
             $command->parentNodeAggregateId,
             $command->succeedingSiblingNodeAggregateId,
-            $command->nodeName,
             $this->getPropertyConverter()->serializePropertyValues(
                 $command->initialPropertyValues->withoutUnsets(),
                 $this->requireNodeType($command->nodeTypeName)
@@ -91,6 +90,9 @@ trait NodeCreation
         );
         if (!$command->tetheredDescendantNodeAggregateIds->isEmpty()) {
             $lowLevelCommand = $lowLevelCommand->withTetheredDescendantNodeAggregateIds($command->tetheredDescendantNodeAggregateIds);
+        }
+        if ($command->nodeName) {
+            $lowLevelCommand = $lowLevelCommand->withNodeName($command->nodeName);
         }
 
         return $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($lowLevelCommand, $commandHandlingDependencies);

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
@@ -85,8 +85,7 @@ final readonly class CopyNodesRecursively implements
         Node $startNode,
         OriginDimensionSpacePoint $dimensionSpacePoint,
         NodeAggregateId $targetParentNodeAggregateId,
-        ?NodeAggregateId $targetSucceedingSiblingNodeAggregateId,
-        ?NodeName $targetNodeName
+        ?NodeAggregateId $targetSucceedingSiblingNodeAggregateId
     ): self {
         $nodeSubtreeSnapshot = NodeSubtreeSnapshot::fromSubgraphAndStartNode($subgraph, $startNode);
 
@@ -96,7 +95,7 @@ final readonly class CopyNodesRecursively implements
             $dimensionSpacePoint,
             $targetParentNodeAggregateId,
             $targetSucceedingSiblingNodeAggregateId,
-            $targetNodeName,
+            null,
             NodeAggregateIdMapping::generateForNodeSubtreeSnapshot($nodeSubtreeSnapshot)
         );
     }
@@ -153,6 +152,24 @@ final readonly class CopyNodesRecursively implements
         );
     }
 
+    /**
+     * The target node's optional name.
+     *
+     * @deprecated the concept regarding node-names for non-tethered nodes is outdated.
+     */
+    public function withTargetNodeName(NodeName $targetNodeName): self
+    {
+        return new self(
+            $this->workspaceName,
+            $this->nodeTreeToInsert,
+            $this->targetDimensionSpacePoint,
+            $this->targetParentNodeAggregateId,
+            $this->targetSucceedingSiblingNodeAggregateId,
+            $targetNodeName,
+            $this->nodeAggregateIdMapping
+        );
+    }
+
     public function createCopyForWorkspace(
         WorkspaceName $targetWorkspaceName,
     ): self {
@@ -163,24 +180,6 @@ final readonly class CopyNodesRecursively implements
             $this->targetParentNodeAggregateId,
             $this->targetSucceedingSiblingNodeAggregateId,
             $this->targetNodeName,
-            $this->nodeAggregateIdMapping
-        );
-    }
-
-    /**
-     * The target node's optional name.
-     *
-     * @deprecated the concept regarding node-names for non-tethered nodes is outdated.
-     */
-    public function withNodeName(NodeName $nodeName): self
-    {
-        return new self(
-            $this->workspaceName,
-            $this->nodeTreeToInsert,
-            $this->targetDimensionSpacePoint,
-            $this->targetParentNodeAggregateId,
-            $this->targetSucceedingSiblingNodeAggregateId,
-            $nodeName,
             $this->nodeAggregateIdMapping
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Command/CopyNodesRecursively.php
@@ -69,12 +69,11 @@ final readonly class CopyNodesRecursively implements
      * @param OriginDimensionSpacePoint $targetDimensionSpacePoint the dimension space point which is the target of the copy
      * @param NodeAggregateId $targetParentNodeAggregateId Node aggregate id of the target node's parent. If not given, the node will be added as the parent's first child
      * @param NodeAggregateId|null $targetSucceedingSiblingNodeAggregateId Node aggregate id of the target node's succeeding sibling (optional)
-     * @param NodeName|null $targetNodeName the root node name of the root-inserted-node
      * @param NodeAggregateIdMapping $nodeAggregateIdMapping An assignment of "old" to "new" NodeAggregateIds ({@see NodeAggregateIdMapping})
      */
-    public static function create(WorkspaceName $workspaceName, NodeSubtreeSnapshot $nodeTreeToInsert, OriginDimensionSpacePoint $targetDimensionSpacePoint, NodeAggregateId $targetParentNodeAggregateId, ?NodeAggregateId $targetSucceedingSiblingNodeAggregateId, ?NodeName $targetNodeName, NodeAggregateIdMapping $nodeAggregateIdMapping): self
+    public static function create(WorkspaceName $workspaceName, NodeSubtreeSnapshot $nodeTreeToInsert, OriginDimensionSpacePoint $targetDimensionSpacePoint, NodeAggregateId $targetParentNodeAggregateId, ?NodeAggregateId $targetSucceedingSiblingNodeAggregateId, NodeAggregateIdMapping $nodeAggregateIdMapping): self
     {
-        return new self($workspaceName, $nodeTreeToInsert, $targetDimensionSpacePoint, $targetParentNodeAggregateId, $targetSucceedingSiblingNodeAggregateId, $targetNodeName, $nodeAggregateIdMapping);
+        return new self($workspaceName, $nodeTreeToInsert, $targetDimensionSpacePoint, $targetParentNodeAggregateId, $targetSucceedingSiblingNodeAggregateId, null, $nodeAggregateIdMapping);
     }
 
     /**
@@ -164,6 +163,24 @@ final readonly class CopyNodesRecursively implements
             $this->targetParentNodeAggregateId,
             $this->targetSucceedingSiblingNodeAggregateId,
             $this->targetNodeName,
+            $this->nodeAggregateIdMapping
+        );
+    }
+
+    /**
+     * The target node's optional name.
+     *
+     * @deprecated the concept regarding node-names for non-tethered nodes is outdated.
+     */
+    public function withNodeName(NodeName $nodeName): self
+    {
+        return new self(
+            $this->workspaceName,
+            $this->nodeTreeToInsert,
+            $this->targetDimensionSpacePoint,
+            $this->targetParentNodeAggregateId,
+            $this->targetSucceedingSiblingNodeAggregateId,
+            $nodeName,
             $this->nodeAggregateIdMapping
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/Command/ChangeNodeAggregateName.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/Command/ChangeNodeAggregateName.php
@@ -20,14 +20,15 @@ use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterfac
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Dto\NodeIdToPublishOrDiscard;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * All variants in a NodeAggregate have the same NodeName - and this can be changed here.
- * This is the case because Node Names are usually only used for tethered nodes (=autocreated in the old CR);
- * as then the Node Name is used for querying.
+ * All variants in a NodeAggregate have the same (optional) NodeName, which this can be changed here.
  *
+ * Node Names are usually only used for tethered nodes; as then the Node Name is used for querying.
+ * Tethered Nodes cannot be renamed via the command API.
+ *
+ * @deprecated the concept regarding node-names for non-tethered nodes is outdated.
  * @api commands are the write-API of the ContentRepository
  */
 final readonly class ChangeNodeAggregateName implements

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCopying.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCopying.php
@@ -49,9 +49,7 @@ trait NodeCopying
         $targetSucceedingSiblingNodeAggregateId = isset($commandArguments['targetSucceedingSiblingNodeAggregateId'])
             ? NodeAggregateId::fromString($commandArguments['targetSucceedingSiblingNodeAggregateId'])
             : null;
-        $targetNodeName = isset($commandArguments['targetNodeName'])
-            ? NodeName::fromString($commandArguments['targetNodeName'])
-            : null;
+
         $workspaceName = isset($commandArguments['workspaceName'])
             ? WorkspaceName::fromString($commandArguments['workspaceName'])
             : $this->currentWorkspaceName;
@@ -62,9 +60,11 @@ trait NodeCopying
             $this->currentNode,
             $targetDimensionSpacePoint,
             NodeAggregateId::fromString($commandArguments['targetParentNodeAggregateId']),
-            $targetSucceedingSiblingNodeAggregateId,
-            $targetNodeName
+            $targetSucceedingSiblingNodeAggregateId
         );
+        if (isset($commandArguments['targetNodeName'])) {
+            $command = $command->withTargetNodeName(NodeName::fromString($commandArguments['targetNodeName']));
+        }
         $command = $command->withNodeAggregateIdMapping(NodeAggregateIdMapping::fromArray($commandArguments['nodeAggregateIdMapping']));
 
         $this->currentContentRepository->handle($command);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
@@ -148,15 +148,15 @@ trait NodeCreation
             isset($commandArguments['succeedingSiblingNodeAggregateId'])
                 ? NodeAggregateId::fromString($commandArguments['succeedingSiblingNodeAggregateId'])
                 : null,
-            isset($commandArguments['nodeName'])
-                ? NodeName::fromString($commandArguments['nodeName'])
-                : null,
             isset($commandArguments['initialPropertyValues'])
                 ? $this->deserializeProperties($commandArguments['initialPropertyValues'])
                 : null,
         );
         if (isset($commandArguments['tetheredDescendantNodeAggregateIds'])) {
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
+        }
+        if (isset($commandArguments['nodeName'])) {
+            $command = $command->withNodeName(NodeName::fromString($commandArguments['nodeName']));
         }
         $this->currentContentRepository->handle($command);
     }
@@ -198,15 +198,15 @@ trait NodeCreation
                 !empty($row['succeedingSiblingNodeAggregateId'])
                     ? NodeAggregateId::fromString($row['succeedingSiblingNodeAggregateId'])
                     : null,
-                isset($row['nodeName'])
-                    ? NodeName::fromString($row['nodeName'])
-                    : null,
                 isset($row['initialPropertyValues'])
                     ? $this->parsePropertyValuesJsonString($row['initialPropertyValues'])
                     : null,
             );
             if (isset($row['tetheredDescendantNodeAggregateIds'])) {
                 $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromJsonString($row['tetheredDescendantNodeAggregateIds']));
+            }
+            if (isset($row['nodeName'])) {
+                $command = $command->withNodeName(NodeName::fromString($row['nodeName']));
             }
             $this->currentContentRepository->handle($command);
         }
@@ -243,15 +243,15 @@ trait NodeCreation
             isset($commandArguments['succeedingSiblingNodeAggregateId'])
                 ? NodeAggregateId::fromString($commandArguments['succeedingSiblingNodeAggregateId'])
                 : null,
-            isset($commandArguments['nodeName'])
-                ? NodeName::fromString($commandArguments['nodeName'])
-                : null,
             isset($commandArguments['initialPropertyValues'])
                 ? SerializedPropertyValues::fromArray($commandArguments['initialPropertyValues'])
                 : null
         );
         if (isset($commandArguments['tetheredDescendantNodeAggregateIds'])) {
             $command = $command->withTetheredDescendantNodeAggregateIds(NodeAggregateIdsByNodePaths::fromArray($commandArguments['tetheredDescendantNodeAggregateIds']));
+        }
+        if (isset($commandArguments['nodeName'])) {
+            $command = $command->withNodeName(NodeName::fromString($commandArguments['nodeName']));
         }
         $this->currentContentRepository->handle($command);
     }

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -116,11 +116,10 @@ readonly class SiteServiceInternals implements ContentRepositoryServiceInterface
             OriginDimensionSpacePoint::fromDimensionSpacePoint($arbitraryRootDimensionSpacePoint),
             $sitesNodeIdentifier,
             null,
-            $site->getNodeName()->toNodeName(),
             PropertyValuesToWrite::fromArray([
                 'title' => $site->getName()
             ])
-        ));
+        )->withNodeName($site->getNodeName()->toNodeName()));
 
         // Handle remaining root dimension space points by creating peer variants
         foreach ($rootDimensionSpacePoints as $rootDimensionSpacePoint) {


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-development-collection/issues/5050

**Upgrade instructions**

The parameter `$nodeName` is not accepted anymore in the main factory via `CreateNodeAggregateWithNode::create` and  `CopyNodesRecursively`.

Please adjust your code to use the additional `with*`-er instead.

```php
$command = CreateNodeAggregateWithNode::create(...);

if ($nodeName) {
    $command = $command->withNodeName($nodeName);
}
```

If you set their value previously simply to `null`, you can just omit setting this argument.

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
