### PR TITLE
BUGFIX: Prevent augmenter from applying data of multiple nodes into the same element

### DIFF
--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -17,8 +17,6 @@ namespace Neos\Neos\Service;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
-use Neos\Flow\Session\SessionInterface;
 use Neos\Fusion\Service\HtmlAugmenter as FusionHtmlAugmenter;
 use Neos\Neos\FrontendRouting\NodeAddressFactory;
 
@@ -33,21 +31,9 @@ class ContentElementWrappingService
 {
     /**
      * @Flow\Inject
-     * @var PrivilegeManagerInterface
-     */
-    protected $privilegeManager;
-
-    /**
-     * @Flow\Inject
      * @var FusionHtmlAugmenter
      */
     protected $htmlAugmenter;
-
-    /**
-     * @Flow\Inject
-     * @var SessionInterface
-     */
-    protected $session;
 
     /**
      * @Flow\Inject
@@ -90,26 +76,5 @@ class ContentElementWrappingService
             'div',
             array_keys($attributes)
         );
-    }
-
-    /**
-     * Add required CSS classes to the attributes.
-     *
-     * @param array<string,mixed> $attributes
-     * @param array<string,mixed> $initialClasses
-     * @return array<string,mixed>
-     */
-    protected function addCssClasses(array $attributes, Node $node, array $initialClasses = []): array
-    {
-        $classNames = $initialClasses;
-        if (!$node->dimensionSpacePoint->equals($node->originDimensionSpacePoint)) {
-            $classNames[] = 'neos-contentelement-shine-through';
-        }
-
-        if ($classNames !== []) {
-            $attributes['class'] = implode(' ', $classNames);
-        }
-
-        return $attributes;
     }
 }

--- a/Neos.Neos/Classes/Service/ContentElementWrappingService.php
+++ b/Neos.Neos/Classes/Service/ContentElementWrappingService.php
@@ -81,7 +81,15 @@ class ContentElementWrappingService
         $attributes['data-__neos-fusion-path'] = $fusionPath;
         $attributes['data-__neos-node-contextpath'] = $nodeAddress->serializeForUri();
 
-        return $this->htmlAugmenter->addAttributes($content, $attributes, 'div');
+        // Define all attribute names as exclusive via the `exclusiveAttributes` parameter, to prevent the data of
+        // two different nodes to be concatenated into the attributes of a single html node.
+        // This way an outer div is added, if the wrapped content already has node related data-attributes set.
+        return $this->htmlAugmenter->addAttributes(
+            $content,
+            $attributes,
+            'div',
+            array_keys($attributes)
+        );
     }
 
     /**


### PR DESCRIPTION
9.0 port of https://github.com/neos/neos-ui/pull/3856

Original Commit MSG:

This fixes a regression introduced in https://github.com/neos/neos-ui/commit/b56135a01ecf59ae3a4990e3fd54ac766732e0e6 which
removed the script tag, causing the augmenter to add the data of multiple nodes into the same
html element in certain cases instead of adding an outer div.

With this change this behaviour is now more explicit instead of relying on the inner workings
of the augmenter.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
