### PR TITLE
BUGFIX: Fix title attribute for impersonate button in user management

### DIFF
--- a/Neos.Neos/Resources/Public/JavaScript/Templates/ImpersonateButton.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Templates/ImpersonateButton.js
@@ -1,11 +1,11 @@
 import {isNil} from "../Helper"
 
 const impersonateIcon = '<i class="fas fa-random icon-white"></i>'
-const localizedTooltip = !isNil(window.Typo3Neos) ?
-    window.NeosCMS.I18n.translate('impersonate.tooltip.impersonateUserButton', 'Login as this user', 'Neos.Neos') :
-    'Login as this user';
 
 const ImpersonateButton = (identifier, disabled) => {
+		const localizedTooltip = !isNil(window.NeosCMS) ?
+			window.NeosCMS.I18n.translate('impersonate.tooltip.impersonateUserButton', 'Login as this user', 'Neos.Neos') :
+			'Login as this user';
     const attributesObject = {
         'data-neos-toggle': 'tooltip',
         'title': localizedTooltip,

--- a/Neos.Neos/Resources/Public/JavaScript/Templates/ImpersonateButton.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Templates/ImpersonateButton.js
@@ -4,8 +4,8 @@ const impersonateIcon = '<i class="fas fa-random icon-white"></i>'
 
 const ImpersonateButton = (identifier, disabled) => {
 		const localizedTooltip = !isNil(window.NeosCMS) ?
-			window.NeosCMS.I18n.translate('impersonate.tooltip.impersonateUserButton', 'Login as this user', 'Neos.Neos') :
-			'Login as this user';
+				window.NeosCMS.I18n.translate('impersonate.tooltip.impersonateUserButton', 'Login as this user', 'Neos.Neos') :
+				'Login as this user';
     const attributesObject = {
         'data-neos-toggle': 'tooltip',
         'title': localizedTooltip,

--- a/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
@@ -18,7 +18,7 @@ const RestoreButton = (user) => {
             'Back to user "{0}"',
             'Neos.Neos',
             'Main',
-            user.accountIdentifier
+            [user.accountIdentifier]
         )
         : `Restore user "${user.accountIdentifier}"`
     return `<button ${attributes}>${impersonateIcon} ${restoreLabel}</button>`

--- a/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
@@ -18,9 +18,9 @@ const RestoreButton = (user) => {
             'Back to user "{0}"',
             'Neos.Neos',
             'Main',
-            [user.accountIdentifier]
+            [user.fullName]
         )
-        : `Restore user "${user.accountIdentifier}"`
+        : `Restore user "${user.fullName}"`
     return `<button ${attributes}>${impersonateIcon} ${restoreLabel}</button>`
 }
 

--- a/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
+++ b/Neos.Neos/Resources/Public/JavaScript/Templates/RestoreButton.js
@@ -12,7 +12,7 @@ const RestoreButton = (user) => {
         attributes += `${key}="${attributesObject[key]}" `
     })
 
-    const restoreLabel = isNil(window.NeosCMS)
+    const restoreLabel = !isNil(window.NeosCMS)
         ? window.NeosCMS.I18n.translate(
             'impersonate.label.restoreUserButton',
             'Back to user "{0}"',


### PR DESCRIPTION
With this change the localized text is rendered instead of always defaulting to english.

Changes: 

- ImpersonateButton.js change postion of const localizedTooltip inside ImpersonateButton function and change isNil(window.Typo3Neos) to isNil(window.NeosCMS)
- RestoreButton.js it was always fallback text used change isNil(window.NeosCMS) to !isNil(window.NeosCMS) 

Fixes: #4511 

Checklist

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
