### PR TITLE
TASK: Add migration for workspaceName constraints

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
@@ -64,4 +64,20 @@ final class MigrateEventsCommandController extends CommandController
         $eventMigrationService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->eventMigrationServiceFactory);
         $eventMigrationService->migratePayloadToWorkspaceName($this->outputLine(...));
     }
+
+    /**
+     * Rewrites all workspaceNames, that are not matching new constraints.
+     *
+     * Needed for feature "Stabilize WorkspaceName value object": https://github.com/neos/neos-development-collection/pull/5193
+     *
+     * Included in August 2024 - before final Neos 9.0 release
+ *
+     * @param string $contentRepository Identifier of the Content Repository to migrate
+     */
+    public function migratePayloadToValidWorkspaceNamesCommand(string $contentRepository = 'default'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $eventMigrationService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->eventMigrationServiceFactory);
+        $eventMigrationService->migratePayloadToValidWorkspaceNames($this->outputLine(...));
+    }
 }


### PR DESCRIPTION
This migration rewrites all events containing a workspaceName, which doesn't match the new workspaceName constraints and rewrites them with (shortend) a md5 hash of themself.

Run the migration with:

```
./flow migrateevents:migratepayloadtovalidworkspacenames
```

If the migration found some workspaceNames or baseWorkspaceNames to migrate, please run a projection replay of the workspace projection.

```
./flow cr:projectionreplay --projection workspace
```

This sould just be neccesary if you **update** your Neos 9 from <= **beta10** **to a newer version**.

Fixes #5201