### PR TITLE
BUGFIX: Convert *DateTime XML elements to \DateTimeImmutable during import

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeImportService.php
@@ -321,7 +321,7 @@ class NodeImportService
             case 'lastModificationDateTime':
             case 'lastPublicationDateTime':
                 $stringValue = trim($xmlReader->readString());
-                $dateValue = $this->propertyMapper->convert($stringValue, 'DateTime', $this->propertyMappingConfiguration);
+                $dateValue = $this->propertyMapper->convert($stringValue, 'DateTimeImmutable', $this->propertyMappingConfiguration);
                 $this->nodeDataStack[count($this->nodeDataStack) - 1][$elementName] = $dateValue;
                 break;
             default:


### PR DESCRIPTION
fixes: #5248

**Steps To Reproduce**

Run `./flow site:import` on a site export (presumably one that has been done with Neos 8.3 or earlier) in a Neos 8.4 setup. Make sure `doctrine/dbal@3.*` is installed. You should see an error like this:
```
Exception #1300360480 in line 99 of [...]/Framework/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php: Error: During import an exception occurred: "Could not convert PHP value of type DateTime to type date_immutable. Expected one of the following types: null, DateTimeImmutable".
```

After checking out this branch, the error should be gone.