### PR TITLE
FEATURE: WorkspaceName with reference for unused contentStream

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphFactory.php
@@ -40,6 +40,10 @@ final readonly class ContentGraphFactory implements ContentGraphFactoryInterface
 
     public function buildForWorkspace(WorkspaceName $workspaceName): ContentGraph
     {
+        if ($workspaceName->isReferencingUnusedContentStream()) {
+            return $this->buildForWorkspaceAndContentStream($workspaceName, $workspaceName->getReferencingUnusedContentStreamId());
+        }
+
         // FIXME: Should be part of this projection, this is forbidden
         $tableName = strtolower(sprintf(
             'cr_%s_p_%s',
@@ -71,7 +75,7 @@ final readonly class ContentGraphFactory implements ContentGraphFactoryInterface
         return $this->buildForWorkspaceAndContentStream($workspaceName, ContentStreamId::fromString($currentContentStreamId));
     }
 
-    public function buildForWorkspaceAndContentStream(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraph
+    private function buildForWorkspaceAndContentStream(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraph
     {
         return new ContentGraph($this->dbal, $this->nodeFactory, $this->contentRepositoryId, $this->nodeTypeManager, $this->tableNames, $workspaceName, $contentStreamId);
     }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/ContentHyperGraphFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/ContentHyperGraphFactory.php
@@ -31,6 +31,10 @@ final readonly class ContentHyperGraphFactory implements ContentGraphFactoryInte
 
     public function buildForWorkspace(WorkspaceName $workspaceName): ContentGraphInterface
     {
+        if ($workspaceName->isReferencingUnusedContentStream()) {
+            return $this->buildForWorkspaceAndContentStream($workspaceName, $workspaceName->getReferencingUnusedContentStreamId());
+        }
+
         // FIXME: Should be part of this projection, this is forbidden
         $tableName = strtolower(sprintf(
             'cr_%s_p_%s',
@@ -55,7 +59,7 @@ final readonly class ContentHyperGraphFactory implements ContentGraphFactoryInte
         return $this->buildForWorkspaceAndContentStream($workspaceName, ContentStreamId::fromString($row['currentcontentstreamid']));
     }
 
-    public function buildForWorkspaceAndContentStream(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraphInterface
+    private function buildForWorkspaceAndContentStream(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraphInterface
     {
         return new ContentHyperGraph($this->dbal, $this->nodeFactory, $this->contentRepositoryId, $this->nodeTypeManager, $this->tableNamePrefix, $workspaceName, $contentStreamId);
     }

--- a/Neos.ContentRepository.Core/Classes/CommandHandlingDependencies.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandlingDependencies.php
@@ -65,6 +65,10 @@ final class CommandHandlingDependencies
             return $this->overridenContentGraphInstances[$workspaceName->value];
         }
 
+        if ($workspaceName->isReferencingUnusedContentStream()) {
+            throw new \RuntimeException(sprintf('Expected actual workspace name. Got a workspace name referencing an unused content stream: "%s" instead.', $workspaceName->getReferencingUnusedContentStreamId()->value), 1719648458);
+        }
+
         return $this->contentRepository->getContentGraph($workspaceName);
     }
 

--- a/Neos.ContentRepository.Core/Classes/CommandHandlingDependencies.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandlingDependencies.php
@@ -83,7 +83,7 @@ final class CommandHandlingDependencies
             throw new \RuntimeException('Contentstream override for this workspace already in effect, nesting not allowed.', 1715170938);
         }
 
-        $contentGraph = $this->contentRepository->projectionState(ContentGraphFinder::class)->getByWorkspaceNameAndContentStreamId($workspaceName, $contentStreamId);
+        $contentGraph = $this->contentRepository->getContentGraph(WorkspaceName::createReferenceForUnusedContentStream($contentStreamId));
         $this->overridenContentGraphInstances[$workspaceName->value] = $contentGraph;
 
         try {

--- a/Neos.ContentRepository.Core/Classes/ContentGraphFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/ContentGraphFactoryInterface.php
@@ -16,7 +16,6 @@ namespace Neos\ContentRepository\Core;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -30,6 +29,4 @@ interface ContentGraphFactoryInterface
      * @throws WorkspaceDoesNotExist if the workspace does not exist
      */
     public function buildForWorkspace(WorkspaceName $workspaceName): ContentGraphInterface;
-
-    public function buildForWorkspaceAndContentStream(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraphInterface;
 }

--- a/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
+++ b/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
@@ -67,16 +67,4 @@ final class ContentGraphFinder implements ProjectionStateInterface
     {
         $this->contentGraphInstances = [];
     }
-
-    /**
-     * For testing we allow getting an instance set by both parameters, effectively overriding the relationship at will
-     *
-     * @param WorkspaceName $workspaceName
-     * @param ContentStreamId $contentStreamId
-     * @internal Only for testing
-     */
-    public function getByWorkspaceNameAndContentStreamId(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraphInterface
-    {
-        return $this->contentGraphFactory->buildForWorkspaceAndContentStream($workspaceName, $contentStreamId);
-    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -900,6 +900,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
     private function requireWorkspaceToNotExist(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void
     {
+        if ($workspaceName->isReferencingUnusedContentStream()) {
+            throw new \RuntimeException(sprintf('Expected actual workspace name. Got a workspace name referencing an unused content stream: "%s" instead.', $workspaceName->getReferencingUnusedContentStreamId()->value), 1719648458);
+        }
+
         try {
             $commandHandlingDependencies->getContentGraph($workspaceName);
         } catch (WorkspaceDoesNotExist) {
@@ -918,6 +922,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function requireWorkspace(WorkspaceName $workspaceName, WorkspaceFinder $workspaceFinder): Workspace
     {
+        if ($workspaceName->isReferencingUnusedContentStream()) {
+            throw new \RuntimeException(sprintf('Expected actual workspace name. Got a workspace name referencing an unused content stream: "%s" instead.', $workspaceName->getReferencingUnusedContentStreamId()->value), 1719648458);
+        }
+
         $workspace = $workspaceFinder->findOneByName($workspaceName);
         if (is_null($workspace)) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -48,6 +48,11 @@ final class WorkspaceName implements \JsonSerializable
         return self::instance($value);
     }
 
+    public static function createReferenceForUnusedContentStream(ContentStreamId $contentStreamId): self
+    {
+        return self::instance('cs:' . $contentStreamId->value);
+    }
+
     public static function forLive(): self
     {
         return self::instance(self::WORKSPACE_NAME_LIVE);
@@ -90,6 +95,19 @@ final class WorkspaceName implements \JsonSerializable
     public function isLive(): bool
     {
         return $this->value === self::WORKSPACE_NAME_LIVE;
+    }
+
+    /**
+     * @phpstan-assert-if-true ContentStreamId $this->getReferencingUnusedContentStreamId()
+     */
+    public function isReferencingUnusedContentStream(): bool
+    {
+        return str_starts_with($this->value, 'cs:');
+    }
+
+    public function getReferencingUnusedContentStreamId(): ?ContentStreamId
+    {
+        return $this->isReferencingUnusedContentStream() ? ContentStreamId::fromString(substr($this->value, 3)) : null;
     }
 
     public function jsonSerialize(): string

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -37,8 +37,6 @@ trait CRTestSuiteRuntimeVariables
 {
     protected ?ContentRepository $currentContentRepository = null;
 
-    protected ?ContentStreamId $currentContentStreamId = null;
-
     protected ?WorkspaceName $currentWorkspaceName = null;
 
     protected ?DimensionSpacePoint $currentDimensionSpacePoint = null;
@@ -92,7 +90,7 @@ trait CRTestSuiteRuntimeVariables
      */
     public function iAmInContentStream(string $contentStreamId): void
     {
-        $this->currentContentStreamId = ContentStreamId::fromString($contentStreamId);
+        $this->currentWorkspaceName = WorkspaceName::createReferenceForUnusedContentStream(ContentStreamId::fromString($contentStreamId));
     }
 
     /**
@@ -101,7 +99,6 @@ trait CRTestSuiteRuntimeVariables
     public function iAmInWorkspace(string $workspaceName): void
     {
         $this->currentWorkspaceName = WorkspaceName::fromString($workspaceName);
-        $this->currentContentStreamId = null;
     }
 
     /**
@@ -147,11 +144,6 @@ trait CRTestSuiteRuntimeVariables
     {
         $contentGraphFinder = $this->currentContentRepository->projectionState(ContentGraphFinder::class);
         $contentGraphFinder->forgetInstances();
-        if (isset($this->currentContentStreamId)) {
-            // This must still be supported for low level tests, e.g. for content stream forking
-            return $contentGraphFinder->getByWorkspaceNameAndContentStreamId($this->currentWorkspaceName, $this->currentContentStreamId)->getSubgraph($this->currentDimensionSpacePoint, $this->currentVisibilityConstraints);
-        }
-
         return $contentGraphFinder->getByWorkspaceName($this->currentWorkspaceName)->getSubgraph(
             $this->currentDimensionSpacePoint,
             $this->currentVisibilityConstraints

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -97,7 +97,6 @@ trait CRTestSuiteTrait
         $this->currentVisibilityConstraints = VisibilityConstraints::frontend();
         $this->currentDimensionSpacePoint = null;
         $this->currentRootNodeAggregateId = null;
-        $this->currentContentStreamId = null;
         $this->currentWorkspaceName = null;
         $this->currentNodeAggregate = null;
         $this->currentNode = null;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Helpers;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -47,10 +48,12 @@ final readonly class NodeDiscriminator implements \JsonSerializable
         );
     }
 
-    public static function fromNode(Node $node): self
+    public static function fromNode(Node $node, ContentRepository $contentRepository): self
     {
+        // todo call ContentGraphFinder::forgetInstances ???
+        $contentStreamOfNode = $contentRepository->getContentGraph($node->workspaceName)->getContentStreamId();
         return new self(
-            $node->subgraphIdentity->contentStreamId,
+            $contentStreamOfNode,
             $node->aggregateId,
             $node->originDimensionSpacePoint
         );

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminators.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminators.php
@@ -53,14 +53,6 @@ final class NodeDiscriminators implements \IteratorAggregate, \ArrayAccess, \Jso
         ));
     }
 
-    public static function fromNodes(Nodes $nodes): self
-    {
-        return new self(...array_map(
-            fn (Node $node): NodeDiscriminator => NodeDiscriminator::fromNode($node),
-            iterator_to_array($nodes)
-        ));
-    }
-
     public function equal(self $other): bool
     {
         return $this->discriminators == $other->discriminators;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -110,7 +110,7 @@ trait ProjectedNodeTrait
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
             Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
-            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
         });
@@ -147,7 +147,7 @@ trait ProjectedNodeTrait
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodePath, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
             Assert::assertNotNull($currentNode, 'No node could be found by node path "' . $nodePath->serializeToString() . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
-            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
         });
@@ -479,7 +479,7 @@ trait ProjectedNodeTrait
                 $actualReferences[$index]->name->value
             );
             $expectedReferenceDiscriminator = NodeDiscriminator::fromShorthand($row['Node']);
-            $actualReferenceDiscriminator = NodeDiscriminator::fromNode($actualReferences[$index]->node);
+            $actualReferenceDiscriminator = NodeDiscriminator::fromNode($actualReferences[$index]->node, $this->currentContentRepository);
             Assert::assertTrue(
                 $expectedReferenceDiscriminator->equals($actualReferenceDiscriminator),
                 'Reference discriminator does not match.'
@@ -553,12 +553,12 @@ trait ProjectedNodeTrait
 
             $parent = $subgraph->findParentNode($currentNode->aggregateId);
             Assert::assertInstanceOf(Node::class, $parent, 'Parent not found.');
-            $actualParentDiscriminator = NodeDiscriminator::fromNode($parent);
+            $actualParentDiscriminator = NodeDiscriminator::fromNode($parent, $this->currentContentRepository);
             Assert::assertTrue($expectedParentDiscriminator->equals($actualParentDiscriminator), 'Parent discriminator does not match. Expected was ' . json_encode($expectedParentDiscriminator) . ', given was ' . json_encode($actualParentDiscriminator));
 
-            $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             $child = $subgraph->findNodeByPath($currentNode->name, $parent->aggregateId);
-            $actualChildDiscriminator = NodeDiscriminator::fromNode($child);
+            $actualChildDiscriminator = NodeDiscriminator::fromNode($child, $this->currentContentRepository);
             Assert::assertTrue($expectedChildDiscriminator->equals($actualChildDiscriminator), 'Child discriminator does not match. Expected was ' . json_encode($expectedChildDiscriminator) . ', given was ' . json_encode($actualChildDiscriminator));
         });
     }
@@ -596,7 +596,10 @@ trait ProjectedNodeTrait
                 Assert::assertTrue($expectedNodeName->equals($actualNodeName), 'ContentSubgraph::findChildNodes: Node name in index ' . $index . ' does not match. Expected: "' . $expectedNodeName->value . '" Actual: "' . $actualNodeName->value . '"');
                 if (isset($row['NodeDiscriminator'])) {
                     $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                    $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualChildNodes[$index]);
+                    $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                        $actualChildNodes[$index],
+                        $this->currentContentRepository
+                    );
                     Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findChildNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator->jsonSerialize()) . ' Actual: ' . json_encode($actualNodeDiscriminator));
                 }
             }
@@ -635,7 +638,10 @@ trait ProjectedNodeTrait
             Assert::assertCount(count($expectedPrecedingSiblingsTable->getHash()), $actualSiblings, 'ContentSubgraph::findPrecedingSiblingNodes: Sibling count does not match');
             foreach ($expectedPrecedingSiblingsTable->getHash() as $index => $row) {
                 $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualSiblings[$index]);
+                $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                    $actualSiblings[$index],
+                    $this->currentContentRepository
+                );
                 Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findPrecedingSiblingNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator) . ' Actual: ' . json_encode($actualNodeDiscriminator));
             }
         });
@@ -672,7 +678,10 @@ trait ProjectedNodeTrait
             Assert::assertCount(count($expectedSucceedingSiblingsTable->getHash()), $actualSiblings, 'ContentSubgraph::findSucceedingSiblingNodes: Sibling count does not match');
             foreach ($expectedSucceedingSiblingsTable->getHash() as $index => $row) {
                 $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualSiblings[$index]);
+                $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                    $actualSiblings[$index],
+                    $this->currentContentRepository
+                );
                 Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findSucceedingSiblingNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator) . ' Actual: ' . json_encode($actualNodeDiscriminator));
             }
         });

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -35,7 +35,6 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues                        | nodeName |
       | a               | root                  | Neos.Neos:Site              | {"title": "Node a"}                          | a        |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -46,12 +46,11 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in workspace "live"
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  | initialPropertyValues                                                | nodeName |
       | a               | root                  | Neos.Neos:Site                | {"title": "Node a"}                                                  | a        |


### PR DESCRIPTION
As written in https://github.com/neos/neos-development-collection/issues/5034#issuecomment-2197400445 we actually decided against it, but look how pretty it seems? :D

introduces the syntax `WorkspaceName('cs:<ContentStreamId>')` ... that way we'd now what to write inside the fetched workspace name of a "forbidden" node.

But we initially didnt want to go down this road:

**_Neos 9.0 weekly - 01-03-2024_**

* Decide for WorkspaceName|DetachedWorkspaceName $workspaceName later if we really need it.
   * Changing this later would be a b/c disaster
   * Instead: WorkspaceName::fromString() stricter without colons (so that we can allow for extension, e.g. WorkspaceName::detached(ContentStreamid $csId) (with an internal representation like “cs:<cs-id>”)

--------

Additionally we should restrict the workspace name to be stricter: https://github.com/neos/neos-development-collection/issues/5125 and discuss if `fromString` should allow the `cs:` notation.


----

TODO

1.) discuss if we are okay with being able to reference the content stream id in a node address per uri:
```
http://localhost/neos/preview?node=%7B%22contentRepositoryId%22%3A%22default%22%2C%22workspaceName%22%3A%22cs%3Acs-identifier%22%2C%22dimensionSpacePoint%22%3A%5B%5D%2C%22aggregateId%22%3A%22non-existing%22%7D
```

2.) disallow the 'fake' workspace name to be used in commands like createWorkspace, or modify a node.

3.) check other usages where a fake workspace name can be passed and see if we should allow it there.

