### PR TITLE
TASK: Deprecate additional site kickstart generators and show helpful output for default afx case

### DIFF
--- a/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.SiteKickstarter/Classes/Command/KickstartCommandController.php
@@ -15,6 +15,7 @@ namespace Neos\SiteKickstarter\Command;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Package\PackageManager;
+use Neos\SiteKickstarter\Generator\AfxTemplateGenerator;
 use Neos\SiteKickstarter\Service\SiteGeneratorCollectingService;
 use Neos\SiteKickstarter\Service\SitePackageGeneratorNameService;
 
@@ -62,27 +63,40 @@ class KickstartCommandController extends CommandController
 
         $generatorClasses = $this->siteGeneratorCollectingService->getAllGenerators();
 
-        $selection = [];
-        $nameToClassMap = [];
-        foreach ($generatorClasses as $generatorClass) {
-            $name = $this->sitePackageGeneratorNameService->getNameOfSitePackageGenerator($generatorClass);
+        if (count($generatorClasses) > 1) {
+            // legacy custom additional generators installed, so we need to show the select box
+            $selection = [];
+            $nameToClassMap = [];
+            foreach ($generatorClasses as $generatorClass) {
+                $name = $this->sitePackageGeneratorNameService->getNameOfSitePackageGenerator($generatorClass);
 
-            $selection[] = $name;
-            $nameToClassMap[$name] = $generatorClass;
+                $selection[] = $name;
+                $nameToClassMap[$name] = $generatorClass;
+            }
+
+            /** @var string $generatorName */
+            $generatorName = $this->output->select(
+                sprintf('What generator do you want to use? (<info>%s</info>): ', array_key_first($selection)),
+                $selection,
+                array_key_first($selection)
+            );
+            $generatorClass = $nameToClassMap[$generatorName];
+        } else {
+            // default happy case, only one generator which MUST be the afx default
+            $generatorClass = AfxTemplateGenerator::class;
         }
-
-        /** @var string $generatorName */
-        $generatorName = $this->output->select(
-            sprintf('What generator do you want to use? (<info>%s</info>): ', array_key_first($selection)),
-            $selection,
-            array_key_first($selection)
-        );
-
-        $generatorClass = $nameToClassMap[$generatorName];
 
         $generatorService = $this->objectManager->get($generatorClass);
 
         $generatedFiles = $generatorService->generateSitePackage($packageKey);
         $this->outputLine(implode(PHP_EOL, $generatedFiles));
+
+        $this->outputLine();
+        $this->outputLine(sprintf('Create a new site based on the new package "%s" by running the site create command', $packageKey));
+
+        if ($generatorClass === AfxTemplateGenerator::class) {
+            $guessedSiteName = strtolower(str_replace('.', '-', $packageKey));
+            $this->outputLine(sprintf('./flow site:create %1$s %2$s %2$s:Document.Homepage', $guessedSiteName, $packageKey));
+        }
     }
 }

--- a/Neos.SiteKickstarter/Classes/Generator/AfxTemplateGenerator.php
+++ b/Neos.SiteKickstarter/Classes/Generator/AfxTemplateGenerator.php
@@ -24,6 +24,7 @@ use Neos\Utility\Files;
 /**
  * Service to generate site packages
  *
+ * @internal
  */
 class AfxTemplateGenerator extends GeneratorService implements SitePackageGeneratorInterface
 {

--- a/Neos.SiteKickstarter/Classes/Generator/SitePackageGeneratorInterface.php
+++ b/Neos.SiteKickstarter/Classes/Generator/SitePackageGeneratorInterface.php
@@ -13,6 +13,9 @@ namespace Neos\SiteKickstarter\Generator;
  * source code.
  */
 
+/**
+ * @deprecated with Neos 9. Custom generators for "kickstart:site" are discouraged.
+ */
 interface SitePackageGeneratorInterface
 {
     /**

--- a/Neos.SiteKickstarter/Classes/Service/FusionRecursiveDirectoryRenderer.php
+++ b/Neos.SiteKickstarter/Classes/Service/FusionRecursiveDirectoryRenderer.php
@@ -15,6 +15,9 @@ namespace Neos\SiteKickstarter\Service;
 
 use Neos\Flow\Annotations as Flow;
 
+/**
+ * @internal
+ */
 class FusionRecursiveDirectoryRenderer
 {
     /**

--- a/Neos.SiteKickstarter/Classes/Service/SimpleTemplateRenderer.php
+++ b/Neos.SiteKickstarter/Classes/Service/SimpleTemplateRenderer.php
@@ -13,6 +13,9 @@ namespace Neos\SiteKickstarter\Service;
  * source code.
  */
 
+/**
+ * @internal
+ */
 class SimpleTemplateRenderer
 {
     /**

--- a/Neos.SiteKickstarter/Classes/Service/SiteGeneratorCollectingService.php
+++ b/Neos.SiteKickstarter/Classes/Service/SiteGeneratorCollectingService.php
@@ -17,6 +17,9 @@ use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Annotations as Flow;
 use Neos\SiteKickstarter\Generator\SitePackageGeneratorInterface;
 
+/**
+ * @internal
+ */
 class SiteGeneratorCollectingService
 {
     /**

--- a/Neos.SiteKickstarter/Classes/Service/SitePackageGeneratorNameService.php
+++ b/Neos.SiteKickstarter/Classes/Service/SitePackageGeneratorNameService.php
@@ -17,6 +17,9 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\SiteKickstarter\Generator\SitePackageGeneratorInterface;
 
+/**
+ * @internal
+ */
 class SitePackageGeneratorNameService
 {
     /**


### PR DESCRIPTION
Follow-up to https://github.com/neos/neos-development-collection/pull/5136

By default (if only the package is installed) no further question will be asked and with AFX proceeded.
Additionally we can hardcode the suggestion to import the new homepage from `Vendor.Site:Document.Homepage` etc.

```
neos-manufacture-90 git:(9.0) ✗ flow kickstart:site Vendor.Site
Created .../Document.Page.yaml
Created .../Document.Homepage.yaml

Create a new site based on the new package "Vendor.Site" by running the site create command
./flow site:create vendor-site Vendor.Site Vendor.Site:Document.Homepage
```

The reason why i think we should deprecate this extension point is that we have a lot of YAGNI extension points and there are no usecases that im aware of.

### The possible future of kickstarters

But i do love kickstarters and think Neos should provide good ones to start with. A good idea would be to see what @mficzel  and @nezaniel did with https://github.com/sitegeist/Sitegeist.Noderobis. I think these more fine tuned kickstarters with much more input are way more useful then trying the impossible to kickstart a full site from scratch with one cli command.
The current practice is using a template repository and cloning from that base distribution and `composer create project` should probably be adjusted to offer a few choices https://github.com/neos/neos-base-distribution/pull/42.


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
