### PR TITLE
BUGFIX: Access isNil function from Helper function to apply selected image to property

### DIFF
--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -55,7 +55,7 @@ window.addEventListener('DOMContentLoaded', () => {
 				}
 
 				const localAssetIdentifier = asset.dataset.localAssetIdentifier;
-				if (localAssetIdentifier !== '' && !NeosCMS.isNil(localAssetIdentifier)) {
+				if (localAssetIdentifier !== '' && !NeosCMS.Helper.isNil(localAssetIdentifier)) {
 					NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
 				} else {
 					if (asset.dataset.importInProcess !== 'true') {


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

_None_

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

Follow-up to: #5117

With the latest Bugfix release of Neos 8.3.14 currently when selecting an image from the media browser it not will be applyied to the image property as the `IsNil` function has to be accessed inside of the `Helper` function.

```javascript
NeosCMS.isNil()
```
In this case, leads to an unresolved function or method.

### Before

https://github.com/neos/neos-development-collection/assets/39345336/ed761221-924d-467f-bd9f-6eb6c97dd553

### After

https://github.com/neos/neos-development-collection/assets/39345336/2c78211a-c8a8-4f55-808a-15b495fde586


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
