### PR TITLE
BUGFIX: Ensure users do not run into "No workspace is assigned to the user with id" after `cr:prune` and site switching

### DIFF
--- a/Neos.Neos/Classes/Command/CrCommandController.php
+++ b/Neos.Neos/Classes/Command/CrCommandController.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Export\ImportService;
 use Neos\ContentRepository\Export\ImportServiceFactory;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\ContentRepositoryRegistry\Service\ProjectionReplayServiceFactory;
+use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -42,6 +43,7 @@ class CrCommandController extends CommandController
         private readonly AssetUsageService $assetUsageService,
         private readonly WorkspaceService $workspaceService,
         private readonly ProjectionReplayServiceFactory $projectionServiceFactory,
+        private readonly CacheManager $cacheManager,
     ) {
         parent::__construct();
     }
@@ -170,6 +172,10 @@ class CrCommandController extends CommandController
 
         // reset the projections state
         $projectionService->resetAllProjections();
+
+        // reset sessions to enforce a new login and personal workspaces are created
+        $this->cacheManager->getCache('Flow_Session_Storage')->flush();
+        $this->cacheManager->getCache('Flow_Session_MetaData')->flush();
 
         $this->outputLine('<success>Done.</success>');
     }


### PR DESCRIPTION
- After `cr:prune` all sessions are destroyed to enforce a fresh login. The login will then create the missing personal workspace if needed.
- During site:switch it is checked wether the new site has a personal workspace for the current user and create this if missing

Resolves: #4566
Relates: #4401

**Review instructions**

This is ugly but a base for discussion the possible solutions for the problem.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
