### PR TITLE
BUGFIX: Prevent multiple imports of the same remote asset in the frontend

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Layouts/Default.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/Default.html
@@ -23,7 +23,7 @@
         </div>
         <div class="neos-media-content{f:if(condition: '{tags -> f:count()} > 25', then: ' neos-media-aside-condensed')}">
             <div class="neos-media-assets">
-                <div id=="neos-notification-container" class="neos-notification-container">
+                <div id="neos-notification-container" class="neos-notification-container">
                     <f:render partial="FlashMessages"/>
                 </div>
                 <f:render section="Content"/>

--- a/Neos.Media.Browser/Resources/Private/Layouts/Default.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/Default.html
@@ -23,7 +23,7 @@
         </div>
         <div class="neos-media-content{f:if(condition: '{tags -> f:count()} > 25', then: ' neos-media-aside-condensed')}">
             <div class="neos-media-assets">
-                <div class="neos-notification-container">
+                <div id=="neos-notification-container" class="neos-notification-container">
                     <f:render partial="FlashMessages"/>
                 </div>
                 <f:render section="Content"/>

--- a/Neos.Media.Browser/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Media.Browser/Resources/Private/Translations/en/Main.xlf
@@ -433,6 +433,12 @@
 			<trans-unit id="createMissingVariants" xml:space="preserve">
 				<source>Create missing variants</source>
 			</trans-unit>
+      <trans-unit id="assetImport.importInfo" xml:space="preserve">
+				<source>Asset is being imported. Please wait.</source>
+			</trans-unit>
+      <trans-unit id="assetImport.importInProcess" xml:space="preserve">
+				<source>Import still in process. Please wait.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -1,71 +1,84 @@
 window.addEventListener('DOMContentLoaded', () => {
 	(function () {
-		if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks) {
-			// we are inside iframe
-			const assets = document.querySelectorAll('[data-asset-identifier]');
-			assets.forEach((asset) => {
-				asset.addEventListener('click', (e) => {
-					if (
-						e.target.closest('a:not([data-asset-identifier]), button:not([data-asset-identifier])') === null &&
-						window.parent.NeosMediaBrowserCallbacks &&
-						typeof window.parent.NeosMediaBrowserCallbacks.assetChosen === 'function'
-					) {
-						let localAssetIdentifier = asset.dataset.localAssetIdentifier;
-						if (localAssetIdentifier !== '') {
-							window.parent.NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
-						} else {
-							if (asset.dataset.importInProcess !== 'true') {
-								asset.dataset.importInProcess = 'true';
-								const message = window.NeosCMS.I18n.translate(
-									'assetImport.importInfo',
-									'Asset is being imported. Please wait.',
-									'Neos.Media.Browser'
-								);
-								window.NeosCMS.Notification.ok(message);
+		const NeosMediaBrowserCallbacks = window.parent.NeosMediaBrowserCallbacks;
+		const NeosCMS = window.NeosCMS;
 
-								const params = new URLSearchParams();
-								params.append('assetSourceIdentifier', asset.dataset.assetSourceIdentifier);
-								params.append('assetIdentifier', asset.dataset.assetIdentifier);
-								params.append('__csrfToken', document.querySelector('body').dataset.csrfToken);
-
-								fetch(
-									document
-										.querySelector('link[rel="neos-media-browser-service-assetproxies-import"]')
-										.getAttribute('href'),
-									{
-										headers: {
-											'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-										},
-										method: 'POST',
-										credentials: 'include',
-										body: params.toString(),
-									}
-								)
-									.then((response) => {
-										if (!response.ok) {
-											throw new Error(`HTTP error! status: ${response.status}`);
-										}
-										return response.json();
-									})
-									.then((data) => {
-										window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
-										asset.removeAttribute('data-import-in-process');
-									})
-									.catch((error) => console.error('Error:', error))
-								e.preventDefault();
-							} else {
-								const message = window.NeosCMS.I18n.translate(
-									'assetImport.importInProcess',
-									'Import still in process. Please wait.',
-									'Neos.Media.Browser'
-								);
-								window.NeosCMS.Notification.warning(message);
-							}
-						}
-						e.preventDefault();
-					}
-				});
-			});
+		if (window.parent === window || !NeosCMS || !NeosMediaBrowserCallbacks || typeof NeosMediaBrowserCallbacks.assetChosen !== 'function') {
+			return;
 		}
+
+		function importAsset(asset) {
+			const params = new URLSearchParams();
+			params.append('assetSourceIdentifier', asset.dataset.assetSourceIdentifier);
+			params.append('assetIdentifier', asset.dataset.assetIdentifier);
+			params.append('__csrfToken', document.querySelector('body').dataset.csrfToken);
+
+			fetch(
+				document
+					.querySelector('link[rel="neos-media-browser-service-assetproxies-import"]')
+					.getAttribute('href'),
+				{
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+					},
+					method: 'POST',
+					credentials: 'include',
+					body: params.toString(),
+				}
+			)
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error(`HTTP error! status: ${response.status}`);
+					}
+					return response.json();
+				})
+				.then((data) => {
+					NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
+					asset.removeAttribute('data-import-in-process');
+				})
+				.catch((error) => {
+					NeosCMS.Notification.error(NeosCMS.I18n.translate(
+						'assetImport.importError',
+						'Asset could not be imported. Please try again.',
+						'Neos.Media.Browser'
+					), error);
+					console.error('Error:', error);
+				})
+		}
+
+		const assets = document.querySelectorAll('[data-asset-identifier]');
+		assets.forEach((asset) => {
+			asset.addEventListener('click', (e) => {
+				const assetLink = e.target.closest('a[data-asset-identifier], button[data-asset-identifier]');
+				if (!assetLink) {
+					return;
+				}
+
+				const localAssetIdentifier = asset.dataset.localAssetIdentifier;
+				if (localAssetIdentifier !== '' && !NeosCMS.isNil(localAssetIdentifier)) {
+					NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
+				} else {
+					if (asset.dataset.importInProcess !== 'true') {
+						asset.dataset.importInProcess = 'true';
+						const message = NeosCMS.I18n.translate(
+							'assetImport.importInfo',
+							'Asset is being imported. Please wait.',
+							'Neos.Media.Browser'
+						);
+						NeosCMS.Notification.ok(message);
+
+						importAsset(asset);
+					} else {
+						const message = NeosCMS.I18n.translate(
+							'assetImport.importInProcess',
+							'Import still in process. Please wait.',
+							'Neos.Media.Browser'
+						);
+						NeosCMS.Notification.warning(message);
+					}
+				}
+				e.preventDefault();
+			});
+		});
 	})();
 });

