### PR TITLE
TASK: Use collection value objects in content graph instead of `iterable`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\CoverageByOrigin;
 use Neos\ContentRepository\Core\Projection\ContentGraph\DimensionSpacePointsBySubtreeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregates;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\OriginByCoverage;
@@ -240,16 +241,21 @@ final class NodeFactory
     }
 
     /**
-     * @param iterable<int,array<string,string>> $nodeRows
-     * @return iterable<int,NodeAggregate>
+     * @param array<int,array<string,string>> $nodeRows
      * @throws NodeTypeNotFound
      */
     public function mapNodeRowsToNodeAggregates(
-        iterable $nodeRows,
+        array $nodeRows,
         WorkspaceName $workspaceName,
         ContentStreamId $contentStreamId,
         VisibilityConstraints $visibilityConstraints
-    ): iterable {
+    ): NodeAggregates {
+        if (empty($nodeRows)) {
+            return NodeAggregates::createEmpty();
+        }
+
+        $nodeAggregates = [];
+
         $nodeTypeNames = [];
         $nodeNames = [];
         $occupiedDimensionSpacePointsByNodeAggregate = [];
@@ -315,7 +321,7 @@ final class NodeFactory
 
         foreach ($nodesByOccupiedDimensionSpacePointsByNodeAggregate as $rawNodeAggregateId => $nodes) {
             /** @var string $rawNodeAggregateId */
-            yield NodeAggregate::create(
+            $nodeAggregates[] = NodeAggregate::create(
                 $this->contentRepositoryId,
                 $workspaceName,
                 NodeAggregateId::fromString($rawNodeAggregateId),
@@ -341,6 +347,8 @@ final class NodeFactory
                 $contentStreamId,
             );
         }
+
+        return NodeAggregates::fromArray($nodeAggregates);
     }
 
     public static function extractNodeTagsFromJson(string $subtreeTagsJson): NodeTags

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
@@ -23,6 +23,7 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindRootNodeAggregatesFilter;
@@ -127,13 +128,10 @@ final class ContentHypergraph implements ContentGraphInterface
         throw new \BadMethodCallException('method findRootNodeAggregates is not implemented yet.', 1645782874);
     }
 
-    /**
-     * @return \Iterator<int,NodeAggregate>
-     */
     public function findNodeAggregatesByType(
         NodeTypeName $nodeTypeName
-    ): \Iterator {
-        return new \Generator();
+    ): NodeAggregates {
+        return NodeAggregates::createEmpty();
     }
 
     public function findNodeAggregateById(
@@ -188,12 +186,9 @@ final class ContentHypergraph implements ContentGraphInterface
         );
     }
 
-    /**
-     * @return iterable<NodeAggregate>
-     */
     public function findParentNodeAggregates(
         NodeAggregateId $childNodeAggregateId
-    ): iterable {
+    ): NodeAggregates {
         $query = HypergraphParentQuery::create($this->contentStreamId, $this->tableNamePrefix);
         $query = $query->withChildNodeAggregateId($childNodeAggregateId);
 
@@ -205,12 +200,9 @@ final class ContentHypergraph implements ContentGraphInterface
         );
     }
 
-    /**
-     * @return iterable<NodeAggregate>
-     */
     public function findChildNodeAggregates(
         NodeAggregateId $parentNodeAggregateId
-    ): iterable {
+    ): NodeAggregates {
         $query = HypergraphChildQuery::create(
             $this->contentStreamId,
             $parentNodeAggregateId,
@@ -244,12 +236,9 @@ final class ContentHypergraph implements ContentGraphInterface
         );
     }
 
