### PR TITLE
BUGFIX: Flush node content caches without workspace name

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -32,7 +32,7 @@ class CacheTag
 
     final public static function forNodeAggregate(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
     ): self {
         return new self(
@@ -51,9 +51,18 @@ class CacheTag
         );
     }
 
+    final public static function forNodeAggregateFromNodeWithoutWorkspace(Node $node): self
+    {
+        return self::forNodeAggregate(
+            $node->contentRepositoryId,
+            null,
+            $node->aggregateId
+        );
+    }
+
     final public static function forDescendantOfNode(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
     ): self {
         return new self(
@@ -72,9 +81,18 @@ class CacheTag
         );
     }
 
+    final public static function forDescendantOfNodeFromNodeWithoutWorkspace(Node $node): self
+    {
+        return self::forDescendantOfNode(
+            $node->contentRepositoryId,
+            null,
+            $node->aggregateId
+        );
+    }
+
     final public static function forAncestorNode(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
     ): self {
         return new self(
@@ -93,9 +111,18 @@ class CacheTag
         );
     }
 
+    final public static function forAncestorNodeFromNodeWithoutWorkspace(Node $node): self
+    {
+        return self::forAncestorNode(
+            $node->contentRepositoryId,
+            null,
+            $node->aggregateId
+        );
+    }
+
     final public static function forNodeTypeName(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         NodeTypeName $nodeTypeName,
     ): self {
         return new self(
@@ -107,7 +134,7 @@ class CacheTag
 
     final public static function forDynamicNodeAggregate(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
     ): self {
         return new self(
@@ -123,9 +150,13 @@ class CacheTag
     }
 
     protected static function getHashForWorkspaceNameAndContentRepositoryId(
-        WorkspaceName $workspaceName,
+        ?WorkspaceName $workspaceName,
         ContentRepositoryId $contentRepositoryId,
     ): string {
-        return sha1($workspaceName->value . '@' . $contentRepositoryId->value);
+        if ($workspaceName) {
+            return sha1($workspaceName->value . '@' . $contentRepositoryId->value);
+        }
+        return sha1($contentRepositoryId->value);
+
     }
 }

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -157,6 +157,5 @@ class CacheTag
             return sha1($workspaceName->value . '@' . $contentRepositoryId->value);
         }
         return sha1($contentRepositoryId->value);
-
     }
 }

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -38,19 +38,19 @@ final class CacheTagSet
         Nodes $nodes
     ): self {
         return new self(...array_map(
-            fn (Node $node): CacheTag => CacheTag::forDescendantOfNodeFromNode(
-                $node
-            ),
-            iterator_to_array($nodes)
+            CacheTag::forDescendantOfNodeFromNode(...),
+            iterator_to_array($nodes),
         ));
     }
 
     public static function forDescendantOfNodesFromNodesWithoutWorkspace(
-        Nodes $nodes
+        Nodes $nodes,
     ): self {
         return new self(...array_map(
-            fn (Node $node): CacheTag => CacheTag::forDescendantOfNodeFromNodeWithoutWorkspace(
-                $node
+            static fn (Node $node) => CacheTag::forDescendantOfNode(
+                $node->contentRepositoryId,
+                CacheTagWorkspaceName::ANY,
+                $node->aggregateId,
             ),
             iterator_to_array($nodes)
         ));
@@ -60,9 +60,7 @@ final class CacheTagSet
         Nodes $nodes
     ): self {
         return new self(...array_map(
-            fn (Node $node): CacheTag => CacheTag::forNodeAggregateFromNode(
-                $node
-            ),
+            CacheTag::forNodeAggregateFromNode(...),
             iterator_to_array($nodes)
         ));
     }
@@ -71,36 +69,24 @@ final class CacheTagSet
         Nodes $nodes
     ): self {
         return new self(...array_map(
-            fn (Node $node): CacheTag => CacheTag::forNodeAggregateFromNodeWithoutWorkspace(
-                $node
+            static fn (Node $node) => CacheTag::forNodeAggregate(
+                $node->contentRepositoryId,
+                CacheTagWorkspaceName::ANY,
+                $node->aggregateId
             ),
-            iterator_to_array($nodes)
+            iterator_to_array($nodes),
         ));
     }
 
     public static function forNodeTypeNames(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName,
+        WorkspaceName|CacheTagWorkspaceName $workspaceName,
         NodeTypeNames $nodeTypeNames
     ): self {
         return new self(...array_map(
-            fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
+            static fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
                 $contentRepositoryId,
                 $workspaceName,
-                $nodeTypeName
-            ),
-            iterator_to_array($nodeTypeNames)
-        ));
-    }
-
-    public static function forNodeTypeNamesWithoutWorkspace(
-        ContentRepositoryId $contentRepositoryId,
-        NodeTypeNames $nodeTypeNames
-    ): self {
-        return new self(...array_map(
-            fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
-                $contentRepositoryId,
-                null,
                 $nodeTypeName
             ),
             iterator_to_array($nodeTypeNames)
@@ -121,7 +107,7 @@ final class CacheTagSet
     public function toStringArray(): array
     {
         return array_map(
-            fn (CacheTag $tag): string => $tag->value,
+            static fn (CacheTag $tag): string => $tag->value,
             array_values($this->tags)
         );
     }

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -45,6 +45,17 @@ final class CacheTagSet
         ));
     }
 
