### PR TITLE
BUGFIX: Share same role details when adding user as when editing them

### DIFF
--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/EditAccount.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/EditAccount.html
@@ -6,7 +6,7 @@
 		<div class="neos-control-group">
 			<label class="neos-control-label">{neos:backend.translate(source: 'Modules', id: 'users.username')}</label>
 			<div class="neos-controls">
-					<span class="neos-span12 neos-uneditable-input" title="{neos:backend.translate(source: 'Modules', id: 'users.usernameCannotBeChanged')}">{account.accountIdentifier}</span>
+				<span class="neos-span12 neos-uneditable-input" title="{neos:backend.translate(source: 'Modules', id: 'users.usernameCannotBeChanged')}">{account.accountIdentifier}</span>
 			</div>
 		</div>
 
@@ -28,83 +28,7 @@
 
 	<f:if condition="{showRoles}">
 		<fieldset class="neos-span6">
-			<legend class="neos-control-label">{neos:backend.translate(source: 'Modules', id: 'users.roles')}</legend>
-			<table class="neos-table" data-neos-expandable="dropdown-group">
-				<thead>
-				<tr>
-					<th></th>
-					<th>Label</th>
-					<th>Description</th>
-					<th></th>
-				</tr>
-				</thead>
-				<tbody>
-				<f:for each="{availableRoles}" as="role" iteration="rolesIteration">
-					<tr>
-						<td>
-							<div class="neos-controls">
-								<label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.identifier}" data-neos-toggle="tooltip" data-placement="right">
-									<f:form.checkbox name="roleIdentifiers" multiple="true" value="{role.identifier}" id="roles-{rolesIteration.cycle}" checked="{f:security.ifHasRole(role: role, account: account, then: true, else: false)}"/>
-									<span></span>
-								</label>
-							</div>
-						</td>
-						<td>
-							<div class="neos-controls">
-								<label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.identifier}" data-neos-toggle="tooltip" data-placement="right">
-									{role.label}
-								</label>
-							</div>
-						</td>
-						<td>
-							<label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.label}" data-neos-toggle="tooltip" data-placement="right">{role.description}</label>
-						</td>
-						<td class="neos-action">
-							<div class="neos-pull-right">
-								<button data-neos-toggle="tooltip" title="{role.identifier}" class="neos-button neos-dropdown-trigger" aria-controls="neos-dropdown-content-{rolesIteration.cycle}" aria-expanded="false">
-									<i class="fas fa-info-circle icon-white"></i>
-								</button>
-							</div>
-						</td>
-					</tr>
-					<tr id="neos-dropdown-content-{rolesIteration.cycle}" class="neos-dropdown-content" hidden="true">
-						<td></td>
-						<td colspan="2">
-							<h2>{neos:backend.translate(source: 'Modules', id: 'users.roles.directlyAssignedPrivileges')}</h2>
-							<ul>
-								<f:render section="privileges" arguments="{role:role}"/>
-								<f:render section="parentRoles" arguments="{role:role}"/>
-							</ul>
-						</td>
-						<td></td>
-					</tr>
-				</f:for>
-				</tbody>
-			</table>
+			<f:render partial="Module/Shared/RolesSelection" arguments="{availableRoles: availableRoles, account: account}" />
 		</fieldset>
 	</f:if>
 </div>
-
-<f:section name="parentRoles">
-	<f:for each="{role.allParentRoles}" as="role">
-		<f:if condition="{role.privileges->f:count()} > 0">
-			<h2><neos:backend.translate id="users.roles.fromParentRole" arguments="{role:role.label}" source="Modules" package="Neos.Neos"/></h2>
-			<f:render section="privileges" arguments="{role:role}"/>
-		</f:if>
-	</f:for>
-</f:section>
-
-<f:section name="privileges">
-	<f:for each="{role.privileges}" as="privilege">
-		<li>
-			<label>
-				<f:switch expression="{privilege.permission}">
-					<f:case value="grant"><span class="neos-badge neos-badge-success">Grant</span></f:case>
-					<f:case value="deny"><span class="neos-badge neos-badge-important">Denied</span></f:case>
-					<f:case value="abstain"><span class="neos-badge neos-badge-inverse">Abstain</span></f:case>
-				</f:switch>
-				{privilege.privilegeTarget.label}
-			</label>
-		</li>
-	</f:for>
-</f:section>

