### PR TITLE
BUGFIX: fix behat configuration template folder path in README.rst

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -124,7 +124,7 @@ Do the following for setting up everything:
 
    .. code-block:: bash
 
-       cp -R Packages/Neos/Neos.ContentRepository.BehavioralTests/DistributionBehatTemplate/ Build/Behat
+       cp -R Packages/Neos/Neos.ContentRepository.BehavioralTests/DistributionConfigurationTemplate/ Build/Behat
        pushd Build/Behat/
        rm composer.lock
        composer install


### PR DESCRIPTION
With #4543 the `Neos.ContentRepository.BehavioralTests/DistributionBehatTemplate` folder was removed.
This fixes the README accordingly