### PR TITLE
BUGFIX: 4909 fusion plugins and tests

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -973,7 +973,7 @@ class Runtime
     private function withSimulatedLegacyControllerContext(\Closure $renderer): ResponseInterface|StreamInterface
     {
         if ($this->legacyActionResponseForCurrentRendering !== null) {
-            throw new Exception('Recursion detected in `Runtime::renderResponse`. This entry point is only allowed to be invoked once per rendering.', 1706993940);
+            throw new Exception('Recursion detected in `Runtime::renderEntryPathWithContext`. This entry point is only allowed to be invoked once per rendering.', 1706993940);
         }
         $this->legacyActionResponseForCurrentRendering = new ActionResponse();
 
@@ -1023,7 +1023,7 @@ class Runtime
         // legacy controller context layer
         $actionRequest = $this->fusionGlobals->get('request');
         if ($this->legacyActionResponseForCurrentRendering === null || !$actionRequest instanceof ActionRequest) {
-            throw new Exception(sprintf('Fusions simulated legacy controller context is only available inside `Runtime::renderResponse` and when the Fusion global "request" is an ActionRequest.'), 1706458355);
+            throw new Exception(sprintf('Fusions simulated legacy controller context is only available inside `Runtime::renderEntryPathWithContext` and when the Fusion global "request" is an ActionRequest.'), 1706458355);
         }
 
         return new LegacyFusionControllerContext(

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -265,6 +265,15 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
         $currentRequestSiteDetectionResult = SiteDetectionResult::fromRouteParameters($parameters);
 
         $nodeAddress = $routeValues[$this->name];
+
+        if (is_string($nodeAddress)) {
+            try {
+                $nodeAddress = NodeAddress::fromJsonString($nodeAddress);
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+        }
+
         if (!$nodeAddress instanceof NodeAddress) {
             return false;
         }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/BehatRuntimeActionController.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/BehatRuntimeActionController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Neos\Flow\Mvc\Controller\ActionController;
+
+/**
+ * Hack to be able to instantiate a at runtime declared controller.
+ *
+ * This is normally not possible because there is no property injection for injections of the ActionController and parents
+ * and also the class would be unknown to the object manager.
+ *
+ * Maybe we might get rid of this class once we also allow anonymous classes extending proxied objects as this is really similar.
+ */
+class BehatRuntimeActionController extends ActionController
+{
+    public static function registerInstance(): void
+    {
+        $controllerInstance = new static();
+
+        /** 1.) take care of injecting all necessary properties of the base "ActionController"
+         ** note any @Flow\Inject in the fixture will not work.
+         *
+         ** - validatorResolver
+         ** - mvcPropertyMappingConfigurationService
+         ** - viewConfigurationManager
+         ** - objectManager
+         **
+         ** run flow property injection code of parent class ActionController not ActionController_Original manually
+         ** as the extended classes is not proxied and doesnt call $this->Flow_Proxy_injectProperties();
+         */
+        $ref = new \ReflectionClass(get_parent_class($controllerInstance));
+        $method = $ref->getMethod('Flow_Proxy_injectProperties');
+        $method->invoke($controllerInstance);
+
+        /** 2.) hack to avoid: No controller could be resolved which would match your request
+         ** which will be caused by {@see \Neos\Flow\Mvc\ActionRequest::getControllerObjectName()}
+         ** calling the object managers {@see \Neos\Flow\ObjectManagement\ObjectManager::getCaseSensitiveObjectName()}
+         ** that's why we register the controller singleton (i) and set its lower case name (l)
+         */
+        $objects = \Neos\Utility\ObjectAccess::getProperty($controllerInstance->objectManager, 'objects', true);
+        $objects[$controllerInstance::class]['i'] = $controllerInstance;
+        $objects[$controllerInstance::class]['l'] = strtolower($controllerInstance::class);
+        $controllerInstance->objectManager->setObjects($objects);
+    }
+
+    public static function getPublicActionMethods($objectManager)
+    {
+        /** 3.) hack, as this class is not proxied reflection doesnt work and doesnt return the desired public action methods
+         ** instead the ActionController's compiled method will be called which returns an empty array */
+        return array_fill_keys(get_class_methods(static::class), true);
+    }
+}

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
@@ -74,18 +74,18 @@ trait FrontendNodeControllerTrait
      */
     public function iDeclareTheFollowingController(string $fullyQualifiedClassName, PyStringNode $expectedResult): void
     {
-        eval(
-            /** make the controller implement our hacked {@see BehatRuntimeActionController} instead and remove the php tag */
-            str_replace(
-                ['extends ActionController', '<?php'],
-                ['extends \\BehatRuntimeActionController', ''],
-                $expectedResult->getRaw()
-            )
-        );
+        $controllerCode = $expectedResult->getRaw();
+        if (str_starts_with($controllerCode, '<?php')) {
+            $controllerCode = substr($controllerCode, strlen('<?php'));
+        }
+        eval($controllerCode);
 
         /** @var class-string<BehatRuntimeActionController> $controllerClassName */
         $controllerClassName = '\\' . ltrim($fullyQualifiedClassName, '\\');
 
+        if (!in_array(BehatRuntimeActionController::class, class_parents($controllerClassName), true)) {
+            throw new \RuntimeException(sprintf('The controller %s must implement %s for testing', $controllerClassName, BehatRuntimeActionController::class), 1740068618);
+        }
         $controllerClassName::registerInstance();
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
@@ -57,6 +57,31 @@ trait FrontendNodeControllerTrait
     }
 
     /**
+     * @When I declare the following controller :fullyQualifiedClassName:
+     */
+    public function iDeclareTheFollowingController(string $fullyQualifiedClassName, PyStringNode $expectedResult): void
+    {
+        eval($expectedResult->getRaw());
+
+        $controllerInstance = new ('\\' . $fullyQualifiedClassName)();
+
+        if ($controllerInstance instanceof \Neos\Flow\Mvc\Controller\ActionController) {
+            // inject all the necessary properties of an action controller, as extended classes dont call $this->Flow_Proxy_injectProperties();
+            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'validatorResolver', $this->getObject(\Neos\Flow\Validation\ValidatorResolver::class), true);
+            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'mvcPropertyMappingConfigurationService', $this->getObject(\Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService::class), true);
+            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'viewConfigurationManager', $this->getObject(\Neos\Flow\Mvc\ViewConfigurationManager::class), true);
+            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'objectManager', $this->getObject(\Neos\Flow\ObjectManagement\ObjectManager::class), true);
+        }
+
+
+        $objectManager = $this->getObject(\Neos\Flow\ObjectManagement\ObjectManager::class);
+        $objects = \Neos\Utility\ObjectAccess::getProperty($objectManager, 'objects', true);
+        $objects[get_class($controllerInstance)]['i'] = $controllerInstance;
+        $objects[get_class($controllerInstance)]['l'] = strtolower(get_class($controllerInstance));
+        $objectManager->setObjects($objects);
+    }
+
+    /**
      * @When I dispatch the following request :requestUri
      */
     public function iDispatchTheFollowingRequest(string $requestUri)

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
@@ -66,13 +66,11 @@ trait FrontendNodeControllerTrait
         $controllerInstance = new ('\\' . $fullyQualifiedClassName)();
 
         if ($controllerInstance instanceof \Neos\Flow\Mvc\Controller\ActionController) {
-            // inject all the necessary properties of an action controller, as extended classes dont call $this->Flow_Proxy_injectProperties();
-            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'validatorResolver', $this->getObject(\Neos\Flow\Validation\ValidatorResolver::class), true);
-            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'mvcPropertyMappingConfigurationService', $this->getObject(\Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService::class), true);
-            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'viewConfigurationManager', $this->getObject(\Neos\Flow\Mvc\ViewConfigurationManager::class), true);
-            \Neos\Utility\ObjectAccess::setProperty($controllerInstance, 'objectManager', $this->getObject(\Neos\Flow\ObjectManagement\ObjectManager::class), true);
+            // run flow property injection code of parent class ActionController not ActionController_Original manually as the extended classes is not proxied and doesnt call $this->Flow_Proxy_injectProperties();
+            $ref = new \ReflectionClass(get_parent_class($controllerInstance));
+            $method = $ref->getMethod('Flow_Proxy_injectProperties');
+            $method->invoke($controllerInstance);
         }
