### PR TITLE
BUGFIX AssetUsage in MediaBrowser

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -102,7 +102,6 @@ class UsageController extends ActionController
 
             // FIXME: AssetUsageReference->workspaceName ?
             $nodeAggregate = $contentRepository->getContentGraph($workspace->workspaceName)->findNodeAggregateById(
-                $usage->getContentStreamId(),
                 $usage->getNodeAggregateId()
             );
             try {
@@ -125,7 +124,6 @@ class UsageController extends ActionController
             }
 
             $subgraph = $contentRepository->getContentGraph($workspace->workspaceName)->getSubgraph(
-                $usage->getContentStreamId(),
                 $usage->getOriginDimensionSpacePoint()->toDimensionSpacePoint(),
                 VisibilityConstraints::withoutRestrictions()
             );

--- a/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
@@ -96,7 +96,7 @@
                             <f:if condition="{nodeInformation.documentNode}">
                                 <f:then>
                                     <neos:link.node node="{nodeInformation.documentNode}" target="_blank"
-                                                    title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: nodeInformation.documentNode.workspace.title})}">
+                                                    title="{neos:backend.translate(id: 'workspaces.openPageInWorkspace', source: 'Modules', package: 'Neos.Neos', arguments: {0: nodeInformation.workspace.workspaceTitle.value})}">
                                 <span title="{f:render(partial: 'Module/Shared/DocumentBreadcrumb', arguments: {node: nodeInformation.documentNode})}" data-neos-toggle="tooltip">{nodeInformation.documentNode.label}</span>
                                         <i class="fas fa-external-link-alt"></i>
                                     </neos:link.node>


### PR DESCRIPTION
Small bugfixes for AssetUsage in MediaBrowser:
* Remove ContentStreamId in AssetUsage Controller
* Use workspace in nodeInformation instead of the documentNode 