### PR TITLE
TASK: 5034 fully completely workspace aware behat tests

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -66,7 +66,6 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier"
     And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -56,15 +56,17 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
       | nodeVariantSelectionStrategy | "allVariants"      |
 
   Scenario: on ForkContentStream, the disabled nodes in the target content stream should still be invisible.
-    When the command ForkContentStream is executed with payload:
-      | Key                   | Value                |
-      | sourceContentStreamId | "cs-identifier"      |
-      | contentStreamId       | "user-cs-identifier" |
-
+    # Uses ForkContentStream implicitly
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | baseWorkspaceName  | "live"               |
+      | workspaceName      | "user-test"          |
+      | newContentStreamId | "user-cs-identifier" |
 
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
-    When I am in content stream "user-cs-identifier" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier"
     And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -50,19 +50,26 @@ Feature: ForkContentStream Without Dimensions
       | propertiesToUnset            | {}                                                      |
 
   Scenario: Ensure that the node is available in the forked content stream
-    When the command "ForkContentStream" is executed with payload:
-      | Key                   | Value                |
-      | contentStreamId       | "user-cs-identifier" |
-      | sourceContentStreamId | "cs-identifier"      |
-    And I am in content stream "user-cs-identifier" and dimension space point {}
+    # Uses ForkContentStream implicitly
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | baseWorkspaceName  | "live"               |
+      | workspaceName      | "user-test"          |
+      | newContentStreamId | "user-cs-identifier" |
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier"
 
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
 
   Scenario: When a change is applied to the forked content stream AFTER the fork, it is not visible in the live content stream.
-    When the command "ForkContentStream" is executed with payload:
-      | Key                   | Value                |
-      | contentStreamId       | "user-cs-identifier" |
-      | sourceContentStreamId | "cs-identifier"      |
+    # Uses ForkContentStream implicitly
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | baseWorkspaceName  | "live"               |
+      | workspaceName      | "user-test"          |
+      | newContentStreamId | "user-cs-identifier" |
+
     And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
       | workspaceName                | "user"                                                  |
@@ -73,15 +80,17 @@ Feature: ForkContentStream Without Dimensions
       | propertyValues               | {"text": {"value": "modified value", "type": "string"}} |
       | propertiesToUnset            | {}                                                      |
 
-      # live
-    When I am in content stream "cs-identifier" and dimension space point {}
+    # live
+    When I am in workspace "live" and dimension space point {}
+    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
       | text | "original value" |
 
     # forked content stream
-    When I am in content stream "user-cs-identifier" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
@@ -89,10 +98,12 @@ Feature: ForkContentStream Without Dimensions
 
   # this is a "reverse" scenario of the scenario above.
   Scenario: When a change is applied on the live content stream AFTER the fork, it is NOT visible in the forked content stream.
-    When the command "ForkContentStream" is executed with payload:
-      | Key                   | Value                |
-      | contentStreamId       | "user-cs-identifier" |
-      | sourceContentStreamId | "cs-identifier"      |
+    # Uses ForkContentStream implicitly
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | baseWorkspaceName  | "live"               |
+      | workspaceName      | "user-test"          |
+      | newContentStreamId | "user-cs-identifier" |
     And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
       | workspaceName                | "live"                                                  |
@@ -104,14 +115,16 @@ Feature: ForkContentStream Without Dimensions
       | propertiesToUnset            | {}                                                      |
 
     # live
-    When I am in content stream "cs-identifier" and dimension space point {}
+    When I am in workspace "live" and dimension space point {}
+    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
       | text | "modified value" |
 
     # forked content stream
-    When I am in content stream "user-cs-identifier" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -58,8 +58,6 @@ Feature: ForkContentStream Without Dimensions
       | newContentStreamId | "user-cs-identifier" |
 
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier"
-
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
 
   Scenario: When a change is applied to the forked content stream AFTER the fork, it is not visible in the live content stream.