-
 
         $objectManager = $this->getObject(\Neos\Flow\ObjectManagement\ObjectManager::class);
         $objects = \Neos\Utility\ObjectAccess::getProperty($objectManager, 'objects', true);

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FrontendNodeControllerTrait.php
@@ -16,6 +16,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use GuzzleHttp\Psr7\Message;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
 use Neos\Fusion\Core\Cache\ContentCache;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -45,6 +46,18 @@ trait FrontendNodeControllerTrait
         $this->getObject(ContentCache::class)->flush();
         $this->getObject(\Neos\Neos\Testing\TestingFusionAutoIncludeHandler::class)->reset();
         $this->frontendNodeControllerResponse = null;
+    }
+
+    /**
+     * @When I have the following Fusion file :fileName:
+     */
+    public function iHaveTheFollowingFusionFile(PyStringNode $fusionCode, string $fileName)
+    {
+        if (!str_starts_with($fileName, 'vfs://fusion/')) {
+            throw new \InvalidArgumentException('Fusion file name must be virtual.');
+        }
+        vfsStream::setup('fusion');
+        file_put_contents($fileName, $fusionCode->getRaw());
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/DefaultFusionRendering.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/DefaultFusionRendering.feature
@@ -97,7 +97,6 @@ Feature: Test the default Fusion rendering for a request
     HTTP/1.1 200 OK
     Content-Type: text/html
     X-Flow-Powered: Flow/dev Neos/dev
-    Content-Length: 486
 
     <!DOCTYPE html><html>
     <!--

--- a/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
@@ -1,0 +1,148 @@
+@flowEntities
+Feature: Tests for sub-request on the frontend node controller in case of the "Neos.Neos:Plugins" Fusion prototype
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root': {}
+    'Neos.Neos:Content': {}
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        title:
+          type: string
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentType':
+      superTypes:
+        Neos.Neos:Document: true
+    'Neos.Neos:Plugin':
+      superTypes:
+        'Neos.Neos:Content': true
+      abstract: true
+
+    'Neos.Neos:Content.MyPlugin':
+      superTypes:
+        'Neos.Neos:Plugin': true
+      properties:
+        'myPluginProp':
+          type: string
+          defaultValue: ''
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+
+    When the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value             |
+      | nodeAggregateId | "root"            |
+      | nodeTypeName    | "Neos.Neos:Sites" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | parentNodeAggregateId | nodeTypeName                | initialPropertyValues                        | nodeName |
+      | a               | root                  | Neos.Neos:Site              | {"title": "Node a"}                          | a        |
+      | a1              | a                     | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a1", "title": "Node a1"} | a1       |
+      | a1a             | a1                    | Neos.Neos:Content.MyPlugin  | {"myPluginProp": "hello from the node"}      | a1a      |
+    And A site exists for node name "a" and domain "http://localhost"
+    And the sites configuration is:
+    """yaml
+    Neos:
+      Neos:
+        sites:
+          'a':
+            preset: default
+            uriPathSuffix: ''
+            contentDimensions:
+              resolver:
+                factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
+    """
+
+  Scenario: Default output
+    When I declare the following controller 'Vendor\Site\Controller\MyPluginController':
+    """php
+    // <?php
+    namespace Vendor\Site\Controller;
+
+    use Neos\Flow\Mvc\Controller\ActionController;
+    use Neos\FluidAdaptor\View\StandaloneView;
+
+    class MyPluginController extends ActionController
+    {
+        protected $defaultViewObjectName = StandaloneView::class;
+
+        public function listAction()
+        {
+            $myPluginProp = $this->request->getInternalArgument('__myPluginProp');
+
+            $uri = $this->uriBuilder->uriFor('show', ['item' => 'hello to other'], 'MyPlugin', 'Vendor.Site');
+
+            return "list\nmyPluginProp: $myPluginProp\nuri to show: $uri";
+        }
+
+        public function showAction() // string $propToOtherAction doesnt work because the object is not proxied
+        {
+            $myPluginProp = $this->request->getInternalArgument('__myPluginProp');
+            $propToOtherAction = $this->request->getArgument('item');
+            return "details\nmyPluginProp: $myPluginProp\nargument: $propToOtherAction";
+        }
+
+        public static function getPublicActionMethods($objectManager)
+        {
+            return array_fill_keys(get_class_methods(get_called_class()), true);
+        }
+    }
+    """
+
+    When the sites Fusion code is:
+    """fusion
+    prototype(Neos.Neos:Test.DocumentType) < prototype(Neos.Fusion:Component) {
+
+      renderer = afx`
+        title: {node.properties.title}{String.chr(10)}
+        children: <Neos.Neos:ContentCase @context.node={q(node).children().get(0)} />
+      `
+    }
+
+    prototype(Neos.Neos:Content.MyPlugin) < prototype(Neos.Neos:Plugin) {
+      package = 'Vendor.Site'
+      controller = 'MyPlugin'
+      action = 'list'
+
+      myPluginProp = ${q(node).property('myPluginProp')}
+    }
+    """
+
+    When I dispatch the following request "/a1"
+    Then I expect the following response:
+    """
+    HTTP/1.1 200 OK
+    Content-Type: text/html
+    X-Flow-Powered: Flow/dev Neos/dev
+
+    title: Node a1
+    children: list
+    myPluginProp: hello from the node
+    uri to show: /a1?--neos_neos-content_myplugin%5B%40package%5D=vendor.site&--neos_neos-content_myplugin%5B%40controller%5D=myplugin&--neos_neos-content_myplugin%5B%40action%5D=show&--neos_neos-content_myplugin%5B%40format%5D=html&--neos_neos-content_myplugin%5Bitem%5D=hello+to+other
+    """
+
+    When I dispatch the following request "/a1?--neos_neos-content_myplugin%5B%40package%5D=vendor.site&--neos_neos-content_myplugin%5B%40controller%5D=myplugin&--neos_neos-content_myplugin%5B%40action%5D=show&--neos_neos-content_myplugin%5B%40format%5D=html&--neos_neos-content_myplugin%5Bitem%5D=hello+to+other"
+    Then I expect the following response:
+    """
+    HTTP/1.1 200 OK
+    Content-Type: text/html
+    X-Flow-Powered: Flow/dev Neos/dev
+
+    title: Node a1
+    children: details
+    myPluginProp: hello from the node
+    argument: hello to other
+    """

--- a/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
@@ -53,7 +53,7 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
       | a1              | a                     | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a1", "title": "Node a1"} | a1       |
       | a2              | a                     | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a2", "title": "Node a3"} | a3       |
       | a1a             | a1                    | Neos.Neos:Content.MyPlugin  | {"myPluginProp": "hello from the node"}      | a1a      |
-    And A site exists for node name "a" and domain "http://localhost"
+    And A site exists for node name "a" and domain "http://localhost" and package Vendor.Site
     And the sites configuration is:
     """yaml
     Neos:
@@ -70,7 +70,7 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
   Scenario: Default output
     When I declare the following controller 'Vendor\Site\Controller\MyPluginController':
     """php
-    // <?php
+    <?php
     namespace Vendor\Site\Controller;
 
     use Neos\Flow\Mvc\Controller\ActionController;
@@ -116,16 +116,10 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
             $this->response->setHttpHeader('X-Custom-Plugin-Header', 'MHS');
             return 'body contents';
         }
