### PR TITLE
TASK: Make single-field Value Objects stringable

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Classes/PhpstanRules/NoStringCastingRule.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/PhpstanRules/NoStringCastingRule.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\PhpstanRules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<\PhpParser\Node\Expr\Cast\String_>
+ */
+class NoStringCastingRule implements Rule
+{
+    /**
+     * @var string[]
+     */
+    private array $namespacePrefixesWhichShouldBeEnforced = [
+        'Neos\\ContentRepository\\Core',
+        'Neos\\ContentGraph',
+    ];
+
+    public function getNodeType(): string
+    {
+        return \PhpParser\Node\Expr\Cast\String_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof \PhpParser\Node\Expr\Cast\String_);
+        $expressionType = $scope->getType($node->expr);
+        if (!$expressionType instanceof ObjectType || !$this->classNameIsWithinConfiguredNamespaces($expressionType->getClassName())) {
+            return [];
+        }
+        return [
+            RuleErrorBuilder::message("Casting objects of class {$expressionType->getClassName()} to string is not allowed.")->build(),
+        ];
+    }
+
+    private function classNameIsWithinConfiguredNamespaces(string $className): bool
+    {
+        foreach ($this->namespacePrefixesWhichShouldBeEnforced as $namespacePrefix) {
+            if (str_starts_with($className, $namespacePrefix . '\\')) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
@@ -61,4 +61,9 @@ final class SubtreeTag implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeName.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeName.php
@@ -55,4 +55,9 @@ final class NodeTypeName implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/AbsoluteNodePath.php
@@ -178,4 +178,9 @@ final readonly class AbsoluteNodePath implements \JsonSerializable
     {
         return $this->serializeToString();
     }
+
+    public function __toString(): string
+    {
+        return $this->serializeToString();
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/Ordering/OrderingFieldName.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/Ordering/OrderingFieldName.php
@@ -32,4 +32,9 @@ final readonly class OrderingFieldName implements JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodePath.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodePath.php
@@ -147,4 +147,9 @@ final readonly class NodePath implements \JsonSerializable
     {
         return $this->serializeToString();
     }
+
+    public function __toString(): string
+    {
+        return $this->serializeToString();
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/ContentRepository/ContentRepositoryId.php
@@ -52,4 +52,9 @@ final readonly class ContentRepositoryId implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateId.php
@@ -69,4 +69,9 @@ final readonly class NodeAggregateId implements \JsonSerializable
     {
         return preg_match(self::PATTERN, $value) === 1;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeName.php
@@ -100,4 +100,9 @@ final readonly class NodeName implements \JsonSerializable
     {
         return $this->value === $other->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/PropertyName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/PropertyName.php
@@ -36,4 +36,9 @@ final readonly class PropertyName implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/ReferenceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/ReferenceName.php
@@ -36,4 +36,9 @@ final readonly class ReferenceName implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/User/UserId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/User/UserId.php
@@ -70,4 +70,9 @@ final class UserId implements \JsonSerializable
     {
         return $this->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/ContentStreamId.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/ContentStreamId.php
@@ -70,4 +70,9 @@ final class ContentStreamId implements \JsonSerializable
     {
         return $this === $other;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceDescription.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceDescription.php
@@ -43,4 +43,9 @@ final readonly class WorkspaceDescription implements \JsonSerializable
     {
         return $this->value === $other->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -114,4 +114,9 @@ final class WorkspaceName implements \JsonSerializable
     {
         return preg_match(self::PATTERN, $value) === 1;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceTitle.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceTitle.php
@@ -43,4 +43,9 @@ final readonly class WorkspaceTitle implements \JsonSerializable
     {
         return $this->value === $other->value;
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver/Separator.php
+++ b/Neos.Neos/Classes/FrontendRouting/DimensionResolution/Resolver/UriPathResolver/Separator.php
@@ -23,4 +23,9 @@ final readonly class Separator
         }
         return new self($value);
     }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,3 +29,4 @@ rules:
     - Neos\ContentRepository\BehavioralTests\PhpstanRules\ApiOrInternalAnnotationRule
     - Neos\ContentRepository\BehavioralTests\PhpstanRules\InternalMethodsNotAllowedOutsideContentRepositoryRule
     - Neos\ContentRepository\BehavioralTests\PhpstanRules\DeclareStrictTypesRule
+    - Neos\ContentRepository\BehavioralTests\PhpstanRules\NoStringCastingRule


### PR DESCRIPTION
Implement the magic `__toString()` method in relevant core value objects that represent a single string value.

Note: This also adds and configures a PHPStan rule that disallows implicit casting in for those

Related: #5239
Reverts parts of https://github.com/neos/neos-development-collection/pull/4156