### PR TITLE
TASK: 5243 remove ContentGraphFinder runtime cache

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -52,7 +52,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Timestamps;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStatus;
-use Neos\ContentRepository\Core\Projection\WithMarkStaleInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
@@ -64,7 +63,7 @@ use Neos\EventStore\Model\EventEnvelope;
  * @implements ProjectionInterface<ContentGraphFinder>
  * @internal but the graph projection is api
  */
-final class DoctrineDbalContentGraphProjection implements ProjectionInterface, WithMarkStaleInterface
+final class DoctrineDbalContentGraphProjection implements ProjectionInterface
 {
     use NodeVariation;
     use SubtreeTagging;
@@ -133,12 +132,6 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface, W
 
         $this->checkpointStorage->acquireLock();
         $this->checkpointStorage->updateAndReleaseLock(SequenceNumber::none());
-        $this->getState()->forgetInstances();
-    }
-
-    public function markStale(): void
-    {
-        $this->getState()->forgetInstances();
     }
 
     public function getCheckpointStorage(): DbalCheckpointStorage

--- a/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
+++ b/Neos.ContentRepository.Core/Classes/ContentGraphFinder.php
@@ -16,7 +16,6 @@ namespace Neos\ContentRepository\Core;
 
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -31,11 +30,6 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  */
 final class ContentGraphFinder implements ProjectionStateInterface
 {
-    /**
-     * @var array<string, ContentGraphInterface>
-     */
-    private array $contentGraphInstances = [];
-
     public function __construct(
         private readonly ContentGraphFactoryInterface $contentGraphFactory
     ) {
@@ -50,22 +44,7 @@ final class ContentGraphFinder implements ProjectionStateInterface
      */
     public function getByWorkspaceName(WorkspaceName $workspaceName): ContentGraphInterface
     {
-        if (isset($this->contentGraphInstances[$workspaceName->value])) {
-            return $this->contentGraphInstances[$workspaceName->value];
-        }
-
-        $this->contentGraphInstances[$workspaceName->value] = $this->contentGraphFactory->buildForWorkspace($workspaceName);
-        return $this->contentGraphInstances[$workspaceName->value];
-    }
-
-   /**
-     * To release all held instances, in case a workspace/content stream relation needs to be reset
-     *
-     * @internal Should only be needed after write operations (which should take care on their own)
-     */
-    public function forgetInstances(): void
-    {
-        $this->contentGraphInstances = [];
+        return $this->contentGraphFactory->buildForWorkspace($workspaceName);
     }
 
     /**


### PR DESCRIPTION
Followup to https://github.com/neos/neos-development-collection/pull/5244
Related https://github.com/neos/neos-development-collection/pull/5242
See https://github.com/neos/neos-development-collection/issues/5243

With the removal of the cr core wrapped content subgraph with runtime cache feature and making it a Neos.Neos feature we dont have to cache the content graphs any further as well. (This was initially only done to ensure that the graphs subgraph pool is used)

The only downside to this is that calling `getContentGraph` will now always issue an sql query to get the underlying content stream id. The advantage obviously that its always the latest, but its not cached.