-
-        public static function getPublicActionMethods($objectManager)
-        {
-            // hack, as this class is not proxied reflection doesnt work and doesnt return the desired public action methods
-            return array_fill_keys(get_class_methods(get_called_class()), true);
-        }
     }
     """
 
-    When the sites Fusion code is:
+    When the Fusion code for package Vendor.Site is:
     """fusion
     prototype(Neos.Neos:Test.DocumentType) < prototype(Neos.Fusion:Component) {
 
@@ -256,7 +250,7 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
 
     When I declare the following controller 'Vendor\Site\Controller\MyPluginWithFusionController':
     """php
-    // <?php
+    <?php
     namespace Vendor\Site\Controller;
 
     use Neos\Flow\Mvc\View\ViewInterface;
@@ -284,16 +278,10 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
         {
             $this->view->assign('node', $this->request->getInternalArgument('__node'));
         }
-
-        public static function getPublicActionMethods($objectManager)
-        {
-            // hack, as this class is not proxied reflection doesnt work and doesnt return the desired public action methods
-            return array_fill_keys(get_class_methods(get_called_class()), true);
-        }
     }
     """
 
-    When the sites Fusion code is:
+    When the Fusion code for package Vendor.Site is:
     """fusion
     prototype(Neos.Neos:Test.DocumentType) < prototype(Neos.Fusion:Component) {
 

--- a/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendNodeController/FusionPlugin.feature
@@ -73,10 +73,9 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
     <?php
     namespace Vendor\Site\Controller;
 
-    use Neos\Flow\Mvc\Controller\ActionController;
     use Neos\FluidAdaptor\View\StandaloneView;
 
-    class MyPluginController extends ActionController
+    class MyPluginController extends \BehatRuntimeActionController
     {
         protected $defaultViewObjectName = StandaloneView::class;
 
@@ -254,10 +253,9 @@ Feature: Tests for sub-request on the frontend node controller in case of the "N
     namespace Vendor\Site\Controller;
 
     use Neos\Flow\Mvc\View\ViewInterface;
-    use Neos\Flow\Mvc\Controller\ActionController;
     use Neos\Fusion\View\FusionView;
 
-    class MyPluginWithFusionController extends ActionController
+    class MyPluginWithFusionController extends \BehatRuntimeActionController
     {
         protected $defaultViewObjectName = FusionView::class;
 


### PR DESCRIPTION
Resolves: #4909

Based on https://github.com/neos/neos-development-collection/pull/5305 introduces a step to declare a flow controller in behat:

```feature
When I declare the following controller 'Vendor\Site\Controller\MyPluginWithFusionController':
"""php
<?php
namespace Vendor\Site\Controller;

use Neos\Flow\Mvc\Controller\ActionController;

class MyPluginWithFusionController extends ActionController
{
    public function renderAction()
    {
    }
}
"""
```

This comes with good and bad things.
The good thing is that the test is self contained and i have seen behat for example see also use that they create virtual php to test if the frame-work works.
Now the downside is that because of php there can only be ONE `MyPluginWithFusionController` across all tests declared which are executed in the same run. But for now this is not a problem as there are only two such fakes.
Another problem is that we need some hacks (see `BehatRuntimeActionController`) to actually make this work.

At first i attempted to have the files also separated in another location in (Test/Functional) of Neos.Neos but aside from them being spread around the whole planed i had problems with the proxybuilding there too.

But i believe that we do want to use behat to write self contained tests even if its hard right now but flow has to adjust at some point to this needs hopefully ^^.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