@@ -82,7 +80,6 @@ Feature: ForkContentStream Without Dimensions
 
     # live
     When I am in workspace "live" and dimension space point {}
-    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
@@ -90,7 +87,6 @@ Feature: ForkContentStream Without Dimensions
 
     # forked content stream
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
@@ -116,7 +112,6 @@ Feature: ForkContentStream Without Dimensions
 
     # live
     When I am in workspace "live" and dimension space point {}
-    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |
@@ -124,7 +119,6 @@ Feature: ForkContentStream Without Dimensions
 
     # forked content stream
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier"
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have the following properties:
       | Key  | Value            |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -45,13 +45,15 @@ Feature: On forking a content stream, node references should be copied as well.
       | referenceName         | "referenceProperty"               |
       | references            | [{"target": "anthony-destinode"}] |
 
-    When the command ForkContentStream is executed with payload:
-      | Key                   | Value                |
-      | contentStreamId       | "user-cs-identifier" |
-      | sourceContentStreamId | "cs-identifier"      |
+    # Uses ForkContentStream implicitly
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | baseWorkspaceName  | "live"               |
+      | workspaceName      | "user-test"          |
+      | newContentStreamId | "user-cs-identifier" |
 
     # after forking, the reference must still exist on the forked content stream (no surprises here).
-    When I am in content stream "user-cs-identifier" and dimension space point {"language": "de"}
+    When I am in workspace "user-test" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node user-cs-identifier;source-nodandaise;{"language": "de"}
     Then I expect this node to have the following references:
       | Name              | Node                                                    | Properties |
@@ -61,7 +63,7 @@ Feature: On forking a content stream, node references should be copied as well.
       | Name              | Node                                                    | Properties |
       | referenceProperty | user-cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in content stream "user-cs-identifier" and dimension space point {"language": "ch"}
+    When I am in workspace "user-test" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node user-cs-identifier;source-nodandaise;{"language": "de"}
     Then I expect this node to have the following references:
       | Name              | Node                                                    | Properties |
@@ -73,7 +75,7 @@ Feature: On forking a content stream, node references should be copied as well.
 
     # after then modifying the node's properties (thus triggering copy-on-write), the reference property
     # should still exist (this was a BUG)
-    When I am in content stream "user-cs-identifier" and dimension space point {"language": "de"}
+    When I am in workspace "user-test" and dimension space point {"language": "de"}
     And the command SetNodeProperties is executed with payload:
       | Key             | Value                                  |
       | nodeAggregateId | "source-nodandaise"                    |
@@ -87,7 +89,7 @@ Feature: On forking a content stream, node references should be copied as well.
       | Name              | Node                                                    | Properties |
       | referenceProperty | user-cs-identifier;source-nodandaise;{"language": "de"} | null       |
 
-    When I am in content stream "user-cs-identifier" and dimension space point {"language": "ch"}
+    When I am in workspace "user-test" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "source-nodandaise" to lead to node user-cs-identifier;source-nodandaise;{"language": "de"}
     And I expect this node to have the following references:
       | Name              | Node                                                    | Properties |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
@@ -68,14 +68,12 @@ Feature: Move dimension space point
     """
     # the original content stream has not been touched
     When I am in workspace "live" and dimension space point {"language": "de"}
-    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language": "de"} to exist in the content graph
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
 
 
     # we find the node underneath the new DimensionSpacePoint, but not underneath the old.
     When I am in workspace "migration-workspace" and dimension space point {"language": "de"}
-    Then I expect the workspace to point to content stream "migration-cs"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When I am in workspace "migration-workspace" and dimension space point {"language": "de_DE"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de_DE"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
@@ -67,13 +67,15 @@ Feature: Move dimension space point
               to: { language: 'de_DE' }
     """
     # the original content stream has not been touched
-    When I am in content stream "cs-identifier" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
+    Then I expect the workspace to point to content stream "cs-identifier"
     Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language": "de"} to exist in the content graph
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
 
 
     # we find the node underneath the new DimensionSpacePoint, but not underneath the old.
     When I am in workspace "migration-workspace" and dimension space point {"language": "de"}
