### PR TITLE
FEATURE: Deprecate `WorkspaceFinder` and introduce new API

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -249,13 +249,13 @@ final class ContentRepository
         return $this->getWorkspaceFinder()->findOneByName($workspaceName);
     }
 
-    public function getWorkspaces(): Workspaces
+    public function findWorkspaces(): Workspaces
     {
         return $this->getWorkspaceFinder()->findAll();
     }
 
     /**
-     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
      */
     public function getWorkspaceFinder(): WorkspaceFinder
     {

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -36,7 +36,9 @@ use Neos\ContentRepository\Core\Projection\ProjectionsAndCatchUpHooks;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStatuses;
 use Neos\ContentRepository\Core\Projection\WithMarkStaleInterface;
+use Neos\ContentRepository\Core\Projection\Workspace\Workspace;
 use Neos\ContentRepository\Core\Projection\Workspace\WorkspaceFinder;
+use Neos\ContentRepository\Core\Projection\Workspace\Workspaces;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryStatus;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
@@ -234,11 +236,6 @@ final class ContentRepository
         $projection->reset();
     }
 
-    public function getNodeTypeManager(): NodeTypeManager
-    {
-        return $this->nodeTypeManager;
-    }
-
     /**
      * @throws WorkspaceDoesNotExist if the workspace does not exist
      */
@@ -247,6 +244,19 @@ final class ContentRepository
         return $this->projectionState(ContentGraphFinder::class)->getByWorkspaceName($workspaceName);
     }
 
+    public function findWorkspaceByName(WorkspaceName $workspaceName): ?Workspace
+    {
+        return $this->getWorkspaceFinder()->findOneByName($workspaceName);
+    }
+
+    public function getWorkspaces(): Workspaces
+    {
+        return $this->getWorkspaceFinder()->findAll();
+    }
+
+    /**
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
+     */
     public function getWorkspaceFinder(): WorkspaceFinder
     {
         return $this->projectionState(WorkspaceFinder::class);
@@ -255,6 +265,11 @@ final class ContentRepository
     public function getContentStreamFinder(): ContentStreamFinder
     {
         return $this->projectionState(ContentStreamFinder::class);
+    }
+
+    public function getNodeTypeManager(): NodeTypeManager
+    {
+        return $this->nodeTypeManager;
     }
 
     public function getVariationGraph(): InterDimensionalVariationGraph

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspace.php
@@ -129,4 +129,9 @@ final readonly class Workspace
     {
         return $this->baseWorkspaceName === null && $this->workspaceOwner === null;
     }
+
+    public function isRootWorkspace(): bool
+    {
+        return $this->baseWorkspaceName !== null;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
@@ -25,7 +25,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceTitle;
 /**
  * The legacy Workspace Finder
  *
- * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
+ * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
  * @api
  */
 final class WorkspaceFinder implements ProjectionStateInterface
@@ -68,7 +68,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
 
     /**
      * @deprecated with 9.0.0-beta14 discouraged. You should just operate on workspace names instead.
-     * To still archive the functionality please use {@see ContentRepository::getWorkspaces()} instead and filter the result:
+     * To still archive the functionality please use {@see ContentRepository::findWorkspaces()} instead and filter the result:
      *
      *     $this->contentRepository->getWorkspaces()->find(
      *         fn (Workspace $workspace) => $workspace->currentContentStreamId->equals($contentStreamId)
@@ -103,9 +103,9 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
-     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see Workspaces::getDependantWorkspaces()} instead.
      * @return array<string,Workspace>
      * @throws DBALException
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaces()} and {@see Workspaces::getDependantWorkspaces()} instead.
      */
     public function findByBaseWorkspace(WorkspaceName $baseWorkspace): array
     {
@@ -153,7 +153,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
-     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} instead
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaces()} instead
      */
     public function findAll(): Workspaces
     {
@@ -174,7 +174,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
-     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} instead and filter the result:
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaces()} instead and filter the result:
      *
      *     $this->contentRepository->getWorkspaces()->filter(
      *         fn (Workspace $workspace) => $workspace->status === WorkspaceStatus::OUTDATED

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
@@ -23,9 +23,10 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceTitle;
 
 /**
- * Workspace Finder
+ * The legacy Workspace Finder
  *
- * @api
+ * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
+ * @internal
  */
 final class WorkspaceFinder implements ProjectionStateInterface
 {
@@ -36,7 +37,9 @@ final class WorkspaceFinder implements ProjectionStateInterface
     ) {
     }
 
-
+    /**
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::findWorkspaceByName()} instead
+     */
     public function findOneByName(WorkspaceName $name): ?Workspace
     {
         $workspace = $this->workspaceRuntimeCache->getWorkspaceByName($name);
@@ -63,6 +66,15 @@ final class WorkspaceFinder implements ProjectionStateInterface
         return $workspace;
     }
 
+    /**
+     * @deprecated with 9.0.0-beta14 discouraged. You should just operate on workspace names instead.
+     * To still archive the functionality please use {@see ContentRepository::getWorkspaces()} instead and filter the result:
+     *
+     *     $this->contentRepository->getWorkspaces()->find(
+     *         fn (Workspace $workspace) => $workspace->currentContentStreamId->equals($contentStreamId)
+     *     )
+     *
+     */
     public function findOneByCurrentContentStreamId(
         ContentStreamId $contentStreamId
     ): ?Workspace {
@@ -91,6 +103,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see Workspaces::getBaseWorkspaces()} instead.
      * @return array<string,Workspace>
      * @throws DBALException
      */
@@ -116,6 +129,9 @@ final class WorkspaceFinder implements ProjectionStateInterface
         return $result;
     }
 
