### PR TITLE
TASK: Unify naming of contentRepositoryIdentifier to contentRepository in ESCR CLI commands

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
@@ -29,7 +29,7 @@ class ContentStreamCommandController extends CommandController
      * to a workspace (f.e. dangling ones in FORKED or CREATED.).
      *
      * @param string $contentRepository Identifier of the content repository. (Default: 'default')
-     * @param boolean $removeTemporary
+     * @param boolean $removeTemporary Will delete all content streams which are currently not assigned (Default: false)
      */
     public function pruneCommand(string $contentRepository = 'default', bool $removeTemporary = false): void
     {

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
@@ -28,7 +28,7 @@ class ContentStreamCommandController extends CommandController
      * If you also call with "--removeTemporary", will delete ALL content streams which are currently not assigned
      * to a workspace (f.e. dangling ones in FORKED or CREATED.).
      *
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @param boolean $removeTemporary
      */
     public function pruneCommand(string $contentRepository = 'default', bool $removeTemporary = false): void
@@ -50,7 +50,7 @@ class ContentStreamCommandController extends CommandController
     /**
      * Remove unused and deleted content streams from the event stream; effectively REMOVING information completely
      *
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      */
     public function pruneRemovedFromEventStreamCommand(string $contentRepository = 'default'): void
     {

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
@@ -27,10 +27,13 @@ class ContentStreamCommandController extends CommandController
      * By default, only content streams in STATE_NO_LONGER_IN_USE and STATE_REBASE_ERROR will be removed.
      * If you also call with "--removeTemporary", will delete ALL content streams which are currently not assigned
      * to a workspace (f.e. dangling ones in FORKED or CREATED.).
+     *
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param boolean $removeTemporary
      */
-    public function pruneCommand(string $contentRepositoryIdentifier = 'default', bool $removeTemporary = false): void
+    public function pruneCommand(string $contentRepository = 'default', bool $removeTemporary = false): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentStreamPruner = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentStreamPrunerFactory());
 
         $unusedContentStreams = $contentStreamPruner->prune($removeTemporary);
@@ -46,10 +49,12 @@ class ContentStreamCommandController extends CommandController
 
     /**
      * Remove unused and deleted content streams from the event stream; effectively REMOVING information completely
+     *
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      */
-    public function pruneRemovedFromEventStreamCommand(string $contentRepositoryIdentifier = 'default'): void
+    public function pruneRemovedFromEventStreamCommand(string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentStreamPruner = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentStreamPrunerFactory());
 
         $unusedContentStreams = $contentStreamPruner->pruneRemovedFromEventStream();

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -50,7 +50,7 @@ class NodeMigrationCommandController extends CommandController
      * @param string $version The version of the migration configuration you want to use.
      * @param string $workspace The workspace where the migration should be applied; by default "live"
      * @param boolean $force Confirm application of this migration, only needed if the given migration contains any warnings.
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @return void
      * @throws StopCommandException
      * @see neos.contentrepositoryregistry:nodemigration:execute

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -50,13 +50,14 @@ class NodeMigrationCommandController extends CommandController
      * @param string $version The version of the migration configuration you want to use.
      * @param string $workspace The workspace where the migration should be applied; by default "live"
      * @param boolean $force Confirm application of this migration, only needed if the given migration contains any warnings.
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @return void
      * @throws StopCommandException
      * @see neos.contentrepositoryregistry:nodemigration:execute
      */
-    public function executeCommand(string $version, string $workspace = 'live', bool $force = false, string $contentRepositoryIdentifier = 'default'): void
+    public function executeCommand(string $version, string $workspace = 'live', bool $force = false, string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
 
         try {
             $migrationConfiguration = $this->migrationFactory->getMigrationForVersion($version);

--- a/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
@@ -33,11 +33,11 @@ final class StructureAdjustmentsCommandController extends CommandController
      * Detect required structure adjustments for the specified node type in the given content repository.
      *
      * @param string|null $nodeType The node type to find structure adjustments for. If not provided, all adjustments will be shown. (Default: null)
-     * @param string $contentRepositoryIdentifier The content repository identifier. (Default: 'default')
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      */
-    public function detectCommand(string $nodeType = null, string $contentRepositoryIdentifier = 'default'): void
+    public function detectCommand(string $nodeType = null, string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $structureAdjustmentService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new StructureAdjustmentServiceFactory());
 
         if ($nodeType !== null) {
@@ -55,12 +55,12 @@ final class StructureAdjustmentsCommandController extends CommandController
      * Apply required structure adjustments for the specified node type in the given content repository.
      *
      * @param string|null $nodeType The node type to apply structure adjustments for. If not provided, all found adjustments will be applied. (Default: null)
-     * @param string $contentRepositoryIdentifier The content repository identifier. (Default: 'default')
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @return void
      */
-    public function fixCommand(string $nodeType = null, string $contentRepositoryIdentifier = 'default'): void
+    public function fixCommand(string $nodeType = null, string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $structureAdjustmentService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new StructureAdjustmentServiceFactory());
 
         if ($nodeType !== null) {

--- a/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
@@ -33,7 +33,7 @@ final class StructureAdjustmentsCommandController extends CommandController
      * Detect required structure adjustments for the specified node type in the given content repository.
      *
      * @param string|null $nodeType The node type to find structure adjustments for. If not provided, all adjustments will be shown. (Default: null)
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      */
     public function detectCommand(string $nodeType = null, string $contentRepository = 'default'): void
     {
@@ -55,7 +55,7 @@ final class StructureAdjustmentsCommandController extends CommandController
      * Apply required structure adjustments for the specified node type in the given content repository.
      *
      * @param string|null $nodeType The node type to apply structure adjustments for. If not provided, all found adjustments will be applied. (Default: null)
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @return void
      */
     public function fixCommand(string $nodeType = null, string $contentRepository = 'default'): void

--- a/Neos.ContentRepositoryRegistry/Classes/Command/SubprocessProjectionCatchUpCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/SubprocessProjectionCatchUpCommandController.php
@@ -25,13 +25,13 @@ class SubprocessProjectionCatchUpCommandController extends CommandController
     protected $contentRepositoryRegistry;
 
     /**
-     * @param string $contentRepositoryIdentifier
+     * @param string $contentRepository
      * @param class-string<ProjectionInterface<ProjectionStateInterface>> $projectionClassName fully qualified class name of the projection to catch up
      * @internal
      */
-    public function catchupCommand(string $contentRepositoryIdentifier, string $projectionClassName): void
+    public function catchupCommand(string $contentRepository, string $projectionClassName): void
     {
-        $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepositoryIdentifier));
-        $contentRepository->catchUpProjection($projectionClassName, CatchUpOptions::create());
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepository));
+        $contentRepositoryInstance->catchUpProjection($projectionClassName, CatchUpOptions::create());
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/SubprocessProjectionCatchUpCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/SubprocessProjectionCatchUpCommandController.php
@@ -25,7 +25,7 @@ class SubprocessProjectionCatchUpCommandController extends CommandController
     protected $contentRepositoryRegistry;
 
     /**
-     * @param string $contentRepository
+     * @param string $contentRepository Identifier of the content repository
      * @param class-string<ProjectionInterface<ProjectionStateInterface>> $projectionClassName fully qualified class name of the projection to catch up
      * @internal
      */

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -64,7 +64,7 @@ class WorkspaceCommandController extends CommandController
      * This command publishes all modified, created or deleted nodes in the specified workspace to its base workspace.
      *
      * @param string $workspace Name of the workspace containing the changes to publish, for example "user-john"
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      */
     public function publishCommand(string $workspace, string $contentRepository = 'default'): void
     {
@@ -87,7 +87,7 @@ class WorkspaceCommandController extends CommandController
      * This command discards all modified, created or deleted nodes in the specified workspace.
      *
      * @param string $workspace Name of the workspace, for example "user-john"
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
     public function discardCommand(string $workspace, string $contentRepository = 'default'): void
@@ -113,7 +113,7 @@ class WorkspaceCommandController extends CommandController
      * This command rebases the given workspace on its base workspace, it may fail if the rebase is not possible.
      *
      * @param string $workspace Name of the workspace, for example "user-john"
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @param bool $force Rebase all events that do not conflict
      * @throws StopCommandException
      */
@@ -141,7 +141,7 @@ class WorkspaceCommandController extends CommandController
      * Create a new root workspace for a content repository.
      *
      * @param string $name Name of the new root
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      */
     public function createRootCommand(string $name, string $contentRepository = 'default'): void
     {
@@ -166,7 +166,7 @@ class WorkspaceCommandController extends CommandController
      * @param string|null $title Human friendly title of the workspace, for example "Christmas Campaign"
      * @param string|null $description A description explaining the purpose of the new workspace
      * @param string $owner The identifier of a User to own the workspace
-     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
     public function createCommand(

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -146,9 +146,9 @@ class WorkspaceCommandController extends CommandController
     public function createRootCommand(string $name, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
-        $contentRepository->handle(CreateRootWorkspace::create(
+        $contentRepositoryInstance->handle(CreateRootWorkspace::create(
             WorkspaceName::fromString($name),
             WorkspaceTitle::fromString($name),
             WorkspaceDescription::fromString($name),
@@ -178,7 +178,7 @@ class WorkspaceCommandController extends CommandController
         string $contentRepository = 'default'
     ): void {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         if ($owner === '') {
             $workspaceOwnerUserId = null;
@@ -192,7 +192,7 @@ class WorkspaceCommandController extends CommandController
         }
 
         try {
-            $contentRepository->handle(CreateWorkspace::create(
+            $contentRepositoryInstance->handle(CreateWorkspace::create(
                 WorkspaceName::fromString($workspace),
                 WorkspaceName::fromString($baseWorkspace),
                 WorkspaceTitle::fromString($title ?: $workspace),
@@ -235,7 +235,7 @@ class WorkspaceCommandController extends CommandController
     public function deleteCommand(string $workspace, bool $force = false, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $workspaceName = WorkspaceName::fromString($workspace);
         if ($workspaceName->isLive()) {
@@ -243,7 +243,7 @@ class WorkspaceCommandController extends CommandController
             $this->quit(2);
         }
 
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName($workspaceName);
+        $workspace = $contentRepositoryInstance->getWorkspaceFinder()->findOneByName($workspaceName);
         if (!$workspace instanceof Workspace) {
             $this->outputLine('Workspace "%s" does not exist', [$workspaceName->value]);
             $this->quit(1);
@@ -258,7 +258,7 @@ class WorkspaceCommandController extends CommandController
             $this->quit(2);
         }
 
-        $dependentWorkspaces = $contentRepository->getWorkspaceFinder()->findByBaseWorkspace($workspaceName);
+        $dependentWorkspaces = $contentRepositoryInstance->getWorkspaceFinder()->findByBaseWorkspace($workspaceName);
         if (count($dependentWorkspaces) > 0) {
             $this->outputLine(
                 'Workspace "%s" cannot be deleted because the following workspaces are based on it:',
@@ -280,7 +280,7 @@ class WorkspaceCommandController extends CommandController
         }
 
         try {
-            $nodesCount = $contentRepository->projectionState(ChangeFinder::class)
+            $nodesCount = $contentRepositoryInstance->projectionState(ChangeFinder::class)
                 ->countByContentStreamId(
                     $workspace->currentContentStreamId
                 );
@@ -306,7 +306,7 @@ class WorkspaceCommandController extends CommandController
             $workspace->discardAllChanges();
         }
 
-        $contentRepository->handle(
+        $contentRepositoryInstance->handle(
             DeleteWorkspace::create(
                 $workspaceName
             )
@@ -349,9 +349,9 @@ class WorkspaceCommandController extends CommandController
     public function listCommand(string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
-        $workspaces = $contentRepository->getWorkspaceFinder()->findAll();
+        $workspaces = $contentRepositoryInstance->getWorkspaceFinder()->findAll();
 
         if (count($workspaces) === 0) {
             $this->outputLine('No workspaces found.');

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -64,13 +64,13 @@ class WorkspaceCommandController extends CommandController
      * This command publishes all modified, created or deleted nodes in the specified workspace to its base workspace.
      *
      * @param string $workspace Name of the workspace containing the changes to publish, for example "user-john"
-     * @param string $contentRepositoryIdentifier
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      */
-    public function publishCommand(string $workspace, string $contentRepositoryIdentifier = 'default'): void
+    public function publishCommand(string $workspace, string $contentRepository = 'default'): void
     {
         // @todo: bypass access control
         $workspace = $this->workspaceProvider->provideForWorkspaceName(
-            ContentRepositoryId::fromString($contentRepositoryIdentifier),
+            ContentRepositoryId::fromString($contentRepository),
             WorkspaceName::fromString($workspace)
         );
         $workspace->publishAllChanges();
@@ -87,14 +87,14 @@ class WorkspaceCommandController extends CommandController
      * This command discards all modified, created or deleted nodes in the specified workspace.
      *
      * @param string $workspace Name of the workspace, for example "user-john"
-     * @param string $contentRepositoryIdentifier
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
-    public function discardCommand(string $workspace, string $contentRepositoryIdentifier = 'default'): void
+    public function discardCommand(string $workspace, string $contentRepository = 'default'): void
     {
         // @todo: bypass access control
         $workspace = $this->workspaceProvider->provideForWorkspaceName(
-            ContentRepositoryId::fromString($contentRepositoryIdentifier),
+            ContentRepositoryId::fromString($contentRepository),
             WorkspaceName::fromString($workspace)
         );
 
@@ -113,16 +113,16 @@ class WorkspaceCommandController extends CommandController
      * This command rebases the given workspace on its base workspace, it may fail if the rebase is not possible.
      *
      * @param string $workspace Name of the workspace, for example "user-john"
-     * @param string $contentRepositoryIdentifier
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @param bool $force Rebase all events that do not conflict
      * @throws StopCommandException
      */
-    public function rebaseCommand(string $workspace, string $contentRepositoryIdentifier = 'default', bool $force = false): void
+    public function rebaseCommand(string $workspace, string $contentRepository = 'default', bool $force = false): void
     {
         try {
             // @todo: bypass access control
             $workspace = $this->workspaceProvider->provideForWorkspaceName(
-                ContentRepositoryId::fromString($contentRepositoryIdentifier),
+                ContentRepositoryId::fromString($contentRepository),
                 WorkspaceName::fromString($workspace)
             );
             $workspace->rebase($force ? RebaseErrorHandlingStrategy::STRATEGY_FORCE : RebaseErrorHandlingStrategy::STRATEGY_FAIL);
@@ -140,12 +140,12 @@ class WorkspaceCommandController extends CommandController
     /**
      * Create a new root workspace for a content repository.
      *
-     * @param string $name
-     * @param string $contentRepositoryIdentifier
+     * @param string $name Name of the new root
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      */
-    public function createRootCommand(string $name, string $contentRepositoryIdentifier = 'default'): void
+    public function createRootCommand(string $name, string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $contentRepository->handle(CreateRootWorkspace::create(
@@ -166,7 +166,7 @@ class WorkspaceCommandController extends CommandController
      * @param string|null $title Human friendly title of the workspace, for example "Christmas Campaign"
      * @param string|null $description A description explaining the purpose of the new workspace
      * @param string $owner The identifier of a User to own the workspace
-     * @param string $contentRepositoryIdentifier
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
     public function createCommand(
@@ -175,9 +175,9 @@ class WorkspaceCommandController extends CommandController
         string $title = null,
         string $description = null,
         string $owner = '',
-        string $contentRepositoryIdentifier = 'default'
+        string $contentRepository = 'default'
     ): void {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         if ($owner === '') {
@@ -229,11 +229,12 @@ class WorkspaceCommandController extends CommandController
      *
      * @param string $workspace Name of the workspace, for example "christmas-campaign"
      * @param boolean $force Delete the workspace and all of its contents
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @see neos.neos:workspace:discard
      */
-    public function deleteCommand(string $workspace, bool $force = false, string $contentRepositoryIdentifier = 'default'): void
+    public function deleteCommand(string $workspace, bool $force = false, string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $workspaceName = WorkspaceName::fromString($workspace);
@@ -315,10 +316,13 @@ class WorkspaceCommandController extends CommandController
 
     /**
      * Rebase all outdated content streams
+     *
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param boolean $force
      */
-    public function rebaseOutdatedCommand(string $contentRepositoryIdentifier = 'default', bool $force = false): void
+    public function rebaseOutdatedCommand(string $contentRepository = 'default', bool $force = false): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $workspaceMaintenanceService = $this->contentRepositoryRegistry->buildService(
             $contentRepositoryId,
             new WorkspaceMaintenanceServiceFactory()
@@ -339,11 +343,12 @@ class WorkspaceCommandController extends CommandController
     /**
      * Display a list of existing workspaces
      *
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
-    public function listCommand(string $contentRepositoryIdentifier = 'default'): void
+    public function listCommand(string $contentRepository = 'default'): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepositoryIdentifier);
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $workspaces = $contentRepository->getWorkspaceFinder()->findAll();

--- a/Neos.Neos/Documentation/References/CommandReference.rst
+++ b/Neos.Neos/Documentation/References/CommandReference.rst
@@ -170,7 +170,7 @@ Arguments
 ^^^^^^^^^
 
 ``--cache-identifier``
-  
+
 
 
 
@@ -1996,7 +1996,7 @@ Options
 ``--simulate``
   If set, this command will only tell what it would do instead of doing it right away
 ``--quiet``
-  
+
 
 
 
@@ -2757,8 +2757,7 @@ Options
   A description explaining the purpose of the new workspace
 ``--owner``
   The identifier of a User to own the workspace
-``--content-repository-identifier``
-  
+``--content-repository``
 
 
 
@@ -2777,15 +2776,13 @@ Arguments
 ^^^^^^^^^
 
 ``--name``
-  
 
 
 
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  
+``--content-repository``
 
 
 
@@ -2814,8 +2811,8 @@ Options
 
 ``--force``
   Delete the workspace and all of its contents
-``--content-repository-identifier``
-  contentRepositoryIdentifier
+``--content-repository``
+  contentRepository
 
 
 
@@ -2847,8 +2844,7 @@ Arguments
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  
+``--content-repository``
 
 
 
@@ -2868,8 +2864,8 @@ Options
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  contentRepositoryIdentifier
+``--content-repository``
+  contentRepository
 
 
 
@@ -2895,8 +2891,7 @@ Arguments
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  
+``--content-repository``
 
 
 
@@ -2922,8 +2917,8 @@ Arguments
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  
+``--content-repository``
+
 ``--force``
   Rebase all events that do not conflict
 
@@ -2945,8 +2940,8 @@ Options
 Options
 ^^^^^^^
 
-``--content-repository-identifier``
-  contentRepositoryIdentifier
+``--content-repository``
+  contentRepository
 ``--force``
   force
 


### PR DESCRIPTION
**Review instructions**

This is a todo part of: #4772

This takes care of unifying and changing the `contentRepositoryIdentifier` to `contentRepository` for the input in our CLI commands for the ESCR.

### Adjust CommandControllers:

- WorkspaceCommandController
- NodeMigrationCommandController
- StructureAdjustmentsCommandController

`SubprocessProjectionCatchUpCommandController` has not been adjusted yet (see my comment below)

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
