### PR TITLE
BUGFIX: Violation detection: Fix selection of node ids by content stream

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -639,9 +639,9 @@ WHERE
     ): array {
         $records = $this->dbal->executeQuery(
             'SELECT
-                DISTINCT nodeaggregateid
+                DISTINCT n.nodeaggregateid
             FROM
-                ' . $this->tableNames->node() . '
+                ' . $this->tableNames->node() . ' n
                 INNER JOIN ' . $this->tableNames->hierarchyRelation() . ' h
                 ON h.childnodeanchor = n.relationanchorpoint
             WHERE

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -638,7 +638,17 @@ WHERE
         ContentStreamId $contentStreamId
     ): array {
         $records = $this->dbal->executeQuery(
-            'SELECT DISTINCT nodeaggregateid FROM ' . $this->tableNames->node()
+            'SELECT
+                DISTINCT nodeaggregateid
+            FROM
+                ' . $this->tableNames->node() . '
+                INNER JOIN ' . $this->tableNames->hierarchyRelation() . ' h
+                ON h.childnodeanchor = n.relationanchorpoint
+            WHERE
+                h.contentstreamid = :contentStreamId',
+            [
+                'contentStreamId' => $contentStreamId->value,
+            ]
         )->fetchAllAssociative();
 
         return array_map(function (array $record) {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
@@ -25,7 +25,7 @@ Feature: Run projection integrity violation detection regarding node aggregate c
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
 
-  Scenario: Create node variants of different type
+  Scenario: Create node variants of different classification
     When the event NodeAggregateWithNodeWasCreated was published with payload:
       | Key                         | Value                                     |
       | workspaceName               | "live"                                    |


### PR DESCRIPTION
Fixes the implementation of `ProjectionIntegrityViolationDetector::findProjectedNodeAggregateIdsInContentStream()` in the `Neos.ContentGraph.DoctrineDbalAdapter` package that never respected the `$contentStreamId` parameter