### PR TITLE
FEATURE: Expose content repository ids from registry

### DIFF
--- a/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryIds.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\ContentRepository;
+
+/**
+ * @implements \IteratorAggregate<ContentRepositoryId>
+ * @api
+ */
+final readonly class ContentRepositoryIds implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var array<ContentRepositoryId>
+     */
+    private array $ids;
+
+    private function __construct(ContentRepositoryId ...$ids)
+    {
+        $this->ids = $ids;
+    }
+
+    /**
+     * @param array<ContentRepositoryId|string> $ids
+     */
+    public static function fromArray(array $ids): self
+    {
+        $processedIds = [];
+        foreach ($ids as $id) {
+            if (is_string($id)) {
+                $id = ContentRepositoryId::fromString($id);
+            }
+            if (!$id instanceof ContentRepositoryId) {
+                throw new \InvalidArgumentException(sprintf('Expected string or instance of %s, got: %s', ContentRepositoryId::class, get_debug_type($id)), 1720424666);
+            }
+            $processedIds[] = $id;
+        }
+        return new self(...$processedIds);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return yield from $this->ids;
+    }
+
+    public function count(): int
+    {
+        return count($this->ids);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryIds.php
@@ -50,7 +50,7 @@ final readonly class ContentRepositoryIds implements \IteratorAggregate, \Counta
 
     public function getIterator(): \Traversable
     {
-        return yield from $this->ids;
+        yield from $this->ids;
     }
 
     public function count(): int

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/ContentRepository/ContentRepositoryIdsTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/ContentRepository/ContentRepositoryIdsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\ContentRepository;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryIds;
+use PHPUnit\Framework\TestCase;
+
+class ContentRepositoryIdsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function fromArraySupportsEmptyArray(): void
+    {
+        $contentRepositoryIds = ContentRepositoryIds::fromArray([]);
+        self::assertCount(0, $contentRepositoryIds);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayConvertsStringsToContentRepositoryIds(): void
+    {
+        $contentRepositoryIds = ContentRepositoryIds::fromArray(['some_cr_id', ContentRepositoryId::fromString('other_cr_id')]);
+        self::assertEquals([ContentRepositoryId::fromString('some_cr_id'), ContentRepositoryId::fromString('other_cr_id')], iterator_to_array($contentRepositoryIds));
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayThrowsExceptionForInvalidItem(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ContentRepositoryIds::fromArray([1234]);
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry;
@@ -17,6 +18,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ProjectionCatchUpTriggerInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryIds;
 use Neos\ContentRepository\Core\SharedModel\User\UserIdProviderInterface;
 use Neos\ContentRepositoryRegistry\Exception\ContentRepositoryNotFoundException;
 use Neos\ContentRepositoryRegistry\Exception\InvalidConfigurationException;
@@ -81,6 +83,11 @@ final class ContentRepositoryRegistry
         return $this->getFactory($contentRepositoryId)->getOrBuild();
     }
 
+    public function getContentRepositoryIds(): ContentRepositoryIds
+    {
+        return ContentRepositoryIds::fromArray(array_keys($this->settings['contentRepositories'] ?? []));
+    }
+
     /**
      * @internal for test cases only
      */
@@ -130,7 +137,8 @@ final class ContentRepositoryRegistry
     /**
      * @throws ContentRepositoryNotFoundException | InvalidConfigurationException
      */
-    private function buildFactory(ContentRepositoryId $contentRepositoryId): ContentRepositoryFactory {
+    private function buildFactory(ContentRepositoryId $contentRepositoryId): ContentRepositoryFactory
+    {
         if (!is_array($this->settings['contentRepositories'] ?? null)) {
             throw InvalidConfigurationException::fromMessage('No Content Repositories are configured');
         }
@@ -202,7 +210,6 @@ final class ContentRepositoryRegistry
             $options['contentDimensions'] = Arrays::arrayMergeRecursiveOverrule($contentRepositorySettings['contentDimensions'], $options['contentDimensions'] ?? []);
         }
         return $contentDimensionSourceFactory->build($contentRepositoryId, $options);
-
     }
 
     /** @param array<string, mixed> $contentRepositorySettings */

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -85,7 +85,9 @@ final class ContentRepositoryRegistry
 
     public function getContentRepositoryIds(): ContentRepositoryIds
     {
-        return ContentRepositoryIds::fromArray(array_keys($this->settings['contentRepositories'] ?? []));
+        /** @var array<string> $contentRepositoryIds */
+        $contentRepositoryIds = array_keys($this->settings['contentRepositories'] ?? []);
+        return ContentRepositoryIds::fromArray($contentRepositoryIds);
     }
 
     /**


### PR DESCRIPTION
Adds a `getContentRepositoryIds()` getter to the `ContentRepositoryRegistry` that allows to iterate over all configured content repositories.

This will be useful for enforcing ACL, cross-CR-linking, etc..

Related: #4726