### PR TITLE
TASK: Remove moveDimensionSpacePoint and refreshRootNodeDimensions command actions

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
@@ -59,7 +59,7 @@ trait NodeVariation
         );
         // we do this check first, because it gives a more meaningful error message on what you need to do.
         // we cannot use sentences with "." because the UI will only print the 1st sentence :/
-        $this->requireNodeAggregateToNotBeRoot($nodeAggregate, 'and Root Node Aggregates cannot be varied; If this error happens, you most likely need to run ./flow content:refreshRootNodeDimensions to update the root node dimensions.');
+        $this->requireNodeAggregateToNotBeRoot($nodeAggregate, 'and Root Node Aggregates cannot be varied; If this error happens, you most likely need to run a node migration "UpdateRootNodeAggregateDimensions" to update the root node dimensions.');
         $this->requireDimensionSpacePointToExist($command->sourceOrigin->toDimensionSpacePoint());
         $this->requireDimensionSpacePointToExist($command->targetOrigin->toDimensionSpacePoint());
         $this->requireNodeAggregateToBeUntethered($nodeAggregate);


### PR DESCRIPTION
We introduced the corresponding node migrations for these commands and don't want to provide two different ways to execute these commands.

Please use NodeMigrations now:
* MoveDimensionSpacePoint
* UpdateRootNodeAggregateDimensions

See: https://github.com/neos/neos-development-collection/pull/5256

Docs:
* https://neos.readthedocs.io/en/9.0/References/NodeMigrations.html
* https://docs.neos.io/guide/content-repository/content-dimensions/migrating-dimension-config

Related: #4984
