### PR TITLE
Fix PHPStan baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,7 +231,7 @@ parameters:
 			path: Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
 
 		-
-			message: "#^Parameter \\#2 \\$length of function fread expects int\\<0, max\\>, int given\\.$#"
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int given\\.$#"
 			count: 1
 			path: Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
 


### PR DESCRIPTION
Without this change, `composer lint` runs into

```
Error: Ignored error pattern #^Parameter \#2 \$length of function fread expects int\<0, max\>, int given\.$# in path /home/runner/work/neos-development-collection/neos-development-collection/neos-development-distribution/Packages/Neos/Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php was not matched in reported errors.
Error: Parameter #2 $length of function fread expects int<1, max>, int given.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         Ignored error pattern #^Parameter \#2 \$length of function fread
         expects int<0, max>, int given\.$# in path
         /home/runner/work/neos-development-collection/neos-development-collection/neos-development-distribution/Packages/Neos/Neos.Neos/Classes/ResourceManagement/NodeTypesStreamWrapper.php
         was not matched in reported errors.
  337    Parameter #2 $length of function fread expects int<1, max>, int
         given.
         🪪  argument.type
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```