### PR TITLE
FEATURE: Reintroduce FlowQuery `context()` operation

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
@@ -54,6 +54,14 @@ final readonly class SubtreeTags implements \IteratorAggregate, \Countable, \Jso
         return new self(...array_map(SubtreeTag::fromString(...), $tags));
     }
 
+    public function with(SubtreeTag $subtreeTagToAdd): self
+    {
+        if ($this->contain($subtreeTagToAdd)) {
+            return $this;
+        }
+        return new self(...[...$this->tags, $subtreeTagToAdd]);
+    }
+
     public function without(SubtreeTag $subtreeTagToRemove): self
     {
         if (!$this->contain($subtreeTagToRemove)) {

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ContextOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ContextOperation.php
@@ -1,0 +1,129 @@
+<?php
+namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\NodeAccess\FlowQueryOperations\CreateNodeHashTrait;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Eel\FlowQuery\FlowQueryException;
+use Neos\Eel\FlowQuery\Operations\AbstractOperation;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * "context" operation working on ContentRepository nodes. Modifies the ContentRepository Context of each
+ * node in the current FlowQuery context by the given properties and returns the same
+ * nodes by identifier if they can be accessed in the new Context (otherwise they
+ * will be skipped).
+ *
+ * Example:
+ *
+ * 	q(node).context({'invisibleContentShown': true}).children()
+ *
+ * Supported options:
+ * - workspaceName
+ * - dimensions
+ * - invisibleContentShown
+ *
+ * Unsupported options:
+ * - currentDateTime
+ * - targetDimensions
+ * - removedContentShown
+ * - inaccessibleContentShown
+ *
+ */
+class ContextOperation extends AbstractOperation
+{
+    use CreateNodeHashTrait;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    protected static $shortName = 'context';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var integer
+     */
+    protected static $priority = 1;
+
+    #[Flow\Inject()]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $context $context onto which this operation should be applied (array or array-like object)
+     * @return boolean true if the operation can be applied onto the $context, false otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return count($context) === 0 || (isset($context[0]) && ($context[0] instanceof Node));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FlowQuery $flowQuery The FlowQuery object
+     * @param array $arguments The arguments for this operation
+     * @return void
+     * @throws FlowQueryException
+     */
+    public function evaluate(FlowQuery $flowQuery, array $arguments)
+    {
+        if (!isset($arguments[0]) || !is_array($arguments[0])) {
+            throw new FlowQueryException('context() requires an array argument of context properties', 1398030427);
+        }
+
+        $newContextProperties = $arguments[0];
+        $newWorkspaceName = isset($newContextProperties['workspaceName']) ? WorkspaceName::fromString($newContextProperties['workspaceName']) : null;
+        $newDimensions = isset($newContextProperties['dimensions']) ? DimensionSpacePoint::fromLegacyDimensionArray($newContextProperties['dimensions']) : null;
+        $newInvisibleContentShown = isset($newContextProperties['invisibleContentShown']) ? (
+            $newContextProperties['invisibleContentShown']
+                ? VisibilityConstraints::withoutRestrictions()
+                : VisibilityConstraints::frontend()
+        ) : null;
+
+        unset($newContextProperties['workspaceName']);
+        unset($newContextProperties['dimensions']);
+        unset($newContextProperties['invisibleContentShown']);
+
+        if (!empty($newContextProperties)) {
+            throw new FlowQueryException('context() doesnt support the legacy properties: ' . join(', ', $newContextProperties), 1717592463);
+        }
+
+        $output = [];
+        /** @var Node $contextNode */
+        foreach ($flowQuery->getContext() as $contextNode) {
+            $contentRepository = $this->contentRepositoryRegistry->get($contextNode->contentRepositoryId);
+            $newSubgraph = $contentRepository->getContentGraph(
+                $newWorkspaceName ?? $contextNode->workspaceName
+            )->getSubgraph(
+                $newDimensions ?? $contextNode->dimensionSpacePoint,
+                $newInvisibleContentShown ?? $contextNode->visibilityConstraints
+            );
+
+            $nodeInModifiedContext = $newSubgraph->findNodeById($contextNode->aggregateId);
+            if ($nodeInModifiedContext !== null) {
+                $output[$this->createNodeHash($nodeInModifiedContext)] = $nodeInModifiedContext;
+            }
+        }
+
+        $flowQuery->setContext(array_values($output));
+    }
+}

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ContextOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ContextOperation.php
@@ -103,7 +103,7 @@ class ContextOperation extends AbstractOperation
         unset($newContextProperties['invisibleContentShown']);
 
         if (!empty($newContextProperties)) {
-            throw new FlowQueryException('context() doesnt support the legacy properties: ' . join(', ', $newContextProperties), 1717592463);
+            throw new FlowQueryException('context() doesnt support the legacy properties: ' . join(', ', array_keys($newContextProperties)), 1717592463);
         }
 
         $output = [];

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -96,27 +96,6 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     include: resource://Neos.Fusion/Private/Fusion/Root.fusion
     include: resource://Neos.Neos/Private/Fusion/Root.fusion
 
-    prototype(Neos.Neos:Test.RenderNodes) < prototype(Neos.Fusion:Component) {
-      nodes = ${value}
-      renderer = Neos.Fusion:Loop {
-        items = ${props.nodes}
-        itemName = 'node'
-        itemRenderer = ${node.aggregateId}
-        @glue = ','
-      }
-    }
-
-    prototype(Neos.Neos:Test.RenderStringDataStructure) < prototype(Neos.Fusion:Component) {
-      items = ${value}
-      renderer = Neos.Fusion:Loop {
-        items = ${props.items}
-        itemKey = 'key'
-        itemName = 'string'
-        itemRenderer = ${key + ':' + (string ? string + ' ' : '')}
-        @glue = "\n"
-      }
-    }
-
     prototype(Neos.Neos:Test.RenderNodesDataStructure) < prototype(Neos.Fusion:Component) {
       items = ${value}
       renderer = Neos.Fusion:Loop {
@@ -125,8 +104,11 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
         itemName = 'nodes'
         itemRenderer = Neos.Fusion:Join {
           name = ${key + ':' + (nodes ? ' ' : '')}
-          ids = Neos.Neos:Test.RenderNodes {
-            nodes = ${nodes}
+          ids = Neos.Fusion:Loop {
+            items = ${nodes}
+            itemName = 'node'
+            itemRenderer = ${node.aggregateId}
+            @glue = ','
           }
         }
         @glue = "\n"
@@ -378,12 +360,14 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
   Scenario: Unique
     When I execute the following Fusion code:
     """fusion
-    test = ${q([node,site,documentNode]).unique().get()}
-    test.@process.render = Neos.Neos:Test.RenderNodes
+    test = Neos.Fusion:DataStructure {
+      unique = ${q([node,site,documentNode]).unique().get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
     """
     Then I expect the following Fusion rendering result:
     """
-    a1a4,a
+    unique: a1a4,a
     """
 
   Scenario: Remove

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery_Advanced.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery_Advanced.feature
@@ -1,0 +1,175 @@
+@flowEntities @contentrepository
+Feature: Tests for Flow Query context operation
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values      | Generalizations |
+      | language   | en, de, gsw | gsw->de->en     |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root': {}
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        title:
+          type: string
+        uriPathSegment:
+          type: string
+        hiddenInMenu:
+          type: bool
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentType1':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+
+    When the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {"language":"en"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value             |
+      | nodeAggregateId | "root"            |
+      | nodeTypeName    | "Neos.Neos:Sites" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                            | nodeName |
+      | a               | root                  | Neos.Neos:Site               | {"title": "Node a"}                              | a        |
+      | a1              | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1", "title": "Node a1"}     | a1       |
+      | a1a             | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1a", "title": "Node a1a"}   | a1a      |
+      | a1a1            | a1a                   | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1a1", "title": "Node a1a1"} | a1a1     |
+      | a1a2            | a1a                   | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1a2", "title": "Node a1a2"} | a1a2     |
+      | a1a3            | a1a                   | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1a3", "title": "Node a1a3"} | a1a3     |
+
+    # special nodes:
+
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value             |
+      | workspaceName      | "other-workspace" |
+      | baseWorkspaceName  | "live"            |
+      | newContentStreamId | "workspace-cs-id" |
+
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | workspaceName   | originDimensionSpacePoint | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                        |
+      | a2-disabled     | live            | {"language":"en"}         | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a2", "title": "Node a2"} |
+      | a3-workspace    | other-workspace | {"language":"en"}         | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a3", "title": "Node a3"} |
+      | a4-german       | live            | {"language":"de"}         | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a4", "title": "Node a4"} |
+
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value             |
+      | nodeAggregateId              | "a2-disabled"     |
+      | coveredDimensionSpacePoint   | {"language":"en"} |
+      | nodeVariantSelectionStrategy | "allVariants"     |
+
+    And A site exists for node name "a" and domain "http://localhost"
+    And the sites configuration is:
+    """yaml
+    Neos:
+      Neos:
+        sites:
+          '*':
+            contentRepository: default
+            contentDimensions:
+              resolver:
+                factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
+    """
+    And the Fusion context request URI is "http://localhost"
+    And I have the following Fusion setup:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    prototype(Neos.Neos:Test.RenderNodesDataStructure) < prototype(Neos.Fusion:Component) {
+      items = ${value}
+      renderer = Neos.Fusion:Loop {
+        items = ${props.items}
+        itemKey = 'key'
+        itemName = 'nodes'
+        itemRenderer = Neos.Fusion:Join {
+          name = ${key + ':' + (nodes ? ' ' : '')}
+          ids = Neos.Fusion:Loop {
+            items = ${nodes}
+            itemName = 'node'
+            itemRenderer = ${node.aggregateId + '[' + node.workspaceName + ',' + Json.stringify(node.dimensionSpacePoint) + ']' + (Neos.Node.isDisabled(node) ? '*' : '')}
+            @glue = ','
+          }
+        }
+        @glue = "\n"
+      }
+    }
+    """
+
+  Scenario: Default context() operation case
+    Workspace Live, Language EN, Visibility hidden
+
+    And the Fusion context node is "a"
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      default = ${q(node).children().get()}
+      explicit = ${q(node).context({'workspaceName': 'live', 'dimensions': {'language': ['en']}, 'invisibleContentShown': false}).children().get()}
+      empty = ${q(node).context({}).children().get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    default: a1[live,{"language":"en"}]
+    explicit: a1[live,{"language":"en"}]
+    empty: a1[live,{"language":"en"}]
+    """
+
+  Scenario: context() operation
+    And the Fusion context node is "a"
+
+    #
+    # Other workspaces
+    #
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      children = ${q(node).context({'workspaceName': 'other-workspace'}).children().get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    children: a1[other-workspace,{"language":"en"}],a3-workspace[other-workspace,{"language":"en"}]
+    """
+
+    #
+    # Other dimension
+    #
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      children = ${q(node).context({'dimensions': {'language': ['de']}}).children().get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    children: a1[live,{"language":"de"}],a4-german[live,{"language":"de"}]
+    """
+
+    #
+    # Show disabled
+    #
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      children = ${q(node).context({'invisibleContentShown': true}).children().get()}
+      @process.render = Neos.Neos:Test.RenderNodesDataStructure
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    children: a1[live,{"language":"en"}],a2-disabled[live,{"language":"en"}]*
+    """


### PR DESCRIPTION
Solves partially https://github.com/neos/neos-development-collection/issues/5100

This pr reintroduces the context FlowQuery operation known from Neos 8.3.

Supported options:

- workspaceName
- dimensions
- invisibleContentShown

The API for the options was left intact though some concepts are now named differently in the core. The context operation should thus not be seen as forever-staying feature and will likely be deprecated and replaced with more explicit ways which fit better the current naming scheme and API. See https://github.com/neos/neos-development-collection/issues/5100. 

- `${q(node).context({'workspaceName': 'other-workspace'})}`
- `${q(node).context({'dimensions': {'language': ['de']}})}`
- `${q(node).context({'invisibleContentShown': true})}`

Due to fundamental changes these options from 8.3 cannot be supported and will throw an exception:
- currentDateTime
- targetDimensions
- removedContentShown
- inaccessibleContentShown

so instead of finding new alternatives and attempting to rector this change proposes to relive the old syntax.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