+    /**
+     * @deprecated with 9.0.0-beta14 owners/collaborators should be assigned to workspaces outside the Content Repository core
+     */
     public function findOneByWorkspaceOwner(string $owner): ?Workspace
     {
         $workspaceRow = $this->dbal->executeQuery(
@@ -135,6 +151,9 @@ final class WorkspaceFinder implements ProjectionStateInterface
         return $this->createWorkspaceFromDatabaseRow($workspaceRow);
     }
 
+    /**
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} instead
+     */
     public function findAll(): Workspaces
     {
         $result = [];
@@ -154,6 +173,12 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} instead and filter the result:
+     *
+     *     $this->contentRepository->getWorkspaces()->filter(
+     *         fn (Workspace $workspace) => $workspace->status === WorkspaceStatus::OUTDATED
+     *     )
+     *
      * @return array<string,Workspace>
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws DBALException

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php
@@ -26,7 +26,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceTitle;
  * The legacy Workspace Finder
  *
  * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see ContentRepository::findWorkspaceByName()} instead.
- * @internal
+ * @api
  */
 final class WorkspaceFinder implements ProjectionStateInterface
 {
@@ -103,7 +103,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
     }
 
     /**
-     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see Workspaces::getBaseWorkspaces()} instead.
+     * @deprecated with 9.0.0-beta14 please use {@see ContentRepository::getWorkspaces()} and {@see Workspaces::getDependantWorkspaces()} instead.
      * @return array<string,Workspace>
      * @throws DBALException
      */
@@ -131,6 +131,7 @@ final class WorkspaceFinder implements ProjectionStateInterface
 
     /**
      * @deprecated with 9.0.0-beta14 owners/collaborators should be assigned to workspaces outside the Content Repository core
+     * For Neos.Neos please use {@see \Neos\Neos\Domain\Service\WorkspaceService::getPersonalWorkspaceForUser()}
      */
     public function findOneByWorkspaceOwner(string $owner): ?Workspace
     {

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspaces.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspaces.php
@@ -93,6 +93,16 @@ final class Workspaces implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Get all dependent workspaces (if they are included in this result set).
+     */
+    public function getDependantWorkspaces(WorkspaceName $workspaceName): Workspaces
+    {
+        return $this->filter(
+            static fn (Workspace $potentiallyDependentWorkspace) => $potentiallyDependentWorkspace->baseWorkspaceName?->equals($workspaceName) ?? false
+        );
+    }
+
+    /**
      * @return \Traversable<int,Workspace>
      */
     public function getIterator(): \Traversable
@@ -119,6 +129,16 @@ final class Workspaces implements \IteratorAggregate, \Countable
             }
         }
         return null;
+    }
+
+    /**
+     * @template T
+     * @param \Closure(Workspace): T $callback
+     * @return list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, array_values($this->workspaces));
     }
 
     public function count(): int

--- a/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspaces.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Workspace/Workspaces.php
@@ -100,8 +100,34 @@ final class Workspaces implements \IteratorAggregate, \Countable
         yield from array_values($this->workspaces);
     }
 
+    /**
+     * @param \Closure(Workspace): bool $callback
+     */
+    public function filter(\Closure $callback): self
+    {
+        return new self(array_filter($this->workspaces, $callback));
+    }
+
+    /**
+     * @param \Closure(Workspace): bool $callback
+     */
+    public function find(\Closure $callback): ?Workspace
+    {
+        foreach ($this->workspaces as $workspace) {
+            if ($callback($workspace)) {
+                return $workspace;
+            }
+        }
+        return null;
+    }
+
     public function count(): int
     {
         return count($this->workspaces);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->workspaces === [];
     }
 }


### PR DESCRIPTION
introduces

- `ContentRepository::findWorkspaces()`
- `ContentRepository::findWorkspaceByName()`

as well as `find` and `filter` methods on the Workspaces collection to replace all functionality of the `WorkspaceFinder`

This is done as preparation for https://github.com/neos/neos-development-collection/pull/5096 which will remove the Workspace projection and thus the finder.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
