### PR TITLE
TASK: Add indices to improve parent/child query performance

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -77,7 +77,8 @@ class DoctrineDbalContentGraphSchemaBuilder
             ->addIndex(['childnodeanchor'])
             ->addIndex(['contentstreamid'])
             ->addIndex(['parentnodeanchor'])
-            ->addIndex(['contentstreamid', 'childnodeanchor', 'dimensionspacepointhash'])
+            ->addIndex(['childnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
+            ->addIndex(['parentnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
             ->addIndex(['contentstreamid', 'dimensionspacepointhash']);
     }
 


### PR DESCRIPTION
We did not have any index on the parentnodeanchor, additionally the anchors should be first, as they are most likely the most discriminating part of the query, also position was added, to potentially improve sort queries.


**Upgrade instructions**

run `./flow cr:setup`