### PR TITLE
BUGFIX: Forward status codes and headers set in module actions

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/ModuleController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ModuleController.php
@@ -96,6 +96,7 @@ class ModuleController extends ActionController
         $moduleResponse = new ActionResponse();
 
         $this->dispatcher->dispatch($moduleRequest, $moduleResponse);
+        $moduleResponse->mergeIntoParentResponse($this->response);
 
         if ($moduleResponse->getRedirectUri() !== null) {
             $this->redirectToUri($moduleResponse->getRedirectUri(), 0, $moduleResponse->getStatusCode());


### PR DESCRIPTION
Previously the status code set in module actions via `throwStatus` or `response->setStatusCode()` was ignored. With this change the individual module response is merged into the generic module response which then contains the desired status code, headers and other properties.

This is essential if the client (f.e. HTMX) relies on proper headers and status codes to behave properly.

**Review instructions**

Use f.e. `$this->throwStatus(404)` in a Neos module controller action and check the status code of the response when calling the action.
The response code should now be 404 instead of 200.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
