### PR TITLE
BUGFIX: Fix content cache for discard, revert #5083 for now

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Fusion\Cache;
 
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\CacheAwareInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
@@ -22,17 +23,18 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
  * The cache entry identifier data transfer object for nodes
  *
  * @Flow\Proxy(false)
+ * @internal
  */
-final class NodeCacheEntryIdentifier implements CacheAwareInterface
+final readonly class NodeCacheEntryIdentifier implements CacheAwareInterface
 {
     private function __construct(
-        private readonly string $value
+        private string $value
     ) {
     }
 
-    public static function fromNode(Node $node): self
+    public static function fromNode(Node $node, ContentStreamId $contentStreamId): self
     {
-        return new self('Node_' . $node->workspaceName->value
+        return new self('Node_' . $contentStreamId->value
             . '_' . $node->dimensionSpacePoint->hash
             . '_' .  $node->aggregateId->value);
     }

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
@@ -37,6 +38,11 @@ class CachingHelper implements ProtectedContextAwareInterface
      * @var ContentRepositoryRegistry
      */
     protected $contentRepositoryRegistry;
+
+    /**
+     * @var array<string, ContentStreamId>
+     */
+    private array $workspaceNameToContentStreamIdMapping = [];
 
     /**
      * Generate a `@cache` entry tag for a single node, array of nodes or a FlowQuery result
@@ -70,7 +76,11 @@ class CachingHelper implements ProtectedContextAwareInterface
      */
     public function entryIdentifierForNode(Node $node): NodeCacheEntryIdentifier
     {
-        return NodeCacheEntryIdentifier::fromNode($node);
+        // Todo adjust content caching to work with workspaces as entry identifier than the content stream id
+        $currentContentStreamId = $this->workspaceNameToContentStreamIdMapping[$node->contentRepositoryId->value . '@' . $node->workspaceName->value]
+            ??= $this->contentRepositoryRegistry->get($node->contentRepositoryId)->getContentGraph($node->workspaceName)->getContentStreamId();
+
+        return NodeCacheEntryIdentifier::fromNode($node, $currentContentStreamId);
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -128,6 +128,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     When the command DiscardWorkspace is executed with payload:
       | Key           | Value         |
       | workspaceName | "user-editor" |
+    # FIXME we have to reevaluated the step as we cache the $currentContentStreamId and it will be outdated after the discard
+    # see https://github.com/neos/neos-development-collection/pull/5162
     And I am in workspace "user-editor" and dimension space point {}
     Then I expect node aggregate identifier "text-node-middle" to lead to no node
 

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -1,0 +1,143 @@
+@flowEntities
+Feature: Tests for the ContentCacheFlusher and cache flushing when applied in user workspaces
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root': {}
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        title:
+          type: string
+        uriPathSegment:
+          type: string
+    'Neos.Neos:ContentCollection':
+      constraints:
+        nodeTypes:
+          'Neos.Neos:Document': false
+          '*': true
+    'Neos.Neos:Content':
+      constraints:
+        nodeTypes:
+          '*': false
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentTypeWithMainCollection':
+      superTypes:
+        'Neos.Neos:Document': true
+      childNodes:
+        main:
+          type: 'Neos.Neos:ContentCollection'
+    'Neos.Neos:Test.TextNode':
+      superTypes:
+        'Neos.Neos:Content': true
+      properties:
+        text:
+          type: string
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "editor"
+
+    When the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                       |
+      | workspaceName      | "user-editor"               |
+      | baseWorkspaceName  | "live"                      |
+      | newContentStreamId | "user-editor-cs-identifier" |
+    And I am in workspace "live" and dimension space point {}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value             |
+      | nodeAggregateId | "root"            |
+      | nodeTypeName    | "Neos.Neos:Sites" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId             | parentNodeAggregateId             | nodeTypeName                                  | initialPropertyValues                                                                     | nodeName                    | tetheredDescendantNodeAggregateIds            |
+      | site                        | root                              | Neos.Neos:Site                                | {}                                                                                        | site                        | {}                                            |
+      | test-document-with-contents | site                              | Neos.Neos:Test.DocumentTypeWithMainCollection | {"uriPathSegment": "test-document-with-contents", "title": "Test document with contents"} | test-document-with-contents | {"main": "test-document-with-contents--main"} |
+      | text-node-start             | test-document-with-contents--main | Neos.Neos:Test.TextNode                       | {"text": "Text Node at the start of the document"}                                        | text-node-start             | {}                                            |
+      | text-node-end               | test-document-with-contents--main | Neos.Neos:Test.TextNode                       | {"text": "Text Node at the end of the document"}                                          | text-node-end               | {}                                            |
+    When the command RebaseWorkspace is executed with payload:
+      | Key           | Value         |
+      | workspaceName | "user-editor" |
+    And A site exists for node name "site" and domain "http://localhost"
+    And the sites configuration is:
+    """yaml
+    Neos:
+      Neos:
+        sites:
+          '*':
+            contentRepository: default
+            contentDimensions:
+              resolver:
+                factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
+    """
+    And the Fusion context node is "site"
+    And the Fusion context request URI is "http://localhost"
+    And I have the following Fusion setup:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    prototype(Neos.Neos:Test.TextNode) < prototype(Neos.Neos:ContentComponent) {
+      renderer = ${"[" + q(node).property("text") + "]"}
+    }
+    """
+
+  Scenario: ContentCache gets flushed when a node that was just created gets discarded
+    Given I have Fusion content cache enabled
+    And I am in workspace "user-editor" and dimension space point {}
+    And the Fusion context node is "test-document-with-contents"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                               | Value                                               |
+      | nodeAggregateId                   | "text-node-middle"                                  |
+      | nodeTypeName                      | "Neos.Neos:Test.TextNode"                           |
+      | parentNodeAggregateId             | "test-document-with-contents--main"                 |
+      | initialPropertyValues             | {"text": "Text Node in the middle of the document"} |
+      | succeedingSiblingNodeAggregateId  | "text-node-end"                                     |
+      | nodeName                          | "text-node-middle"                                  |
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node in the middle of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command DiscardWorkspace is executed with payload:
+      | Key           | Value         |
+      | workspaceName | "user-editor" |
+    And I am in workspace "user-editor" and dimension space point {}
+    Then I expect node aggregate identifier "text-node-middle" to lead to no node
+
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
+    """


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-development-collection/issues/5150

Readds the contentstreamid to node cache entry identifier (effectively reverting the changes in #5083 conceptional)

The change was taken too lightly and the whole content cache flushing depends on the assumption that after publishing or discard, everything will be rendered.
With this knowledge and the added test we should be able to refactor it correctly in the feature without introducing a regression again.

The regression #5150 was attempted to be fixed in several ways https://github.com/neos/neos-development-collection/pull/5155 or https://github.com/neos/neos-development-collection/pull/5160 but it seems we need more brain power to finish this.
For the meantime this pr restores the behaviour again and lets us continue development in the Neos Ui with green e2e tests. 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
