### PR TITLE
TASK: Throw `InvalidArgumentException` as `\Throwable` is not caught …

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -182,4 +182,4 @@ Feature: Create node aggregate with node
       | nodeAggregateId       | "nody-mc-nodeface"                                           |
       | nodeTypeName          | "Neos.ContentRepository.Testing:NodeWithInvalidDefaultValue" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                                     |
-    Then the last command should have thrown an exception of type "CallErrorException"
+    Then the last command should have thrown an exception of type "InvalidArgumentException"

--- a/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PostalAddress.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/PostalAddress.php
@@ -31,10 +31,10 @@ final readonly class PostalAddress
     public static function fromArray(array $array): self
     {
         return new self(
-            $array['streetAddress'],
-            $array['postalCode'],
-            $array['addressLocality'],
-            $array['addressCountry']
+            $array['streetAddress'] ?? throw new \InvalidArgumentException('streetAddress is not set.'),
+            $array['postalCode'] ?? throw new \InvalidArgumentException('postalCode is not set.'),
+            $array['addressLocality'] ?? throw new \InvalidArgumentException('addressLocality is not set.'),
+            $array['addressCountry'] ?? throw new \InvalidArgumentException('addressCountry is not set.')
         );
     }
 


### PR DESCRIPTION
…in tests

> Type error: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress::__construct(): Argument #1 ($streetAddress) must be of type string, null given

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
