### PR TITLE
TASK: Improve JSON error handling

### DIFF
--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/AbstractDimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/AbstractDimensionSpacePoint.php
@@ -145,11 +145,12 @@ abstract class AbstractDimensionSpacePoint implements \JsonSerializable
         return $this->coordinates;
     }
 
-    /**
-     * @throws \JsonException
-     */
     final public function toJson(): string
     {
-        return json_encode($this, JSON_THROW_ON_ERROR);
+        try {
+            return json_encode($this, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-encode %s: %s', static::class, $e->getMessage()), 1723031263, $e);
+        }
     }
 }

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/ContentSubgraphVariationWeight.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/ContentSubgraphVariationWeight.php
@@ -105,11 +105,12 @@ final readonly class ContentSubgraphVariationWeight implements \JsonSerializable
         return $this->value;
     }
 
-    /**
-     * @throws \JsonException
-     */
     public function toJson(): string
     {
-        return json_encode($this, JSON_THROW_ON_ERROR);
+        try {
+            return json_encode($this, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-encode %s: %s', self::class, $e->getMessage()), 1723031892, $e);
+        }
     }
 }

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePointSet.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePointSet.php
@@ -156,11 +156,12 @@ final readonly class DimensionSpacePointSet implements
         yield from $this->points;
     }
 
-    /**
-     * @throws \JsonException
-     */
     public function toJson(): string
     {
-        return json_encode($this, JSON_THROW_ON_ERROR);
+        try {
+            return json_encode($this, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-encode %s: %s', self::class, $e->getMessage()), 1723031979, $e);
+        }
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Dto/NodeAggregateIdsByNodePaths.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Dto/NodeAggregateIdsByNodePaths.php
@@ -101,12 +101,13 @@ final class NodeAggregateIdsByNodePaths implements \JsonSerializable
         return new self($nodeAggregateIds);
     }
 
-    /**
-     * @throws \JsonException
-     */
     public static function fromJsonString(string $jsonString): self
     {
-        return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        try {
+            return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-decode "%s": %s', $jsonString, $e->getMessage()), 1723032037, $e);
+        }
     }
 
     public function merge(self $other): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyValuesToWrite.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyValuesToWrite.php
@@ -51,12 +51,13 @@ final readonly class PropertyValuesToWrite
         return new self($values);
     }
 
-    /**
-     * @throws \JsonException
-     */
     public static function fromJsonString(string $jsonString): self
     {
-        return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        try {
+            return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-decode "%s": %s', $jsonString, $e->getMessage()), 1723032130, $e);
+        }
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValue.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValue.php
@@ -77,13 +77,17 @@ final readonly class SerializedPropertyValue implements \JsonSerializable
 
     /**
      * @return array<string, string>
-     * @throws \JsonException
      */
     public function __debugInfo(): array
     {
+        try {
+            $valueAsJson = json_encode($this->value, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-encode %s: %s', self::class, $e->getMessage()), 1723032361, $e);
+        }
         return [
             'type' => $this->type,
-            'value' => json_encode($this->value, JSON_THROW_ON_ERROR)
+            'value' => $valueAsJson,
         ];
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/NodeReferencesToWrite.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Dto/NodeReferencesToWrite.php
@@ -75,12 +75,13 @@ final readonly class NodeReferencesToWrite implements \IteratorAggregate, \Count
         ));
     }
 
-    /**
-     * @throws \JsonException
-     */
     public static function fromJsonString(string $jsonString): self
     {
-        return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        try {
+            return self::fromArray(\json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR));
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Failed to JSON-decode "%s": %s', $jsonString, $e->getMessage()), 1723032146, $e);
+        }
     }
 
     /**

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -725,7 +725,6 @@ class WorkspaceController extends AbstractModuleController
      * Computes the number of added, changed and removed nodes for the given workspace
      *
      * @return array<string,int>
-     * @throws \JsonException
      */
     protected function computeChangesCount(Workspace $selectedWorkspace, ContentRepository $contentRepository): array
     {
@@ -751,7 +750,6 @@ class WorkspaceController extends AbstractModuleController
     /**
      * Builds an array of changes for sites in the given workspace
      * @return array<string,mixed>
-     * @throws \JsonException
      */
     protected function computeSiteChanges(Workspace $selectedWorkspace, ContentRepository $contentRepository): array
     {


### PR DESCRIPTION
Replaces all `@throws JsonException` annotations with a try/catch block.

Background:

Adding the `@throws` tag means that this exception has to be handled in the calling side. But in the affected cases the JSON that is to be en/decoded does not come from a foreign source. So an exception in those cases is very unlikely – i.e. exceptional.

Besides, throwing an expception with more context, will make ease debugging of those cases