+    public static function forDescendantOfNodesFromNodesWithoutWorkspace(
+        Nodes $nodes
+    ): self {
+        return new self(...array_map(
+            fn (Node $node): CacheTag => CacheTag::forDescendantOfNodeFromNodeWithoutWorkspace(
+                $node
+            ),
+            iterator_to_array($nodes)
+        ));
+    }
+
     public static function forNodeAggregatesFromNodes(
         Nodes $nodes
     ): self {
@@ -56,6 +67,16 @@ final class CacheTagSet
         ));
     }
 
+    public static function forNodeAggregatesFromNodesWithoutWorkspace(
+        Nodes $nodes
+    ): self {
+        return new self(...array_map(
+            fn (Node $node): CacheTag => CacheTag::forNodeAggregateFromNodeWithoutWorkspace(
+                $node
+            ),
+            iterator_to_array($nodes)
+        ));
+    }
 
     public static function forNodeTypeNames(
         ContentRepositoryId $contentRepositoryId,
@@ -66,6 +87,20 @@ final class CacheTagSet
             fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
                 $contentRepositoryId,
                 $workspaceName,
+                $nodeTypeName
+            ),
+            iterator_to_array($nodeTypeNames)
+        ));
+    }
+
+    public static function forNodeTypeNamesWithoutWorkspace(
+        ContentRepositoryId $contentRepositoryId,
+        NodeTypeNames $nodeTypeNames
+    ): self {
+        return new self(...array_map(
+            fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
+                $contentRepositoryId,
+                null,
                 $nodeTypeName
             ),
             iterator_to_array($nodeTypeNames)

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagWorkspaceName.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagWorkspaceName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Fusion\Cache;
+
+/**
+ * A special enum to explicitly represent any workspace {@see CacheTag}
+ */
+enum CacheTagWorkspaceName
+{
+    case ANY;
+}

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -80,9 +80,8 @@ class ContentCacheFlusher
     }
 
     /**
-     * WorkspaceNameToFlush is nullable, so we can flush all workspaces as no specific workspaceName is provided.
-     * This is needed to flush nodes on asset changes, as the asset can get rendered in all workspaces, but lives
-     * usually only in live workspace.
+     * @param bool $anyWorkspace This is needed to flush nodes on asset changes, as the asset can get rendered in all workspaces, but lives
+     *                            usually only in live workspace.
      *
      * @return array<string,string>
      */

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -72,7 +72,7 @@ class ContentCacheFlusher
         $tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
 
         $tagsToFlush = array_merge(
-            $this->collectTagsForChangeOnNodeAggregate($contentRepository, $workspaceName, $nodeAggregateId, $workspaceName),
+            $this->collectTagsForChangeOnNodeAggregate($contentRepository, $workspaceName, $nodeAggregateId, false),
             $tagsToFlush
         );
 
@@ -90,7 +90,7 @@ class ContentCacheFlusher
         ContentRepository $contentRepository,
         WorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
-        ?WorkspaceName $workspaceNameToFlush
+        bool $anyWorkspace,
     ): array {
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
 
@@ -101,6 +101,7 @@ class ContentCacheFlusher
             // Node Aggregate was removed in the meantime, so no need to clear caches on this one anymore.
             return [];
         }
