### PR TITLE
TASK: Update GitHub actions (8.3)

### DIFF
--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Maybe remove base branch label

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: .
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ env.NEOS_FOLDER }}
 
@@ -96,7 +96,7 @@ jobs:
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
       - name: Checkout development distribution
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: neos/neos-development-distribution
           ref: ${{ env.NEOS_TARGET_VERSION }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/composer

--- a/.github/workflows/doctum.yml
+++ b/.github/workflows/doctum.yml
@@ -9,7 +9,7 @@ jobs:
   build-api-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build API documentation
         uses: sudo-bot/action-doctum@v5
@@ -20,7 +20,7 @@ jobs:
           cli-args: "--output-format=github --no-ansi --no-progress --ignore-parse-errors --only-version=${{ github.ref_name }}"
 
       - name: Check out documentation site
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: neos/neos.github.io
           path: docs-site

--- a/.github/workflows/postgresql-versions.yml
+++ b/.github/workflows/postgresql-versions.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: .
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ env.NEOS_FOLDER }}
 
@@ -80,7 +80,7 @@ jobs:
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
       - name: Checkout development distribution
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: neos/neos-development-distribution
           ref: ${{ env.NEOS_TARGET_VERSION }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/composer


### PR DESCRIPTION
Fix warnings:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/



