### PR TITLE
TASK: Allow setting itemsPerPage in user administration listing

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -127,6 +127,7 @@ class UsersController extends AbstractModuleController
             'searchTerm' => $searchTerm,
             'sortBy' => $sortBy,
             'sortDirection' => $sortDirection,
+            'settings' => $this->moduleConfiguration['settings']
         ]);
     }
 

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -370,6 +370,9 @@ Neos:
               new:
                 label: 'Neos.Neos:Modules:users.actions.new.label'
                 title: 'Neos.Neos:Modules:users.actions.new.title'
+            settings:
+              pagination:
+                itemsPerPage: 10
           packages:
             label: 'Neos.Neos:Modules:packages.label'
             controller: 'Neos\Neos\Controller\Module\Administration\PackagesController'

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Users/Index.html
@@ -20,7 +20,7 @@
 		</f:if>
 
 		<f:if condition="{users}">
-			<f:widget.paginate objects="{users}" as="paginatedUsers">
+			<f:widget.paginate objects="{users}" as="paginatedUsers" configuration="{'itemsPerPage': settings.pagination.itemsPerPage}">
 			<table class="neos-table">
 					<thead>
 						<tr>


### PR DESCRIPTION
With Neos 8.3, pagination was added to the user management module, but the number of users page page was not made configurable and set at a very low number of 10. This non-breaking change introduces this as a setting, keeping the default of 10.