### PR TITLE
BUGFIX: Ensure a valid target workspace name in node migrations

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -59,7 +59,7 @@ class NodeMigrationCommandController extends CommandController
     public function executeCommand(string $version, string $sourceWorkspace = 'live', bool $publishOnSuccess = true, bool $force = false, string $contentRepository = 'default'): void
     {
         $sourceWorkspaceName = WorkspaceName::fromString($sourceWorkspace);
-        $targetWorkspaceName = WorkspaceName::fromString(sprintf('migration-%s-%s', $sourceWorkspaceName->value, $version));
+        $targetWorkspaceName = WorkspaceName::transliterateFromString(sprintf('migration-%s-%s', $version, $sourceWorkspaceName->value));
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
 
         try {


### PR DESCRIPTION
Resolves #5199

Related to #5201