### PR TITLE
!!! BUGFIX: Consider entry node when filtering in reference editor

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Cri
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThan;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueStartsWith;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\SharedModel\Id\UuidFactory;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -178,6 +178,9 @@ final readonly class NodeQueryBuilder
 
     public function addSearchTermConstraints(QueryBuilder $queryBuilder, SearchTerm $searchTerm, string $nodeTableAlias = 'n'): void
     {
+        if ($searchTerm->term === '') {
+            return;
+        }
         $queryBuilder->andWhere('JSON_SEARCH(' . $nodeTableAlias . '.properties, "one", :searchTermPattern, NULL, "$.*.value") IS NOT NULL')->setParameter('searchTermPattern', '%' . $searchTerm->term . '%');
     }
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -76,8 +76,9 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | a1              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1"}                                                                                                                                                                                       | {}                                       |
       | a2              | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2"}                                                                                                                                                                                       | {}                                       |
       | a2a             | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}                                                                                                                                                                                      | {}                                       |
-      | a2a1            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1", "stringProperty": "the brown fox", "booleanProperty": true, "integerProperty": 33, "floatProperty": 12.345, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}} | {}                                       |
+      | a2a1            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1", "stringProperty": "the brown fox likes Äpfel", "booleanProperty": true, "integerProperty": 33, "floatProperty": 12.345, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}} | {}                                       |
       | a2a2            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2", "stringProperty": "the red fox", "booleanProperty": false, "integerProperty": 22, "floatProperty": 12.34, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-14"}}   | {}                                       |
+      # Note that this node is disabled! See below.
       | a2a3            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a3", "stringProperty": "the red Bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-12"}}                                                    | {}                                       |
       | a2a4            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a4", "stringProperty": "the brown Bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-12"}}                                                  | {}                                       |
       | a2a5            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a5", "stringProperty": "the brown bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}}                                                  | {}                                       |
@@ -109,7 +110,15 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
 
      # Child nodes filtered by search term
     When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "brown"}' I expect the nodes "a2a1,a2a4,a2a5" to be returned
+    # The total count highlights that the search is case insensitive
     When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "bear", "pagination": {"limit": 3, "offset": 1}}' I expect the nodes "a2a5" to be returned and the total count to be 2
+    # Case insensitive multibyte search
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "äpfel"}' I expect the nodes "a2a1" to be returned
+    # Search for numbers (could be considered useless)
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "22"}' I expect the nodes "a2a2" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "12.34"}' I expect the nodes "a2a1,a2a2" to be returned
+    # Search for boolean (could be considered useless)
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": "true"}' I expect the nodes "a2a1" to be returned
 
      # Child nodes paginated
     When I execute the findChildNodes query for parent node aggregate id "home" and filter '{"pagination": {"limit": 3}}' I expect the nodes "terms,contact,a" to be returned and the total count to be 4

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -78,10 +78,12 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | a2a             | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}                                                                                                                                                                                      | {}                                       |
       | a2a1            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1", "stringProperty": "the brown fox likes Äpfel", "booleanProperty": true, "integerProperty": 33, "floatProperty": 12.345, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}} | {}                                       |
       | a2a2            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2", "stringProperty": "the red fox", "booleanProperty": false, "integerProperty": 22, "floatProperty": 12.34, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-14"}}   | {}                                       |
-      # Note that this node is disabled! See below.
-      | a2a3            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a3", "stringProperty": "the red Bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-12"}}                                                    | {}                                       |
+      # Note that the node a2a3 is disabled! See below.
+      | a2a3-disabled   | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a3", "stringProperty": "the red Bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-12"}}                                                    | {}                                       |
       | a2a4            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a4", "stringProperty": "the brown Bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-12"}}                                                  | {}                                       |
       | a2a5            | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a5", "stringProperty": "the brown bear", "integerProperty": 19, "dateProperty": {"__type": "DateTimeImmutable", "value": "1980-12-13"}}                                                  | {}                                       |
+      # Note that the node a2a6 must not contain any properties!
+      | a2a6-empty      | Neos.ContentRepository.Testing:Page        | a2a                    | {}                                                                                                                                                                                                   | {}                                       |
       | b               | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}                                                                                                                                                                                        | {}                                       |
       | b1              | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}                                                                                                                                                                                       | {}                                       |
     And the current date and time is "2023-03-16T13:00:00+01:00"
@@ -90,16 +92,19 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | nodeAggregateId | "a2a5"                  |
       | propertyValues  | {"integerProperty": 20} |
     And the command DisableNodeAggregate is executed with payload:
-      | Key                          | Value         |
-      | nodeAggregateId              | "a2a3"        |
-      | nodeVariantSelectionStrategy | "allVariants" |
+      | Key                          | Value           |
+      | nodeAggregateId              | "a2a3-disabled" |
+      | nodeVariantSelectionStrategy | "allVariants"   |
 
   Scenario:
       # Child nodes without filter
     When I execute the findChildNodes query for parent node aggregate id "home" I expect the nodes "terms,contact,a,b" to be returned
     When I execute the findChildNodes query for parent node aggregate id "a" I expect the nodes "a1,a2" to be returned
     When I execute the findChildNodes query for parent node aggregate id "a1" I expect no nodes to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" I expect the nodes "a2a1,a2a2,a2a4,a2a5" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
+      # Child nodes with empty filter
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"searchTerm": ""}' I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"nodeTypes": ""}' I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
 
       # Child nodes filtered by node type
     When I execute the findChildNodes query for parent node aggregate id "home" and filter '{"nodeTypes": "Neos.ContentRepository.Testing:AbstractPage"}' I expect the nodes "terms,contact,a,b" to be returned
@@ -149,10 +154,10 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
     When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"propertyValue": "stringProperty $=~ \"Bear\""}' I expect the nodes "a2a4,a2a5" to be returned
 
     #  Child nodes with custom ordering
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "text", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5" to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "text", "direction": "DESCENDING"}]}' I expect the nodes "a2a5,a2a4,a2a2,a2a1" to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "non_existing", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5" to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "booleanProperty", "direction": "ASCENDING"}, {"type": "propertyName", "field": "dateProperty", "direction": "ASCENDING"}]}' I expect the nodes "a2a4,a2a5,a2a2,a2a1" to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "CREATED", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5" to be returned
-    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "LAST_MODIFIED", "direction": "DESCENDING"}]}' I expect the nodes "a2a5,a2a1,a2a2,a2a4" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "text", "direction": "ASCENDING"}]}' I expect the nodes "a2a6-empty,a2a1,a2a2,a2a4,a2a5" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "text", "direction": "DESCENDING"}]}' I expect the nodes "a2a5,a2a4,a2a2,a2a1,a2a6-empty" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "non_existing", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "propertyName", "field": "booleanProperty", "direction": "ASCENDING"}, {"type": "propertyName", "field": "dateProperty", "direction": "ASCENDING"}]}' I expect the nodes "a2a6-empty,a2a4,a2a5,a2a2,a2a1" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "CREATED", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
+    When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "LAST_MODIFIED", "direction": "DESCENDING"}]}' I expect the nodes "a2a5,a2a1,a2a2,a2a4,a2a6-empty" to be returned
 

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValue.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValue.php
@@ -38,8 +38,6 @@ final readonly class SerializedPropertyValue implements \JsonSerializable
     }
 
     /**
-     * If the value is NULL an unset-property instruction will be returned instead.
-     *
      * @param Value $value
      */
     public static function create(

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
@@ -7,7 +7,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
@@ -7,7 +7,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::countChildNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
@@ -7,7 +7,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::countDescendantNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
@@ -7,7 +7,7 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindBackReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindBackReferencesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::findChildNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindDescendantNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindDescendantNodesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::findDescendantNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindPrecedingSiblingNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindPrecedingSiblingNodesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::findPrecedingSiblingNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindReferencesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSucceedingSiblingNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSucceedingSiblingNodesFilter.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Ordering\Ordering
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\Pagination\Pagination;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueCriteriaInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\PropertyValueCriteriaParser;
-use Neos\ContentRepository\Core\Projection\ContentGraph\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 
 /**
  * Immutable filter DTO for {@see ContentSubgraphInterface::findSucceedingSiblingNodes()}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTerm.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTerm.php
@@ -12,7 +12,7 @@
 
 declare(strict_types=1);
 
-namespace Neos\ContentRepository\Core\Projection\ContentGraph;
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm;
 
 /**
  * A search term for use in Filters for the {@see ContentSubgraphInterface} API.

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTerm.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTerm.php
@@ -17,6 +17,12 @@ namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm;
 /**
  * A search term for use in Filters for the {@see ContentSubgraphInterface} API.
  *
+ * The search is defined the following:
+ * - test all properties if one contains the term
+ * - the term is checked case-insensitive
+ * - an empty term will lead to no filtering
+ * - FIXME: define the search behaviour across non-string-typed properties
+ *
  * @api DTO for {@see ContentSubgraphInterface}
  */
 final readonly class SearchTerm

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm;
 
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
@@ -43,11 +42,11 @@ class SearchTermMatcher
 
         return match (true) {
             is_string($value) => mb_stripos($value, $searchTerm->term) !== false,
-            // the following behaviour might seem odd, but is implemented after how the database filtering should behave
+            // the following behaviour might seem odd, but is implemented after how the doctrine adapter filtering is currently implemented
             is_int($value),
             is_float($value) => str_contains((string)$value, $searchTerm->term),
-            $value === true => $searchTerm->term === 'true',
-            $value === false => $searchTerm->term === 'false',
+            $value === true => str_contains('true', $searchTerm->term),
+            $value === false => str_contains('false', $searchTerm->term),
             default => throw new \InvalidArgumentException(sprintf('Handling for type %s is not implemented.', get_debug_type($value))),
         };
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
@@ -23,22 +23,32 @@ class SearchTermMatcher
     public static function matchesSerializedPropertyValues(SerializedPropertyValues $serializedPropertyValues, SearchTerm $searchTerm): bool
     {
         foreach ($serializedPropertyValues as $serializedPropertyValue) {
-            if (self::matchesSerializedPropertyValue($serializedPropertyValue, $searchTerm)) {
+            if (self::matchesValue($serializedPropertyValue->value, $searchTerm)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static function matchesSerializedPropertyValue(SerializedPropertyValue $serializedPropertyValue, SearchTerm $searchTerm): bool
+    private static function matchesValue(mixed $value, SearchTerm $searchTerm): bool
     {
+        if (is_array($value) || $value instanceof \ArrayObject) {
+            foreach ($value as $subValue) {
+                if (self::matchesValue($subValue, $searchTerm)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         return match (true) {
-            is_string($serializedPropertyValue->value) => mb_stripos($serializedPropertyValue->value, $searchTerm->term) !== false,
+            is_string($value) => mb_stripos($value, $searchTerm->term) !== false,
             // the following behaviour might seem odd, but is implemented after how the database filtering should behave
-            is_int($serializedPropertyValue->value),
-            is_float($serializedPropertyValue->value) => str_contains((string)$serializedPropertyValue->value, $searchTerm->term),
-            $serializedPropertyValue->value === true => $searchTerm->term === 'true',
-            $serializedPropertyValue->value === false => $searchTerm->term === 'false'
+            is_int($value),
+            is_float($value) => str_contains((string)$value, $searchTerm->term),
+            $value === true => $searchTerm->term === 'true',
+            $value === false => $searchTerm->term === 'false',
+            default => throw new \InvalidArgumentException(sprintf('Handling for type %s is not implemented.', get_debug_type($value))),
         };
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
@@ -21,6 +21,9 @@ class SearchTermMatcher
 
     public static function matchesSerializedPropertyValues(SerializedPropertyValues $serializedPropertyValues, SearchTerm $searchTerm): bool
     {
+        if ($searchTerm->term === '') {
+            return true;
+        }
         foreach ($serializedPropertyValues as $serializedPropertyValue) {
             if (self::matchesValue($serializedPropertyValue->value, $searchTerm)) {
                 return true;

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm;
+
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+
+/**
+ * Performs search term check against the nodes properties
+ *
+ * @internal
+ */
+class SearchTermMatcher
+{
+    public static function matchesNode(Node $node, SearchTerm $searchTerm): bool
+    {
+        return static::matchesSerializedPropertyValues($node->properties->serialized(), $searchTerm);
+    }
+
+    public static function matchesSerializedPropertyValues(SerializedPropertyValues $serializedPropertyValues, SearchTerm $searchTerm): bool
+    {
+        foreach ($serializedPropertyValues as $serializedPropertyValue) {
+            if (self::matchesSerializedPropertyValue($serializedPropertyValue, $searchTerm)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function matchesSerializedPropertyValue(SerializedPropertyValue $serializedPropertyValue, SearchTerm $searchTerm): bool
+    {
+        return match (true) {
+            is_string($serializedPropertyValue->value) => mb_stripos($serializedPropertyValue->value, $searchTerm->term) !== false,
+            // the following behaviour might seem odd, but is implemented after how the database filtering should behave
+            is_int($serializedPropertyValue->value),
+            is_float($serializedPropertyValue->value) => str_contains((string)$serializedPropertyValue->value, $searchTerm->term),
+            $serializedPropertyValue->value === true => $searchTerm->term === 'true',
+            $serializedPropertyValue->value === false => $searchTerm->term === 'false'
+        };
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -124,6 +124,11 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
         return self::fromArray($nodes);
     }
 
+    public function prepend(Node $node): self
+    {
+        return new self([$node, ...$this->nodes]);
+    }
+
     public function append(Node $node): self
     {
         return new self([...$this->nodes, $node]);

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -124,6 +124,11 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
         return self::fromArray($nodes);
     }
 
+    public function append(Node $node): self
+    {
+        return new self([...$this->nodes, $node]);
+    }
+
     public function reverse(): self
     {
         return new self(array_reverse($this->nodes));

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\Projection\ContentGraph\Filter\SearchTerm;
+
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTermMatcher;
+use PHPUnit\Framework\TestCase;
+
+class SearchTermMatcherTest extends TestCase
+{
+    public function matchingStringComparisonExamples(): iterable
+    {
+        yield 'string found inside string' => ['brown', self::value('the brown fox')];
+        yield 'string found inside string (ci)' => ['BrOWn', self::value('the brown fox')];
+
+        yield 'string found inside multibyte string (ci)' => ['Äpfel', self::value('Auer schreit der bauer die äpfel sind zu sauer.')];
+
+        yield 'string matches full string' => ['Sheep', self::value('Sheep')];
+        yield 'string matches full string (ci)' => ['sheep', self::value('Sheep')];
+
+        yield 'string found inside string with special chars' => ['ä b-c+#@', self::value('the example: "ä b-c+#@"')];
+    }
+
+    public function matchingNumberLikeComparisonExamples(): iterable
+    {
+        yield 'string-number found inside string' => [
+            '22',
+            self::value('feeling like 22 ;)'),
+        ];
+
+        yield 'string-number found inside string-number' => [
+            '00',
+            self::value('007'),
+        ];
+
+        yield 'string-number found inside int' => [
+            '23',
+            self::value(1234),
+        ];
+
+        yield 'string-number found inside float' => [
+            '23',
+            self::value(1234.56),
+        ];
+
+        yield 'string-float matches float' => [
+            '1234.56',
+            self::value(1234.56),
+        ];
+
+        yield 'string-int matches int' => [
+            '0',
+            self::value(0),
+        ];
+    }
+
+    public function matchingBooleanLikeComparisonExamples(): iterable
+    {
+        yield 'string-boolean inside string' => [
+            'true',
+            self::value('this is true'),
+        ];
+
+        yield 'string-true matches boolean' => [
+            'true',
+            self::value(true),
+        ];
+
+        yield 'string-false matches boolean' => [
+            'false',
+            self::value(false),
+        ];
+    }
+
+    public function notMatchingExamples(): iterable
+    {
+        yield 'different chars' => ['aepfel', self::value('äpfel')];
+        yield 'upper boolean string representation' => ['TRUE', self::value(true)];
+        yield 'string not found inside string' => ['reptv', self::value('eras tour')];
+        yield 'integer' => ['0999', self::value(999)];
+        yield 'float with comma' => ['12,45', self::value(12.34)];
+    }
+
+    /**
+     * @test
+     * @dataProvider matchingStringComparisonExamples
+     * @dataProvider matchingNumberLikeComparisonExamples
+     * @dataProvider matchingBooleanLikeComparisonExamples
+     */
+    public function searchTermMatchesProperties(
+        string $searchTerm,
+        SerializedPropertyValues $properties,
+    ) {
+        self::assertTrue(
+            SearchTermMatcher::matchesSerializedPropertyValues(
+                $properties,
+                SearchTerm::fulltext($searchTerm)
+            )
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider notMatchingExamples
+     */
+    public function searchTermDoesntMatchesProperties(
+        string $searchTerm,
+        SerializedPropertyValues $properties,
+    ) {
+        self::assertFalse(
+            SearchTermMatcher::matchesSerializedPropertyValues(
+                $properties,
+                SearchTerm::fulltext($searchTerm)
+            )
+        );
+    }
+
+    private static function value(string|bool|float|int $value): SerializedPropertyValues
+    {
+        return SerializedPropertyValues::fromArray([
+            'test-property' => SerializedPropertyValue::create(
+                $value,
+                gettype($value)
+            ),
+        ]);
+    }
+}

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
@@ -74,6 +74,11 @@ class SearchTermMatcherTest extends TestCase
             'false',
             self::value(false),
         ];
+
+        yield 'string part matches boolean' => [
+            'ru',
+            self::value(true),
+        ];
     }
 
     public static function matchingArrayComparisonExamples(): iterable

--- a/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Projection/ContentGraph/Filter/SearchTerm/SearchTermMatcherTest.php
@@ -106,6 +106,12 @@ class SearchTermMatcherTest extends TestCase
         }
     }
 
+    public function emptySearchTermAlwaysMatches(): iterable
+    {
+        yield '1 property' => ['', self::value('foo')];
+        yield '1 empty property' => ['', self::value('foo')];
+        yield '0 properties' => ['', SerializedPropertyValues::fromArray([])];
+    }
 
     public function notMatchingExamples(): iterable
     {
@@ -125,6 +131,7 @@ class SearchTermMatcherTest extends TestCase
      * @dataProvider matchingNumberLikeComparisonExamples
      * @dataProvider matchingBooleanLikeComparisonExamples
      * @dataProvider matchingArrayComparisonExamples
+     * @dataProvider emptySearchTermAlwaysMatches
      */
     public function searchTermMatchesProperties(
         string $searchTerm,

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -114,7 +114,7 @@ class NodesController extends ActionController
         string $contextNode = null,
         array|string $nodeIdentifiers = []
     ): void {
-        $searchTerm = $searchTerm === '' ? null : SearchTerm::fulltext($searchTerm);
+        $searchTerm = SearchTerm::fulltext($searchTerm);
         $nodeTypeCriteria = NodeTypeCriteria::create(
             NodeTypeNames::fromStringArray($nodeTypes),
             NodeTypeNames::createEmpty()
@@ -176,7 +176,7 @@ class NodesController extends ActionController
                 }
             }
         } else {
-            if (!empty($searchTerm)) {
+            if ($searchTerm->term !== '') {
                 throw new \RuntimeException('Combination of $nodeIdentifiers and $searchTerm not supported');
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -166,11 +166,6 @@ parameters:
 			path: Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
 
 		-
-			message: "#^Parameter \\#2 \\$searchTerm of static method Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTermMatcher\\:\\:matchesNode\\(\\) expects Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTerm, Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTerm\\|null given\\.$#"
-			count: 1
-			path: Neos.Neos/Classes/Controller/Service/NodesController.php
-
-		-
 			message: "#^The internal method \"Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\NodeType\\\\ExpandedNodeTypeCriteria\\:\\:matches\" is called\\.$#"
 			count: 1
 			path: Neos.Neos/Classes/Controller/Service/NodesController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -166,6 +166,16 @@ parameters:
 			path: Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
 
 		-
+			message: "#^Parameter \\#2 \\$searchTerm of static method Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTermMatcher\\:\\:matchesNode\\(\\) expects Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTerm, Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\SearchTerm\\\\SearchTerm\\|null given\\.$#"
+			count: 1
+			path: Neos.Neos/Classes/Controller/Service/NodesController.php
+
+		-
+			message: "#^The internal method \"Neos\\\\ContentRepository\\\\Core\\\\Projection\\\\ContentGraph\\\\Filter\\\\NodeType\\\\ExpandedNodeTypeCriteria\\:\\:matches\" is called\\.$#"
+			count: 1
+			path: Neos.Neos/Classes/Controller/Service/NodesController.php
+
+		-
 			message: "#^The internal method \"Neos\\\\ContentRepository\\\\Core\\\\DimensionSpace\\\\WeightedDimensionSpacePoint\\:\\:getIdentityHash\" is called\\.$#"
 			count: 3
 			path: Neos.Neos/Classes/Presentation/Dimensions/VisualInterDimensionalVariationGraph.php


### PR DESCRIPTION
If you search via the reference editor, the site node will never be found since we use `ContentSubgraphInterface::findDescendantNodes` from the starting point.
We need a means to also check the entry point against the search term `$somehow`.

This pr introduces an internal `SearchTermMatcher` similar to the `PropertyValueCriteriaMatcher` to compare a nodes php-object properties against any given search term. Note that the behaviour seems currently a little weird but its modelled after our mariadb database implementation of the subgraph (see `\Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder::addSearchTermConstraints`).
The intentional quirks might be adjusted and fixed altogether with the postgres implementation but since this is a purely internal api for now this is fine.

Further the `SearchTerm` behaviour was adjusted to imply no filtering when being empty `""`.

The new official behaviour is as follows:

 - test all properties if one contains the term
 - the term is checked case-insensitive
 - an empty term will lead to no filtering
 - FIXME: define the search behaviour across non-string-typed properties

**Upgrade instructions**

The `SearchTerm` was moved from `Neos\ContentRepository\Core\Projection\ContentGraph` into `Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm`


<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

See also our slack conversation: https://neos-project.slack.com/archives/C04PYL8H3/p1722437173713789


<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
