### PR TITLE
BUGFIX: Fix linting error in `ConvertUrisImplementation`

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -187,7 +187,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
                 return $matches[0];
             }
 
-            return $resolvedUri;
+            return (string)$resolvedUri;
         }, $text);
         assert($processedContent !== null, 'preg_* error');
 


### PR DESCRIPTION
Without that fix, the latest supported version of PHPStan yields an error:

    Parameter #2 $callback of function preg_replace_callback expects callable(array<int|string, string>): string, Closure(array): (string|false) given.