### PR TITLE
FEATURE: Support doctrine/dbal 2.x and 3.x

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
@@ -13,6 +13,7 @@ namespace Neos\ContentRepository\Domain\Service\ImportExport;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Aspect\PersistenceMagicInterface;
@@ -119,19 +120,19 @@ class NodeImportService
         'dimensionValues' => [],
         'properties' => [],
         'hiddenBeforeDateTime' => [
-            'columnType' => Type::DATETIME
+            'columnType' => Types::DATE_IMMUTABLE
         ],
         'hiddenAfterDateTime' => [
-            'columnType' => Type::DATETIME
+            'columnType' => Types::DATE_IMMUTABLE
         ],
         'creationDateTime' => [
-            'columnType' => Type::DATETIME
+            'columnType' => Types::DATE_IMMUTABLE
         ],
         'lastModificationDateTime' => [
-            'columnType' => Type::DATETIME
+            'columnType' => Types::DATE_IMMUTABLE
         ],
         'lastPublicationDateTime' => [
-            'columnType' => Type::DATETIME
+            'columnType' => Types::DATE_IMMUTABLE
         ],
         'accessRoles' => []
     ];

--- a/Neos.Media/composer.json
+++ b/Neos.Media/composer.json
@@ -21,7 +21,7 @@
         "imagine/imagine": "*",
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/orm": "^2.6",
-        "doctrine/dbal": "^2.8"
+        "doctrine/dbal": "^2.8 || ^3"
     },
     "replace": {
         "typo3/media": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "enshrined/svg-sanitize": "^0.17.0",
         "neos/imagine": "^3.1.0",
         "imagine/imagine": "*",
-        "doctrine/dbal": "^2.8",
+        "doctrine/dbal": "^2.8 || ^3",
         "neos/party": "*",
         "neos/fusion-form": "^1.0 || ^2.0",
         "neos/form": "*",


### PR DESCRIPTION
Declares compatibility with `doctrine/dbal` 3.x (in addition to the already supported versions `2.8+`) and adjusts affected code such that it works with both versions