### PR TITLE
BUGFIX: Fix admin workspace permissions for workspaces without metadata

### DIFF
--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -25,6 +25,7 @@ use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Neos\AssetUsage\AssetUsageService;
 use Neos\Neos\Domain\Model\WorkspaceRole;
 use Neos\Neos\Domain\Model\WorkspaceRoleAssignment;
+use Neos\Neos\Domain\Model\WorkspaceTitle;
 use Neos\Neos\Domain\Service\WorkspaceService;
 use Neos\Utility\Files;
 
@@ -120,6 +121,8 @@ class CrCommandController extends CommandController
         $projectionService->replayAllProjections(CatchUpOptions::create());
 
         $this->outputLine('Assigning live workspace role');
+        // set the live-workspace title to (implicitly) create the metadata record for this workspace
+        $this->workspaceService->setWorkspaceTitle($contentRepositoryId, WorkspaceName::forLive(), WorkspaceTitle::fromString('Live workspace'));
         $this->workspaceService->assignWorkspaceRole($contentRepositoryId, WorkspaceName::forLive(), WorkspaceRoleAssignment::createForGroup('Neos.Neos:LivePublisher', WorkspaceRole::COLLABORATOR));
 
         $this->outputLine('<success>Done</success>');

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -279,7 +279,7 @@ final class WorkspaceService
             throw new \RuntimeException(sprintf('Failed to determine roles for user "%s", check your package dependencies: %s', $user->getId()->value, $e->getMessage()), 1727084881, $e);
         }
         $workspaceMetadata = $this->loadWorkspaceMetadata($contentRepositoryId, $workspaceName);
-        if ($workspaceMetadata?->ownerUserId !== null && $workspaceMetadata?->ownerUserId->equals($user->getId())) {
+        if ($workspaceMetadata !== null && $workspaceMetadata->ownerUserId !== null && $workspaceMetadata->ownerUserId->equals($user->getId())) {
             return WorkspacePermissions::all();
         }
         $userWorkspaceRole = $this->loadWorkspaceRoleOfUser($contentRepositoryId, $workspaceName, $user->getId(), $userRoles);

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -278,16 +278,12 @@ final class WorkspaceService
         } catch (NoSuchRoleException $e) {
             throw new \RuntimeException(sprintf('Failed to determine roles for user "%s", check your package dependencies: %s', $user->getId()->value, $e->getMessage()), 1727084881, $e);
         }
-        $userIsAdministrator = in_array('Neos.Neos:Administrator', $userRoles, true);
         $workspaceMetadata = $this->loadWorkspaceMetadata($contentRepositoryId, $workspaceName);
-        if ($workspaceMetadata === null) {
-            return WorkspacePermissions::create(false, false, $userIsAdministrator);
-        }
-        if ($workspaceMetadata->ownerUserId !== null && $workspaceMetadata->ownerUserId->equals($user->getId())) {
+        if ($workspaceMetadata?->ownerUserId !== null && $workspaceMetadata?->ownerUserId->equals($user->getId())) {
             return WorkspacePermissions::all();
         }
-
         $userWorkspaceRole = $this->loadWorkspaceRoleOfUser($contentRepositoryId, $workspaceName, $user->getId(), $userRoles);
+        $userIsAdministrator = in_array('Neos.Neos:Administrator', $userRoles, true);
         if ($userWorkspaceRole === null) {
             return WorkspacePermissions::create(false, false, $userIsAdministrator);
         }

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/WorkspaceService.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/WorkspaceService.feature
@@ -209,3 +209,10 @@ Feature: Neos WorkspaceService related features
     When the role COLLABORATOR is assigned to workspace "some-root-workspace" for group "Neos.Neos:Editor"
     When the role MANAGER is assigned to workspace "some-root-workspace" for user "editor"
     And the Neos user "editor" should have the permissions "read,write,manage" for workspace "some-root-workspace"
+
+  Scenario: Permissions for workspace without metadata
+    Given a root workspace "some-root-workspace" exists without metadata
+    When the role COLLABORATOR is assigned to workspace "some-root-workspace" for user "janedoe"
+    Then the Neos user "jane.doe" should have the permissions "read,write,manage" for workspace "some-root-workspace"
+    And the Neos user "john.doe" should have no permissions for workspace "some-root-workspace"
+    And the Neos user "editor" should have no permissions for workspace "some-root-workspace"


### PR DESCRIPTION
This change makes sure that metadata exists for the `live` workspace after running the `cr:import` command. Furthermore it fixes the permission determiniation for administrators in case no metadata is specified for a workspace but the role assignment exists

Related: #4726
Followup to https://github.com/neos/neos-development-collection/pull/5283