### PR TITLE
BUGFIX: show workspace owner/title in media usage tab

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -21,7 +21,6 @@ use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Security\Context;
-use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Neos\Controller\CreateContentContextTrait;
@@ -87,12 +86,6 @@ class UsageController extends ActionController
      * @var Context
      */
     protected $securityContext;
-
-    /**
-     * @Flow\Inject
-     * @var PolicyService
-     */
-    protected $policyService;
 
     /**
      * @Flow\InjectConfiguration(package="Neos.Media.Browser", path="features.showWorkspaceOwnerOrName")
@@ -202,13 +195,12 @@ class UsageController extends ActionController
      */
     private function getNodeFrom(AssetUsageInNodeProperties $assetUsage)
     {
-        $context = $this->_contextFactory->create(
-            [
-                'workspaceName' => $assetUsage->getWorkspaceName(),
-                'dimensions' => $assetUsage->getDimensionValues(),
-                'invisibleContentShown' => true,
-                'removedContentShown' => true]
-        );
+        $context = $this->_contextFactory->create([
+            'workspaceName' => $assetUsage->getWorkspaceName(),
+            'dimensions' => $assetUsage->getDimensionValues(),
+            'invisibleContentShown' => true,
+            'removedContentShown' => true
+        ]);
         return $context->getNodeByIdentifier($assetUsage->getNodeIdentifier());
     }
 }

--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -21,6 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Security\Context;
+use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Neos\Controller\CreateContentContextTrait;
@@ -88,6 +89,12 @@ class UsageController extends ActionController
     protected $securityContext;
 
     /**
+     * @Flow\Inject
+     * @var PolicyService
+     */
+    protected $policyService;
+
+    /**
      * @Flow\InjectConfiguration(package="Neos.Media.Browser", path="features.showWorkspaceOwnerOrName")
      * @var array
      */
@@ -106,14 +113,7 @@ class UsageController extends ActionController
 
         $isPrivilegedRole = false;
         if ($currentAccount != null && $this->showWorkspaceOwnerOrNameConfiguration['enable']) {
-            $roles = array_keys($currentAccount->getRoles());
-
-            foreach ($this->showWorkspaceOwnerOrNameConfiguration['privilegedRoles'] as $role) {
-                if (in_array($role, $roles)) {
-                    $isPrivilegedRole = true;
-                    break;
-                }
-            }
+            $isPrivilegedRole = $this->securityContext->hasRole('Neos.Media.Browser:WorkspaceName');
         }
 
         $usageReferences = $this->assetService->getUsageReferences($asset);
@@ -204,10 +204,10 @@ class UsageController extends ActionController
     {
         $context = $this->_contextFactory->create(
             [
-            'workspaceName' => $assetUsage->getWorkspaceName(),
-            'dimensions' => $assetUsage->getDimensionValues(),
-            'invisibleContentShown' => true,
-            'removedContentShown' => true]
+                'workspaceName' => $assetUsage->getWorkspaceName(),
+                'dimensions' => $assetUsage->getDimensionValues(),
+                'invisibleContentShown' => true,
+                'removedContentShown' => true]
         );
         return $context->getNodeByIdentifier($assetUsage->getNodeIdentifier());
     }

--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -20,6 +20,7 @@ use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
@@ -88,10 +89,10 @@ class UsageController extends ActionController
     protected $securityContext;
 
     /**
-     * @Flow\InjectConfiguration(package="Neos.Media.Browser", path="features.showWorkspaceOwnerOrName")
-     * @var array
+     * @Flow\Inject
+     * @var PrivilegeManagerInterface
      */