+    Then I expect the workspace to point to content stream "migration-cs"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When I am in workspace "migration-workspace" and dimension space point {"language": "de_DE"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de_DE"} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -38,7 +38,7 @@ Feature: Publishing hide/show scenario of nodes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in workspace "live"
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -104,12 +104,13 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "remaining-cs-id"                                                                                        |
       | contentStreamIdForMatchingPart  | "matching-cs-id"                                                                                         |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
 
-    When I am in content stream "remaining-cs-id" and dimension space point {}
+    When I am in workspace "user-test"
+    Then I expect the workspace to point to content stream "remaining-cs-id"
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -110,8 +110,10 @@ Feature: Publishing hide/show scenario of nodes
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
 
     When I am in workspace "user-test"
-    Then I expect the workspace to point to content stream "remaining-cs-id"
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
+    # Ensure that we are in content stream remaining-cs-id
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node remaining-cs-id;lady-eleonode-rootford;{}
+
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -54,7 +54,8 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier"
+    # Ensure that we are in content user-cs-identifier
+    Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier;root-node;{}
 
     When the command RebaseWorkspace is executed with payload:
       | Key                    | Value                        |
@@ -66,7 +67,6 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     Then I expect the content stream "user-cs-identifier" to not exist
 
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect the workspace to point to content stream "user-cs-identifier-rebased"
     Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-rebased;root-node;{}
 
   Scenario: NO_LONGER_IN_USE content streams can be cleaned up completely (simple case)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -53,6 +53,9 @@ Feature: If content streams are not in use anymore by the workspace, they can be
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier"
+
     When the command RebaseWorkspace is executed with payload:
       | Key                    | Value                        |
       | workspaceName          | "user-test"                  |
@@ -60,11 +63,10 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     # now, we have one unused content stream (the old content stream of the user-test workspace)
 
     When I prune unused content streams
-
-    When I am in content stream "user-cs-identifier" and dimension space point {}
-    Then I expect node aggregate identifier "root-node" to lead to no node
+    Then I expect the content stream "user-cs-identifier" to not exist
 
     When I am in workspace "user-test" and dimension space point {}
+    Then I expect the workspace to point to content stream "user-cs-identifier-rebased"
     Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-rebased;root-node;{}
 
   Scenario: NO_LONGER_IN_USE content streams can be cleaned up completely (simple case)

--- a/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
+++ b/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
@@ -73,7 +73,7 @@ final class ContentGraphFinder implements ProjectionStateInterface
      *
      * @param WorkspaceName $workspaceName
      * @param ContentStreamId $contentStreamId
-     * @internal Only for testing
+     * @internal Only for the write side during publishing {@see \Neos\ContentRepository\Core\CommandHandlingDependencies::overrideContentStreamId}
      */
     public function getByWorkspaceNameAndContentStreamId(WorkspaceName $workspaceName, ContentStreamId $contentStreamId): ContentGraphInterface
     {

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamClosing/Command/CloseContentStream.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamClosing/Command/CloseContentStream.php
@@ -18,7 +18,9 @@ use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail. You must not use this command directly.
+ * Direct use may lead to hard to revert senseless state in your content repository.
+ * Please use the higher level workspace commands instead.
  */
 final readonly class CloseContentStream implements CommandInterface
 {

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamClosing/Command/ReopenContentStream.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamClosing/Command/ReopenContentStream.php
@@ -19,7 +19,9 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamState;
 
 /**
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail. You must not use this command directly.
+ * Direct use may lead to hard to revert senseless state in your content repository.
+ * Please use the higher level workspace commands instead.
  */
 final readonly class ReopenContentStream implements CommandInterface
 {

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamCreation/Command/CreateContentStream.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamCreation/Command/CreateContentStream.php
@@ -21,7 +21,9 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  * CreateContentStream for creating the FIRST content stream.
  * All other content streams will be FORKED from this FIRST content stream.
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail. You must not use this command directly.
+ * Direct use may lead to hard to revert senseless state in your content repository.
+ * Please use the higher level workspace commands instead.
  */
 final readonly class CreateContentStream implements CommandInterface
 {

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Command/ForkContentStream.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Command/ForkContentStream.php
@@ -20,7 +20,9 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 /**
  * ForkContentStream for creating a new fork of a content stream.
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail. You must not use this command directly.
+ * Direct use may lead to hard to revert senseless state in your content repository.
+ * Please use the higher level workspace commands instead.
  */
 final readonly class ForkContentStream implements CommandInterface
 {

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamRemoval/Command/RemoveContentStream.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamRemoval/Command/RemoveContentStream.php
@@ -20,7 +20,9 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 /**
  * Command to remove an existing content stream
  *
- * @api commands are the write-API of the ContentRepository
+ * @internal implementation detail. You must not use this command directly.
+ * Direct use may lead to hard to revert senseless state in your content repository.
+ * Please use the higher level workspace commands instead.
  */
 final readonly class RemoveContentStream implements CommandInterface
 {

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -37,8 +37,6 @@ trait CRTestSuiteRuntimeVariables
 {
     protected ?ContentRepository $currentContentRepository = null;
 
-    protected ?ContentStreamId $currentContentStreamId = null;
-
     protected ?WorkspaceName $currentWorkspaceName = null;
 
     protected ?DimensionSpacePoint $currentDimensionSpacePoint = null;
@@ -93,7 +91,6 @@ trait CRTestSuiteRuntimeVariables
     public function iAmInWorkspace(string $workspaceName): void
     {
         $this->currentWorkspaceName = WorkspaceName::fromString($workspaceName);
-        $this->currentContentStreamId = null;
     }
 
     /**
@@ -115,15 +112,6 @@ trait CRTestSuiteRuntimeVariables
     }
 
     /**
-     * @Given /^I am in content stream "([^"]*)" and dimension space point (.*)$/
-     */
-    public function iAmInContentStreamAndDimensionSpacePoint(string $contentStreamId, string $dimensionSpacePoint): void
-    {
-        $this->currentContentStreamId = ContentStreamId::fromString($contentStreamId);
-        $this->iAmInDimensionSpacePoint($dimensionSpacePoint);
-    }
-
-    /**
      * @When /^VisibilityConstraints are set to "(withoutRestrictions|frontend)"$/
      */
     public function visibilityConstraintsAreSetTo(string $restrictionType): void
@@ -138,11 +126,8 @@ trait CRTestSuiteRuntimeVariables
     public function getCurrentSubgraph(): ContentSubgraphInterface
     {
         $contentGraphFinder = $this->currentContentRepository->projectionState(ContentGraphFinder::class);
+        // todo why do we use the ContentGraphFinder here and clear caches? Test pass without
         $contentGraphFinder->forgetInstances();
-        if (isset($this->currentContentStreamId)) {
-            // This must still be supported for low level tests, e.g. for content stream forking
-            return $contentGraphFinder->getByWorkspaceNameAndContentStreamId($this->currentWorkspaceName, $this->currentContentStreamId)->getSubgraph($this->currentDimensionSpacePoint, $this->currentVisibilityConstraints);
-        }
 
         return $contentGraphFinder->getByWorkspaceName($this->currentWorkspaceName)->getSubgraph(
             $this->currentDimensionSpacePoint,

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -88,14 +88,6 @@ trait CRTestSuiteRuntimeVariables
     }
 
     /**
-     * @Given /^I am in content stream "([^"]*)"$/
-     */
-    public function iAmInContentStream(string $contentStreamId): void
-    {
-        $this->currentContentStreamId = ContentStreamId::fromString($contentStreamId);
-    }
-
-    /**
      * @Given /^I am in workspace "([^"]*)"$/
      */
     public function iAmInWorkspace(string $workspaceName): void
@@ -127,7 +119,7 @@ trait CRTestSuiteRuntimeVariables
      */
     public function iAmInContentStreamAndDimensionSpacePoint(string $contentStreamId, string $dimensionSpacePoint): void
     {
-        $this->iAmInContentStream($contentStreamId);
+        $this->currentContentStreamId = ContentStreamId::fromString($contentStreamId);
         $this->iAmInDimensionSpacePoint($dimensionSpacePoint);
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -142,23 +142,6 @@ trait CRTestSuiteTrait
     }
 
     /**
-     * @Then /^I expect the workspace to point to content stream "([^"]*)"$/
-     */
-    public function iExpectTheWorkspaceToPointToContentStream(string $rawContentStreamId): void
-    {
-        if ($this->currentContentStreamId !== null) {
-            throw new \RuntimeException('programming error. invalid case.');
-        }
-
-        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName($this->currentWorkspaceName);
-
-        Assert::assertTrue(
-            ContentStreamId::fromString($rawContentStreamId)->equals($workspace->currentContentStreamId),
-            sprintf('The workspace %s was expected to point to %s but points to %s actually.', $this->currentWorkspaceName->value, $rawContentStreamId, $workspace->currentContentStreamId->value)
-        );
-    }
-
-    /**
      * @Then /^workspace ([^"]*) has status ([^"]*)$/
      */
     public function workspaceHasStatus(string $rawWorkspaceName, string $status): void

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -25,7 +25,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\Service\ContentStreamPruner;
 use Neos\ContentRepository\Core\Service\ContentStreamPrunerFactory;
 use Neos\ContentRepository\Core\SharedModel\Exception\RootNodeAggregateDoesNotExist;
@@ -132,31 +131,31 @@ trait CRTestSuiteTrait
     }
 
     /**
-     * @Then /^workspace "([^"]*)" points to another content stream than workspace "([^"]*)"$/
+     * @Then /^I expect the content stream "([^"]*)" to not exist$/
      */
-    public function workspacesPointToDifferentContentStreams(string $rawWorkspaceNameA, string $rawWorkspaceNameB): void
+    public function iExpectTheContentStreamToNotExist(string $rawContentStreamId): void
     {
-        $workspaceA = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($rawWorkspaceNameA));
-        Assert::assertInstanceOf(Workspace::class, $workspaceA, 'Workspace "' . $rawWorkspaceNameA . '" does not exist.');
-        $workspaceB = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($rawWorkspaceNameB));
-        Assert::assertInstanceOf(Workspace::class, $workspaceB, 'Workspace "' . $rawWorkspaceNameB . '" does not exist.');
-        if ($workspaceA && $workspaceB) {
-            Assert::assertNotEquals(
-                $workspaceA->currentContentStreamId->value,
-                $workspaceB->currentContentStreamId->value,
-                'Workspace "' . $rawWorkspaceNameA . '" points to the same content stream as "' . $rawWorkspaceNameB . '"'
-            );
-        }
+        Assert::assertTrue(
+            $this->currentContentRepository->getContentStreamFinder()->hasContentStream(ContentStreamId::fromString($rawContentStreamId)),
+            sprintf('The content stream "%s" does exist.', $rawContentStreamId)
+        );
     }
 
     /**
-     * @Then /^workspace "([^"]*)" does not point to content stream "([^"]*)"$/
+     * @Then /^I expect the workspace to point to content stream "([^"]*)"$/
      */
-    public function workspaceDoesNotPointToContentStream(string $rawWorkspaceName, string $rawContentStreamId): void
+    public function iExpectTheWorkspaceToPointToContentStream(string $rawContentStreamId): void
     {
-        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName(WorkspaceName::fromString($rawWorkspaceName));
+        if ($this->currentContentStreamId !== null) {
+            throw new \RuntimeException('programming error. invalid case.');
+        }
 
-        Assert::assertNotEquals($rawContentStreamId, $workspace->currentContentStreamId->value);
+        $workspace = $this->currentContentRepository->getWorkspaceFinder()->findOneByName($this->currentWorkspaceName);
+
+        Assert::assertTrue(
+            ContentStreamId::fromString($rawContentStreamId)->equals($workspace->currentContentStreamId),
+            sprintf('The workspace %s was expected to point to %s but points to %s actually.', $this->currentWorkspaceName->value, $rawContentStreamId, $workspace->currentContentStreamId->value)
+        );
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -96,7 +96,6 @@ trait CRTestSuiteTrait
         $this->currentVisibilityConstraints = VisibilityConstraints::frontend();
         $this->currentDimensionSpacePoint = null;
         $this->currentRootNodeAggregateId = null;
-        $this->currentContentStreamId = null;
         $this->currentWorkspaceName = null;
         $this->currentNodeAggregate = null;
         $this->currentNode = null;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Helpers;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -47,10 +48,11 @@ final readonly class NodeDiscriminator implements \JsonSerializable
         );
     }
 
-    public static function fromNode(Node $node): self
+    public static function fromNode(Node $node, ContentRepository $contentRepository): self
     {
+        $contentStreamOfNode = $contentRepository->getContentGraph($node->workspaceName)->getContentStreamId();
         return new self(
-            $node->subgraphIdentity->contentStreamId,
+            $contentStreamOfNode,
             $node->aggregateId,
             $node->originDimensionSpacePoint
         );

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminators.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/NodeDiscriminators.php
@@ -53,14 +53,6 @@ final class NodeDiscriminators implements \IteratorAggregate, \ArrayAccess, \Jso
         ));
     }
 
-    public static function fromNodes(Nodes $nodes): self
-    {
-        return new self(...array_map(
-            fn (Node $node): NodeDiscriminator => NodeDiscriminator::fromNode($node),
-            iterator_to_array($nodes)
-        ));
-    }
-
     public function equal(self $other): bool
     {
         return $this->discriminators == $other->discriminators;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -110,7 +110,7 @@ trait ProjectedNodeTrait
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodeAggregateId, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeById($nodeAggregateId);
             Assert::assertNotNull($currentNode, 'No node could be found by node aggregate id "' . $nodeAggregateId->value . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
-            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
         });
@@ -147,7 +147,7 @@ trait ProjectedNodeTrait
         $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodePath, $expectedDiscriminator) {
             $currentNode = $subgraph->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
             Assert::assertNotNull($currentNode, 'No node could be found by node path "' . $nodePath->serializeToString() . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
-            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
             return $currentNode;
         });
@@ -479,7 +479,7 @@ trait ProjectedNodeTrait
                 $actualReferences[$index]->name->value
             );
             $expectedReferenceDiscriminator = NodeDiscriminator::fromShorthand($row['Node']);
-            $actualReferenceDiscriminator = NodeDiscriminator::fromNode($actualReferences[$index]->node);
+            $actualReferenceDiscriminator = NodeDiscriminator::fromNode($actualReferences[$index]->node, $this->currentContentRepository);
             Assert::assertTrue(
                 $expectedReferenceDiscriminator->equals($actualReferenceDiscriminator),
                 'Reference discriminator does not match.'
@@ -553,12 +553,12 @@ trait ProjectedNodeTrait
 
             $parent = $subgraph->findParentNode($currentNode->aggregateId);
             Assert::assertInstanceOf(Node::class, $parent, 'Parent not found.');
-            $actualParentDiscriminator = NodeDiscriminator::fromNode($parent);
+            $actualParentDiscriminator = NodeDiscriminator::fromNode($parent, $this->currentContentRepository);
             Assert::assertTrue($expectedParentDiscriminator->equals($actualParentDiscriminator), 'Parent discriminator does not match. Expected was ' . json_encode($expectedParentDiscriminator) . ', given was ' . json_encode($actualParentDiscriminator));
 
-            $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode);
+            $expectedChildDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
             $child = $subgraph->findNodeByPath($currentNode->name, $parent->aggregateId);
-            $actualChildDiscriminator = NodeDiscriminator::fromNode($child);
+            $actualChildDiscriminator = NodeDiscriminator::fromNode($child, $this->currentContentRepository);
             Assert::assertTrue($expectedChildDiscriminator->equals($actualChildDiscriminator), 'Child discriminator does not match. Expected was ' . json_encode($expectedChildDiscriminator) . ', given was ' . json_encode($actualChildDiscriminator));
         });
     }