--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -1,54 +1,71 @@
-window.addEventListener('DOMContentLoaded', (event) => {
-	$(function() {
-			if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks) {
-					// we are inside iframe
-					$('.asset-list').on('click', '[data-asset-identifier]', function(e) {
-							if (
-								$(e.target).closest('a, button').not('[data-asset-identifier]').length === 0 &&
-									window.parent.NeosMediaBrowserCallbacks &&
-									typeof window.parent.NeosMediaBrowserCallbacks.assetChosen === 'function'
-							) {
-									let localAssetIdentifier = $(this).attr('data-local-asset-identifier');
-									if (localAssetIdentifier !== '') {
-											window.parent.NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
-									} else {
-										if ($(this).attr('data-import-in-process') !== 'true') {
-											$(this).attr('data-import-in-process', 'true')
-											const message = window.NeosCMS.I18n.translate(
-												'assetImport.importInfo',
-												'Asset is being imported. Please wait.',
-												'Neos.Media.Browser',
-												'Main',
-												[]
-											)
-											window.NeosCMS.Notification.ok(message)
-											$.post(
-												$('link[rel="neos-media-browser-service-assetproxies-import"]').attr('href'),
-												{
-													assetSourceIdentifier: $(this).attr('data-asset-source-identifier'),
-													assetIdentifier: $(this).attr('data-asset-identifier'),
-													__csrfToken: $('body').attr('data-csrf-token')
-												},
-												function (data) {
-													window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
-													$(this).removeAttr('data-import-in-process')
-												}
-											);
-										}
-										else {
-											const message = window.NeosCMS.I18n.translate(
-												'assetImport.importInProcess',
-												'Import still in process. Please wait.',
-												'Neos.Media.Browser',
-												'Main',
-												[]
-											)
-											window.NeosCMS.Notification.warning(message)
-										}
+window.addEventListener('DOMContentLoaded', () => {
+	(function () {
+		if (window.parent !== window && window.parent.NeosMediaBrowserCallbacks) {
+			// we are inside iframe
+			const assets = document.querySelectorAll('[data-asset-identifier]');
+			assets.forEach((asset) => {
+				asset.addEventListener('click', (e) => {
+					if (
+						e.target.closest('a:not([data-asset-identifier]), button:not([data-asset-identifier])') === null &&
+						window.parent.NeosMediaBrowserCallbacks &&
+						typeof window.parent.NeosMediaBrowserCallbacks.assetChosen === 'function'
+					) {
+						let localAssetIdentifier = asset.dataset.localAssetIdentifier;
+						if (localAssetIdentifier !== '') {
+							window.parent.NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
+						} else {
+							if (asset.dataset.importInProcess !== 'true') {
+								asset.dataset.importInProcess = 'true';
+								const message = window.NeosCMS.I18n.translate(
+									'assetImport.importInfo',
+									'Asset is being imported. Please wait.',
+									'Neos.Media.Browser'
+								);
+								window.NeosCMS.Notification.ok(message);
+
+								const params = new URLSearchParams();
+								params.append('assetSourceIdentifier', asset.dataset.assetSourceIdentifier);
+								params.append('assetIdentifier', asset.dataset.assetIdentifier);
+								params.append('__csrfToken', document.querySelector('body').dataset.csrfToken);
+
+								fetch(
+									document
+										.querySelector('link[rel="neos-media-browser-service-assetproxies-import"]')
+										.getAttribute('href'),
+									{
+										headers: {
+											'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+										},
+										method: 'POST',
+										credentials: 'include',
+										body: params.toString(),
 									}
-									e.preventDefault();
+								)
+									.then((response) => {
+										if (!response.ok) {
+											throw new Error(`HTTP error! status: ${response.status}`);
+										}
+										return response.json();
+									})
+									.then((data) => {
+										window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
+										asset.removeAttribute('data-import-in-process');
+									})
+									.catch((error) => console.error('Error:', error))
+								e.preventDefault();
+							} else {
+								const message = window.NeosCMS.I18n.translate(
+									'assetImport.importInProcess',
+									'Import still in process. Please wait.',
+									'Neos.Media.Browser'
+								);
+								window.NeosCMS.Notification.warning(message);
 							}
-					});
-			}
-	});
+						}
+						e.preventDefault();
+					}
+				});
+			});
+		}
+	})();
 });

--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -31,7 +31,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
 												},
 												function (data) {
 													window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
-													$(this).remove('data-import-in-process')
+													$(this).removeAttr('data-import-in-process')
 												}
 											);
 										}

--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -12,17 +12,39 @@ window.addEventListener('DOMContentLoaded', (event) => {
 									if (localAssetIdentifier !== '') {
 											window.parent.NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
 									} else {
-										$.post(
-											$('link[rel="neos-media-browser-service-assetproxies-import"]').attr('href'),
-													{
-															assetSourceIdentifier: $(this).attr('data-asset-source-identifier'),
-															assetIdentifier: $(this).attr('data-asset-identifier'),
-															__csrfToken: $('body').attr('data-csrf-token')
-													},
-													function(data) {
-															window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
-													}
+										if ($(this).attr('data-import-in-process') !== 'true') {
+											$(this).attr('data-import-in-process', 'true')
+											const message = window.NeosCMS.I18n.translate(
+												'assetImport.importInfo',
+												'Asset is being imported. Please wait.',
+												'Neos.Media.Browser',
+												'Main',
+												[]
+											)
+											window.NeosCMS.Notification.ok(message)
+											$.post(
+												$('link[rel="neos-media-browser-service-assetproxies-import"]').attr('href'),
+												{
+													assetSourceIdentifier: $(this).attr('data-asset-source-identifier'),
+													assetIdentifier: $(this).attr('data-asset-identifier'),
+													__csrfToken: $('body').attr('data-csrf-token')
+												},
+												function (data) {
+													window.parent.NeosMediaBrowserCallbacks.assetChosen(data.localAssetIdentifier);
+													$(this).remove('data-import-in-process')
+												}
 											);
+										}
+										else {
+											const message = window.NeosCMS.I18n.translate(
+												'assetImport.importInProcess',
+												'Import still in process. Please wait.',
+												'Neos.Media.Browser',
+												'Main',
+												[]
+											)
+											window.NeosCMS.Notification.warning(message)
+										}
 									}
 									e.preventDefault();
 							}

--- a/Neos.Neos/Resources/Public/JavaScript/Services/Configuration.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Services/Configuration.js
@@ -1,6 +1,6 @@
 import { getCollectionValueByPath, isNil } from "../Helper";
 
-const hasConfiguration = !isNil(window.NeosCMS?.Configuration);
+let hasConfiguration = !isNil(window.NeosCMS?.Configuration);
 
 const init = () => {
   if (isNil(window.NeosCMS)) {
@@ -9,6 +9,7 @@ const init = () => {
 
   if (isNil(window.NeosCMS.Configuration)) {
     window.NeosCMS.Configuration = {};
+		hasConfiguration = true;
   }
 
   // append xliff uri


### PR DESCRIPTION
This is a frontend fix for #5116 and prevents users from triggering multiple import processes for the same remote asset. It is not a sufficient fix to only prevent this in the frontend though, since it doesn't catch it, if two or more different users trigger the import for the same asset at the same time.

Changes:
- `select.js`: add data attribute `data-import-in-process` to asset once import process has started and remove it when import is done
- `select.js`: check for new data attribute and only start import process if attribute does not exist
- `select.js`: add notification to inform user that asset is being imported
- `select.js`: add notification as warning for user if import is already in process
- `Main.xlf`: add new notification messages for english
- `Default.html`: add id for notification container to be able to send notifications to it via js
- `Configuration.js`: update `hasConfiguration` after configuration object was created, because otherwise it will always be false and the translations don't work

`related:` https://github.com/neos/neos-development-collection/issues/5116

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions

**Info for testing:**
You need to bundle the Neos.Neos assets to get the text for the notification messages.
- navigate to the Neos.Neos package
- run `yarn`
- run `yarn build`
