### PR TITLE
FEATURE: Make number of users per page in user module configurable

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -83,6 +83,12 @@ class UsersController extends AbstractModuleController
     protected $authenticationProviderSettings;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="modules.administration.submodules.users.options")
+     * @var array
+     */
+    protected $moduleOptions;
+
+    /**
      * @return void
      * @throws NoSuchArgumentException
      */
@@ -127,6 +133,7 @@ class UsersController extends AbstractModuleController
             'searchTerm' => $searchTerm,
             'sortBy' => $sortBy,
             'sortDirection' => $sortDirection,
+            'usersPerPage' => $this->moduleOptions['usersPerPage'] ?? 10,
         ]);
     }
 

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -370,6 +370,8 @@ Neos:
               new:
                 label: 'Neos.Neos:Modules:users.actions.new.label'
                 title: 'Neos.Neos:Modules:users.actions.new.title'
+            options:
+              usersPerPage: 10
           packages:
             label: 'Neos.Neos:Modules:packages.label'
             controller: 'Neos\Neos\Controller\Module\Administration\PackagesController'

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
@@ -20,7 +20,7 @@
 		</f:if>
 
 		<f:if condition="{users}">
-			<f:widget.paginate objects="{users}" as="paginatedUsers">
+			<f:widget.paginate objects="{users}" as="paginatedUsers" configuration="{itemsPerPage: usersPerPage}">
 			<table class="neos-table">
 					<thead>
 						<tr>


### PR DESCRIPTION
**Review instructions**

1. Adjust the new configuration `Neos.Neos.modules.administration.submodules.users.options.usersPerPage` to f.e. to 1
2. The users list should now show the corresponding number of users in its index view.
