### PR TITLE
WIP FEATURE: Configurable node search service

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/NodeSearchIdentifierResolver.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchIdentifierResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Neos\Neos\Domain\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Validation\Validator\NodeIdentifierValidator;
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+class NodeSearchIdentifierResolver implements NodeSearchResolverInterface
+{
+    /**
+     * @param string[] $searchNodeTypes
+     * @return NodeInterface[]
+     */
+    public function resolve(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): array {
+        $nodeByIdentifier = $context->getNodeByIdentifier($term);
+        if ($nodeByIdentifier !== null && $this->nodeSatisfiesSearchNodeTypes(
+                $nodeByIdentifier,
+                $searchNodeTypes
+            )) {
+            return [$nodeByIdentifier->getPath() => $nodeByIdentifier];
+        }
+        return [];
+    }
+
+    /**
+     * This resolver accepts node identifiers only
+     *
+     * @param string[] $searchNodeTypes
+     */
+    public function matches(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): bool {
+        return preg_match(NodeIdentifierValidator::PATTERN_MATCH_NODE_IDENTIFIER, $term) === 1;
+    }
+
+    /**
+     * Whether the given $node satisfies the specified types
+     *
+     * @param string[] $searchNodeTypes
+     */
+    protected function nodeSatisfiesSearchNodeTypes(NodeInterface $node, array $searchNodeTypes): bool
+    {
+        foreach ($searchNodeTypes as $nodeTypeName) {
+            if ($node->getNodeType()->isOfType($nodeTypeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Neos.Neos/Classes/Domain/Service/NodeSearchPathResolver.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchPathResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Neos\Neos\Domain\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+class NodeSearchPathResolver implements NodeSearchResolverInterface
+{
+    /**
+     * @param string[] $searchNodeTypes
+     * @return NodeInterface[]
+     */
+    public function resolve(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): array {
+        $nodeByPath = $context->getNode($term);
+        if ($nodeByPath !== null && $this->nodeSatisfiesSearchNodeTypes(
+                $nodeByPath,
+                $searchNodeTypes
+            )) {
+            return [$nodeByPath->getPath() => $nodeByPath];
+        }
+        return [];
+    }
+
+    /**
+     * This resolver accepts node paths only
+     *
+     * @param string[] $searchNodeTypes
+     */
+    public function matches(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): bool {
+        return preg_match(NodeInterface::MATCH_PATTERN_PATH, $term) === 1;
+    }
+
+    /**
+     * Whether the given $node satisfies the specified types
+     *
+     * @param string[] $searchNodeTypes
+     */
+    protected function nodeSatisfiesSearchNodeTypes(NodeInterface $node, array $searchNodeTypes): bool
+    {
+        foreach ($searchNodeTypes as $nodeTypeName) {
+            if ($node->getNodeType()->isOfType($nodeTypeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Neos.Neos/Classes/Domain/Service/NodeSearchResolverInterface.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+namespace Neos\Neos\Domain\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\Context;
+
+interface NodeSearchResolverInterface
+{
+    /**
+     * @param string[] $searchNodeTypes
+     * @return NodeInterface[]
+     */
+    public function resolve(string $term, array $searchNodeTypes, Context $context, NodeInterface $startingPoint = null): array;
+
+    public function matches(string $term, array $searchNodeTypes, Context $context, NodeInterface $startingPoint = null): bool;
+}

--- a/Neos.Neos/Classes/Domain/Service/NodeSearchTermResolver.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchTermResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Neos\Neos\Domain\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Factory\NodeFactory;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Flow\Annotations as Flow;
+
+class NodeSearchTermResolver implements NodeSearchResolverInterface
+{
+    #[Flow\Inject]
+    protected NodeDataRepository $nodeDataRepository;
+
+    #[Flow\Inject]
+    protected NodeFactory $nodeFactory;
+
+    /**
+     * @param string[] $searchNodeTypes
+     * @return NodeInterface[]
+     */
+    public function resolve(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): array {
+        $searchResult = [];
+        $nodeTypeFilter = implode(',', $searchNodeTypes);
+        $nodeDataRecords = $this->nodeDataRepository->findByProperties(
+            $term,
+            $nodeTypeFilter,
+            $context->getWorkspace(),
+            $context->getDimensions(),
+            $startingPoint?->getPath()
+        );
+        foreach ($nodeDataRecords as $nodeData) {
+            $node = $this->nodeFactory->createFromNodeData($nodeData, $context);
+            if ($node !== null) {
+                $searchResult[$node->getPath()] = $node;
+            }
+        }
+        return $searchResult;
+    }
+
+    /**
+     * This resolver accepts any term for searching
+     *
+     * @param string[] $searchNodeTypes
+     */
+    public function matches(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): bool {
+        return true;
+    }
+}

--- a/Neos.Neos/Classes/Domain/Service/NodeSearchURLResolver.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchURLResolver.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Neos\Neos\Domain\Service;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Uri;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Domain\Utility\NodePaths;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Routing\Dto\RouteContext;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
+use Neos\Flow\Mvc\Routing\Router;
+use Neos\Flow\Mvc\Routing\RouterInterface;
+
+class NodeSearchURLResolver implements NodeSearchResolverInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    #[Flow\Inject]
+    protected $router;
+
+    /**
+     * @param string[] $searchNodeTypes
+     * @return NodeInterface[]
+     */
+    public function resolve(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): array {
+        $uri = new Uri($term);
+
+        $routeParameters = RouteParameters::createEmpty();
+        $routeParameters = $routeParameters->withParameter('requestUriHost', $uri->getHost());
+
+        $routeContext = new RouteContext(
+            new ServerRequest('GET', $uri),
+            $routeParameters
+        );
+
+        $router = new Router();
+
+        try {
+            $matches = $router->route($routeContext);
+        } catch (\Exception) {
+            return [];
+        }
+
+        if (!$matches) {
+            return [];
+        }
+
+        $nodeContextPath = $matches['node'] ?? null;
+
+        if (!$nodeContextPath) {
+            return [];
+        }
+
+        $nodePath = NodePaths::explodeContextPath($nodeContextPath)['nodePath'];
+        $matchingNode = $context->getNode($nodePath);
+        if ($matchingNode && $this->nodeSatisfiesSearchNodeTypes($matchingNode, $searchNodeTypes)) {
+            return [$matchingNode->getPath() => $matchingNode];
+        }
+        return [];
+    }
+
+    /**
+     * This resolver accepts node paths only
+     *
+     * @param string[] $searchNodeTypes
+     */
+    public function matches(
+        string $term,
+        array $searchNodeTypes,
+        Context $context,
+        NodeInterface $startingPoint = null
+    ): bool {
+        return preg_match('/^https?:\/\/.*$/', $term) === 1;
+    }
+
+    /**
+     * Whether the given $node satisfies the specified types
+     *
+     * @param string[] $searchNodeTypes
+     */
+    protected function nodeSatisfiesSearchNodeTypes(NodeInterface $node, array $searchNodeTypes): bool
+    {
+        foreach ($searchNodeTypes as $nodeTypeName) {
+            if ($node->getNodeType()->isOfType($nodeTypeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Neos.Neos/Configuration/Settings.NodeSearch.yaml
+++ b/Neos.Neos/Configuration/Settings.NodeSearch.yaml
@@ -1,0 +1,16 @@
+Neos:
+  Neos:
+    NodeSearch:
+      # Resolvers for various types of inputs which NodeSearchServiceInterface implementations can use to resolve search terms
+      resolvers:
+        'nodeIdentifier':
+          class: 'Neos\Neos\Domain\Service\NodeSearchIdentifierResolver'
+          position: 'start'
+        'nodePath':
+          class: 'Neos\Neos\Domain\Service\NodeSearchPathResolver'
+        'url':
+          class: 'Neos\Neos\Domain\Service\NodeSearchUrlResolver'
+        'term':
+          # Default fallback resolver
+          class: 'Neos\Neos\Domain\Service\NodeSearchTermResolver'
+          position: 'end'


### PR DESCRIPTION
Just a WIP idea to make the NodeSearchService fully configurable, so it doesn't need to be fully replaced by a plugin, but instead calls a list of resolvers which can accept a term and return results.

Its unclear whether this service will still exist in 9.0, but having a concept for a configurable service might still be good in the future.
This one helps me right now a lot in a real project.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
