### PR TITLE
BUGFIX: Partial publish breaks uri and change Projection

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepositoryReadModel.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepositoryReadModel.php
@@ -68,6 +68,10 @@ final class ContentRepositoryReadModel implements ProjectionStateInterface
      */
     public function getContentGraphByWorkspaceName(WorkspaceName $workspaceName): ContentGraphInterface
     {
+        if ($workspaceName->isVirtual() && $workspaceName->virtualContentStreamId()) {
+            return $this->adapter->buildContentGraph($workspaceName, $workspaceName->virtualContentStreamId());
+        }
+
         $workspace = $this->findWorkspaceByName($workspaceName);
         if ($workspace === null) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -28,7 +28,12 @@ final class WorkspaceName implements \JsonSerializable
 
     private const PATTERN = '/^[a-z0-9][a-z0-9\-]{0,' . (self::MAX_LENGTH - 1) . '}$/';
 
+    private const VIRTUAL_PREFIX = 'vrt-';
+
     public const WORKSPACE_NAME_LIVE = 'live';
+
+    /** This is only used for virtual workspaces */
+    protected ContentStreamId $contentStreamId;
 
     /**
      * @var array<string,self>
@@ -94,6 +99,29 @@ final class WorkspaceName implements \JsonSerializable
         }
 
         return self::fromString($name);
+    }
+
+    /**
+     * @internal
+     */
+    public static function virtualFromContentStreamId(ContentStreamId $contentStreamId): self
+    {
+        $instance = self::instance(self::VIRTUAL_PREFIX . md5($contentStreamId->value));
+        $instance->contentStreamId = $contentStreamId;
+        return $instance;
+    }
+
+    public function isVirtual(): bool
+    {
+        return str_starts_with($this->value, self::VIRTUAL_PREFIX);
+    }
+
+    /**
+     * @internal
+     */
+    public function virtualContentStreamId(): ?ContentStreamId
+    {
+        return $this->contentStreamId ?? null;
     }
 
     public function isLive(): bool

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -49,6 +49,9 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
     {
         if ($eventInstance instanceof EmbedsWorkspaceName && $eventInstance instanceof EmbedsContentStreamId) {
             // Safeguard for temporary content streams created during partial publish -> We want to skip these events, because their workspace doesn't match current content stream.
+            if ($eventInstance->getWorkspaceName()->isVirtual()) {
+                return;
+            }
             try {
                 $contentGraph = $this->contentRepository->getContentGraph($eventInstance->getWorkspaceName());
             } catch (WorkspaceDoesNotExist) {
@@ -70,6 +73,9 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
     {
         if ($eventInstance instanceof EmbedsWorkspaceName && $eventInstance instanceof EmbedsContentStreamId) {
             // Safeguard for temporary content streams created during partial publish -> We want to skip these events, because their workspace doesn't match current content stream.
+            if ($eventInstance->getWorkspaceName()->isVirtual()) {
+                return;
+            }
             try {
                 $contentGraph = $this->contentRepository->getContentGraph($eventInstance->getWorkspaceName());
             } catch (WorkspaceDoesNotExist) {

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
@@ -1,0 +1,68 @@
+@flowEntities @contentrepository
+Feature: Test cases for partial publish to live and uri path generation
+
+  Scenario: Create Document in another workspace and partially publish to live
+    Given using the following content dimensions:
+      | Identifier | Values               | Generalizations |
+      | example    | source,peer,peerSpec | peerSpec->peer  |
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {"example":"source"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                    |
+      | nodeAggregateId           | "shernode-homes"         |
+      | nodeTypeName              | "Neos.Neos:Site"         |
+      | parentNodeAggregateId     | "lady-eleonode-rootford" |
+      | originDimensionSpacePoint | {"example":"source"}     |
+    And the command CreateWorkspace is executed with payload:
+      | Key                       | Value                    |
+      | workspaceName             | "myworkspace"            |
+      | baseWorkspaceName         | "live"                   |
+      | workspaceTitle            | "My Personal Workspace"  |
+      | workspaceDescription      | ""                       |
+      | newContentStreamId        | "cs-myworkspace"         |
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                     |
+      | nodeAggregateId           | "justsomepage"            |
+      | nodeTypeName              | "Neos.Neos:Document"      |
+      | parentNodeAggregateId     | "shernode-homes"          |
+      | originDimensionSpacePoint | {"example":"source"}      |
+      | properties                | {"uriPathSegment": "just"}|
+      | workspaceName             | "myworkspace"             |
+    And the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                       | Value                      |
+      | workspaceName             | "myworkspace"              |
+      | nodesToPublish            | [{"nodeAggregateId": "justsomepage", "dimensionSpacePoint": {"example":"source"}}]       |
+
+    Then I expect the documenturipath table to contain exactly:
+      # source: 65901ded4f068dac14ad0dce4f459b29
+      # spec: 9a723c057afa02982dae9d0b541739be
+      # leafSpec: c60c44685475d0e2e4f2b964e6158ce2
+      | dimensionspacepointhash            | uripath    | nodeaggregateidpath                                          | nodeaggregateid          | parentnodeaggregateid    | precedingnodeaggregateid | succeedingnodeaggregateid | nodetypename         |
+      | "2ca4fae2f65267c94c85602df0cbb728" | ""         | "lady-eleonode-rootford"                                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"    |
+      | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford"                                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"    |
+      | "fbe53ddc3305685fbb4dbf529f283a0e" | ""         | "lady-eleonode-rootford"                                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"    |
+      | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford/shernode-homes"                      | "shernode-homes"         | "lady-eleonode-rootford" | null                     | null                      | "Neos.Neos:Site"     |
+      | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford/shernode-homes/justsomepage"         | "justsomepage"           | "shernode-homes"         | null                     | null                      | "Neos.Neos:Document"     |


### PR DESCRIPTION
A partial publish results in events annotated for "live" workspace yet are not in the "live" content stream.

This is due to a fork of the live content stream being created with the partially published events in, which is then published to the actual live content stream.
This leaves behind duplicate events both containing "workspaceName: live" yet only one of them is in the live content stream. A catchup or replay will fail however due to duplicate database entries for the projections relying on anything with "workspaceName: live" being actually in the live content stream.

The provided test fails showing the behavior.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
