### PR TITLE
BUGFIX: Improve performance on find*Aggregates

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -175,10 +175,9 @@ final class ContentGraph implements ContentGraphInterface
     public function findParentNodeAggregates(
         NodeAggregateId $childNodeAggregateId
     ): NodeAggregates {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
-            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
-            ->andWhere('ch.contentstreamid = :contentStreamId')
+        $queryBuilder = $this->nodeQueryBuilder->buildParentNodeAggregateQuery()
+            ->innerJoin('h', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor')
+            ->andWhere('h.contentstreamid = :contentStreamId')
             ->andWhere('cn.nodeaggregateid = :nodeAggregateId')
             ->setParameters([
                 'nodeAggregateId' => $childNodeAggregateId->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -56,18 +56,26 @@ final readonly class NodeQueryBuilder
         return $this->createQueryBuilder()
             ->select('cn.*, ch.contentstreamid, ch.subtreetags, cdsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'pn')
-            ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ph', 'ph.childnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('ch', $this->tableNames->dimensionSpacePoints(), 'cdsp', 'cdsp.hash = ch.dimensionspacepointhash')
             ->innerJoin('ch', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
             ->where('pn.nodeaggregateid = :parentNodeAggregateId')
-            ->andWhere('ph.contentstreamid = :contentStreamId')
             ->andWhere('ch.contentstreamid = :contentStreamId')
             ->orderBy('ch.position')
             ->setParameters([
                 'parentNodeAggregateId' => $parentNodeAggregateId->value,
                 'contentStreamId' => $contentStreamId->value,
             ]);
+    }
+
+    public function buildParentNodeAggregateQuery(): QueryBuilder
+    {
+        return $this->createQueryBuilder()
+            ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->from($this->tableNames->node(), 'n')
+            ->innerJoin('n', $this->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = n.relationanchorpoint')
+            ->innerJoin('h', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash')
+            ->where('h.contentstreamid = :contentStreamId');
     }
 
     public function buildFindRootNodeAggregatesQuery(ContentStreamId $contentStreamId, FindRootNodeAggregatesFilter $filter): QueryBuilder


### PR DESCRIPTION
The queries to determine the child or parent aggregates have been joined the hierarchy relation (hr) twice. Once for the parent and once for the children. But the hr does contain already both anchorpoints, so a second join is not needed.

Replay without this change:
```
Replaying events for projection "doctrineDbalContentGraph" of Content Repository "default" ...
 60440/60440 [============================] 100% 13 mins, 59 secs/13 mins, 59 secs 52.0 MiB
```

Replay with this change:
```
Replaying events for projection "doctrineDbalContentGraph" of Content Repository "default" ...
 60440/60440 [============================] 100%  4 mins, 13 secs/4 mins, 13 secs  52.0 MiB
```

Fixes: #5269 