### PR TITLE
BUGFIX: #5234 Display site-name on neos login view

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -26,7 +26,7 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
   }
 
   renderer = afx`
-    <Neos.Neos:Core.BackendPage title={I18n.translate('login.index.title', 'Login to') + ' ' + props.site.name.value} additionalResources.styles={private.additionalStyles}>
+    <Neos.Neos:Core.BackendPage title={I18n.translate('login.index.title', 'Login to') + ' ' + props.site.name} additionalResources.styles={private.additionalStyles}>
       <Neos.Fusion:Fragment @path='additionalResources.inlineStyles'>
         <style type="text/css" @if.set={private.backgroundImageSource && !private.backgroundImageSourceIsWebp}>
           {'body.neos--bg,.neos-login-box:before{background-image:url(' + private.backgroundImageSource + ')}'}
@@ -46,7 +46,7 @@ prototype(Neos.Neos:View.Login) < prototype(Neos.Fusion:Component) {
               </figure>
 
               <h1 class="neos-login-heading">
-                {I18n.id('login.index.title').value('Login to').package('Neos.Neos').source('Main')} <strong>{props.site.name.value}</strong>
+                {I18n.id('login.index.title').value('Login to').package('Neos.Neos').source('Main')} <strong>{props.site.name}</strong>
               </h1>
 
               <div class="neos-login-body neos">


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

_None_

**Review instructions**

Resolves: #5234 

Displays the `site-name` title in the Neos Login screen.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
