### PR TITLE
FEATURE: Overhaul ContentCacheFlusher

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -58,6 +58,8 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
 
 /**
  * @implements ProjectionInterface<ContentGraphFinder>
@@ -171,6 +173,8 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
             RootNodeAggregateWithNodeWasCreated::class,
             SubtreeWasTagged::class,
             SubtreeWasUntagged::class,
+            WorkspaceWasDiscarded::class,
+            WorkspaceWasPartiallyDiscarded::class
         ]);
     }
 
@@ -195,6 +199,8 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
             RootNodeAggregateWithNodeWasCreated::class => $this->whenRootNodeAggregateWithNodeWasCreated($event, $eventEnvelope),
             SubtreeWasTagged::class => $this->whenSubtreeWasTagged($event),
             SubtreeWasUntagged::class => $this->whenSubtreeWasUntagged($event),
+            WorkspaceWasDiscarded::class => null, // only needed for GraphProjectorCatchUpHookForCacheFlushing
+            WorkspaceWasPartiallyDiscarded::class => null, // only needed for GraphProjectorCatchUpHookForCacheFlushing
             default => throw new \InvalidArgumentException(sprintf('Unsupported event %s', get_debug_type($event))),
         };
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -6,7 +6,6 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeRemoval;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeVariation;
@@ -43,6 +42,8 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregate
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
 use Neos\ContentRepository\Core\Infrastructure\DbalCheckpointStorage;
 use Neos\ContentRepository\Core\Infrastructure\DbalSchemaDiff;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -58,8 +59,6 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
-use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
-use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
 
 /**
  * @implements ProjectionInterface<ContentGraphFinder>
@@ -930,8 +929,7 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
 
         usort(
             $hierarchyRelations,
-            static fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int
-            => $relationA->position <=> $relationB->position
+            static fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int => $relationA->position <=> $relationB->position
         );
 
         foreach ($hierarchyRelations as $relation) {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -70,7 +70,7 @@ Feature: ForkContentStream Without Dimensions
 
     And the event NodePropertiesWereSet was published with payload:
       | Key                          | Value                                                   |
-      | workspaceName                | "user"                                                  |
+      | workspaceName                | "user-test"                                             |
       | contentStreamId              | "user-cs-identifier"                                    |
       | nodeAggregateId              | "nody-mc-nodeface"                                      |
       | originDimensionSpacePoint    | {}                                                      |

--- a/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Neos\Neos\Fusion\Cache;
+
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\AssetVariantInterface;
+use Neos\Neos\AssetUsage\Dto\AssetUsageFilter;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\Neos\AssetUsage\GlobalAssetUsageService;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\ContentRepository;
+
+class AssetChangeHandlerForCacheFlushing
+{
+    public function __construct(
+        protected readonly GlobalAssetUsageService $globalAssetUsageService,
+        protected readonly ContentRepositoryRegistry $contentRepositoryRegistry,
+        protected readonly PersistenceManagerInterface $persistenceManager,
+        protected readonly ContentCacheFlusher $contentCacheFlusher,
+    ) {
+    }
+
+    /**
+     * Fetches possible usages of the asset and registers nodes that use the asset as changed.
+     */
+    public function registerAssetChange(AssetInterface $asset): void
+    {
+        // In Nodes only assets are referenced, never asset variants directly. When an asset
+        // variant is updated, it is passed as $asset, but since it is never "used" by any node
+        // no flushing of corresponding entries happens. Thus we instead use the original asset
+        // of the variant.
+        if ($asset instanceof AssetVariantInterface) {
+            $asset = $asset->getOriginalAsset();
+        }
+
+        $filter = AssetUsageFilter::create()
+            ->withAsset($this->persistenceManager->getIdentifierByObject($asset))
+            ->includeVariantsOfAsset();
+
+        $workspaceNamesByContentStreamId = [];
+        foreach ($this->globalAssetUsageService->findByFilter($filter) as $contentRepositoryId => $usages) {
+            $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepositoryId));
+            foreach ($usages as $usage) {
+                // TODO: Remove when WorkspaceName is part of the AssetUsageProjection
+                $workspaceName = $workspaceNamesByContentStreamId[$contentRepositoryId][$usage->contentStreamId->value] ?? null;
+                if ($workspaceName === null) {
+                    $workspace = $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($usage->contentStreamId);
+                    if ($workspace === null) {
+                        continue;
+                    }
+                    $workspaceName = $workspace->workspaceName;
+                    $workspaceNamesByContentStreamId[$contentRepositoryId][$usage->contentStreamId->value] = $workspaceName;
+                }
+                //
+
+                $nodeAggregate = $contentRepository->getContentGraph($workspaceName)->findNodeAggregateById($usage->nodeAggregateId);
+                if ($nodeAggregate === null) {
+                    continue;
+                }
+                $flushNodeAggregateRequest = FlushNodeAggregateRequest::create(
+                    $contentRepository->id,
+                    $workspaceName,
+                    $nodeAggregate->nodeAggregateId,
+                    $nodeAggregate->nodeTypeName,
+                    $this->determineParentNodeAggregateIds($contentRepository, $workspaceName, $nodeAggregate->nodeAggregateId),
+                );
+                $this->contentCacheFlusher->flushNodeAggregate($flushNodeAggregateRequest, CacheFlushingStrategy::ON_SHUTDOWN);
+            }
+        }
+    }
+
+    private function determineParentNodeAggregateIds(ContentRepository $contentRepository, WorkspaceName $workspaceName, NodeAggregateId $childNodeAggregateId): NodeAggregateIds
+    {
+        $parentNodeAggregates = $contentRepository->getContentGraph($workspaceName)->findParentNodeAggregates($childNodeAggregateId);
+        $parentNodeAggregateIds = NodeAggregateIds::fromArray(
+            array_map(static fn (NodeAggregate $parentNodeAggregate) => $parentNodeAggregate->nodeAggregateId, iterator_to_array($parentNodeAggregates))
+        );
+
+        foreach ($parentNodeAggregateIds as $parentNodeAggregateId) {
+            // Prevent infinite loops
+            if (!$parentNodeAggregateIds->contain($parentNodeAggregateId)) {
+                $parentNodeAggregateIds->merge($this->determineParentNodeAggregateIds($contentRepository, $workspaceName, $parentNodeAggregateId));
+            }
+        }
+
+        return $parentNodeAggregateIds;
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Cache;
 
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetVariantInterface;
 use Neos\Neos\AssetUsage\Dto\AssetUsageFilter;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\Neos\AssetUsage\GlobalAssetUsageService;
-use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
-use Neos\ContentRepository\Core\ContentRepository;
 
 class AssetChangeHandlerForCacheFlushing
 {

--- a/Neos.Neos/Classes/Fusion/Cache/CacheFlushingStrategy.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheFlushingStrategy.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Fusion\Cache;
+
+enum CacheFlushingStrategy
+{
+    case IMMEDIATELY;
+    case ON_SHUTDOWN;
+}

--- a/Neos.Neos/Classes/Fusion/Cache/CacheFlushingStrategy.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheFlushingStrategy.php
@@ -6,6 +6,6 @@ namespace Neos\Neos\Fusion\Cache;
 
 enum CacheFlushingStrategy
 {
-    case IMMEDIATELY;
+    case IMMEDIATE;
     case ON_SHUTDOWN;
 }

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -23,6 +23,7 @@ class CacheTag
     protected const PREFIX_ANCESTOR = 'Ancestor';
     protected const PREFIX_NODE_TYPE = 'NodeType';
     protected const PREFIX_DYNAMIC_NODE_TAG = 'DynamicNodeTag';
+    protected const PREFIX_WORKSPACE = 'Workspace';
 
     private function __construct(
         public readonly string $value
@@ -124,6 +125,16 @@ class CacheTag
             self::PREFIX_DYNAMIC_NODE_TAG,
             self::getHashForWorkspaceNameAndContentRepositoryId($workspaceName, $contentRepositoryId),
             $nodeAggregateId->value,
+        );
+    }
+
+    final public static function forWorkspaceName(
+        ContentRepositoryId $contentRepositoryId,
+        WorkspaceName $workspaceName)
+    {
+        return self::fromSegments(
+            self::PREFIX_WORKSPACE,
+            self::getHashForWorkspaceNameAndContentRepositoryId($workspaceName, $contentRepositoryId),
         );
     }
 

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -130,8 +130,8 @@ class CacheTag
 
     final public static function forWorkspaceName(
         ContentRepositoryId $contentRepositoryId,
-        WorkspaceName $workspaceName)
-    {
+        WorkspaceName $workspaceName
+    ) {
         return self::fromSegments(
             self::PREFIX_WORKSPACE,
             self::getHashForWorkspaceNameAndContentRepositoryId($workspaceName, $contentRepositoryId),

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTag.php
@@ -131,7 +131,7 @@ class CacheTag
     final public static function forWorkspaceName(
         ContentRepositoryId $contentRepositoryId,
         WorkspaceName $workspaceName
-    ) {
+    ): self {
         return self::fromSegments(
             self::PREFIX_WORKSPACE,
             self::getHashForWorkspaceNameAndContentRepositoryId($workspaceName, $contentRepositoryId),

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -93,6 +93,18 @@ final class CacheTagSet
         ));
     }
 
+    public static function forWorkspaceNameFromNodes(Nodes $nodes): self
+    {
+        return new self(...array_map(
+            static fn (Node $node): CacheTag => CacheTag::forWorkspaceName(
+                $node->contentRepositoryId,
+                $node->workspaceName,
+            ),
+            iterator_to_array($nodes)
+        ));
+
+    }
+
     public function add(CacheTag $cacheTag): self
     {
         $tags = $this->tags;
@@ -106,9 +118,11 @@ final class CacheTagSet
      */
     public function toStringArray(): array
     {
-        return array_map(
-            static fn (CacheTag $tag): string => $tag->value,
-            array_values($this->tags)
+        return array_unique(
+            array_map(
+                static fn (CacheTag $tag): string => $tag->value,
+                array_values($this->tags)
+            )
         );
     }
 

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -102,7 +102,6 @@ final class CacheTagSet
             ),
             iterator_to_array($nodes)
         ));
-
     }
 
     public function add(CacheTag $cacheTag): self

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -67,8 +67,9 @@ class ContentCacheFlusher
 
         $nodeCacheIdentifier = CacheTag::forWorkspaceName($flushWorkspaceRequest->contentRepositoryId, $flushWorkspaceRequest->workspaceName);
         $tagsToFlush[$nodeCacheIdentifier->value] = sprintf(
-            'which were tagged with "%s" because that identifier has changed.',
-            $nodeCacheIdentifier->value
+            'which were tagged with "%s" because something on the workspace "%s" has changed.',
+            $nodeCacheIdentifier->value,
+            $flushWorkspaceRequest->workspaceName->value
         );
 
         $this->flushTags($tagsToFlush, $cacheFlushingStrategy);

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -70,7 +70,7 @@ class ContentCacheFlusher
     ): void {
         $tagsToFlush[ContentCache::TAG_EVERYTHING] = 'which were tagged with "Everything".';
 
-        $nodeCacheIdentifier = CacheTag::forWorkspaceName( $flushWorkspaceRequest->contentRepositoryId, $flushWorkspaceRequest->workspaceName);
+        $nodeCacheIdentifier = CacheTag::forWorkspaceName($flushWorkspaceRequest->contentRepositoryId, $flushWorkspaceRequest->workspaceName);
         $tagsToFlush[$nodeCacheIdentifier->value] = sprintf(
             'which were tagged with "%s" because that identifier has changed.',
             $nodeCacheIdentifier->value
@@ -117,7 +117,6 @@ class ContentCacheFlusher
 
         $parentNodeAggregateIds = $flushNodeAggregateRequest->parentNodeAggregateIds;
         foreach ($parentNodeAggregateIds as $parentNodeAggregateId) {
-
             $tagName = CacheTag::forDescendantOfNode($flushNodeAggregateRequest->contentRepositoryId, $workspaceNameToFlush, $parentNodeAggregateId);
             $tagsToFlush[$tagName->value] = sprintf(
                 'which were tagged with "%s" because node "%s" has changed.',

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -199,7 +199,7 @@ class ContentCacheFlusher
     protected function flushTags(array $tagsToFlush, CacheFlushingStrategy $cacheFlushingStrategy): void
     {
         match ($cacheFlushingStrategy) {
-            CacheFlushingStrategy::IMMEDIATELY => $this->flushTagsImmediately($tagsToFlush),
+            CacheFlushingStrategy::IMMEDIATE => $this->flushTagsImmediately($tagsToFlush),
             CacheFlushingStrategy::ON_SHUTDOWN => $this->collectTagsForFlushOnShutdown($tagsToFlush)
         };
     }

--- a/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Neos\Neos\Fusion\Cache;
+
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+
+final readonly class FlushNodeAggregateRequest
+{
+    private function __construct(
+        public ContentRepositoryId $contentRepositoryId,
+        public WorkspaceName $workspaceName,
+        public NodeAggregateId $nodeAggregateId,
+        public NodeTypeName $nodeTypeName,
+        public NodeAggregateIds $parentNodeAggregateIds,
+    ) {
+
+    }
+
+    public static function create(
+        ContentRepositoryId $contentRepositoryId,
+        WorkspaceName $workspaceName,
+        NodeAggregateId $nodeAggregateId,
+        NodeTypeName $nodeTypeName,
+        NodeAggregateIds $parentNodeAggregateIds
+    ): self {
+        return new self($contentRepositoryId,
+            $workspaceName,
+            $nodeAggregateId,
+            $nodeTypeName,
+            $parentNodeAggregateIds
+        );
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
@@ -18,7 +18,6 @@ final readonly class FlushNodeAggregateRequest
         public NodeTypeName $nodeTypeName,
         public NodeAggregateIds $parentNodeAggregateIds,
     ) {
-
     }
 
     public static function create(
@@ -28,7 +27,8 @@ final readonly class FlushNodeAggregateRequest
         NodeTypeName $nodeTypeName,
         NodeAggregateIds $parentNodeAggregateIds
     ): self {
-        return new self($contentRepositoryId,
+        return new self(
+            $contentRepositoryId,
             $workspaceName,
             $nodeAggregateId,
             $nodeTypeName,

--- a/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushNodeAggregateRequest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Cache;
 
-use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 final readonly class FlushNodeAggregateRequest
 {

--- a/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Neos\Neos\Fusion\Cache;
+
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+
+final readonly class FlushWorkspaceRequest
+{
+    private function __construct(
+        public ContentRepositoryId $contentRepositoryId,
+        public WorkspaceName $workspaceName,
+    ) {
+
+    }
+
+    public static function create(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): self
+    {
+        return new self($contentRepositoryId, $workspaceName);
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
@@ -15,7 +15,6 @@ final readonly class FlushWorkspaceRequest
         public ContentRepositoryId $contentRepositoryId,
         public WorkspaceName $workspaceName,
     ) {
-
     }
 
     public static function create(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): self

--- a/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
+++ b/Neos.Neos/Classes/Fusion/Cache/FlushWorkspaceRequest.php
@@ -1,13 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Cache;
 
-use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
-use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 final readonly class FlushWorkspaceRequest
 {

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -298,13 +298,13 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
     public function onBeforeBatchCompleted(): void
     {
         foreach ($this->flushNodeAggregateRequestsOnBeforeBatchCompleted as $index => $request) {
-            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATELY);
+            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATE);
             $this->flushNodeAggregateRequestsOnAfterCatchUp[$index] = $request;
         }
         $this->flushNodeAggregateRequestsOnBeforeBatchCompleted = [];
 
         foreach ($this->flushWorkspaceRequestsOnBeforeBatchCompleted as $index => $request) {
-            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATELY);
+            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATE);
             $this->flushWorkspaceRequestsOnAfterCatchUp[$index] = $request;
         }
         $this->flushWorkspaceRequestsOnBeforeBatchCompleted = [];
@@ -313,12 +313,12 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
     public function onAfterCatchUp(): void
     {
         foreach ($this->flushNodeAggregateRequestsOnAfterCatchUp as $request) {
-            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATELY);
+            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATE);
         }
         $this->flushNodeAggregateRequestsOnAfterCatchUp = [];
 
         foreach ($this->flushWorkspaceRequestsOnAfterCatchUp as $request) {
-            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATELY);
+            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATE);
         }
         $this->flushWorkspaceRequestsOnAfterCatchUp = [];
     }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -21,7 +21,6 @@ use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventEnvelope;
-use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
@@ -263,13 +262,13 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
     public function onBeforeBatchCompleted(): void
     {
         foreach ($this->flushNodeAggregateRequestsOnBeforeBatchCompleted as $index => $request) {
-            $this->contentCacheFlusher->flushNodeAggregate($request);
+            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATELY);
             $this->flushNodeAggregateRequestsOnAfterCatchUp[$index] = $request;
         }
         $this->flushNodeAggregateRequestsOnBeforeBatchCompleted = [];
 
         foreach ($this->flushWorkspaceRequestsOnBeforeBatchCompleted as $index => $request) {
-            $this->contentCacheFlusher->flushWorkspace($request);
+            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATELY);
             $this->flushWorkspaceRequestsOnAfterCatchUp[$index] = $request;
         }
         $this->flushWorkspaceRequestsOnBeforeBatchCompleted = [];
@@ -278,12 +277,12 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
     public function onAfterCatchUp(): void
     {
         foreach ($this->flushNodeAggregateRequestsOnAfterCatchUp as $request) {
-            $this->contentCacheFlusher->flushNodeAggregate($request);
+            $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATELY);
         }
         $this->flushNodeAggregateRequestsOnAfterCatchUp = [];
 
         foreach ($this->flushWorkspaceRequestsOnAfterCatchUp as $request) {
-            $this->contentCacheFlusher->flushWorkspace($request);
+            $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATELY);
         }
         $this->flushWorkspaceRequestsOnAfterCatchUp = [];
     }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Cache;
 
 /*
@@ -17,14 +19,14 @@ use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamAndNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
-use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\EventStore\Model\EventEnvelope;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
+use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\EventStore\Model\EventEnvelope;
 
 /**
  * Also contains a pragmatic performance booster for some "batch" operations, where the cache flushing

--- a/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
@@ -32,9 +32,9 @@ final readonly class NodeCacheEntryIdentifier implements CacheAwareInterface
     ) {
     }
 
-    public static function fromNode(Node $node, ContentStreamId $contentStreamId): self
+    public static function fromNode(Node $node): self
     {
-        return new self('Node_' . $contentStreamId->value
+        return new self('Node_' . $node->workspaceName->value
             . '_' . $node->dimensionSpacePoint->hash
             . '_' .  $node->aggregateId->value);
     }

--- a/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Fusion\Cache;
 
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
-use Neos\Flow\Annotations as Flow;
 use Neos\Cache\CacheAwareInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Flow\Annotations as Flow;
 
 /**
  * The cache entry identifier data transfer object for nodes

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -19,14 +19,13 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Neos\Fusion\Cache\NodeCacheEntryIdentifier;
 use Neos\Neos\Fusion\Cache\CacheTag;
 use Neos\Neos\Fusion\Cache\CacheTagSet;
 use Neos\Neos\Fusion\Cache\CacheTagWorkspaceName;
+use Neos\Neos\Fusion\Cache\NodeCacheEntryIdentifier;
 
 /**
  * Caching helper to make cache tag generation easier.

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\Neos;
 
-use Neos\EventStore\Model\EventEnvelope;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Monitor\FileMonitor;
@@ -26,14 +25,13 @@ use Neos\Media\Domain\Service\AssetService;
 use Neos\Neos\Controller\Backend\ContentController;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteService;
-use Neos\Neos\FrontendRouting\Projection\DocumentUriPathProjection;
 use Neos\Neos\Routing\Cache\RouteCacheFlusher;
-use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
 use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Neos\Service\EditorContentStreamZookeeper;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Neos\AssetUsage\GlobalAssetUsageService;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Neos\Fusion\Cache\AssetChangeHandlerForCacheFlushing;
 
 /**
  * The Neos Package
@@ -102,7 +100,7 @@ class Package extends BasePackage
         $dispatcher->connect(
             AssetService::class,
             'assetUpdated',
-            ContentCacheFlusher::class,
+            AssetChangeHandlerForCacheFlushing::class,
             'registerAssetChange',
             false
         );

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -20,18 +20,18 @@ use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
+use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Service\AssetService;
+use Neos\Neos\AssetUsage\GlobalAssetUsageService;
 use Neos\Neos\Controller\Backend\ContentController;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteService;
-use Neos\Neos\Routing\Cache\RouteCacheFlusher;
-use Neos\Fusion\Core\Cache\ContentCache;
-use Neos\Neos\Service\EditorContentStreamZookeeper;
-use Neos\Media\Domain\Model\AssetInterface;
-use Neos\Neos\AssetUsage\GlobalAssetUsageService;
-use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Neos\Fusion\Cache\AssetChangeHandlerForCacheFlushing;
+use Neos\Neos\Routing\Cache\RouteCacheFlusher;
+use Neos\Neos\Service\EditorContentStreamZookeeper;
 
 /**
  * The Neos Package

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
@@ -39,12 +39,13 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | nodeAggregateId | "root"            |
       | nodeTypeName    | "Neos.Neos:Sites" |
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                            | nodeName |
-      | a               | root                  | Neos.Neos:Site               | {}                                               | site     |
-      | a1              | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1", "title": "Node a1"}     | a1       |
-      | a1-1            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-1", "title": "Node a1-1"} | a1-1     |
-      | a2              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2"}     | a2       |
-      | a3              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a3", "title": "Node a3"}     | a3       |
+      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                 | initialPropertyValues                                | nodeName |
+      | a               | root                  | Neos.Neos:Site               | {}                                                   | site     |
+      | a1              | a                     | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1", "title": "Node a1"}         | a1       |
+      | a1-1            | a1                    | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-1", "title": "Node a1-1"}     | a1-1     |
+      | a1-1-1          | a1-1                  | Neos.Neos:Test.DocumentType1 | {"uriPathSegment": "a1-1-1", "title": "Node a1-1-1"} | a1-1-1   |
+      | a2              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a2", "title": "Node a2"}         | a2       |
+      | a3              | a                     | Neos.Neos:Test.DocumentType2 | {"uriPathSegment": "a3", "title": "Node a3"}         | a3       |
     And A site exists for node name "a" and domain "http://localhost"
     And the sites configuration is:
     """yaml
@@ -264,6 +265,38 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       | contentStreamId | "cs-identifier"            |
       | nodeAggregateId | "a1-1"                     |
       | propertyValues  | {"title": "Node a1-1 new"} |
+
+    And the Fusion context node is "a1"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.DocumentType1 {
+      cacheVerifier = ${"second execution"}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    cacheVerifier=second execution, title=Node a1
+    """
+
+  Scenario: ContentCache gets flushed when a property of a node has changed of a descendant node (2 levels)
+    Given I have Fusion content cache enabled
+    And the Fusion context node is "a1"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:Test.DocumentType1 {
+      cacheVerifier = ${"first execution"}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    cacheVerifier=first execution, title=Node a1
+    """
+
+    When the command SetNodeProperties is executed with payload:
+      | Key             | Value                      |
+      | contentStreamId | "cs-identifier"            |
+      | nodeAggregateId | "a1-1-1"                     |
+      | propertyValues  | {"title": "Node a1-1-1 new"} |
 
     And the Fusion context node is "a1"
     And I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -107,13 +107,13 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     """
 
     When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                               | Value                                               |
-      | nodeAggregateId                   | "text-node-middle"                                  |
-      | nodeTypeName                      | "Neos.Neos:Test.TextNode"                           |
-      | parentNodeAggregateId             | "test-document-with-contents--main"                 |
-      | initialPropertyValues             | {"text": "Text Node in the middle of the document"} |
-      | succeedingSiblingNodeAggregateId  | "text-node-end"                                     |
-      | nodeName                          | "text-node-middle"                                  |
+      | Key                              | Value                                               |
+      | nodeAggregateId                  | "text-node-middle"                                  |
+      | nodeTypeName                     | "Neos.Neos:Test.TextNode"                           |
+      | parentNodeAggregateId            | "test-document-with-contents--main"                 |
+      | initialPropertyValues            | {"text": "Text Node in the middle of the document"} |
+      | succeedingSiblingNodeAggregateId | "text-node-end"                                     |
+      | nodeName                         | "text-node-middle"                                  |
     And I execute the following Fusion code:
     """fusion
     test = Neos.Neos:ContentCollection {
@@ -128,6 +128,59 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     When the command DiscardWorkspace is executed with payload:
       | Key           | Value         |
       | workspaceName | "user-editor" |
+    Then I expect node aggregate identifier "text-node-middle" to lead to no node
+
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
+    """
+
+  Scenario: ContentCache gets flushed when a node that was just created gets partially discarded
+    Given I have Fusion content cache enabled
+    And I am in workspace "user-editor" and dimension space point {}
+    And the Fusion context node is "test-document-with-contents"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                              | Value                                               |
+      | nodeAggregateId                  | "text-node-middle"                                  |
+      | nodeTypeName                     | "Neos.Neos:Test.TextNode"                           |
+      | parentNodeAggregateId            | "test-document-with-contents--main"                 |
+      | initialPropertyValues            | {"text": "Text Node in the middle of the document"} |
+      | succeedingSiblingNodeAggregateId | "text-node-end"                                     |
+      | nodeName                         | "text-node-middle"                                  |
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node in the middle of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command DiscardIndividualNodesFromWorkspace is executed with payload:
+      | Key                | Value                                                                                                                                                                                                                                        |
+      | workspaceName      | "user-editor"                                                                                                                                                                                                                                |
+      | nodesToDiscard     | [{"workspaceName": "user-editor", "dimensionSpacePoint": {}, "nodeAggregateId": "text-node-middle"}] |
+      | newContentStreamId | "user-cs-id-discard"                                                                                                                                                                                                                         |
+
     Then I expect node aggregate identifier "text-node-middle" to lead to no node
 
     When I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -193,3 +193,55 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     """
     <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
     """
+
+  Scenario: ContentCache gets flushed when a child node that was just created gets changed
+    Given I have Fusion content cache enabled
+    And I am in workspace "user-editor" and dimension space point {}
+    And the Fusion context node is "test-document-with-contents"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                              | Value                                               |
+      | nodeAggregateId                  | "text-node-middle"                                  |
+      | nodeTypeName                     | "Neos.Neos:Test.TextNode"                           |
+      | parentNodeAggregateId            | "test-document-with-contents--main"                 |
+      | initialPropertyValues            | {"text": "Text Node in the middle of the document"} |
+      | succeedingSiblingNodeAggregateId | "text-node-end"                                     |
+      | nodeName                         | "text-node-middle"                                  |
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node in the middle of the document][Text Node at the end of the document]</div>
+    """
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                            |
+      | nodeAggregateId           | "text-node-middle"               |
+      | originDimensionSpacePoint | {} |
+      | propertyValues            | {"text": "Text Node in the middle of the document has changed"}    |
+
+
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">[Text Node at the start of the document][Text Node in the middle of the document has changed][Text Node at the end of the document]</div>
+    """

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -57,6 +57,7 @@ class CachingHelperTest extends UnitTestCase
                 [
                     'NodeType_364cfc8e70b2baa23dbd14503d2bd00e063829e7_Neos_Neos-Foo',
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
+                    'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
                 ]
             ],
             [[$nodeTypeName1, $nodeTypeName2, $nodeTypeName3],
@@ -67,6 +68,7 @@ class CachingHelperTest extends UnitTestCase
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Bar',
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Moo',
+                    'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
                 ]
             ],
             [(new \ArrayObject([$nodeTypeName1, $nodeTypeName2, $nodeTypeName3])),
@@ -77,6 +79,7 @@ class CachingHelperTest extends UnitTestCase
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Foo',
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Bar',
                     'NodeType_7505d64a54e061b7acd54ccd58b49dc43500b635_Neos_Neos-Moo',
+                    'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
                 ]
             ],
         ];
@@ -113,22 +116,26 @@ class CachingHelperTest extends UnitTestCase
             [$node1, [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [[$node1], [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [[$node1, $node2], [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [(new \ArrayObject([$node1, $node2])), [
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]]
         ];
     }
@@ -159,7 +166,11 @@ class CachingHelperTest extends UnitTestCase
 
         $actual = $helper->nodeTagForIdentifier($nodeIdentifier, $node);
 
-        self::assertEquals('Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306', $actual);
+        self::assertEquals([
+            'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+            'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
+        ], $actual);
     }
 
     /**
@@ -173,7 +184,11 @@ class CachingHelperTest extends UnitTestCase
         $contextNode = $this->createNode(NodeAggregateId::fromString("na"));
 
         $actual = $helper->nodeTagForIdentifier($identifier, $contextNode);
-        self::assertEquals('Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_some-uuid-identifier', $actual);
+        self::assertEquals([
+            'Node_364cfc8e70b2baa23dbd14503d2bd00e063829e7_some-uuid-identifier',
+            'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_some-uuid-identifier',
+            'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
+        ], $actual);
     }
 
     public function descendantOfDataProvider()
@@ -189,22 +204,26 @@ class CachingHelperTest extends UnitTestCase
             [$node1, [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [[$node1], [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [[$node1, $node2], [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]],
             [(new \ArrayObject([$node1, $node2])), [
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_364cfc8e70b2baa23dbd14503d2bd00e063829e7_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
+                'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
             ]]
         ];
     }


### PR DESCRIPTION
**Cleanup ContentCacheFlusher**
* The `ContentCacheFlusher` is now only responsible for creating `CacheTags` and flushing them, based on a `Flush**Request`. No node traversing within the `ContentCacheFlusher` anymore.
* Also I introduced a `CacheFlushingStrategy` to control the time of "real" flushing, but keeping the interface clean and equal for different cases (immediately or on shutdown).
* The ContentCacheFlusher doesn't handle assets anymore. This has been moved into `AssetChangeHandlerForCacheFlushing`
* New method to flush all caches of a workspace.

**GraphProjectorCatchUpHookForCacheFlushing**
* Determining all parent nodes here, instead of the `ContentCacheFlusher` .
* Listen to the `Workspace*Discard` events.
* Handle cache flush requests for workspaces on `Workspace*Discard` events.
* Flush cache also for the deleted node, and not just their parents.
* Replace contentstream with workspaceName of events.

**CacheTag**
* I introduced a new `CacheTag` which allows to flush all cache entries of a workspace.
* This is needed to reset the cache of a user workspace after a discard event.

**NodeCacheEntryIdentifier**
* Re-Reverted changes to the EntryIdentifier, which is now based on the workspaceName again.

**AssetChangeHandlerForCacheFlushing**
* New slot for `AssetService::assetUpdated` signal, to handle asset changes.
* Determining all parent nodes here, instead of the `ContentCacheFlusher` .


**Tests**
Added tests for:
* Cache flush on partial discard of changes
* Cache flush on descendant nodes (2 levels)

Resolves #5175 and related issues