--- a/Neos.Neos/Resources/Private/Partials/Module/Shared/RolesSelection.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Shared/RolesSelection.html
@@ -1,0 +1,85 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<legend class="neos-control-label">{neos:backend.translate(source: 'Modules', id: 'users.roles')}</legend>
+<table class="neos-table" data-neos-expandable="dropdown-group">
+  <thead>
+  <tr>
+    <th></th>
+    <th>Label</th>
+    <th>Description</th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+  <f:for each="{availableRoles}" as="role" iteration="rolesIteration">
+    <tr>
+      <td>
+        <div class="neos-controls">
+          <label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.identifier}" data-neos-toggle="tooltip" data-placement="right">
+            <f:if condition="{account}">
+              <f:then>
+                <f:form.checkbox name="roleIdentifiers" multiple="true" value="{role.identifier}" id="roles-{rolesIteration.cycle}" checked="{f:security.ifHasRole(role: role, account: account, then: true, else: false)}"/>
+              </f:then>
+              <f:else>
+                <f:form.checkbox name="roleIdentifiers" multiple="true" value="{role.identifier}" id="roles-{rolesIteration.cycle}"/>
+              </f:else>
+            </f:if>
+            <span></span>
+          </label>
+        </div>
+      </td>
+      <td>
+        <div class="neos-controls">
+          <label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.identifier}" data-neos-toggle="tooltip" data-placement="right">
+            {role.label}
+          </label>
+        </div>
+      </td>
+      <td>
+        <label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.label}" data-neos-toggle="tooltip" data-placement="right">{role.description}</label>
+      </td>
+      <td class="neos-action">
+        <div class="neos-pull-right">
+          <button data-neos-toggle="tooltip" title="{role.identifier}" class="neos-button neos-dropdown-trigger" aria-controls="neos-dropdown-content-{rolesIteration.cycle}" aria-expanded="false">
+            <i class="fas fa-info-circle icon-white"></i>
+          </button>
+        </div>
+      </td>
+    </tr>
+    <tr id="neos-dropdown-content-{rolesIteration.cycle}" class="neos-dropdown-content" hidden="true">
+      <td></td>
+      <td colspan="2">
+        <h2>{neos:backend.translate(source: 'Modules', id: 'users.roles.directlyAssignedPrivileges')}</h2>
+        <ul>
+          <f:render section="privileges" arguments="{role:role}"/>
+          <f:render section="parentRoles" arguments="{role:role}"/>
+        </ul>
+      </td>
+      <td></td>
+    </tr>
+  </f:for>
+  </tbody>
+</table>
+
+<f:section name="parentRoles">
+  <f:for each="{role.allParentRoles}" as="role">
+    <f:if condition="{role.privileges->f:count()} > 0">
+      <h2><neos:backend.translate id="users.roles.fromParentRole" arguments="{role:role.label}" source="Modules" package="Neos.Neos"/></h2>
+      <f:render section="privileges" arguments="{role:role}"/>
+    </f:if>
+  </f:for>
+</f:section>
+
+<f:section name="privileges">
+  <f:for each="{role.privileges}" as="privilege">
+    <li>
+      <label>
+        <f:switch expression="{privilege.permission}">
+          <f:case value="grant"><span class="neos-badge neos-badge-success">Grant</span></f:case>
+          <f:case value="deny"><span class="neos-badge neos-badge-important">Denied</span></f:case>
+          <f:case value="abstain"><span class="neos-badge neos-badge-inverse">Abstain</span></f:case>
+        </f:switch>
+        {privilege.privilegeTarget.label}
+      </label>
+    </li>
+  </f:for>
+</f:section>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/New.html
@@ -33,28 +33,17 @@
 						<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'password'}"/>
 					</div>
 				</div>
