### PR TITLE
BUGFIX: Case insensitive user search on PostgreSQL

### DIFF
--- a/Neos.Neos/Classes/Domain/Repository/UserRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/UserRepository.php
@@ -53,8 +53,8 @@ class UserRepository extends Repository
             $query = $this->createQuery();
             $query->matching(
                 $query->logicalOr(
-                    $query->like('accounts.accountIdentifier', '%' . $searchTerm . '%'),
-                    $query->like('name.fullName', '%' . $searchTerm . '%')
+                    $query->like('accounts.accountIdentifier', '%' . $searchTerm . '%', false),
+                    $query->like('name.fullName', '%' . $searchTerm . '%', false)
                 )
             );
             return $query->setOrderings([$sortBy => $sortDirection])->execute();


### PR DESCRIPTION
PostgreSQL is by default case sensitive and its hard to find users depending on their name in the users
module.