### PR TITLE
TASK: Use `NodeType -> references` configuration instead of properties of `type: reference/s`

### DIFF
--- a/Neos.NodeTypes.ContentReferences/NodeTypes/Content/ContentReferences.yaml
+++ b/Neos.NodeTypes.ContentReferences/NodeTypes/Content/ContentReferences.yaml
@@ -11,9 +11,8 @@
           label: i18n
           position: 10
           icon: 'icon-copy'
-  properties:
+  references:
     references:
-      type: 'references'
       ui:
         inspector:
           group: 'references'

--- a/Neos.NodeTypes.Navigation/NodeTypes/Content/Navigation.yaml
+++ b/Neos.NodeTypes.Navigation/NodeTypes/Content/Navigation.yaml
@@ -12,6 +12,21 @@
           label: i18n #'Options'
           position: 30
           icon: 'icon-sliders'
+  references:
+    selection:
+      ui:
+        reloadIfChanged: true
+        label: i18n
+        inspector:
+          group: 'options'
+    startingPoint:
+      constraints:
+        maxItems: 1
+      ui:
+        reloadIfChanged: true
+        label: i18n
+        inspector:
+          group: 'options'
   properties:
     startLevel:
       type: string
@@ -46,20 +61,6 @@
                 label: i18n
               '6':
                 label: i18n
-    selection:
-      type: 'references'
-      ui:
-        reloadIfChanged: true
-        label: i18n
-        inspector:
-          group: 'options'
-    startingPoint:
-      type: 'reference'
-      ui:
-        reloadIfChanged: true
-        label: i18n
-        inspector:
-          group: 'options'
     maximumLevels:
       type: string
       defaultValue: '1'


### PR DESCRIPTION
The properties of `type: reference/s` are now configured via the references as references via properties are deprecated and are converted internally anyways.

**Review instructions**

This has to be tested together with: https://github.com/neos/Neos.Demo/pull/197 since the Neos.Demo package overrides some reference property configuartions and will cause errors if not adjusted synchronously.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