-          <f:if condition="{providers -> f:count()} > 1">
-            <f:then>
-              <div class="neos-control-group{f:validation.ifHasErrors(for: 'authenticationProviderName', then: ' neos-error')}">
-                <label class="neos-control-label" for="authenticationProviderName">{neos:backend.translate(id: 'users.new.userData.authenticationProviderName', value: 'Authentication Provider', source: 'Modules', package: 'Neos.Neos')}</label>
-                <div class="neos-controls">
-                  <f:form.select name="authenticationProviderName" id="authenticationProviderName" options="{providers}" optionLabelField="label" optionValueField="identifier" prependOptionLabel="{neos:backend.translate(id: 'users.new.userData.authenticationProviderName.useDefault', source: 'Modules', value: 'Use system default')}" prependOptionValue="" class="neos-span12" />
-                  <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'authenticationProviderName'}"/>
-                </div>
-              </div>
-            </f:then>
-          </f:if>
-				<div class="neos-control-group">
-					<label class="neos-control-label">{neos:backend.translate(id: 'users.new.userData.roles', value: 'Role(s)', source: 'Modules', package: 'Neos.Neos')}</label>
-					<f:for each="{roles}" as="role" iteration="rolesIteration">
-						<div class="neos-controls">
-							<label for="roles-{rolesIteration.cycle}" class="neos-checkbox" title="{role.packageKey}" data-neos-toggle="tooltip" data-placement="right">
-								<f:form.checkbox name="roleIdentifiers" multiple="true" value="{role.identifier}" id="roles-{rolesIteration.cycle}" /><span></span>
-								{f:if(condition: role.label, then: role.label, else: role.name)}
-							</label>
+				<f:if condition="{providers -> f:count()} > 1">
+					<f:then>
+						<div class="neos-control-group{f:validation.ifHasErrors(for: 'authenticationProviderName', then: ' neos-error')}">
+							<label class="neos-control-label" for="authenticationProviderName">{neos:backend.translate(id: 'users.new.userData.authenticationProviderName', value: 'Authentication Provider', source: 'Modules', package: 'Neos.Neos')}</label>
+							<div class="neos-controls">
+								<f:form.select name="authenticationProviderName" id="authenticationProviderName" options="{providers}" optionLabelField="label" optionValueField="identifier" prependOptionLabel="{neos:backend.translate(id: 'users.new.userData.authenticationProviderName.useDefault', source: 'Modules', value: 'Use system default')}" prependOptionValue="" class="neos-span12" />
+								<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'authenticationProviderName'}"/>
+							</div>
 						</div>
-					</f:for>
-				</div>
+					</f:then>
+				</f:if>
 			</fieldset>
 
 			<fieldset class="neos-span5 neos-offset1">
@@ -84,6 +73,11 @@
 						<f:form.select property="preferences.interfaceLanguage" id="interfaceLanguage" options="{settings.userInterface.availableLanguages}" value="{currentUser.preferences.interfaceLanguage}" prependOptionLabel="{neos:backend.translate(id: 'user.preferences.useDefaultInterfaceLanguage', source: 'Modules', value: 'Use system default')}" />
 					</div>
 				</div>
+			</fieldset>
+		</div>
+		<div class="neos-row-fluid">
+			<fieldset class="neos-span12">
+				<f:render partial="Module/Shared/RolesSelection" arguments="{availableRoles: roles, account: null}" />
 			</fieldset>
 		</div>
 		<div class="neos-footer">


### PR DESCRIPTION
When editing users, much more information was shown about the individual roles than when adding a user, where whoever adds them gets no information about the role except its name.

With this change the descriptions of the role and their individual privileges are displayed in the same way as in the edit account view.

**Review instructions**

Before:

<img src="https://github.com/user-attachments/assets/744c1f60-3927-4178-810e-1e0635af9dcc" width="500" />

After:

<img src="https://github.com/user-attachments/assets/b725bf47-925e-474b-890b-0e06eae410a3" width="500" />


Current edit account view:

<img src="https://github.com/user-attachments/assets/603889c7-38af-4d6f-92b0-e3e1640a1f5e" width="500" />

