### PR TITLE
BUGFIX: Improve output of `PropertyCannotBeSet` exception

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -113,7 +113,7 @@ trait NodeCreation
             if (!$propertyType->isMatchedBy($propertyValue)) {
                 throw PropertyCannotBeSet::becauseTheValueDoesNotMatchTheConfiguredType(
                     PropertyName::fromString($propertyName),
-                    get_debug_type($propertyValues),
+                    get_debug_type($propertyValue),
                     $propertyType->value
                 );
             }


### PR DESCRIPTION
When a property cannot be matched on NodeCreation, an exception is thrown, but the message is not helpful because it outputs the result of `get_debug_type($propertyValues)` for the complete PropertyValuesToWrite object instead of the actual property. This fixes this behavior.
