### PR TITLE
BUGFIX: Adjust service templates for references

### DIFF
--- a/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Neos\ViewHelpers\Node;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
@@ -7,7 +8,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 
 /**
- *
+ * Viewhelper to render a label for a given Node
  */
 class LabelViewHelper extends AbstractViewHelper
 {

--- a/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
@@ -1,0 +1,29 @@
+<?php
+namespace Neos\Neos\ViewHelpers\Node;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Flow\Annotations as Flow;
+use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
+
+/**
+ *
+ */
+class LabelViewHelper extends AbstractViewHelper
+{
+    #[Flow\Inject()]
+    protected NodeLabelGeneratorInterface $nodeLabelGenerator;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('node', Node::class, 'Node', true);
+    }
+
+    public function render(): string
+    {
+        /** @var Node $node */
+        $node = $this->arguments['node'];
+        return $this->nodeLabelGenerator->getLabel($node);
+    }
+}

--- a/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Nodes/Index.html
@@ -25,7 +25,7 @@
                                 </f:else>
                             </f:if>
                         </f:alias>
-                        <label class="node-label">{node.label}</label>
+                        <label class="node-label">{neos:node.label(node: node)}</label>
                         (<span class="node-identifier">{node.aggregateId.value}</span>)
                         [<span class="node-type">{node.nodeTypeName.value}</span>]
                         <f:link.action rel="node-show" controller="Service\Nodes" action="show" arguments="{identifier: node.aggregateId.value}" format="html">{neos:backend.translate(id: 'service.nodes.show', value: 'Show')}</f:link.action>
@@ -35,4 +35,5 @@
         </div>
     </body>
 </html>
-<f:section name="breadcrumb"><f:if condition="{node.parent} && {node.parent.depth} > 1"><f:render section="breadcrumb" arguments="{node: node.parent}" /> &gt; </f:if>{node.label}</f:section>
+<f:section name="breadcrumb"><f:if condition="{node.parent} && {node.parent.depth} > 1"><f:render section="breadcrumb" arguments="{node: node.parent}" /> &gt; </f:if>{neos:node.label(node: node)}</f:section>
+

--- a/Neos.Neos/Resources/Private/Templates/Service/Nodes/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Service/Nodes/Show.html
@@ -1,14 +1,14 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <html>
     <head>
-        <title>{neos:backend.translate(id: 'node', value: 'Node')}: {node.label}</title>
+        <title>{neos:backend.translate(id: 'node', value: 'Node')}: {neos:node.label(node: node)}</title>
         <meta charset="UTF-8"/>
     </head>
     <body>
         <div>
-            <h1>{neos:backend.translate(id: 'node', value: 'Node')}: {node.label}</h1>
+            <h1>{neos:backend.translate(id: 'node', value: 'Node')}: {neos:node.label(node: node)}</h1>
             <div class="node">
-                <label class="node-label">{node.label}</label>
+                <label class="node-label">{neos:node.label(node: node)}</label>
                 <table class="node-properties">
                     <caption>{neos:backend.translate(id: 'service.nodes.nodeProperties', value: 'Node Properties')}</caption>
                     <tr>
@@ -17,7 +17,7 @@
                     </tr>
                     <tr>
                         <th>_path</th>
-                        <td class="node-path">{node.path}</td>
+                        <td class="node-path">{node.name}</td>
                     </tr>
                     <tr>
                         <th>nodeContextPath</th>


### PR DESCRIPTION
These templates are used e.g. in the reference editor, we should create a better endpoint in the UI package, but for now this will fix setting references and provides Fluid users with a viewhelper to render node labels.

Related https://github.com/neos/neos-development-collection/issues/5023
Fixes partially https://github.com/neos/neos-development-collection/issues/5030