### PR TITLE
TASK: Streamline value object mapping usages

### DIFF
--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -45,8 +45,9 @@ final class Events implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @param \Closure $callback
-     * @return array<mixed>
+     * @template T
+     * @param \Closure(EventInterface|DecoratedEvent $event): T $callback
+     * @return list<T>
      */
     public function map(\Closure $callback): array
     {

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
@@ -89,8 +89,9 @@ final readonly class SubtreeTags implements \IteratorAggregate, \Countable, \Jso
     }
 
     /**
-     * @param \Closure(SubtreeTag): mixed $callback
-     * @return array<mixed>
+     * @template T
+     * @param \Closure(SubtreeTag $tag): T $callback
+     * @return list<T>
      */
     public function map(\Closure $callback): array
     {

--- a/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeNames.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/NodeTypeNames.php
@@ -49,7 +49,7 @@ final class NodeTypeNames implements \IteratorAggregate
      */
     public static function fromStringArray(array $array): self
     {
-        return new self(... array_map(
+        return new self(...array_map(
             fn(string $serializedNodeTypeName): NodeTypeName => NodeTypeName::fromString($serializedNodeTypeName),
             $array
         ));
@@ -80,11 +80,21 @@ final class NodeTypeNames implements \IteratorAggregate
     }
 
     /**
+     * @template T
+     * @param \Closure(NodeTypeName $nodeTypeName): T $callback
+     * @return list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, $this->nodeTypeNames);
+    }
+
+    /**
      * @return array<string>
      */
     public function toStringArray(): array
     {
-        return array_map(fn(NodeTypeName $nodeTypeName) => $nodeTypeName->value, $this->nodeTypeNames);
+        return $this->map(fn(NodeTypeName $nodeTypeName) => $nodeTypeName->value);
     }
 
     public function isEmpty(): bool

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeTags.php
@@ -97,8 +97,9 @@ final readonly class NodeTags implements \IteratorAggregate, \Countable, \JsonSe
     }
 
     /**
-     * @param \Closure(SubtreeTag $tag, bool $inherited): mixed $callback
-     * @return array<mixed>
+     * @template T
+     * @param \Closure(SubtreeTag $tag, bool $inherited): T $callback
+     * @return list<T>
      */
     public function map(\Closure $callback): array
     {

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -209,8 +209,9 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
     }
 
     /**
-     * @param \Closure(Node $node): mixed $callback
-     * @return array<mixed>
+     * @template T
+     * @param \Closure(Node $node): T $callback
+     * @return list<T>
      */
     public function map(\Closure $callback): array
     {

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Nodes.php
@@ -220,8 +220,6 @@ final class Nodes implements \IteratorAggregate, \ArrayAccess, \Countable
 
     public function toNodeAggregateIds(): NodeAggregateIds
     {
-        return NodeAggregateIds::create(...$this->map(
-            fn (Node $node): NodeAggregateId => $node->aggregateId,
-        ));
+        return NodeAggregateIds::fromNodes($this);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\SharedModel\Node;
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 
 /**
@@ -37,7 +38,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
 
     public static function createEmpty(): self
     {
-        return new self(...[]);
+        return new self();
     }
 
     public static function create(NodeAggregateId ...$nodeAggregateIds): self
@@ -69,7 +70,9 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
 
     public static function fromNodes(Nodes $nodes): self
     {
-        return $nodes->toNodeAggregateIds();
+        return self::fromArray($nodes->map(
+            fn (Node $node): NodeAggregateId => $node->aggregateId,
+        ));
     }
 
     public function merge(self $other): self

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\SharedModel\Node;
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 
 /**
@@ -23,7 +22,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
  * @implements \IteratorAggregate<string,NodeAggregateId>
  * @api
  */
-final class NodeAggregateIds implements \IteratorAggregate, \JsonSerializable
+final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
      * @var array<string,NodeAggregateId>
@@ -123,5 +122,10 @@ final class NodeAggregateIds implements \IteratorAggregate, \JsonSerializable
     public function map(\Closure $callback): array
     {
         return array_map($callback, $this->nodeAggregateIds);
+    }
+
+    public function count(): int
+    {
+        return count($this->nodeAggregateIds);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -70,9 +70,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \JsonSerializable
 
     public static function fromNodes(Nodes $nodes): self
     {
-        return self::fromArray(
-            array_map(fn(Node $node) => $node->aggregateId, iterator_to_array($nodes))
-        );
+        return $nodes->toNodeAggregateIds();
     }
 
     public function merge(self $other): self

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -116,4 +116,14 @@ final class NodeAggregateIds implements \IteratorAggregate, \JsonSerializable
     {
         yield from $this->nodeAggregateIds;
     }
+
+    /**
+     * @template T
+     * @param \Closure(NodeAggregateId $nodeAggregateId): T $callback
+     * @return list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, $this->nodeAggregateIds);
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -121,7 +121,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
      */
     public function map(\Closure $callback): array
     {
-        return array_map($callback, $this->nodeAggregateIds);
+        return array_map($callback, array_values($this->nodeAggregateIds));
     }
 
     public function count(): int

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -117,12 +117,7 @@ final class CacheTagSet
      */
     public function toStringArray(): array
     {
-        return array_unique(
-            array_map(
-                static fn (CacheTag $tag): string => $tag->value,
-                array_values($this->tags)
-            )
-        );
+        return array_keys($this->tags);
     }
 
     public function union(self $other): self

--- a/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
+++ b/Neos.Neos/Classes/Fusion/Cache/CacheTagSet.php
@@ -37,44 +37,38 @@ final class CacheTagSet
     public static function forDescendantOfNodesFromNodes(
         Nodes $nodes
     ): self {
-        return new self(...array_map(
-            CacheTag::forDescendantOfNodeFromNode(...),
-            iterator_to_array($nodes),
-        ));
+        return new self(...$nodes->map(CacheTag::forDescendantOfNodeFromNode(...)));
     }
 
     public static function forDescendantOfNodesFromNodesWithoutWorkspace(
         Nodes $nodes,
     ): self {
-        return new self(...array_map(
+        return new self(...$nodes->map(
             static fn (Node $node) => CacheTag::forDescendantOfNode(
                 $node->contentRepositoryId,
                 CacheTagWorkspaceName::ANY,
                 $node->aggregateId,
-            ),
-            iterator_to_array($nodes)
+            )
         ));
     }
 
     public static function forNodeAggregatesFromNodes(
         Nodes $nodes
     ): self {
-        return new self(...array_map(
-            CacheTag::forNodeAggregateFromNode(...),
-            iterator_to_array($nodes)
+        return new self(...$nodes->map(
+            CacheTag::forNodeAggregateFromNode(...)
         ));
     }
 
     public static function forNodeAggregatesFromNodesWithoutWorkspace(
         Nodes $nodes
     ): self {
-        return new self(...array_map(
+        return new self(...$nodes->map(
             static fn (Node $node) => CacheTag::forNodeAggregate(
                 $node->contentRepositoryId,
                 CacheTagWorkspaceName::ANY,
                 $node->aggregateId
-            ),
-            iterator_to_array($nodes),
+            )
         ));
     }
 
@@ -83,24 +77,22 @@ final class CacheTagSet
         WorkspaceName|CacheTagWorkspaceName $workspaceName,
         NodeTypeNames $nodeTypeNames
     ): self {
-        return new self(...array_map(
+        return new self(...$nodeTypeNames->map(
             static fn (NodeTypeName $nodeTypeName): CacheTag => CacheTag::forNodeTypeName(
                 $contentRepositoryId,
                 $workspaceName,
                 $nodeTypeName
-            ),
-            iterator_to_array($nodeTypeNames)
+            )
         ));
     }
 
     public static function forWorkspaceNameFromNodes(Nodes $nodes): self
     {
-        return new self(...array_map(
+        return new self(...$nodes->map(
             static fn (Node $node): CacheTag => CacheTag::forWorkspaceName(
                 $node->contentRepositoryId,
                 $node->workspaceName,
-            ),
-            iterator_to_array($nodes)
+            )
         ));
     }
 

--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -311,7 +311,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
         );
 
         $this->currentNodeRootlineAggregateIds = NodeAggregateIds::create($this->currentNode->aggregateId)
-            ->merge(NodeAggregateIds::fromNodes($currentNodeAncestors));
+            ->merge($currentNodeAncestors->toNodeAggregateIds());
 
         return $this->currentNodeRootlineAggregateIds;
     }

--- a/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/MenuItemsImplementation.php
@@ -196,7 +196,7 @@ class MenuItemsImplementation extends AbstractMenuItemsImplementation
                 $maximumLevels = min($maximumLevels, $maxLevelsBasedOnLastLevel);
             } elseif ($lastLevels < 0) {
                 $currentNodeAncestorAggregateIds = $this->getCurrentNodeRootlineAggregateIds();
-                $depthOfCurrentDocument = count(iterator_to_array($currentNodeAncestorAggregateIds)) - 1;
+                $depthOfCurrentDocument = count($currentNodeAncestorAggregateIds) - 1;
                 $maxLevelsBasedOnLastLevel = max($depthOfCurrentDocument + $lastLevels - $depthOfEntryParentNodeAggregateId + 1, 0);
                 $maximumLevels = min($maximumLevels, $maxLevelsBasedOnLastLevel);
             }


### PR DESCRIPTION
Instead of using `iterator_to_array` in combination with `array_map` we use a dedicated `map` function.
Also the `map` functions across the code base were made generic.
Further-on - as specified by the according commits - further minor cosmetic changes were carried out.

This change is does not contain any breaking changes - only minor php api features.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