@@ -596,7 +596,10 @@ trait ProjectedNodeTrait
                 Assert::assertTrue($expectedNodeName->equals($actualNodeName), 'ContentSubgraph::findChildNodes: Node name in index ' . $index . ' does not match. Expected: "' . $expectedNodeName->value . '" Actual: "' . $actualNodeName->value . '"');
                 if (isset($row['NodeDiscriminator'])) {
                     $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                    $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualChildNodes[$index]);
+                    $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                        $actualChildNodes[$index],
+                        $this->currentContentRepository
+                    );
                     Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findChildNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator->jsonSerialize()) . ' Actual: ' . json_encode($actualNodeDiscriminator));
                 }
             }
@@ -635,7 +638,10 @@ trait ProjectedNodeTrait
             Assert::assertCount(count($expectedPrecedingSiblingsTable->getHash()), $actualSiblings, 'ContentSubgraph::findPrecedingSiblingNodes: Sibling count does not match');
             foreach ($expectedPrecedingSiblingsTable->getHash() as $index => $row) {
                 $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualSiblings[$index]);
+                $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                    $actualSiblings[$index],
+                    $this->currentContentRepository
+                );
                 Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findPrecedingSiblingNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator) . ' Actual: ' . json_encode($actualNodeDiscriminator));
             }
         });
