### PR TITLE
BUGFIX: Flush cache also for deleted nodes

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -159,7 +159,7 @@ class ContentCacheFlusher
     {
         // Ensure that we're dealing with the variant of the given node that actually
         // lives in the given workspace
-        if ($node->getWorkspace()->getName() !== $workspace->getName()) {
+        if ($node->isRemoved() === false && $node->getWorkspace()->getName() !== $workspace->getName()) {
             $workspaceContext = $this->contextFactory->create(
                 array_merge(
                     $node->getContext()->getProperties(),


### PR DESCRIPTION
Removed nodes can't get found, so they regarding caches don't get flushed.

The bug was introduced with #4291
Fixes: #5105 