+        $workspaceNameToFlush = $anyWorkspace ? CacheTagWorkspaceName::ANY : $workspaceName;
         $tagsToFlush = $this->collectTagsForChangeOnNodeIdentifier($contentRepository->id, $workspaceNameToFlush, $nodeAggregateId);
 
         $tagsToFlush = array_merge($this->collectTagsForChangeOnNodeType(
@@ -164,7 +165,7 @@ class ContentCacheFlusher
      */
     private function collectTagsForChangeOnNodeIdentifier(
         ContentRepositoryId $contentRepositoryId,
-        ?WorkspaceName $workspaceName,
+        WorkspaceName|CacheTagWorkspaceName $workspaceName,
         NodeAggregateId $nodeAggregateId,
     ): array {
         $tagsToFlush = [];
@@ -197,7 +198,7 @@ class ContentCacheFlusher
     private function collectTagsForChangeOnNodeType(
         NodeTypeName $nodeTypeName,
         ContentRepositoryId $contentRepositoryId,
-        ?WorkspaceName $workspaceName,
+        WorkspaceName|CacheTagWorkspaceName $workspaceName,
         ?NodeAggregateId $referenceNodeIdentifier,
         ContentRepository $contentRepository
     ): array {
@@ -311,7 +312,7 @@ class ContentCacheFlusher
                         $contentRepository,
                         $workspaceName,
                         $usage->nodeAggregateId,
-                        null
+                        true
                     ),
                     $tagsToFlush
                 );

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -25,6 +25,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Model\NodeCacheEntryIdentifier;
 use Neos\Neos\Fusion\Cache\CacheTag;
 use Neos\Neos\Fusion\Cache\CacheTagSet;
+use Neos\Neos\Fusion\Cache\CacheTagWorkspaceName;
 
 /**
  * Caching helper to make cache tag generation easier.
@@ -103,8 +104,9 @@ class CachingHelper implements ProtectedContextAwareInterface
                 $contextNode->workspaceName,
                 NodeTypeNames::fromStringArray($nodeTypes)
             )->toStringArray(),
-            CacheTagSet::forNodeTypeNamesWithoutWorkspace(
+            CacheTagSet::forNodeTypeNames(
                 $contextNode->contentRepositoryId,
+                CacheTagWorkspaceName::ANY,
                 NodeTypeNames::fromStringArray($nodeTypes)
             )->toStringArray(),
         );

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -53,7 +53,10 @@ class CachingHelper implements ProtectedContextAwareInterface
             $nodes = iterator_to_array($nodes);
         }
 
-        return CacheTagSet::forNodeAggregatesFromNodes(Nodes::fromArray($nodes))->toStringArray();
+        return array_merge(
+            CacheTagSet::forNodeAggregatesFromNodes(Nodes::fromArray($nodes))->toStringArray(),
+            CacheTagSet::forNodeAggregatesFromNodesWithoutWorkspace(Nodes::fromArray($nodes))->toStringArray(),
+        );
     }
 
     public function entryIdentifierForNode(Node $node): NodeCacheEntryIdentifier
@@ -94,11 +97,17 @@ class CachingHelper implements ProtectedContextAwareInterface
             $nodeTypes = iterator_to_array($nodeTypes);
         }
 
-        return CacheTagSet::forNodeTypeNames(
-            $contextNode->contentRepositoryId,
-            $contextNode->workspaceName,
-            NodeTypeNames::fromStringArray($nodeTypes)
-        )->toStringArray();
+        return array_merge(
+            CacheTagSet::forNodeTypeNames(
+                $contextNode->contentRepositoryId,
+                $contextNode->workspaceName,
+                NodeTypeNames::fromStringArray($nodeTypes)
+            )->toStringArray(),
+            CacheTagSet::forNodeTypeNamesWithoutWorkspace(
+                $contextNode->contentRepositoryId,
+                NodeTypeNames::fromStringArray($nodeTypes)
+            )->toStringArray(),
+        );
     }
 
     /**
@@ -118,9 +127,10 @@ class CachingHelper implements ProtectedContextAwareInterface
             $nodes = iterator_to_array($nodes);
         }
 
-        return CacheTagSet::forDescendantOfNodesFromNodes(
-            Nodes::fromArray($nodes)
-        )->toStringArray();
+        return array_merge(
+            CacheTagSet::forDescendantOfNodesFromNodes(Nodes::fromArray($nodes))->toStringArray(),
+            CacheTagSet::forDescendantOfNodesFromNodesWithoutWorkspace(Nodes::fromArray($nodes))->toStringArray(),
+        );
     }
 
     /**

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -57,12 +57,20 @@ class CachingHelperTest extends UnitTestCase
         $nodeTypeName3 = 'Neos.Neos:Moo';
 
         return [
-            [$nodeTypeName1, ['NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Foo']],
+            [$nodeTypeName1,
+                [
+                    'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Foo',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
+                ]
+            ],
             [[$nodeTypeName1, $nodeTypeName2, $nodeTypeName3],
                 [
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Foo',
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Bar',
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Moo',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Bar',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Moo',
                 ]
             ],
             [(new \ArrayObject([$nodeTypeName1, $nodeTypeName2, $nodeTypeName3])),
@@ -70,6 +78,9 @@ class CachingHelperTest extends UnitTestCase
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Foo',
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Bar',
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Moo',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Bar',
+                    'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Moo',
                 ]
             ],
         ];
@@ -103,15 +114,25 @@ class CachingHelperTest extends UnitTestCase
         $node2 = $this->createNode(NodeAggregateId::fromString($nodeIdentifier2));
 
         return [
-            [$node1, ['Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306']],
-            [[$node1], ['Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306']],
+            [$node1, [
+                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            ]],
+            [[$node1], [
+                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            ]],
             [[$node1, $node2], [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
-                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a'
+                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
             ]],
             [(new \ArrayObject([$node1, $node2])), [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
-                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a'
+                'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
             ]]
         ];
     }
@@ -169,15 +190,25 @@ class CachingHelperTest extends UnitTestCase
 
 
         return [
-            [$node1, ['DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306']],
-            [[$node1], ['DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306']],
+            [$node1, [
+                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            ]],
+            [[$node1], [
+                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            ]],
             [[$node1, $node2], [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
-                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a'
+                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
             ]],
             [(new \ArrayObject([$node1, $node2])), [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
-                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a'
+                'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
             ]]
         ];
     }


### PR DESCRIPTION
As we don't want to iterate over all workspaces on flushing content caches, caused by asset changes, we add addionally node cache tags without a workspace name. So we can flush all node aggregates in all workspaces with just the node aggregate id.