### PR TITLE
TASK: Optimize afx rendering by disabling sorting on generated `Neos.Fusion:Join`

### DIFF
--- a/Neos.Fusion.Afx/Classes/Service/AfxService.php
+++ b/Neos.Fusion.Afx/Classes/Service/AfxService.php
@@ -209,6 +209,8 @@ class AfxService
 
         $index = 0;
         $fusion = 'Neos.Fusion:Join {' . PHP_EOL;
+        $fusion .= $indentation . self::INDENTATION . '@sortProperties = false' . PHP_EOL;
+
         foreach ($payload as $astNode) {
             // detect key
             $fusionName = 'item_' . ++$index;

--- a/Neos.Fusion.Afx/README.md
+++ b/Neos.Fusion.Afx/README.md
@@ -52,6 +52,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
     renderer = Neos.Fusion:Tag {
         tagName = 'div'
         content = Neos.Fusion:Join {
+            @sortProperties = false
             headline = Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = ${props.title}
@@ -191,6 +192,7 @@ Neos.Fusion:Tag {
 
 If an AFX-tag contains more than one child the content is are rendered as `Neos.Fusion:Join` into the
 `content`-attribute. The children are interpreted as string, eel-expression, html- or fusion-object-tag.
+The sorting of the items is disables via `@sortProperties = false`
 
 The following AFX-Code:
 
@@ -202,6 +204,7 @@ Is transpiled as:
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Join {
+        @sortProperties = false
         item_1 = {props.title}
         item_2 = ': '
         item_3 = ${props.subtitle}
@@ -222,6 +225,7 @@ Is transpiled as:
 ```
 Vendor.Site:Prototype {
     text = Neos.Fusion:Join {
+        @sortProperties = false
         title = Neos.Fusion:Tag {
             tagName = 'h2'
             content  = ${props.title}
@@ -313,6 +317,7 @@ Is transpiled as:
 Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Join {
+		@sortProperties = false
 		item_1 = ${'eelExpression 1'}
 		item_2 = ${'eelExpression 2'}
 	}
@@ -331,6 +336,7 @@ Is transpiled as:
 Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Join {
+		@sortProperties = false
 		item_1 = ${'eelExpression 1'}
 		item_2 = ' '
 		item_3 = ${'eelExpression 2'}
@@ -347,6 +353,7 @@ foo<!-- comment -->bar
 Is transpiled as:
 ```
 Neos.Fusion:Join {
+    @sortProperties = false
     item_1 = 'foo'
     item_2 = 'bar'
 }

--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -68,7 +68,7 @@ class AfxServiceTest extends TestCase
     {
         $afxCode = <<<'EOF'
             <h1>
-                
+
             </h1>
             EOF;
 
@@ -89,6 +89,7 @@ class AfxServiceTest extends TestCase
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Join {
+                @sortProperties = false
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -111,6 +112,7 @@ class AfxServiceTest extends TestCase
         $afxCode = 'Foo<h1></h1>Bar<p></p>Baz';
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Join {
+                @sortProperties = false
                 item_1 = 'Foo'
                 item_2 = Neos.Fusion:Tag {
                     tagName = 'h1'
@@ -133,6 +135,7 @@ class AfxServiceTest extends TestCase
         $afxCode = '  <h1></h1><p></p>  ';
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Join {
+                @sortProperties = false
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -152,6 +155,7 @@ class AfxServiceTest extends TestCase
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
             Neos.Fusion:Join {
+                @sortProperties = false
                 item_1 = Neos.Fusion:Tag {
                     tagName = 'h1'
                 }
@@ -478,6 +482,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -499,11 +504,11 @@ EOF;
     {
         $afxCode = <<<'EOF'
             <h1>
-                
+
                 <strong>foo</strong>
-                    
+
                 <i>bar</i>
-                
+
             </h1>
             EOF;
 
@@ -511,6 +516,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -535,6 +541,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     key_one = Neos.Fusion:Tag {
                         tagName = 'strong'
                         content = 'foo'
@@ -559,6 +566,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = 'a string'
                     item_2 = Neos.Fusion:Tag {
                         tagName = 'strong'
@@ -624,6 +632,7 @@ EOF;
                     content = 'bar'
                 }
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = Neos.Fusion:Tag {
                         tagName = 'div'
                         content = 'a tag'
@@ -673,6 +682,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = ${eelExpression1}
                     item_2 = ${eelExpression2}
                     item_3 = ${eelExpression3}
@@ -695,6 +705,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = ${eelExpression1}
                     item_2 = ' '
                     item_3 = ${eelExpression2}
@@ -717,6 +728,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = 'String '
                     item_2 = ${eelExpression}
                     item_3 = ' String'
@@ -852,6 +864,7 @@ EOF;
             Neos.Fusion:Tag {
                 tagName = 'h1'
                 content = Neos.Fusion:Join {
+                    @sortProperties = false
                     item_1 = 'Example'
                     item_2 = 'Content'
                 }


### PR DESCRIPTION
The sorting requires a little compute power that we can spare. In the result this will reduce rendering time of presentational afx about 10%.

**Upgrade instructions**

This would cause problems when @position is used in afx to reorder children. This makes not much sense imho so i would consider this probably non breaky.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