@@ -672,7 +678,10 @@ trait ProjectedNodeTrait
             Assert::assertCount(count($expectedSucceedingSiblingsTable->getHash()), $actualSiblings, 'ContentSubgraph::findSucceedingSiblingNodes: Sibling count does not match');
             foreach ($expectedSucceedingSiblingsTable->getHash() as $index => $row) {
                 $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
-                $actualNodeDiscriminator = NodeDiscriminator::fromNode($actualSiblings[$index]);
+                $actualNodeDiscriminator = NodeDiscriminator::fromNode(
+                    $actualSiblings[$index],
+                    $this->currentContentRepository
+                );
                 Assert::assertTrue($expectedNodeDiscriminator->equals($actualNodeDiscriminator), 'ContentSubgraph::findSucceedingSiblingNodes: Node discriminator in index ' . $index . ' does not match. Expected: ' . json_encode($expectedNodeDiscriminator) . ' Actual: ' . json_encode($actualNodeDiscriminator));
             }
         });

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -35,7 +35,6 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues                        | nodeName |
       | a               | root                  | Neos.Neos:Site              | {"title": "Node a"}                          | a        |

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -46,12 +46,11 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in workspace "live"
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  | initialPropertyValues                                                | nodeName |
       | a               | root                  | Neos.Neos:Site                | {"title": "Node a"}                                                  | a        |


### PR DESCRIPTION
Resolves: #5034
Replaces: https://github.com/neos/neos-development-collection/pull/5167
Replaces: https://github.com/neos/neos-development-collection/pull/5144

- Remove `CRTestSuiteRuntimeVariables::$currentContentStreamId`
- gets rid of the final usages of `I am in content stream` in the behat tests.
- Additionally our hack `\Neos\ContentRepository\Core\ContentGraphFinder::getByWorkspaceNameAndContentStreamId` is now no longer in use by the tests and can be changed to be not at all exposed.
- Removes deprecated usage `$node->subgraphIdentity->contentStreamId` in `\Neos\ContentRepository\TestSuite\Behavior\...\NodeDiscriminator::fromNode`


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
