### PR TITLE
TASK: Add and enforce `strict_type` declarations

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Neos.ContentGraph.DoctrineDbalAdapter package.
  *

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphTableNames.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphTableNames.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\Exception as DBALException;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\Connection;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\ArrayParameterType;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/ContentHyperGraphFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/ContentHyperGraphFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter;
 
 use Doctrine\DBAL\Connection;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/HypergraphSchemaBuilder.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/HypergraphSchemaBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\SchemaBuilder;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/JsonbType.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/JsonbType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\SchemaBuilder;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/UuidArrayType.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/UuidArrayType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\SchemaBuilder;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/UuidType.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/UuidType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\SchemaBuilder;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/VarcharArrayType.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Projection/SchemaBuilder/VarcharArrayType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentGraph\PostgreSQLAdapter\Domain\Projection\SchemaBuilder;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/Neos.ContentRepository.BehavioralTests/Classes/PhpstanRules/DeclareStrictTypesRule.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/PhpstanRules/DeclareStrictTypesRule.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\PhpstanRules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<FileNode>
+ */
+class DeclareStrictTypesRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof FileNode);
+        $nodes = $node->getNodes();
+        if (0 === \count($nodes)) {
+            return [];
+        }
+        $firstNode = \array_shift($nodes);
+
+        if ($firstNode instanceof Node\Stmt\Declare_) {
+            foreach ($firstNode->declares as $declare) {
+                if (
+                    $declare->value instanceof Node\Scalar\LNumber
+                    && $declare->key->toLowerString() === 'strict_types'
+                    && $declare->value->value === 1
+                ) {
+                    return [];
+                }
+            }
+        }
+
+        return [
+            'File is missing a "declare(strict_types=1)" declaration.',
+        ];
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryServiceFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryServiceFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Factory;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryServiceInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Factory;
 
 use Neos\ContentRepository\Core\ContentRepository;

