### PR TITLE
TASK: Remove migrations in CR setup

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -110,24 +110,6 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     {
         $statements = $this->determineRequiredSqlStatements();
 
-        // MIGRATION from 2024-05-25: copy data from "cr_<crid>_p_workspace"/"cr_<crid>_p_contentstream" to "cr_<crid>_p_graph_workspace"/"cr_<crid>_p_graph_contentstream" tables
-        $legacyWorkspaceTableName = str_replace('_p_graph_workspace', '_p_workspace', $this->tableNames->workspace());
-        if (
-            $this->dbal->getSchemaManager()->tablesExist([$legacyWorkspaceTableName])
-            && !$this->dbal->getSchemaManager()->tablesExist([$this->tableNames->workspace()])
-        ) {
-            // we ignore the legacy fields workspacetitle, workspacedescription and workspaceowner
-            $statements[] = 'INSERT INTO ' . $this->tableNames->workspace() . ' (name, baseWorkspaceName, currentContentStreamId, status) SELECT workspacename AS name, baseworkspacename, currentcontentstreamid, status FROM ' . $legacyWorkspaceTableName;
-        }
-        $legacyContentStreamTableName = str_replace('_p_graph_contentstream', '_p_contentstream', $this->tableNames->contentStream());
-        if (
-            $this->dbal->getSchemaManager()->tablesExist([$legacyContentStreamTableName])
-            && !$this->dbal->getSchemaManager()->tablesExist([$this->tableNames->contentStream()])
-        ) {
-            $statements[] = 'INSERT INTO ' . $this->tableNames->contentStream() . ' (id, version, sourceContentStreamId, status, removed) SELECT contentStreamId AS id, version, sourceContentStreamId, state AS status, removed FROM ' . $legacyContentStreamTableName;
-        }
-        // /MIGRATION
-
         foreach ($statements as $statement) {
             try {
                 $this->dbal->executeStatement($statement);

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -108,10 +108,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
         $schemaManager = $this->dbal->createSchemaManager();
         $schema = (new DocumentUriPathSchemaBuilder($this->tableNamePrefix))->buildSchema($schemaManager);
         $statements = DbalSchemaDiff::determineRequiredSqlStatements($this->dbal, $schema);
-        // MIGRATIONS
-        if ($this->dbal->getSchemaManager()->tablesExist([$this->tableNamePrefix . '_livecontentstreams'])) {
-            $statements[] = sprintf('DROP table %s_livecontentstreams;', $this->tableNamePrefix);
-        }
+
         return $statements;
     }
 

--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
@@ -140,10 +140,7 @@ class ChangeProjection implements ProjectionInterface
 
         $schema = DbalSchemaFactory::createSchemaWithTables($schemaManager, [$changeTable]);
         $statements = DbalSchemaDiff::determineRequiredSqlStatements($connection, $schema);
-        // MIGRATIONS
-        if ($this->dbal->getSchemaManager()->tablesExist([$this->tableNamePrefix . '_livecontentstreams'])) {
-            $statements[] = sprintf('DROP table %s_livecontentstreams;', $this->tableNamePrefix);
-        }
+
         return $statements;
     }
 


### PR DESCRIPTION
As we need to replay the projections in upcoming release anyway, we want to get rid of these migrations in cr:setup