### PR TITLE
BUGFIX 5222 - use valid workspace name substitutes

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -298,8 +298,8 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
 
             // ... and update the event
             // the payload is only used for rebasing where we override the workspace either way:
-            $eventMetaData['commandPayload']['workspaceName'] = WorkspaceName::fromString(
-                'missing-' . \mb_substr($eventMetaData['commandPayload']['contentStreamId'] ?? '', 0, WorkspaceName::MAX_LENGTH - 8)
+            $eventMetaData['commandPayload']['workspaceName'] = WorkspaceName::transliterateFromString(
+                'missing-' . ($eventMetaData['commandPayload']['contentStreamId'] ?? '')
             )->value;
             unset($eventMetaData['commandPayload']['contentStreamId']);
 

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -298,7 +298,9 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
 
             // ... and update the event
             // the payload is only used for rebasing where we override the workspace either way:
-            $eventMetaData['commandPayload']['workspaceName'] = 'missing:' . ($eventMetaData['commandPayload']['contentStreamId'] ?? '');
+            $eventMetaData['commandPayload']['workspaceName'] = WorkspaceName::fromString(
+                'missing-' . \mb_substr($eventMetaData['commandPayload']['contentStreamId'] ?? '', 0, 28)
+            )->value;
             unset($eventMetaData['commandPayload']['contentStreamId']);
 
             $outputRewriteNotice(sprintf('Metadata: Added `workspaceName`'));

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -299,7 +299,7 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
             // ... and update the event
             // the payload is only used for rebasing where we override the workspace either way:
             $eventMetaData['commandPayload']['workspaceName'] = WorkspaceName::fromString(
-                'missing-' . \mb_substr($eventMetaData['commandPayload']['contentStreamId'] ?? '', 0, 28)
+                'missing-' . \mb_substr($eventMetaData['commandPayload']['contentStreamId'] ?? '', 0, WorkspaceName::MAX_LENGTH - 8)
             )->value;
             unset($eventMetaData['commandPayload']['contentStreamId']);
 


### PR DESCRIPTION
Resolves #5222

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
