### PR TITLE
BUGFIX: Change workspace runs into endless while-loop

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -960,13 +960,18 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         if ($workspace->workspaceName->equals($baseWorkspace->workspaceName)) {
             throw new BaseWorkspaceEqualsWorkspaceException(sprintf('The base workspace of the target must be different from the given workspace "%s".', $workspace->workspaceName->value));
         }
-
+        $count = 1;
         $nextBaseWorkspace = $baseWorkspace;
-        while ($nextBaseWorkspace->baseWorkspaceName->value !== 'live') {
+        while (!is_null($nextBaseWorkspace->baseWorkspaceName) && !$nextBaseWorkspace->baseWorkspaceName->isLive()) {
             if ($workspace->workspaceName->equals($nextBaseWorkspace->baseWorkspaceName)) {
                 throw new CircularRelationBetweenWorkspacesException(sprintf('The workspace "%s" is already on the path of the target workspace "%s".', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value));
             }
             $nextBaseWorkspace = $this->requireBaseWorkspace($workspace, $workspaceFinder);
+            $count++;
+            if($count == 5){
+                die();
+            }
+            var_dump($nextBaseWorkspace->baseWorkspaceName);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -961,11 +961,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             throw new BaseWorkspaceEqualsWorkspaceException(sprintf('The base workspace of the target must be different from the given workspace "%s".', $workspace->workspaceName->value));
         }
         $nextBaseWorkspace = $baseWorkspace;
-        while (!is_null($nextBaseWorkspace->baseWorkspaceName) && !$nextBaseWorkspace->baseWorkspaceName->isLive()) {
+        while (!is_null($nextBaseWorkspace->baseWorkspaceName)) {
             if ($workspace->workspaceName->equals($nextBaseWorkspace->baseWorkspaceName)) {
                 throw new CircularRelationBetweenWorkspacesException(sprintf('The workspace "%s" is already on the path of the target workspace "%s".', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value));
             }
-            $nextBaseWorkspace = $this->requireBaseWorkspace($workspace, $workspaceFinder);
+            $nextBaseWorkspace = $this->requireBaseWorkspace($nextBaseWorkspace, $workspaceFinder);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -960,18 +960,12 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         if ($workspace->workspaceName->equals($baseWorkspace->workspaceName)) {
             throw new BaseWorkspaceEqualsWorkspaceException(sprintf('The base workspace of the target must be different from the given workspace "%s".', $workspace->workspaceName->value));
         }
-        $count = 1;
         $nextBaseWorkspace = $baseWorkspace;
         while (!is_null($nextBaseWorkspace->baseWorkspaceName) && !$nextBaseWorkspace->baseWorkspaceName->isLive()) {
             if ($workspace->workspaceName->equals($nextBaseWorkspace->baseWorkspaceName)) {
                 throw new CircularRelationBetweenWorkspacesException(sprintf('The workspace "%s" is already on the path of the target workspace "%s".', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value));
             }
             $nextBaseWorkspace = $this->requireBaseWorkspace($workspace, $workspaceFinder);
-            $count++;
-            if($count == 5){
-                die();
-            }
-            var_dump($nextBaseWorkspace->baseWorkspaceName);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -962,7 +962,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         }
 
         $nextBaseWorkspace = $baseWorkspace;
-        while ($nextBaseWorkspace->baseWorkspaceName !== null) {
+        while ($nextBaseWorkspace->baseWorkspaceName->value !== 'live') {
             if ($workspace->workspaceName->equals($nextBaseWorkspace->baseWorkspaceName)) {
                 throw new CircularRelationBetweenWorkspacesException(sprintf('The workspace "%s" is already on the path of the target workspace "%s".', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value));
             }


### PR DESCRIPTION
**Review instructions**
Currently when switching the workspace in the UI it just runs endlessly and the docker container complains if you switch workspaces too often.  

Apparently the bug was introduced here: [PR](https://github.com/neos/neos-development-collection/commit/7d691d85394c9819b64996c51cc208f321603212#diff-3e5de1a138586c8c85cdd71ed1a765ecc0ba0d79ab2579a6000475d427cefda2L944 )


The line used to be 
`$nextBaseWorkspace = $contentRepository->getWorkspaceFinder()->findOneByName($nextBaseWorkspace->baseWorkspaceName);`

and was changed to 
`$nextBaseWorkspace = $this->requireBaseWorkspace($workspace, $workspaceFinder);`


since we always check for $workspace, the $nextBaseWorkspace always stays the same
**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
