### PR TITLE
BUGFIX: Improve performance on hierarchy relations

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -553,31 +553,33 @@ final class ContentSubgraph implements ContentSubgraphInterface
      */
     private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter|FindClosestNodeFilter $filter): array
     {
+        // 1) Fetch the hierarchy relation of the initial node aggregate, where this node is stored as child node.
+        //    The parent node anchor points to the first parent node of the given node aggregate. This is also used for
+        //    the recursive part, to determine its ancestors.
         $queryBuilderInitial = $this->createQueryBuilder()
-            ->select('n.*, ph.subtreetags, ph.parentnodeanchor')
+            ->select('ph.subtreetags, ph.parentnodeanchor')
             ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
-            // we need to join with the hierarchy relation, because we need the node name.
-            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ch.childnodeanchor')
-            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
-            ->where('ch.contentstreamid = :contentStreamId')
-            ->andWhere('ch.dimensionspacepointhash = :dimensionSpacePointHash')
+            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.parentnodeanchor')
+            ->innerJoin('ph', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ph.childnodeanchor')
             ->andWhere('ph.contentstreamid = :contentStreamId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('c.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
-        $this->addSubtreeTagConstraints($queryBuilderInitial, 'ch');
 
+        // 2) Fetch the parent hierarchy recursive, starting with the anchor point of the resulting parent as child anchor
+        //    point for the next iteration.
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('pn.*, h.subtreetags, h.parentnodeanchor')
+            ->select('h.subtreetags, h.parentnodeanchor')
             ->from('ancestry', 'cn')
-            ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = cn.parentnodeanchor')
-            ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = pn.relationanchorpoint')
+            ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = cn.parentnodeanchor')
             ->where('h.contentstreamid = :contentStreamId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint, 'ancestry', 'a');
+        // 3) Finally we join the node table to all collected parent node anchor
+        $queryBuilderCte->innerJoin('a', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = a.parentnodeanchor');
+
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
         }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -355,27 +355,34 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findClosestNode(NodeAggregateId $entryNodeAggregateId, FindClosestNodeFilter $filter): ?Node
     {
+        // 1) Fetch the hierarchy relation of the initial node aggregate, where this node is stored as child node.
+        //    The parent node anchor points to the first parent node of the given node aggregate. This is also used for
+        //    the recursive part, to determine its ancestors.
         $queryBuilderInitial = $this->createQueryBuilder()
-            ->select('n.*, ph.subtreetags, ph.parentnodeanchor')
-            ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
-            // we need to join with the hierarchy relation, because we need the node name.
-            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
+            ->select('ph.subtreetags, ph.childnodeanchor, ph.parentnodeanchor')
+            ->from($this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph')
+            ->innerJoin('ph', $this->nodeQueryBuilder->tableNames->node(), 'n', 'n.relationanchorpoint = ph.childnodeanchor')
             ->andWhere('ph.contentstreamid = :contentStreamId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('n.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
 
+        // 2) Fetch the parent hierarchy recursive, starting with the anchor point of the resulting parent as child
+        //    anchor point for the next iteration.
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('pn.*, h.subtreetags, h.parentnodeanchor')
+            ->select('h.subtreetags, h.childnodeanchor, h.parentnodeanchor')
             ->from('ancestry', 'cn')
-            ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = cn.parentnodeanchor')
-            ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = pn.relationanchorpoint')
+            ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = cn.parentnodeanchor')
             ->where('h.contentstreamid = :contentStreamId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint, 'ancestry', 'a');
+
+        // 3) Finally we join the node table to all collected child node anchor as we also need the starting node included for finding the "closest" node.
+        $queryBuilderCte->innerJoin('a', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = a.childnodeanchor');
         $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
+
         $nodeRows = $this->fetchCteResults(
             $queryBuilderInitial,
             $queryBuilderRecursive,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -564,7 +564,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         //    The parent node anchor points to the first parent node of the given node aggregate. This is also used for
         //    the recursive part, to determine its ancestors.
         $queryBuilderInitial = $this->createQueryBuilder()
-            ->select('ph.subtreetags, ph.parentnodeanchor')
+            ->select('ph.subtreetags, ph.parentnodeanchor, ph.childnodeanchor')
             ->from($this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph')
             ->innerJoin('ph', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ph.childnodeanchor')
             ->andWhere('ph.contentstreamid = :contentStreamId')
@@ -575,7 +575,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         // 2) Fetch the parent hierarchy recursive, starting with the anchor point of the resulting parent as child anchor
         //    point for the next iteration.
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('h.subtreetags, h.parentnodeanchor')
+            ->select('h.subtreetags, h.parentnodeanchor, h.childnodeanchor')
             ->from('ancestry', 'cn')
             ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = cn.parentnodeanchor')
             ->where('h.contentstreamid = :contentStreamId')
@@ -584,7 +584,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint, 'ancestry', 'a');
         // 3) Finally we join the node table to all collected parent node anchor
-        $queryBuilderCte->innerJoin('a', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = a.parentnodeanchor');
+        $queryBuilderCte->innerJoin('a', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = a.childnodeanchor AND pn.nodeaggregateid <> :entryNodeAggregateId');
 
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -558,8 +558,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         //    the recursive part, to determine its ancestors.
         $queryBuilderInitial = $this->createQueryBuilder()
             ->select('ph.subtreetags, ph.parentnodeanchor')
-            ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
-            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.parentnodeanchor')
+            ->from($this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph')
             ->innerJoin('ph', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ph.childnodeanchor')
             ->andWhere('ph.contentstreamid = :contentStreamId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')


### PR DESCRIPTION
Followup of https://github.com/neos/neos-development-collection/pull/5268


> It seems we found the culprit. The reason for this obsolete join is history. Originally the nodename was stored in the hierarchy relation table. And with #5018 as stated:
> 
> > Node names are now stored in the contentgraph's node table
> 
> The node name is now in the node table.
> 
> There are actually more hidden places that can seemingly be optimised we found at least 4 places where a `join` was annotated being made for the legacy reason:
> 
> ```
> // we need to join with the hierarchy relation, because we need the node name.
> ```