### PR TITLE
BUGFIX 5218 - declare dependency of Registry on StructureAdjustments

### DIFF
--- a/Neos.ContentRepositoryRegistry/composer.json
+++ b/Neos.ContentRepositoryRegistry/composer.json
@@ -16,6 +16,7 @@
         "neos/flow": "~9.0.0",
         "neos/contentrepository-core": "self.version",
         "neos/contentrepositoryregistry-storageclient": "self.version",
+        "neos/contentrepository-structureadjustment": "self.version",
         "symfony/property-access": "^5.4|^6.0",
         "psr/clock": "^1"
     },


### PR DESCRIPTION
resolves #5218

This adds the missing dependency declaration

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
