### PR TITLE
BUGFIX: Dont initialize $currentContentStreamId by default in behat tests

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -100,12 +100,8 @@ trait CRTestSuiteRuntimeVariables
      */
     public function iAmInWorkspace(string $workspaceName): void
     {
-        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($workspaceName));
-        if ($workspace === null) {
-            throw new \Exception(sprintf('Workspace "%s" does not exist, projection not yet up to date?', $workspaceName), 1548149355);
-        }
         $this->currentWorkspaceName = WorkspaceName::fromString($workspaceName);
-        $this->currentContentStreamId = $workspace->currentContentStreamId;
+        $this->currentContentStreamId = null;
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -128,9 +128,6 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     When the command DiscardWorkspace is executed with payload:
       | Key           | Value         |
       | workspaceName | "user-editor" |
-    # FIXME we have to reevaluated the step as we cache the $currentContentStreamId and it will be outdated after the discard
-    # see https://github.com/neos/neos-development-collection/pull/5162
-    And I am in workspace "user-editor" and dimension space point {}
     Then I expect node aggregate identifier "text-node-middle" to lead to no node
 
     When I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
@@ -44,7 +44,6 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
     #        earl-o-documentbourgh
     #      nody-mc-nodeface
     #
-    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues                    | nodeName |
       | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "ignore-me"}          | node1    |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
@@ -222,7 +222,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | "c"     | "lady-eleonode-rootford/shernode-homes/c"    | "c"                      | "shernode-homes"         | "b"                      | null                      | "Neos.Neos:Test.Routing.Page" |
 
   Scenario: ab(> b1, b2 > b2a)c => a(> b2 > b2a)b(> b1)c (moving b1 below a)
-    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues     | nodeName |
       | b1              | b                     | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "b1"}  | b1       |
@@ -246,7 +245,6 @@ Feature: Low level tests covering the inner behavior of the routing projection
       | "c"        | "lady-eleonode-rootford/shernode-homes/c"        | "c"                      | "shernode-homes"         | "b"                      | null                      | "Neos.Neos:Test.Routing.Page" |
 
   Scenario: ab(> b1, b2 > b2a)c => b(> b1, a, b2 > b2a)c (moving a below b)
-    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues     | nodeName |
       | b1              | b                     | Neos.Neos:Test.Routing.Page | {"uriPathSegment": "b1"}  | b1       |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
@@ -43,7 +43,6 @@ Feature: Route cache invalidation
     #        earl-o-documentbourgh
     #      nody-mc-nodeface
     #
-    And I am in workspace "live" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues                    | nodeName |
       | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {"uriPathSegment": "ignore-me"}          | node1    |


### PR DESCRIPTION
Related https://github.com/neos/neos-development-collection/issues/5034

With https://github.com/neos/neos-development-collection/pull/5040
the step `I am in the active content stream of workspace "live"` was turned into `I am in workspace "live"`.


That is problematic as the step
```
 And I am in workspace "live"
```

now hardcodes the `$currentContentStreamId` making assertions after changing the workspaces content stream (publish or discard) seem at first broken.

A current workaround is to repeat the step after discarding for example:

```
When the command DiscardWorkspace is executed with payload:
  | Key           | Value         |
  | workspaceName | "user-editor" |
# FIXME we have to reevaluated the step as we cache the $currentContentStreamId and it will be outdated after the discard
And I am in workspace "user-editor" and dimension space point {}
Then I expect node aggregate identifier "text-node-middle" to lead to no node
```

... but all test pass after these adjustments so id say we dont need the hack in the first place.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
