### PR TITLE
TASK: remove ui script tag neos 9 followup

### DIFF
--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -21,8 +21,6 @@ use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Fusion\Service\HtmlAugmenter as FusionHtmlAugmenter;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
-use Neos\Neos\Ui\Domain\Service\UserLocaleService;
-use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
 
 /**
  * The content element wrapping service adds the necessary markup around
@@ -50,18 +48,6 @@ class ContentElementWrappingService
      * @var SessionInterface
      */
     protected $session;
-
-    /**
-     * @Flow\Inject
-     * @var UserLocaleService
-     */
-    protected $userLocaleService;
-
-    /**
-     * @Flow\Inject
-     * @var NodeInfoHelper
-     */
-    protected $nodeInfoHelper;
 
     /**
      * @Flow\Inject
@@ -95,20 +81,7 @@ class ContentElementWrappingService
         $attributes['data-__neos-fusion-path'] = $fusionPath;
         $attributes['data-__neos-node-contextpath'] = $nodeAddress->serializeForUri();
 
-        $this->userLocaleService->switchToUILocale();
-
-        // TODO illegal dependency on ui
-        $serializedNode = json_encode($this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node));
-
-        $this->userLocaleService->switchToUILocale(true);
-
-        $wrappedContent = $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
-        $nodeContextPath = $nodeAddress->serializeForUri();
-        /** @codingStandardsIgnoreStart */
-        $wrappedContent .= "<script data-neos-nodedata>(function(){(this['@Neos.Neos.Ui:Nodes'] = this['@Neos.Neos.Ui:Nodes'] || {})['{$nodeContextPath}'] = {$serializedNode}})()</script>";
-        /** @codingStandardsIgnoreEnd */
-
-        return $wrappedContent;
+        return $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
     }
 
     /**


### PR DESCRIPTION
The `Classes/Aspects/AugmentationAspect.php` was adjusted via

https://github.com/neos/neos-ui/pull/3770

but in Neos 9.0 it resides here in Neos.Neos

Thus we have to redo the adjustments.

Fixes partially https://github.com/neos/neos-development-collection/issues/4951 by removing illegal php dependencies

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
