### PR TITLE
BUGFIX: Force direct access on setting node properties in node data similarize

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\ContentRepository\Domain\Model;
 
 /*
@@ -475,9 +476,9 @@ class NodeData extends AbstractNodeData
      * @param string $identifier The identifier of the node, unique within the workspace, optional(!)
      * @param Workspace $workspace
      * @param array $dimensions An array of dimension name to dimension values
-     * @throws NodeExistsException if a node with this path already exists.
-     * @throws \InvalidArgumentException if the node name is not accepted.
      * @return NodeData
+     * @throws \InvalidArgumentException if the node name is not accepted.
+     * @throws NodeExistsException if a node with this path already exists.
      */
     public function createSingleNodeData($name, NodeType $nodeType = null, $identifier = null, Workspace $workspace = null, array $dimensions = null)
     {
@@ -773,8 +774,16 @@ class NodeData extends AbstractNodeData
             $propertyNames[] = 'index';
             $propertyNames[] = 'removed';
         }
+
+        // We need to force direct access for the following properties, as they don't have a setter in AbstractNodeData
+        $propertyNamesToForceDirectAccess = ['creationDateTime', 'lastModificationDateTime'];
         foreach ($propertyNames as $propertyName) {
-            ObjectAccess::setProperty($this, $propertyName, ObjectAccess::getProperty($sourceNode, $propertyName), true);
+            ObjectAccess::setProperty(
+                $this,
+                $propertyName,
+                ObjectAccess::getProperty($sourceNode, $propertyName),
+                in_array($propertyName, $propertyNamesToForceDirectAccess)
+            );
         }
 
         $contentObject = $sourceNode->getContentObject();

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -768,7 +768,6 @@ class NodeData extends AbstractNodeData
         ];
         if (!$isCopy) {
             $propertyNames[] = 'creationDateTime';
-            $propertyNames[] = 'lastModificationDateTime';
         }
         if ($sourceNode instanceof NodeData) {
             $propertyNames[] = 'index';
@@ -776,7 +775,7 @@ class NodeData extends AbstractNodeData
         }
 
         // We need to force direct access for the following properties, as they don't have a setter in AbstractNodeData
-        $propertyNamesToForceDirectAccess = ['creationDateTime', 'lastModificationDateTime'];
+        $propertyNamesToForceDirectAccess = ['creationDateTime'];
         foreach ($propertyNames as $propertyName) {
             ObjectAccess::setProperty(
                 $this,

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -774,7 +774,7 @@ class NodeData extends AbstractNodeData
             $propertyNames[] = 'removed';
         }
         foreach ($propertyNames as $propertyName) {
-            ObjectAccess::setProperty($this, $propertyName, ObjectAccess::getProperty($sourceNode, $propertyName));
+            ObjectAccess::setProperty($this, $propertyName, ObjectAccess::getProperty($sourceNode, $propertyName), true);
         }
 
         $contentObject = $sourceNode->getContentObject();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -670,6 +670,27 @@ class NodeDataTest extends UnitTestCase
     /**
      * @test
      */
+    public function similarizeCopiesCreationAndLastModificationDateTimes()
+    {
+        $creationDateTime = \DateTime::createFromFormat('Y-m-d', '2000-01-01 12:00:00');
+        $lastModificationDateTime = \DateTime::createFromFormat('Y-m-d', '2002-02-02 12:00:00');
+
+        /** @var $sourceNode NodeData */
+        $sourceNode = $this->getAccessibleMock(NodeData::class, ['addOrUpdate'], ['/foo/bar', $this->mockWorkspace]);
+        $this->inject($sourceNode, 'nodeTypeManager', $this->mockNodeTypeManager);
+        $sourceNode->_set('nodeDataRepository', $this->createMock(RepositoryInterface::class));
+        $sourceNode->_set('creationDateTime', $creationDateTime);
+        $sourceNode->_set('lastModificationDateTime', $lastModificationDateTime);
+
+        $this->nodeData->similarize($sourceNode);
+
+        self::assertSame($creationDateTime, $this->nodeData->getCreationDateTime());
+        self::assertSame($lastModificationDateTime, $this->nodeData->getLastModificationDateTime());
+    }
+
+    /**
+     * @test
+     */
     public function matchesWorkspaceAndDimensionsWithDifferentWorkspaceReturnsFalse()
     {
         $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -673,19 +673,16 @@ class NodeDataTest extends UnitTestCase
     public function similarizeCopiesCreationAndLastModificationDateTimes()
     {
         $creationDateTime = \DateTime::createFromFormat('Y-m-d', '2000-01-01 12:00:00');
-        $lastModificationDateTime = \DateTime::createFromFormat('Y-m-d', '2002-02-02 12:00:00');
 
         /** @var $sourceNode NodeData */
         $sourceNode = $this->getAccessibleMock(NodeData::class, ['addOrUpdate'], ['/foo/bar', $this->mockWorkspace]);
         $this->inject($sourceNode, 'nodeTypeManager', $this->mockNodeTypeManager);
         $sourceNode->_set('nodeDataRepository', $this->createMock(RepositoryInterface::class));
         $sourceNode->_set('creationDateTime', $creationDateTime);
-        $sourceNode->_set('lastModificationDateTime', $lastModificationDateTime);
 
         $this->nodeData->similarize($sourceNode);
 
         self::assertSame($creationDateTime, $this->nodeData->getCreationDateTime());
-        self::assertSame($lastModificationDateTime, $this->nodeData->getLastModificationDateTime());
     }
 
     /**


### PR DESCRIPTION
The `creationDateTime` has no setters in AbstractNodeData, so the NodeData::similarize can't set them in the target node propery. We need to allow the `ObjectAccess::setProperty` to force direct access to the class properties.

The `lastModificationDateTime` was also not copied before this bugfix and shouldn't be copied anyways.

Fixes: #5280 