### PR TITLE
TASK: Remove obsolete OUTDATED_CONFLICT state leftovers

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceProjection.php
@@ -291,7 +291,7 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
 
     private function whenWorkspaceRebaseFailed(WorkspaceRebaseFailed $event): void
     {
-        $this->markWorkspaceAsOutdatedConflict($event->workspaceName);
+        $this->markWorkspaceAsOutdated($event->workspaceName);
     }
 
     private function whenWorkspaceWasRemoved(WorkspaceWasRemoved $event): void
@@ -370,20 +370,6 @@ class WorkspaceProjection implements ProjectionInterface, WithMarkStaleInterface
                 workspacename = :workspaceName
         ', [
             'outdated' => WorkspaceStatus::OUTDATED->value,
-            'workspaceName' => $workspaceName->value
-        ]);
-    }
-
-    private function markWorkspaceAsOutdatedConflict(WorkspaceName $workspaceName): void
-    {
-        $this->dbal->executeUpdate('
-            UPDATE ' . $this->tableName . '
-            SET
-                status = :outdatedConflict
-            WHERE
-                workspacename = :workspaceName
-        ', [
-            'outdatedConflict' => WorkspaceStatus::OUTDATED_CONFLICT->value,
             'workspaceName' => $workspaceName->value
         ]);
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceStatus.php
@@ -45,18 +45,6 @@ enum WorkspaceStatus: string implements \JsonSerializable
      */
     case OUTDATED = 'OUTDATED';
 
-    /**
-     * CONFLICT Example:
-     *
-     * CONFLICT is a special case of OUTDATED, but then an error happens during the rebasing.
-     *
-     * Workspace Review <----------------------------------- Workspace User-Foo
-     *      |                                                .             |
-     *      Content Stream A2 (current)  <-- Content Stream B2 (rebasing)  |
-     *                                                        Content Stream B1
-     */
-    case OUTDATED_CONFLICT = 'OUTDATED_CONFLICT';
-
     public function equals(self $other): bool
     {
         return $this->value === $other->value;


### PR DESCRIPTION
Resolves: #5101

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

MUST BE CAREFULLY REVIEWED... please dont trust my proposal :D

with https://github.com/neos/neos-development-collection/pull/4965 we never create rebase was failed events anymore and the logic to query `OUTDATED_CONFLICT` workspaces was removed.
To have a consistent and understandable codebase without dead artefacts i removed the `OUTDATED_CONFLICT` flag and for the legacy event (in case of a replay) `OUTDATED` will be written to the database as otherwise the workspace will probably disappear and not be to recover

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
