### PR TITLE
BUGFIX: Flush content cache on rebase workspace

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -44,6 +44,7 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Infrastructure\DbalCheckpointStorage;
 use Neos\ContentRepository\Core\Infrastructure\DbalSchemaDiff;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -166,7 +167,8 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
             SubtreeWasTagged::class,
             SubtreeWasUntagged::class,
             WorkspaceWasDiscarded::class,
-            WorkspaceWasPartiallyDiscarded::class
+            WorkspaceWasPartiallyDiscarded::class,
+            WorkspaceWasRebased::class
         ]);
     }
 
@@ -191,11 +193,12 @@ final class DoctrineDbalContentGraphProjection implements ProjectionInterface
             RootNodeAggregateWithNodeWasCreated::class => $this->whenRootNodeAggregateWithNodeWasCreated($event, $eventEnvelope),
             SubtreeWasTagged::class => $this->whenSubtreeWasTagged($event),
             SubtreeWasUntagged::class => $this->whenSubtreeWasUntagged($event),
-            // the following two events are not actually handled, but we need to include them in {@see canHandle()} in order
+            // the following three events are not actually handled, but we need to include them in {@see canHandle()} in order
             // to trigger the catchup hooks for those (i.e. {@see GraphProjectorCatchUpHookForCacheFlushing}). This can
             // be removed with https://github.com/neos/neos-development-collection/issues/4992
-            WorkspaceWasDiscarded::class => null,
-            WorkspaceWasPartiallyDiscarded::class => null,
+            WorkspaceWasDiscarded::class,
+            WorkspaceWasPartiallyDiscarded::class,
+            WorkspaceWasRebased::class => null,
             default => throw new \InvalidArgumentException(sprintf('Unsupported event %s', get_debug_type($event))),
         };
     }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -264,7 +264,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
     {
         foreach ($this->flushNodeAggregateRequestsOnAfterCatchUp as $request) {
             // We do not need to flush single node aggregates if we flush the whole workspace anyway.
-            if (!$this->hasMatchingFlushWorkspaceRequest($request)) {
+            if (!isset($this->flushWorkspaceRequestsOnAfterCatchUp[$request->workspaceName->value])) {
                 $this->contentCacheFlusher->flushNodeAggregate($request, CacheFlushingStrategy::IMMEDIATE);
             }
         }
@@ -274,10 +274,5 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
             $this->contentCacheFlusher->flushWorkspace($request, CacheFlushingStrategy::IMMEDIATE);
         }
         $this->flushWorkspaceRequestsOnAfterCatchUp = [];
-    }
-
-    private function hasMatchingFlushWorkspaceRequest(FlushNodeAggregateRequest $request): bool
-    {
-        return isset($this->flushWorkspaceRequestsOnAfterCatchUp[$request->workspaceName->value]);
     }
 }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -35,6 +35,7 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -130,7 +131,8 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
             SubtreeWasTagged::class,
             SubtreeWasUntagged::class,
             WorkspaceWasDiscarded::class,
-            WorkspaceWasPartiallyDiscarded::class
+            WorkspaceWasPartiallyDiscarded::class,
+            WorkspaceWasRebased::class
         ]);
     }
 
@@ -186,6 +188,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
         if (
             $eventInstance instanceof WorkspaceWasDiscarded
             || $eventInstance instanceof WorkspaceWasPartiallyDiscarded
+            || $eventInstance instanceof WorkspaceWasRebased
         ) {
             $this->scheduleCacheFlushJobForWorkspaceName($this->contentRepository, $eventInstance->workspaceName);
         } elseif (

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -87,7 +87,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     include: resource://Neos.Neos/Private/Fusion/Root.fusion
 
     prototype(Neos.Neos:Test.TextNode) < prototype(Neos.Neos:ContentComponent) {
-      renderer = ${"[" + q(node).property("text") + "]"}
+      cacheVerifier = ${null}
+      renderer = ${props.cacheVerifier + "[" + q(node).property("text") + "]"}
     }
     """
 
@@ -244,4 +245,53 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     Then I expect the following Fusion rendering result:
     """
     <div class="neos-contentcollection">[Text Node at the start of the document][Text Node in the middle of the document has changed][Text Node at the end of the document]</div>
+    """
+
+  Scenario: ContentCache gets flushed when a workspace gets rebased
+    Given I have Fusion content cache enabled
+    And I am in workspace "user-editor" and dimension space point {}
+    And the Fusion context node is "test-document-with-contents"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      prototype(Neos.Neos:Test.TextNode) {
+        cacheVerifier = "firstRender"
+      }
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">firstRender[Text Node at the start of the document]firstRender[Text Node at the end of the document]</div>
+    """
+
+    When I am in workspace "live" and dimension space point {}
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                              | Value                                               |
+      | nodeAggregateId                  | "text-node-middle"                                  |
+      | nodeTypeName                     | "Neos.Neos:Test.TextNode"                           |
+      | parentNodeAggregateId            | "test-document-with-contents--main"                 |
+      | initialPropertyValues            | {"text": "Text Node in the middle of the document"} |
+      | succeedingSiblingNodeAggregateId | "text-node-end"                                     |
+      | nodeName                         | "text-node-middle"                                  |
+
+    When I am in workspace "user-editor" and dimension space point {}
+    And the command RebaseWorkspace is executed with payload:
+      | Key           | Value       |
+      | workspaceName | "user-editor" |
+      | rebasedContentStreamId | "user-editor-cs-identifier-rebased" |
+    Then I expect node aggregate identifier "text-node-middle" to lead to node user-editor-cs-identifier-rebased;text-node-middle;{}
+
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      prototype(Neos.Neos:Test.TextNode) {
+        cacheVerifier = "secondRender"
+      }
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">secondRender[Text Node at the start of the document]secondRender[Text Node in the middle of the document]secondRender[Text Node at the end of the document]</div>
     """

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -295,3 +295,4 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     """
     <div class="neos-contentcollection">secondRender[Text Node at the start of the document]secondRender[Text Node in the middle of the document]secondRender[Text Node at the end of the document]</div>
     """
+    


### PR DESCRIPTION
On workspace rebase we flush the content cache for the whole workspace.

I also added a small performance fix. We skip flushing single node aggregates, if we flush the workspace anyway.

Fixes: #5255