-    protected $showWorkspaceOwnerOrNameConfiguration;
+    protected $privilegeManager;
 
     /**
      * Get Related Nodes for an asset
@@ -105,8 +106,8 @@ class UsageController extends ActionController
         $currentAccount = $this->securityContext->getAccount();
 
         $isPrivilegedRole = false;
-        if ($currentAccount != null && $this->showWorkspaceOwnerOrNameConfiguration['enable']) {
-            $isPrivilegedRole = $this->securityContext->hasRole('Neos.Media.Browser:WorkspaceName');
+        if ($currentAccount != null) {
+            $isPrivilegedRole = $this->privilegeManager->isPrivilegeTargetGranted('Neos.Media.Browser:WorkspaceName');
         }
 
         $usageReferences = $this->assetService->getUsageReferences($asset);

--- a/Neos.Media.Browser/Configuration/Policy.yaml
+++ b/Neos.Media.Browser/Configuration/Policy.yaml
@@ -29,6 +29,9 @@ privilegeTargets:
       matcher: 'method(Neos\Media\Browser\Controller\(Asset|Image)Controller->(replaceAssetResource|updateAssetResource)Action())'
 
 roles:
+  'Neos.Media.Browser:WorkspaceName':
+    abstract: true
+
   'Neos.Neos:AbstractEditor':
     privileges:
       -

--- a/Neos.Media.Browser/Configuration/Policy.yaml
+++ b/Neos.Media.Browser/Configuration/Policy.yaml
@@ -28,10 +28,11 @@ privilegeTargets:
       label: Allowed to replace asset resources
       matcher: 'method(Neos\Media\Browser\Controller\(Asset|Image)Controller->(replaceAssetResource|updateAssetResource)Action())'
 
-roles:
-  'Neos.Media.Browser:WorkspaceName':
-    abstract: true
+    'Neos.Media.Browser:WorkspaceName':
+      label: Allowed to see workspace owner
+      matcher: 'method(Neos\Media\Browser\Controller\UsageController->relatedNodesAction())'
 
+roles:
   'Neos.Neos:AbstractEditor':
     privileges:
       -
@@ -57,6 +58,9 @@ roles:
     privileges:
       -
         privilegeTarget: 'Neos.Media.Browser:ManageAssetCollections'
+        permission: GRANT
+      -
+        privilegeTarget: 'Neos.Media.Browser:WorkspaceName'
         permission: GRANT
 
   'Neos.Flow:Everybody':

--- a/Neos.Media.Browser/Configuration/Policy.yaml
+++ b/Neos.Media.Browser/Configuration/Policy.yaml
@@ -28,6 +28,8 @@ privilegeTargets:
       label: Allowed to replace asset resources
       matcher: 'method(Neos\Media\Browser\Controller\(Asset|Image)Controller->(replaceAssetResource|updateAssetResource)Action())'
 
+    # We evaluate the WorkspaceName privilegeTarget in code (UsageController) to determine whether we should show workspace names or not.
+    # To control access to the module in general, Neos.Media.Browser:AssetUsage is used (so that's why they have the same matcher string).
     'Neos.Media.Browser:WorkspaceName':
       label: Allowed to see workspace owner
       matcher: 'method(Neos\Media\Browser\Controller\UsageController->relatedNodesAction())'

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -27,9 +27,6 @@ Neos:
         # By default, enable the option to create redirects for replaced asset resources
         createAssetRedirectsOption:
           enable: true
-        # By default, enable showing the workspace owner/title in media browser usage tab
-        showWorkspaceOwnerOrName:
-          enable: true
 
   Flow:
     security:

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -29,8 +29,7 @@ Neos:
           enable: true
         # By default, disable showing the workspace owner/title in media browser usage tab
         showWorkspaceOwnerOrName:
-          enable: false
-          privilegedRoles: ['Neos.Neos:Administrator']
+          enable: true
 
   Flow:
     security:

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -27,6 +27,10 @@ Neos:
         # By default, enable the option to create redirects for replaced asset resources
         createAssetRedirectsOption:
           enable: true
+        # By default, disable showing the workspace owner/title in media browser usage tab
+        showWorkspaceOwnerOrName:
+          enable: false
+          privilegedRoles: ['Neos.Neos:Administrator']
 
   Flow:
     security:

--- a/Neos.Media.Browser/Configuration/Settings.yaml
+++ b/Neos.Media.Browser/Configuration/Settings.yaml
@@ -27,7 +27,7 @@ Neos:
         # By default, enable the option to create redirects for replaced asset resources
         createAssetRedirectsOption:
           enable: true
-        # By default, disable showing the workspace owner/title in media browser usage tab
+        # By default, enable showing the workspace owner/title in media browser usage tab
         showWorkspaceOwnerOrName:
           enable: true
 

--- a/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
@@ -39,6 +39,7 @@
                                    title="{neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'Neos.Neos')}"
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'Neos.Neos')}
+															  <f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.title})</f:if>
                             </f:case>
                             <f:case value="{inaccessibleRelation.workspace.privateWorkspace}">
                                 <i class="fas fa-shield"
@@ -46,6 +47,7 @@
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.privateWorkspace', source: 'Modules', package:
                                 'Neos.Neos')}
+																<f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.owner.name.fullName})</f:if>
                             </f:case>
                             <f:case value="{inaccessibleRelation.workspace.internalWorkspace}">
                                 <i class="fas fa-group"
@@ -53,6 +55,7 @@
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.internalWorkspace', source: 'Modules', package:
                                 'Neos.Neos')}
+																<f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.title})</f:if>
                             </f:case>
                             <f:defaultCase>
                                 ---

--- a/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
+++ b/Neos.Media.Browser/Resources/Private/Templates/Usage/RelatedNodes.html
@@ -39,7 +39,7 @@
                                    title="{neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'Neos.Neos')}"
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.personalWorkspace', source: 'Modules', package: 'Neos.Neos')}
-															  <f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.title})</f:if>
+															  {inaccessibleRelation.label}
                             </f:case>
                             <f:case value="{inaccessibleRelation.workspace.privateWorkspace}">
                                 <i class="fas fa-shield"
@@ -47,7 +47,7 @@
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.privateWorkspace', source: 'Modules', package:
                                 'Neos.Neos')}
-																<f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.owner.name.fullName})</f:if>
+															{inaccessibleRelation.label}
                             </f:case>
                             <f:case value="{inaccessibleRelation.workspace.internalWorkspace}">
                                 <i class="fas fa-group"
@@ -55,7 +55,7 @@
                                    data-neos-toggle="tooltip"></i>
                                 {neos:backend.translate(id: 'workspaces.internalWorkspace', source: 'Modules', package:
                                 'Neos.Neos')}
-																<f:if condition="{isPrivilegedRole}">({inaccessibleRelation.workspace.title})</f:if>
+															{inaccessibleRelation.label}
                             </f:case>
                             <f:defaultCase>
                                 ---

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -325,8 +325,7 @@ roles:
   'Neos.Neos:Administrator':
     label: Neos Administrator
     description: Grants access to all modules and functionalities of the Neos backend.
-
-    parentRoles: ['Neos.Neos:Editor']
+    parentRoles: ['Neos.Neos:Editor', 'Neos.Media.Browser:WorkspaceName']
     privileges:
       -
         privilegeTarget: 'Neos.Neos:Backend.Module.Administration'

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -325,7 +325,7 @@ roles:
   'Neos.Neos:Administrator':
     label: Neos Administrator
     description: Grants access to all modules and functionalities of the Neos backend.
-    parentRoles: ['Neos.Neos:Editor', 'Neos.Media.Browser:WorkspaceName']
+    parentRoles: ['Neos.Neos:Editor']
     privileges:
       -
         privilegeTarget: 'Neos.Neos:Backend.Module.Administration'


### PR DESCRIPTION
Issue: https://github.com/neos/neos-development-collection/issues/5181

Possibility to enable showing all workspace titles/owners to user with certain roles in the media usage tab.

**Checklist**

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [X] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [X] Reviewer - The first section explains the change briefly for change-logs
- [X] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
