### PR TITLE
BUGFIX: Make URI suffix configurable for the ESFrontendNode RoutePart

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -189,7 +189,8 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
             throw new ResolvedSiteNotFoundException(sprintf('No site found for siteNodeName "%s"', $siteDetectionResult->siteNodeName->value));
         }
 
-        $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath, $resolvedSite->getConfiguration()->uriPathSuffix);
+        $uriPathSuffix = $this->options['uriPathSuffix'] ?? $resolvedSite->getConfiguration()->uriPathSuffix;
+        $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath, $uriPathSuffix);
 
         $dimensionResolvingResult = $this->delegatingResolver->fromRequestToDimensionSpacePoint(
             RequestToDimensionSpacePointContext::fromUriPathAndRouteParametersAndResolvedSite(


### PR DESCRIPTION
This makes the uri suffix (e.g. .html) configurable on route (part) level, which is essential for Neos.SEO's XML sitemap and robots.txt as well as custom formats for rendering nodes as pdf etc.

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