-    /**
-     * @return iterable<NodeAggregate>
-     */
     public function findTetheredChildNodeAggregates(
         NodeAggregateId $parentNodeAggregateId
-    ): iterable {
+    ): NodeAggregates {
         $query = HypergraphChildQuery::create(
             $this->contentStreamId,
             $parentNodeAggregateId,
@@ -298,12 +287,9 @@ final class ContentHypergraph implements ContentGraphInterface
         return $this->dbal->executeQuery($query)->fetchOne();
     }
 
-    /**
-     * @return iterable<int,NodeTypeName>
-     */
-    public function findUsedNodeTypeNames(): iterable
+    public function findUsedNodeTypeNames(): NodeTypeNames
     {
-        return [];
+        return NodeTypeNames::createEmpty();
     }
 
     public function getContentStreamId(): ContentStreamId

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -22,11 +22,11 @@ use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyV
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
-use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphIdentity;
 use Neos\ContentRepository\Core\Projection\ContentGraph\CoverageByOrigin;
 use Neos\ContentRepository\Core\Projection\ContentGraph\DimensionSpacePointsBySubtreeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregates;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\OriginByCoverage;
@@ -37,7 +37,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Timestamps;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
@@ -264,14 +263,14 @@ final class NodeFactory
 
     /**
      * @param array<int,array<string,mixed>> $nodeRows
-     * @return iterable<int,\Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate>
      */
-    public function mapNodeRowsToNodeAggregates(array $nodeRows, VisibilityConstraints $visibilityConstraints): iterable
+    public function mapNodeRowsToNodeAggregates(array $nodeRows, VisibilityConstraints $visibilityConstraints): NodeAggregates
     {
-        $nodeAggregates = [];
         if (empty($nodeRows)) {
-            return $nodeAggregates;
+            return NodeAggregates::createEmpty();
         }
+
+        $nodeAggregates = [];
 
         $contentStreamId = null;
         /** @var NodeAggregateId[] $nodeAggregateIds */
@@ -342,7 +341,7 @@ final class NodeFactory
         }
 
         foreach ($nodeAggregateIds as $key => $nodeAggregateId) {
-            yield NodeAggregate::create(
+            $nodeAggregates[] = NodeAggregate::create(
                 $this->contentRepositoryId,
                 WorkspaceName::fromString('missing'), // todo
                 $nodeAggregateId,
@@ -360,6 +359,8 @@ final class NodeFactory
                 $contentStreamId,
             );
         }
+
+        return NodeAggregates::fromArray($nodeAggregates);
     }
 
     private static function parseDateTimeString(string $string): \DateTimeImmutable

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeAggregatesTypeIsAmbiguous;
@@ -58,11 +59,7 @@ interface ContentGraphInterface extends ProjectionStateInterface
     ): ContentSubgraphInterface;
 
     /**
-     * Throws exception if no root aggregate found, because a Content Repository needs at least
-     * one root node to function.
-     *
-     * Also throws exceptions if multiple root node aggregates of the given $nodeTypeName were found,
-     * as this would lead to nondeterministic results in your code.
+     * Throws exception if no root aggregate of the given type found.
      *
      * @throws RootNodeAggregateDoesNotExist
      * @api
@@ -79,12 +76,11 @@ interface ContentGraphInterface extends ProjectionStateInterface
     ): NodeAggregates;
 
     /**
-     * @return iterable<NodeAggregate>
      * @api
      */
     public function findNodeAggregatesByType(
         NodeTypeName $nodeTypeName
-    ): iterable;
+    ): NodeAggregates;
 
     /**
      * @throws NodeAggregatesTypeIsAmbiguous
@@ -97,10 +93,9 @@ interface ContentGraphInterface extends ProjectionStateInterface
     /**
      * Returns all node types in use, from the graph projection
      *
-     * @return iterable<NodeTypeName>
      * @api
      */
-    public function findUsedNodeTypeNames(): iterable;
+    public function findUsedNodeTypeNames(): NodeTypeNames;
 
     /**
      * @internal only for consumption inside the Command Handler
@@ -111,20 +106,18 @@ interface ContentGraphInterface extends ProjectionStateInterface
     ): ?NodeAggregate;
 
     /**
-     * @return iterable<NodeAggregate>
      * @internal only for consumption inside the Command Handler
      */
     public function findParentNodeAggregates(
         NodeAggregateId $childNodeAggregateId
-    ): iterable;
+    ): NodeAggregates;
 
     /**
-     * @return iterable<NodeAggregate>
      * @internal only for consumption inside the Command Handler
      */
     public function findChildNodeAggregates(
         NodeAggregateId $parentNodeAggregateId
-    ): iterable;
+    ): NodeAggregates;
 
     /**
      * A node aggregate can have no or exactly one child node aggregate with a given name as enforced by constraint checks
@@ -137,12 +130,11 @@ interface ContentGraphInterface extends ProjectionStateInterface
     ): ?NodeAggregate;
 
     /**
-     * @return iterable<NodeAggregate>
      * @internal only for consumption inside the Command Handler
      */
     public function findTetheredChildNodeAggregates(
         NodeAggregateId $parentNodeAggregateId
-    ): iterable;
+    ): NodeAggregates;
 
     /**
      * @internal only for consumption inside the Command Handler


### PR DESCRIPTION
Solves partially: https://github.com/neos/neos-development-collection/issues/5102

In the content graph we have some methods returning `NodeAggregates` and others `iterable<NodeAggregate>` while it seems like it, the `iterable` is also not lazy and yielded but fetches all nodes eagerly so there is no performance / memory gain.


This change is not really breaking, as `NodeAggregates` implement `\IteratorAggregate` and thus `foreach`ing or calling `iterator_to_array` on the results will not make a difference.

Though this change should happen before a final release :D

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
