### PR TITLE
TASK: Case sensitive migration and migration of baseWorkspaceName

### DIFF
--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -23,9 +23,9 @@ use Behat\Transliterator\Transliterator;
  */
 final class WorkspaceName implements \JsonSerializable
 {
-    public const MAX_LENGTH = 30;
+    public const MAX_LENGTH = 36;
 
-    private const PATTERN = '/^[a-z][a-z0-9\-]{0,' . (self::MAX_LENGTH - 1) . '}$/';
+    private const PATTERN = '/^[a-z0-9][a-z0-9\-]{0,' . (self::MAX_LENGTH - 1) . '}$/';
 
     public const WORKSPACE_NAME_LIVE = 'live';
 
@@ -89,8 +89,7 @@ final class WorkspaceName implements \JsonSerializable
 
         // If the name is still invalid at this point, we fall back to md5
         if (!self::hasValidFormat($name)) {
-            $prefix = 'workspace-';
-            $name = $prefix . substr(md5($originalName), 0, self::MAX_LENGTH - strlen($prefix));
+            $name = substr(md5($originalName), 0, self::MAX_LENGTH);
         }
 
         return self::fromString($name);

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspaceNameTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspaceNameTest.php
@@ -58,11 +58,10 @@ final class WorkspaceNameTest extends TestCase
     private static function invalidWorkspaceNames(): iterable
     {
         yield 'empty string' => [''];
-        yield 'only digits' => ['123'];
         yield 'leading dash' => ['-invalid'];
         yield 'upper case characters' => ['thisIsNotAllowed'];
         yield 'whitespace' => ['this neither'];
-        yield 'exceeding max length' => ['this-is-just-a-little-too-long-'];
+        yield 'exceeding max length' => ['this-is-just-a-little-little-bit-too-long-'];
     }
 
     /**
@@ -99,8 +98,8 @@ final class WorkspaceNameTest extends TestCase
         yield 'chinese characters' => ['value' => '北京', 'expectedResult' => 'bei-jing'];
         yield 'german umlauts' => ['value' => 'ümläute', 'expectedResult' => 'umlaute'];
         yield 'white space' => ['value' => ' Contains spaces ', 'expectedResult' => 'contains-spaces'];
-        yield 'exceeding max length' => ['value' => 'This name is just a little too long', 'expectedResult' => 'this-name-is-just-a-little-too'];
-        yield 'only special characters' => ['value' => '-', 'expectedResult' => 'workspace-336d5ebc5436534e61d1'];
+        yield 'exceeding max length' => ['value' => 'This name is just a little little bit too long', 'expectedResult' => 'this-name-is-just-a-little-little-bi'];
+        yield 'only special characters' => ['value' => '-', 'expectedResult' => '336d5ebc5436534e61d16e63ddfca327'];
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -428,6 +428,7 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
         $outputFn();
         $outputFn(sprintf('Migration applied to %s events and changed the workspaceName.', $affectedRowsWorkspaceName));
         $outputFn(sprintf('Migration applied to %s events and changed the baseWorkspaceName.', $affectedRowsBaseWorkspaceName));
+        $outputFn(sprintf('You need to replay your projection for workspaces. Please run: ./flow cr:projectionreplay --projection=workspace'));
     }
 
     /** ------------------------ */

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -388,20 +388,34 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
         $statementWorkspaceName = <<<SQL
                 UPDATE {$eventTableName}
                 SET
-                  payload = JSON_SET(payload, '$.workspaceName', LEFT(CONCAT('w', MD5(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName')))), 30))
+                    payload = JSON_SET(
+                          payload, 
+                          '$.workspaceName',
+                          IF(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName')) REGEXP '^[a-z0-9][a-z0-9\-]{0,35}$',
+                            LOWER(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName'))),
+                            MD5(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName')))
+                          )
+                        )
                 WHERE
                   JSON_EXTRACT(payload, '$.workspaceName') IS NOT NULL
-                  AND BINARY JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName')) NOT REGEXP '^[a-z][a-z0-9\-]{0,30}$'
+                  AND BINARY JSON_UNQUOTE(JSON_EXTRACT(payload, '$.workspaceName')) NOT REGEXP '^[a-z0-9][a-z0-9\-]{0,35}$'
             SQL;
         $affectedRowsWorkspaceName = $this->connection->executeStatement($statementWorkspaceName);
 
         $statementBaseWorkspaceName = <<<SQL
                 UPDATE {$eventTableName}
                 SET
-                  payload = JSON_SET(payload, '$.baseWorkspaceName', LEFT(CONCAT('w', MD5(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName')))), 30))
+                    payload = JSON_SET(
+                          payload, 
+                          '$.baseWorkspaceName',
+                          IF(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName')) REGEXP '^[a-z0-9][a-z0-9\-]{0,35}$',
+                            LOWER(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName'))),
+                            MD5(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName')))
+                          )
+                        )
                 WHERE
                   JSON_EXTRACT(payload, '$.baseWorkspaceName') IS NOT NULL
-                  AND BINARY JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName')) NOT REGEXP '^[a-z][a-z0-9\-]{0,30}$'
+                  AND BINARY JSON_UNQUOTE(JSON_EXTRACT(payload, '$.baseWorkspaceName')) NOT REGEXP '^[a-z0-9][a-z0-9\-]{0,35}$'
             SQL;
         $affectedRowsBaseWorkspaceName = $this->connection->executeStatement($statementBaseWorkspaceName);
         $this->connection->commit();

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -406,7 +406,7 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
         $affectedRowsBaseWorkspaceName = $this->connection->executeStatement($statementBaseWorkspaceName);
         $this->connection->commit();
 
-        if ($affectedRowsWorkspaceName + $affectedRowsBaseWorkspaceName === 0) {
+        if ($affectedRowsWorkspaceName === 0 && $affectedRowsBaseWorkspaceName === 0) {
             $outputFn('Migration was not necessary.');
             return;
         }

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceNameBuilder.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceNameBuilder.php
@@ -30,6 +30,6 @@ final class WorkspaceNameBuilder
                 1645656253
             );
         }
-        return WorkspaceName::fromString($name);
+        return WorkspaceName::transliterateFromString($name);
     }
 }


### PR DESCRIPTION
Follow up of #5202 

- Increase workspaceName lenght to 36 chars.
- Lower constraints on content so also a hash or UUID is valid.
- Ensure migration works case sensitive. 
- Ensure newly created user-workspaceNames will be valid.
- Also applying to baseWorkspaceName.

Fixes #5201