### PR TITLE
BUGFIX Disable uriPathSegment Validation on Hompage

### DIFF
--- a/Neos.Neos/NodeTypes/Mixin/Site.yaml
+++ b/Neos.Neos/NodeTypes/Mixin/Site.yaml
@@ -10,6 +10,7 @@
     'Neos.Neos:Document': true
   properties:
     uriPathSegment:
+      validation: null
       ui:
         inspector:
           hidden: true


### PR DESCRIPTION
Disable uriPathSegment Validation on Hompage

Followup to https://github.com/neos/neos-development-collection/issues/4621

**Upgrade instructions**

nothing

**Review instructions**

before this change the it was not possible to save Properties of the Hompage.
And a red warning showed up:

![image](https://github.com/neos/neos-development-collection/assets/85400359/6130583a-ebf7-4ab6-803e-4c2a60657c64)


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
