### PR TITLE
BUGFIX: Don’t copy removed nodes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -1743,6 +1743,10 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
         }
         /** @var $childNode Node */
         foreach ($this->getChildNodes() as $childNode) {
+            // Don't copy removed nodes
+            if ($childNode->isRemoved()) {
+                continue;
+            }
             // Prevent recursive copy when copying into itself
             if ($childNode->getIdentifier() !== $copiedNode->getIdentifier()) {
                 $childNode->copyIntoInternal($copiedNode, $childNode->getName(), $detachedCopy);

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -771,6 +771,7 @@ class NodeData extends AbstractNodeData
         }
         if ($sourceNode instanceof NodeData) {
             $propertyNames[] = 'index';
+            $propertyNames[] = 'removed';
         }
         foreach ($propertyNames as $propertyName) {
             ObjectAccess::setProperty($this, $propertyName, ObjectAccess::getProperty($sourceNode, $propertyName));

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -262,6 +262,34 @@ class NodesTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function removedChildNodesAreNotCopied()
+    {
+        $rootNode = $this->context->getRootNode();
+        $parentNode = $rootNode->createNode('parent');
+        $parentNode->createNode('child');
+
+        $context = $this->contextFactory->create([
+            'workspaceName' => 'user-admin',
+            'removedContentShown' => true,
+        ]);
+        $this->persistenceManager->persistAll();
+
+        $rootNode = $context->getRootNode();
+        $parentNode = $rootNode->getNode('parent');
+        self::assertTrue($parentNode->hasChildNodes(), 'Parent node should have child nodes, before they are removed');
+
+        $parentNode->getNode('child')->remove();
+        $this->persistenceManager->persistAll();
+
+        $parentNode = $rootNode->getNode('parent');
+        $parentClone = $parentNode->copyInto($rootNode, 'parent-clone');
+
+        self::assertFalse($parentClone->hasChildNodes(), 'Copied parent node should not have any child nodes');
+    }
+
+    /**
+     * @test
+     */
     public function creatingAChildNodeAndRetrievingItAfterPersistAllWorks()
     {
         $rootNode = $this->context->getRootNode();


### PR DESCRIPTION
With this change, removed nodes are not copied anymore in the recursive copy actions. 

Also the removed state is now kept when a node is similarisied to prevent unpublished removed nodes from popping up again inadvertendly.

Resolves: #5185
