### PR TITLE
BUGFIX: Translate FlashMessage if asset is still in use in media browser inspector 

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -70,8 +70,11 @@ use Neos\Utility\MediaTypes;
  */
 class AssetController extends ActionController
 {
-    use CreateContentContextTrait;
     use BackendUserTranslationTrait;
+    use BackendUserTranslationTrait {
+        BackendUserTranslationTrait::initializeObject as BackendUserTranslationTraitInitializeObject;
+    }
+    use CreateContentContextTrait;
     use AddTranslatedFlashMessageTrait;
 
     protected const TAG_GIVEN = 0;
@@ -170,6 +173,8 @@ class AssetController extends ActionController
      */
     public function initializeObject(): void
     {
+        $this->backendUserTranslationTraitInitializeObject();
+
         $domain = $this->domainRepository->findOneByActiveRequest();
 
         // Set active asset collection to the current site's asset collection, if it has one, on the first view if a matching domain is found

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -72,7 +72,7 @@ class AssetController extends ActionController
 {
     use BackendUserTranslationTrait;
     use BackendUserTranslationTrait {
-        BackendUserTranslationTrait::initializeObject as BackendUserTranslationTraitInitializeObject;
+        BackendUserTranslationTrait::initializeObject as backendUserTranslationTraitInitializeObject;
     }
     use CreateContentContextTrait;
     use AddTranslatedFlashMessageTrait;

--- a/Neos.Media.Browser/Resources/Private/Layouts/Default.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/Default.html
@@ -23,7 +23,7 @@
         </div>
         <div class="neos-media-content{f:if(condition: '{tags -> f:count()} > 25', then: ' neos-media-aside-condensed')}">
             <div class="neos-media-assets">
-                <div class="neos-notification-container">
+                <div id="neos-notification-container">
                     <f:render partial="FlashMessages"/>
                 </div>
                 <f:render section="Content"/>


### PR DESCRIPTION
Bugfix for #5085 no error if asset still in use and show flashmessage solution set class neos-notification-container as id

In media browser inspector if assets are deleted wich are still used no FlashMessage was showed  and on second delete an error pages was showed.

Solution:
In Neos.Media:Browser/Resources/Private/Layouts/Default.html change class neos-notification-container to id neos-notification-container, because Notification.js / Toast is searching for id neos-notification-container to insert FlashMessages.

`       <div class="neos-media-content{f:if(condition: '{tags -> f:count()} > 25', then: ' neos-media-aside-condensed')}">
            <div class="neos-media-assets">
                <div **id="neos-notification-container"**>
                    <f:render partial="FlashMessages"/>
                </div>
                <f:render section="Content"/>
            </div>
            <aside class="neos-media-aside">`

related: #5085

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