--- a/Neos.ContentRepository.Core/Classes/Factory/ProjectionsAndCatchUpHooksFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ProjectionsAndCatchUpHooksFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Factory;
 
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactories;

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeAggregateIdMapping.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDuplication/Dto/NodeAggregateIdMapping.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Feature\NodeDuplication\Dto;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/NodeType/ConstraintCheck.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/ConstraintCheck.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\NodeType;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookInterface.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\EventStore\CatchUp\CheckpointStorageInterface;
 use Neos\EventStore\Model\EventEnvelope;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/CheckpointStorageStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CheckpointStorageStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/DelegatingCatchUpHook.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/DelegatingCatchUpHook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatusType.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatusType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatuses.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionStatuses.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceStatus.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\Projection\Workspace;
 
 /**

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyDoesNotExist.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyDoesNotExist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyExists.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyExists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsAmbiguous.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsAmbiguous.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsDescendant.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsDescendant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNotRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNotRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsTethered.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsTethered.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeNameIsAlreadyCovered.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeNameIsAlreadyCovered.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsAbstract.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsNotOfTypeRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsNotOfTypeRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsOfTypeRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsOfTypeRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Core\SharedModel\Exception;
 
 /*

--- a/Neos.ContentRepository.Export/src/Exception/LiveWorkspaceContentStreamExistsException.php
+++ b/Neos.ContentRepository.Export/src/Exception/LiveWorkspaceContentStreamExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\Export\Exception;
 
 use Neos\Flow\Annotations as Flow;

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferenceNodesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferenceNodesOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferencesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/BackReferencesOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ChildrenOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ChildrenOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ClosestOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ClosestOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FilterOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/FindOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/HasOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/HasOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/IdOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/IdOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/LabelOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/LabelOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextAllOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextAllOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NextUntilOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NodeTypeNameOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/NodeTypeNameOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ParentsUntilOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevAllOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevAllOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevUntilOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PrevUntilOperation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferenceNodesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferenceNodesOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencesOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencesOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/RemoveOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/RemoveOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/SiblingsOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/SiblingsOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/UniqueOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/UniqueOperation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepository\NodeAccess\FlowQueryOperations;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentStreamCommandController.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Command;
 
 use Neos\ContentRepository\Core\Service\ContentStreamPrunerFactory;

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeMigrationCommandController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Command;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeTypesCommandController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Command;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryNotFoundException.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Exception/ContentRepositoryNotFoundException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Exception;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;

--- a/Neos.ContentRepositoryRegistry/Classes/Exception/InvalidConfigurationException.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Exception/InvalidConfigurationException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Exception;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;

--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/Configuration.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/Configuration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Migration\Configuration;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/ConfigurationInterface.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/ConfigurationInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Migration\Configuration;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/YamlConfiguration.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Configuration/YamlConfiguration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Migration\Configuration;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Migration/Factory/MigrationFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Migration/Factory/MigrationFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Migration\Factory;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Package.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Package.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry;
 
 /*

--- a/Neos.ContentRepositoryRegistry/Classes/Service/NodeMigrationGeneratorService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/NodeMigrationGeneratorService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\ContentRepositoryRegistry\Service;
 
 /*

--- a/Neos.Fusion/Classes/Core/Cache/CacheSegmentParser.php
+++ b/Neos.Fusion/Classes/Core/Cache/CacheSegmentParser.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\Cache;
 
 /*

--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\Cache;
 
 /*

--- a/Neos.Fusion/Classes/Core/Cache/FileMonitorListener.php
+++ b/Neos.Fusion/Classes/Core/Cache/FileMonitorListener.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\Cache;
 
 /*

--- a/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\Cache;
 
 /*

--- a/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/RuntimeContentCache.php
@@ -249,7 +249,7 @@ class RuntimeContentCache
             }
             $cacheTags = $this->buildCacheTags($evaluateContext['configuration'], $evaluateContext['fusionPath'], $fusionObject);
             $cacheMetadata = array_pop($this->cacheMetadata);
-            $output = $this->contentCache->createDynamicCachedSegment($output, $evaluateContext['fusionPath'], $this->serializeContext($contextVariables), $evaluateContext['cacheIdentifierValues'], $cacheTags, $cacheMetadata['lifetime'], $evaluateContext['cacheDiscriminator']);
+            $output = $this->contentCache->createDynamicCachedSegment($output, $evaluateContext['fusionPath'], $this->serializeContext($contextVariables), $evaluateContext['cacheIdentifierValues'], $cacheTags, $cacheMetadata['lifetime'], (string)$evaluateContext['cacheDiscriminator']);
         } elseif ($this->enableContentCache && $evaluateContext['cacheForPathEnabled']) {
             $cacheTags = $this->buildCacheTags($evaluateContext['configuration'], $evaluateContext['fusionPath'], $fusionObject);
             $cacheMetadata = array_pop($this->cacheMetadata);

--- a/Neos.Fusion/Classes/Core/DslInterface.php
+++ b/Neos.Fusion/Classes/Core/DslInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/AbsorbingHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/AbsorbingHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/AbstractRenderingExceptionHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/AbstractRenderingExceptionHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/BubblingHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/BubblingHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/ContextDependentHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/ContextDependentHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/HtmlMessageHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/PlainTextHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/PlainTextHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/ThrowingHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/ThrowingHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/XmlCommentHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/XmlCommentHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core\ExceptionHandlers;
 
 /*

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core;
 
 /*

--- a/Neos.Fusion/Classes/Core/RuntimeFactory.php
+++ b/Neos.Fusion/Classes/Core/RuntimeFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Fusion\Core;
 
 /*

--- a/Neos.Media/Classes/Domain/Service/AssetSourceService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetSourceService.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Neos\Media\Domain\Service;
 

--- a/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
+++ b/Neos.Neos/Classes/Controller/Backend/MenuHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Controller\Backend;
 
 /*

--- a/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
+++ b/Neos.Neos/Classes/Controller/Module/User/UserSettingsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Controller\Module\User;
 
 /*
@@ -215,7 +217,7 @@ class UserSettingsController extends AbstractModuleController
         $this->userService->updateUser($user);
 
         $this->addFlashMessage(
-            $this->translator->translateById('userSettings.electronicAddressRemoved.body', [htmlspecialchars($electronicAddress->getIdentifier()), htmlspecialchars($electronicAddress->getType()), htmlspecialchars($user->getName())], null, null, 'Modules', 'Neos.Neos'),
+            $this->translator->translateById('userSettings.electronicAddressRemoved.body', [htmlspecialchars($electronicAddress->getIdentifier()), htmlspecialchars($electronicAddress->getType()), htmlspecialchars((string)$user->getName())], null, null, 'Modules', 'Neos.Neos'),
             $this->translator->translateById('userSettings.electronicAddressRemoved.title', [], null, null, 'Modules', 'Neos.Neos'),
             Message::SEVERITY_NOTICE,
             [],

--- a/Neos.Neos/Classes/Domain/NodeLabel/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.Neos/Classes/Domain/NodeLabel/ExpressionBasedNodeLabelGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Domain\NodeLabel;
 
 /*

--- a/Neos.Neos/Classes/Domain/Service/FusionConfigurationCache.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionConfigurationCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Domain\Service;
 
 /*

--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\FrontendRouting\CatchUpHook;
 
 use Neos\ContentRepository\Core\ContentRepository;

--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\FrontendRouting\CatchUpHook;
 
 use Neos\ContentRepository\Core\ContentRepository;

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathSchemaBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\FrontendRouting\Projection;
 
 use Doctrine\DBAL\Exception as DBALException;

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Cache;
 
 /*

--- a/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/BackendHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Fusion\Helper;
 
 /*

--- a/Neos.Neos/Classes/Service/XliffService.php
+++ b/Neos.Neos/Classes/Service/XliffService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Service;
 
 /*
@@ -92,7 +94,7 @@ class XliffService
      */
     public function getCachedJson(Locale $locale): string
     {
-        $cacheIdentifier = md5($locale);
+        $cacheIdentifier = md5((string)$locale);
 
         if ($this->xliffToJsonTranslationsCache->has($cacheIdentifier)) {
             $json = $this->xliffToJsonTranslationsCache->get($cacheIdentifier);

--- a/Neos.Neos/Classes/Utility/User.php
+++ b/Neos.Neos/Classes/Utility/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\Utility;
 
 use Neos\Neos\Domain\Service\WorkspaceNameBuilder;

--- a/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Node/LabelViewHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\Neos\ViewHelpers\Node;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;

--- a/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
+++ b/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\NodeTypes\Form\Service\DataSource;
 
 /*

--- a/Neos.TimeableNodeVisibility/Classes/Command/TimeableNodeVisibilityCommandController.php
+++ b/Neos.TimeableNodeVisibility/Classes/Command/TimeableNodeVisibilityCommandController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\TimeableNodeVisibility\Command;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;

--- a/Neos.TimeableNodeVisibility/Classes/Domain/ChangedVisibilities.php
+++ b/Neos.TimeableNodeVisibility/Classes/Domain/ChangedVisibilities.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\TimeableNodeVisibility\Domain;
 
 /**

--- a/Neos.TimeableNodeVisibility/Classes/Domain/ChangedVisibility.php
+++ b/Neos.TimeableNodeVisibility/Classes/Domain/ChangedVisibility.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\TimeableNodeVisibility\Domain;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;

--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Neos\TimeableNodeVisibility\Service;
 
 use Neos\ContentRepository\Core\ContentRepository;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,3 +28,4 @@ parameters:
 rules:
     - Neos\ContentRepository\BehavioralTests\PhpstanRules\ApiOrInternalAnnotationRule
     - Neos\ContentRepository\BehavioralTests\PhpstanRules\InternalMethodsNotAllowedOutsideContentRepositoryRule
+    - Neos\ContentRepository\BehavioralTests\PhpstanRules\DeclareStrictTypesRule


### PR DESCRIPTION
Adds a

```
declare(strict_types=1);
```

declaration to all PHP files of the core that were missing one and implements & defines a new PHPStan rule to enforce them from now on

Related: #5239