### PR TITLE
FEATURE: Fusion eel neos deprecation tracer

### DIFF
--- a/Neos.Fusion/Classes/Core/EelNeosDeprecationTracer.php
+++ b/Neos.Fusion/Classes/Core/EelNeosDeprecationTracer.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Fusion\Core;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Eel\EelInvocationTracerInterface;
+use Neos\Flow\Annotations as Flow;
+use Psr\Log\LoggerInterface;
+
+final class EelNeosDeprecationTracer implements EelInvocationTracerInterface
+{
+    /** @Flow\Inject */
+    protected LoggerInterface $logger;
+
+    /**
+     * These are the lowercase names of the Neos 8 Node fields that were removed in 9.0.
+     * Only the fields name, nodeTypeName and properties will continue to exist.
+     */
+    private const LEGACY_NODE_FIELDS = [
+        'accessrestrictions' => true,
+        'accessroles' => true,
+        'accessible' => true,
+        'autocreated' => true,
+        'cacheentryidentifier' => true,
+        'childnodes' => true,
+        'contentobject' => true,
+        'context' => true,
+        'contextpath' => true,
+        'creationdatetime' => true,
+        'depth' => true,
+        'dimensions' => true,
+        'hidden' => true,
+        'hiddenafterdatetime' => true,
+        'hiddenbeforedatetime' => true,
+        'hiddeninindex' => true,
+        'identifier' => true,
+        'index' => true,
+        'label' => true,
+        'lastmodificationdatetime' => true,
+        'lastpublicationdatetime' => true,
+        'nodeaggregateidentifier' => true,
+        'nodedata' => true,
+        'nodename' => true,
+        'nodetype' => true,
+        'numberofchildnodes' => true,
+        'othernodevariants' => true,
+        'parent' => true,
+        'parentpath' => true,
+        'path' => true,
+        'primarychildnode' => true,
+        'propertynames' => true,
+        'removed' => true,
+        'root' => true,
+        'tethered' => true,
+        'visible' => true,
+        'workspace' => true,
+    ];
+
+    public function __construct(
+        private readonly string $eelExpression,
+        private readonly bool $throwExceptions,
+    ) {
+    }
+
+    public function recordPropertyAccess(object $object, string $propertyName): void
+    {
+        if (
+            // deliberate cross package reference from Neos.Fusion to simplify the wiring of this temporary migration helper
+            $object instanceof Node
+            && array_key_exists(strtolower($propertyName), self::LEGACY_NODE_FIELDS)
+        ) {
+            $this->logDeprecationOrThrowException(
+                sprintf('The node field "%s" is removed in "%s"', $propertyName, $this->eelExpression)
+            );
+        }
+    }
+
+    public function recordMethodCall(object $object, string $methodName, array $arguments): void
+    {
+    }
+
+    public function recordFunctionCall(callable $function, string $functionName, array $arguments): void
+    {
+    }
+
+    private function logDeprecationOrThrowException(string $message): void
+    {
+        if ($this->throwExceptions) {
+            throw new \RuntimeException($message);
+        } else {
+            $this->logger->debug($message);
+        }
+    }
+}

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -786,7 +786,13 @@ class Runtime
             $this->eelEvaluator->_activateDependency();
         }
 
-        return EelUtility::evaluateEelExpression($expression, $this->eelEvaluator, $contextVariables);
+        $tracer = match ($this->settings['deprecationTracer'] ?? null) {
+            'LOG' => new EelNeosDeprecationTracer($expression, false),
+            'EXCEPTION' => new EelNeosDeprecationTracer($expression, true),
+            default => null
+        };
+
+        return EelUtility::evaluateEelExpression($expression, $this->eelEvaluator, $contextVariables, [], $tracer);
     }
 
     /**

--- a/Neos.Fusion/Configuration/Development/Settings.yaml
+++ b/Neos.Fusion/Configuration/Development/Settings.yaml
@@ -1,4 +1,5 @@
 Neos:
   Fusion:
+    deprecationTracer: "LOG"
     rendering:
       exceptionHandler: Neos\Fusion\Core\ExceptionHandlers\HtmlMessageHandler

--- a/Neos.Fusion/Configuration/Settings.yaml
+++ b/Neos.Fusion/Configuration/Settings.yaml
@@ -33,6 +33,11 @@ Neos:
     # This option is suited only for development and enabled there by default.
     enableParsePartialsCache: true
 
+    # Experimental logging for deprecated fusion code at runtime.
+    # Either disabled or "LOG" or "EXCEPTION" to let the exception handler step in ensuring no deprecated syntax is used.
+    # Should only be used during development
+    deprecationTracer: false
+
     # Default context objects that are available in Eel expressions
     #
     # New variables should be added with a package key prefix. Example:

--- a/Neos.Fusion/Resources/Private/Schema/Settings.Neos.Fusion.schema.yaml
+++ b/Neos.Fusion/Resources/Private/Schema/Settings.Neos.Fusion.schema.yaml
@@ -19,6 +19,8 @@ properties:
     type: boolean
   enableParsePartialsCache:
     type: boolean
+  deprecationTracer:
+    type: [string, boolean]
   defaultContext:
     type: dictionary
     additionalProperties:


### PR DESCRIPTION
Requires: https://github.com/neos/flow-development-collection/pull/3386

Related: https://github.com/neos/neos-development-collection/issues/4208
Related: https://github.com/neos/neos-development-collection/issues/5022


Will by default log as "DEBUG" in development context hints if we use deprecated node field access:

```
24-09-24 18:39:26 97069      DEBUG                          The Node field "label" is deprecated in "${q(site).property('titleOverride') || site.label}"
24-09-24 18:39:26 97069      DEBUG                          The Node field "label" is deprecated in "${item.label}"
24-09-24 18:39:26 97069      DEBUG                          The Node field "identifier" is deprecated in "${node.identifier}"
```



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
