### PR TITLE
BUGFIX: Remove rootnode when user workspace is deleted

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -902,8 +902,13 @@ class UserService
     {
         $userWorkspace = $this->workspaceRepository->findByIdentifier(UserUtility::getPersonalWorkspaceNameForUsername($accountIdentifier));
         if ($userWorkspace instanceof Workspace) {
+            $rootNode = $userWorkspace->getRootNodeData();
             $this->publishingService->discardAllNodes($userWorkspace);
             $this->workspaceRepository->remove($userWorkspace);
+
+            // Persist removal of workspace so we can remove the root node without a foreign key constraint violation
+            $this->persistenceManager->persistAll();
+            $rootNode->remove();
         }
     }
 


### PR DESCRIPTION
Fixes: #2193

**Review instructions**

Previously all root nodes of workspaces that belonged to removed users stayed in the database.
With this change, the root nodes are removed as well.

1. Create a user
2. Delete the new user
3. No root node should remain of the personal workspace of the removed user