### PR TITLE
BUGFIX: Improve error of nearest content collection

### DIFF
--- a/Neos.Neos/Classes/Domain/NodeLabel/DelegatingNodeLabelRenderer.php
+++ b/Neos.Neos/Classes/Domain/NodeLabel/DelegatingNodeLabelRenderer.php
@@ -59,10 +59,10 @@ final readonly class DelegatingNodeLabelRenderer implements NodeLabelGeneratorIn
                 public function getLabel(Node $node): string
                 {
                     return sprintf(
-                        '%s %s',
+                        '%s%s',
                         $node->nodeTypeName->value,
                         $node->name
-                            ? sprintf('(%s)', $node->name->value)
+                            ? sprintf(' (%s)', $node->name->value)
                             : ''
                     );
                 }

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -53,13 +53,13 @@ class NodeHelper implements ProtectedContextAwareInterface
      *
      * @throws Exception
      */
-    public function nearestContentCollection(Node $node, string $nodePath): Node
+    public function nearestContentCollection(Node $node, ?string $nodePath): Node
     {
         $contentCollectionType = NodeTypeNameFactory::NAME_CONTENT_COLLECTION;
         if ($this->isOfType($node, $contentCollectionType)) {
             return $node;
         } else {
-            if ($nodePath === '') {
+            if ($nodePath === null || $nodePath === '') {
                 throw new Exception(sprintf(
                     'No content collection of type %s could be found in the current node and no node path was provided.'
                     . ' You might want to configure the nodePath property'

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -158,11 +158,17 @@ class NodeHelper implements ProtectedContextAwareInterface
             return $node;
         } else {
             if ($nodePath === null || $nodePath === '') {
+                $nodePathOfNode = VisualNodePath::buildFromAncestors(
+                    $node,
+                    $this->contentRepositoryRegistry->get($node->contentRepositoryId),
+                    $this->nodeLabelGenerator
+                );
                 throw new Exception(sprintf(
-                    'No content collection of type %s could be found in the current node and no node path was provided.'
+                    'No content collection of type %s could be found in the current node (%s) and no node path was provided.'
                     . ' You might want to configure the nodePath property'
                     . ' with a relative path to the content collection.',
-                    $contentCollectionType
+                    $contentCollectionType,
+                    $nodePathOfNode->value
                 ), 1409300545);
             }
             $nodePath = NodePath::fromString($nodePath);
@@ -173,13 +179,10 @@ class NodeHelper implements ProtectedContextAwareInterface
             if ($subNode !== null && $this->isOfType($subNode, $contentCollectionType)) {
                 return $subNode;
             } else {
-                $nodePathOfNode = VisualNodePath::fromAncestors(
+                $nodePathOfNode = VisualNodePath::buildFromAncestors(
                     $node,
-                    $this->contentRepositoryRegistry->subgraphForNode($node)
-                        ->findAncestorNodes(
-                            $node->aggregateId,
-                            FindAncestorNodesFilter::create()
-                        )
+                    $this->contentRepositoryRegistry->get($node->contentRepositoryId),
+                    $this->nodeLabelGenerator
                 );
                 throw new Exception(sprintf(
                     'No content collection of type %s could be found in the current node (%s) or at the path "%s".'

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -48,55 +48,6 @@ class NodeHelper implements ProtectedContextAwareInterface
     protected NodeLabelGeneratorInterface $nodeLabelGenerator;
 
     /**
-     * Check if the given node is already a collection, find collection by nodePath otherwise, throw exception
-     * if no content collection could be found
-     *
-     * @throws Exception
-     */
-    public function nearestContentCollection(Node $node, ?string $nodePath): Node
-    {
-        $contentCollectionType = NodeTypeNameFactory::NAME_CONTENT_COLLECTION;
-        if ($this->isOfType($node, $contentCollectionType)) {
-            return $node;
-        } else {
-            if ($nodePath === null || $nodePath === '') {
-                throw new Exception(sprintf(
-                    'No content collection of type %s could be found in the current node and no node path was provided.'
-                    . ' You might want to configure the nodePath property'
-                    . ' with a relative path to the content collection.',
-                    $contentCollectionType
-                ), 1409300545);
-            }
-            $nodePath = NodePath::fromString($nodePath);
-            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
-
-            $subNode = $subgraph->findNodeByPath($nodePath, $node->aggregateId);
-
-            if ($subNode !== null && $this->isOfType($subNode, $contentCollectionType)) {
-                return $subNode;
-            } else {
-                $nodePathOfNode = VisualNodePath::fromAncestors(
-                    $node,
-                    $this->contentRepositoryRegistry->subgraphForNode($node)
-                        ->findAncestorNodes(
-                            $node->aggregateId,
-                            FindAncestorNodesFilter::create()
-                        )
-                );
-                throw new Exception(sprintf(
-                    'No content collection of type %s could be found in the current node (%s) or at the path "%s".'
-                    . ' You might want to adjust your node type configuration and create the missing child node'
-                    . ' through the "flow structureadjustments:fix --node-type %s" command.',
-                    $contentCollectionType,
-                    $nodePathOfNode->value,
-                    $nodePath->serializeToString(),
-                    $node->nodeTypeName->value
-                ), 1389352984);
-            }
-        }
-    }
-
-    /**
      * Renders the actual node label based on the NodeType definition in Fusion.
      */
     public function label(Node $node): string
@@ -191,6 +142,56 @@ class NodeHelper implements ProtectedContextAwareInterface
     public function subgraphForNode(Node $node): ContentSubgraphInterface
     {
         return $this->contentRepositoryRegistry->subgraphForNode($node);
+    }
+
+    /**
+     * Check if the given node is already a collection, find collection by nodePath otherwise, throw exception
+     * if no content collection could be found
+     *
+     * @throws Exception
+     * @internal implementation detail of Neos.Neos:ContentCollection
+     */
+    public function nearestContentCollection(Node $node, ?string $nodePath): Node
+    {
+        $contentCollectionType = NodeTypeNameFactory::NAME_CONTENT_COLLECTION;
+        if ($this->isOfType($node, $contentCollectionType)) {
+            return $node;
+        } else {
+            if ($nodePath === null || $nodePath === '') {
+                throw new Exception(sprintf(
+                    'No content collection of type %s could be found in the current node and no node path was provided.'
+                    . ' You might want to configure the nodePath property'
+                    . ' with a relative path to the content collection.',
+                    $contentCollectionType
+                ), 1409300545);
+            }
+            $nodePath = NodePath::fromString($nodePath);
+            $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
+
+            $subNode = $subgraph->findNodeByPath($nodePath, $node->aggregateId);
+
+            if ($subNode !== null && $this->isOfType($subNode, $contentCollectionType)) {
+                return $subNode;
+            } else {
+                $nodePathOfNode = VisualNodePath::fromAncestors(
+                    $node,
+                    $this->contentRepositoryRegistry->subgraphForNode($node)
+                        ->findAncestorNodes(
+                            $node->aggregateId,
+                            FindAncestorNodesFilter::create()
+                        )
+                );
+                throw new Exception(sprintf(
+                    'No content collection of type %s could be found in the current node (%s) or at the path "%s".'
+                    . ' You might want to adjust your node type configuration and create the missing child node'
+                    . ' through the "flow structureadjustments:fix --node-type %s" command.',
+                    $contentCollectionType,
+                    $nodePathOfNode->value,
+                    $nodePath->serializeToString(),
+                    $node->nodeTypeName->value
+                ), 1389352984);
+            }
+        }
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
@@ -75,7 +75,7 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
     """
     Then I expect the following Fusion rendering error:
     """
-    No content collection of type Neos.Neos:ContentCollection could be found in the current node (/[root]) or at the path "to-be-set-by-user". You might want to adjust your node type configuration and create the missing child node through the "flow structureadjustments:fix --node-type Neos.Neos:Site" command.
+    No content collection of type Neos.Neos:ContentCollection could be found in the current node (/Neos.Neos:Sites/Neos.Neos:Site) or at the path "to-be-set-by-user". You might want to adjust your node type configuration and create the missing child node through the "flow structureadjustments:fix --node-type Neos.Neos:Site" command.
     """
 
   Scenario: invalid nodePath
@@ -90,7 +90,7 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
     """
     Then I expect the following Fusion rendering error:
     """
-    No content collection of type Neos.Neos:ContentCollection could be found in the current node (/[root]) or at the path "invalid". You might want to adjust your node type configuration and create the missing child node through the "flow structureadjustments:fix --node-type Neos.Neos:Site" command.
+    No content collection of type Neos.Neos:ContentCollection could be found in the current node (/Neos.Neos:Sites/Neos.Neos:Site) or at the path "invalid". You might want to adjust your node type configuration and create the missing child node through the "flow structureadjustments:fix --node-type Neos.Neos:Site" command.
     """
 
   Scenario: empty ContentCollection


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Currently in 9.0-dev
> Fatal error: Uncaught TypeError: Neos\Neos\Fusion\Helper\NodeHelper_Original::nearestContentCollection(): Argument https://github.com/neos/neos-development-collection/pull/2 ($nodePath) must be of type string, null given

will be thrown, while in 8.3 the error was more readable

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
