### PR TITLE
BUGFIX: Ensure workspace roles and metadata are pruned with the CR.

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -13,6 +13,7 @@ use Neos\ContentRepositoryRegistry\Service\ProjectionReplayServiceFactory;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventStore\StatusType;
 use Neos\Flow\Cli\CommandController;
+use Neos\Neos\Domain\Service\WorkspaceService;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\Output;
@@ -203,45 +204,5 @@ final class CrCommandController extends CommandController
             $progressBar->finish();
             $this->outputLine('<success>Done.</success>');
         }
-    }
-
-    /**
-     * This will completely prune the data of the specified content repository.
-     *
-     * @param string $contentRepository Name of the content repository where the data should be pruned from.
-     * @param bool $force Prune the cr without confirmation. This cannot be reverted!
-     * @return void
-     */
-    public function pruneCommand(string $contentRepository = 'default', bool $force = false): void
-    {
-        if (!$force && !$this->output->askConfirmation(sprintf('> This will prune your content repository "%s". Are you sure to proceed? (y/n) ', $contentRepository), false)) {
-            $this->outputLine('<comment>Abort.</comment>');
-            return;
-        }
-
-        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-
-        $contentStreamPruner = $this->contentRepositoryRegistry->buildService(
-            $contentRepositoryId,
-            new ContentStreamPrunerFactory()
-        );
-
-        $workspaceMaintenanceService = $this->contentRepositoryRegistry->buildService(
-            $contentRepositoryId,
-            new WorkspaceMaintenanceServiceFactory()
-        );
-
-        $projectionService = $this->contentRepositoryRegistry->buildService(
-            $contentRepositoryId,
-            $this->projectionServiceFactory
-        );
-
-        // reset the events table
-        $contentStreamPruner->pruneAll();
-        $workspaceMaintenanceService->pruneAll();
-        // reset the projections state
-        $projectionService->resetAllProjections();
-
-        $this->outputLine('<success>Done.</success>');
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -382,6 +382,28 @@ final class WorkspaceService
         }
     }
 
+    public function pruneWorkspaceMetadata(ContentRepositoryId $contentRepositoryId): void
+    {
+        try {
+            $this->dbal->delete(self::TABLE_NAME_WORKSPACE_METADATA, [
+                'content_repository_id' => $contentRepositoryId->value,
+            ]);
+        } catch (DbalException $e) {
+            throw new \RuntimeException(sprintf('Failed to prune workspace metadata Content Repository "%s": %s', $contentRepositoryId->value, $e->getMessage()), 1729512100, $e);
+        }
+    }
+
+    public function pruneRoleAsssignments(ContentRepositoryId $contentRepositoryId): void
+    {
+        try {
+            $this->dbal->delete(self::TABLE_NAME_WORKSPACE_ROLE, [
+                'content_repository_id' => $contentRepositoryId->value,
+            ]);
+        } catch (DbalException $e) {
+            throw new \RuntimeException(sprintf('Failed to prune workspace roles for Content Repository "%s": %s', $contentRepositoryId->value, $e->getMessage()), 1729512142, $e);
+        }
+    }
+
     private function createWorkspace(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, WorkspaceTitle $title, WorkspaceDescription $description, WorkspaceName $baseWorkspaceName, UserId|null $ownerId, WorkspaceClassification $classification): void
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);


### PR DESCRIPTION
The `cr:prune` command is moved into Neos.Neos package where it has access to the workspaceService.

This ensures that a `cr:import` will work even if the same cr already had a live workspace before that was pruned.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
