### PR TITLE
!!! TASK: Catchups will only be able to access the state of the projection they are registered for

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/RaceTrackerCatchUpHookFactory.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/RaceTrackerCatchUpHookFactory.php
@@ -14,11 +14,10 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\BehavioralTests\ProjectionRaceConditionTester;
 
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
  * For full docs and context, see {@see RaceTrackerCatchUpHook}
@@ -28,7 +27,7 @@ use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryI
  */
 final class RaceTrackerCatchUpHookFactory implements CatchUpHookFactoryInterface
 {
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
+    public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface
     {
         return new RaceTrackerCatchUpHook();
     }

--- a/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/RaceTrackerCatchUpHookFactory.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/RaceTrackerCatchUpHookFactory.php
@@ -14,18 +14,21 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\BehavioralTests\ProjectionRaceConditionTester;
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
  * For full docs and context, see {@see RaceTrackerCatchUpHook}
  *
+ * @implements CatchUpHookFactoryInterface<ContentGraphReadModelInterface>
  * @internal
  */
 final class RaceTrackerCatchUpHookFactory implements CatchUpHookFactoryInterface
 {
-    public function build(ContentRepository $contentRepository): CatchUpHookInterface
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
     {
         return new RaceTrackerCatchUpHook();
     }

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -25,6 +25,7 @@ use Neos\ContentRepository\Core\EventStore\InitiatingEventMetadata;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryFactory;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\CatchUp;
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpOptions;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
@@ -45,7 +46,6 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
 use Neos\EventStore\EventStoreInterface;
-use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\EventStore\Model\EventEnvelope;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Psr\Clock\ClockInterface;
@@ -147,7 +147,13 @@ final class ContentRepository
         $projection = $this->projectionsAndCatchUpHooks->projections->get($projectionClassName);
 
         $catchUpHookFactory = $this->projectionsAndCatchUpHooks->getCatchUpHookFactoryForProjection($projection);
-        $catchUpHook = $catchUpHookFactory?->build($this->id, $projection->getState());
+        $catchUpHook = $catchUpHookFactory?->build(new CatchUpHookFactoryDependencies(
+            $this->id,
+            $projection->getState(),
+            $this->nodeTypeManager,
+            $this->contentDimensionSource,
+            $this->variationGraph
+        ));
 
         // TODO allow custom stream name per projection
         $streamName = VirtualStreamName::all();

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -147,7 +147,7 @@ final class ContentRepository
         $projection = $this->projectionsAndCatchUpHooks->projections->get($projectionClassName);
 
         $catchUpHookFactory = $this->projectionsAndCatchUpHooks->getCatchUpHookFactoryForProjection($projection);
-        $catchUpHook = $catchUpHookFactory?->build($this);
+        $catchUpHook = $catchUpHookFactory?->build($this->id, $projection->getState());
 
         // TODO allow custom stream name per projection
         $streamName = VirtualStreamName::all();

--- a/Neos.ContentRepository.Core/Classes/Factory/ProjectionsAndCatchUpHooksFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ProjectionsAndCatchUpHooksFactory.php
@@ -6,12 +6,12 @@ namespace Neos\ContentRepository\Core\Factory;
 
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactories;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\Projections;
 use Neos\ContentRepository\Core\Projection\ProjectionsAndCatchUpHooks;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
 
 /**
  * @api for custom framework integrations, not for users of the CR
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionIn
 final class ProjectionsAndCatchUpHooksFactory
 {
     /**
-     * @var array<string, array{factory: ProjectionFactoryInterface<ProjectionInterface<ProjectionStateInterface>>, options: array<string, mixed>, catchUpHooksFactories: array<CatchUpHookFactoryInterface>}>
+     * @var array<string, array{factory: ProjectionFactoryInterface<ProjectionInterface<ProjectionStateInterface>>, options: array<string, mixed>, catchUpHooksFactories: array<CatchUpHookFactoryInterface<ProjectionStateInterface>>}>
      */
     private array $factories = [];
 
@@ -40,7 +40,7 @@ final class ProjectionsAndCatchUpHooksFactory
 
     /**
      * @param ProjectionFactoryInterface<ProjectionInterface<ProjectionStateInterface>> $factory
-     * @param CatchUpHookFactoryInterface $catchUpHookFactory
+     * @param CatchUpHookFactoryInterface<ProjectionStateInterface> $catchUpHookFactory
      * @return void
      * @api
      */

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactories.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactories.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection;
 
-use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
+ * @implements CatchUpHookFactoryInterface<ProjectionStateInterface>
  * @internal
  */
 final class CatchUpHookFactories implements CatchUpHookFactoryInterface
 {
     /**
-     * @var array<mixed,CatchUpHookFactoryInterface>
+     * @var array<mixed,CatchUpHookFactoryInterface<ProjectionStateInterface>>
      */
     private array $catchUpHookFactories;
 
+    /**
+     * @param CatchUpHookFactoryInterface<ProjectionStateInterface> ...$catchUpHookFactories
+     */
     private function __construct(CatchUpHookFactoryInterface ...$catchUpHookFactories)
     {
         $this->catchUpHookFactories = $catchUpHookFactories;
@@ -26,6 +30,10 @@ final class CatchUpHookFactories implements CatchUpHookFactoryInterface
         return new self();
     }
 
+    /**
+     * @param CatchUpHookFactoryInterface<ProjectionStateInterface> $catchUpHookFactory
+     * @return self
+     */
     public function with(CatchUpHookFactoryInterface $catchUpHookFactory): self
     {
         if ($this->has($catchUpHookFactory::class)) {
@@ -44,9 +52,9 @@ final class CatchUpHookFactories implements CatchUpHookFactoryInterface
         return array_key_exists($catchUpHookFactoryClassName, $this->catchUpHookFactories);
     }
 
-    public function build(ContentRepository $contentRepository): CatchUpHookInterface
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
     {
-        $catchUpHooks = array_map(static fn(CatchUpHookFactoryInterface $catchUpHookFactory) => $catchUpHookFactory->build($contentRepository), $this->catchUpHookFactories);
+        $catchUpHooks = array_map(static fn(CatchUpHookFactoryInterface $catchUpHookFactory) => $catchUpHookFactory->build($contentRepositoryId, $projectionState), $this->catchUpHookFactories);
         return new DelegatingCatchUpHook(...$catchUpHooks);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactories.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactories.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection;
 
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-
 /**
  * @implements CatchUpHookFactoryInterface<ProjectionStateInterface>
  * @internal
@@ -52,9 +50,9 @@ final class CatchUpHookFactories implements CatchUpHookFactoryInterface
         return array_key_exists($catchUpHookFactoryClassName, $this->catchUpHookFactories);
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
+    public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface
     {
-        $catchUpHooks = array_map(static fn(CatchUpHookFactoryInterface $catchUpHookFactory) => $catchUpHookFactory->build($contentRepositoryId, $projectionState), $this->catchUpHookFactories);
+        $catchUpHooks = array_map(static fn(CatchUpHookFactoryInterface $catchUpHookFactory) => $catchUpHookFactory->build($dependencies), $this->catchUpHookFactories);
         return new DelegatingCatchUpHook(...$catchUpHooks);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryDependencies.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryDependencies.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection;
+
+use Neos\ContentRepository\Core\Dimension\ContentDimensionSourceInterface;
+use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+
+/**
+ * @template-covariant T of ProjectionStateInterface
+ *
+ * @api provides available dependencies for implementing a catch-up hook.
+ */
+final readonly class CatchUpHookFactoryDependencies
+{
+    /**
+     * @param ContentRepositoryId $contentRepositoryId the content repository the catchup was registered in
+     * @param ProjectionStateInterface&T $projectionState the state of the projection the catchup was registered to (Its only safe to access this projections state)
+     */
+    public function __construct(
+        public ContentRepositoryId $contentRepositoryId,
+        public ProjectionStateInterface $projectionState,
+        public NodeTypeManager $nodeTypeManager,
+        public ContentDimensionSourceInterface $contentDimensionSource,
+        public InterDimensionalVariationGraph $variationGraph
+    ) {
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection;
 
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-
 /**
  * @template T of ProjectionStateInterface
  * @api
@@ -16,9 +14,8 @@ interface CatchUpHookFactoryInterface
      * Note that a catchup doesn't have access to the full content repository, as it would allow full recursion via handle and accessing other projections
      * state is not safe as the other projection might not be behind - the order is undefined.
      *
-     * @param ContentRepositoryId $contentRepositoryId the content repository the catchup was registered in
-     * @param ProjectionStateInterface&T $projectionState the state of the projection the catchup was registered to (Its only safe to access this projections state)
+     * @param CatchUpHookFactoryDependencies<T> $dependencies available dependencies to intialise the catchup hook
      * @return CatchUpHookInterface
      */
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface;
+    public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface;
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHookFactoryInterface.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Projection;
 
-use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
+ * @template T of ProjectionStateInterface
  * @api
  */
 interface CatchUpHookFactoryInterface
 {
-    public function build(ContentRepository $contentRepository): CatchUpHookInterface;
+    /**
+     * Note that a catchup doesn't have access to the full content repository, as it would allow full recursion via handle and accessing other projections
+     * state is not safe as the other projection might not be behind - the order is undefined.
+     *
+     * @param ContentRepositoryId $contentRepositoryId the content repository the catchup was registered in
+     * @param ProjectionStateInterface&T $projectionState the state of the projection the catchup was registered to (Its only safe to access this projections state)
+     * @return CatchUpHookInterface
+     */
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface;
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphReadModelInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphReadModelInterface.php
@@ -24,7 +24,11 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
 
 /**
- * @api for creating a custom content repository graph projection implementation, **not for users of the CR**
+ * This low level interface gives access to the content graph and workspaces
+ *
+ * Generally this is not accessible for users of the CR, except for registering a catchup-hook on the content graph
+ *
+ * @api as dependency in catchup hooks and for creating a custom content repository graph projection implementation
  */
 interface ContentGraphReadModelInterface extends ProjectionStateInterface
 {

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionsAndCatchUpHooks.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionsAndCatchUpHooks.php
@@ -26,6 +26,7 @@ final readonly class ProjectionsAndCatchUpHooks
 
     /**
      * @param ProjectionInterface<ProjectionStateInterface> $projection
+     * @return ?CatchUpHookFactoryInterface<ProjectionStateInterface>
      */
     public function getCatchUpHookFactoryForProjection(ProjectionInterface $projection): ?CatchUpHookFactoryInterface
     {

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/FlushSubgraphCachePoolCatchUpHookFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/FlushSubgraphCachePoolCatchUpHookFactory.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry\SubgraphCachingInMemory;
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
  * Factory for {@see FlushSubgraphCachePoolCatchUpHook}, auto-registered in Settings.yaml for GraphProjection
  *
+ * @implements CatchUpHookFactoryInterface<ContentGraphReadModelInterface>
  * @internal
  */
 class FlushSubgraphCachePoolCatchUpHookFactory implements CatchUpHookFactoryInterface
@@ -20,7 +23,8 @@ class FlushSubgraphCachePoolCatchUpHookFactory implements CatchUpHookFactoryInte
         private readonly SubgraphCachePool $subgraphCachePool
     ) {
     }
-    public function build(ContentRepository $contentRepository): CatchUpHookInterface
+
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
     {
         return new FlushSubgraphCachePoolCatchUpHook($this->subgraphCachePool);
     }

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/FlushSubgraphCachePoolCatchUpHookFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/FlushSubgraphCachePoolCatchUpHookFactory.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry\SubgraphCachingInMemory;
 
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
  * Factory for {@see FlushSubgraphCachePoolCatchUpHook}, auto-registered in Settings.yaml for GraphProjection
@@ -24,7 +23,7 @@ class FlushSubgraphCachePoolCatchUpHookFactory implements CatchUpHookFactoryInte
     ) {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
+    public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface
     {
         return new FlushSubgraphCachePoolCatchUpHook($this->subgraphCachePool);
     }

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
@@ -14,10 +14,9 @@ namespace Neos\Neos\AssetUsage\CatchUpHook;
  * source code.
  */
 
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 
 /**
@@ -30,11 +29,11 @@ class AssetUsageCatchUpHookFactory implements CatchUpHookFactoryInterface
     ) {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): AssetUsageCatchUpHook
+    public function build(CatchUpHookFactoryDependencies $dependencies): AssetUsageCatchUpHook
     {
         return new AssetUsageCatchUpHook(
-            $contentRepositoryId,
-            $projectionState,
+            $dependencies->contentRepositoryId,
+            $dependencies->projectionState,
             $this->assetUsageIndexingService
         );
     }

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
@@ -14,10 +14,15 @@ namespace Neos\Neos\AssetUsage\CatchUpHook;
  * source code.
  */
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 
+/**
+ * @implements CatchUpHookFactoryInterface<ContentGraphReadModelInterface>
+ */
 class AssetUsageCatchUpHookFactory implements CatchUpHookFactoryInterface
 {
     public function __construct(
@@ -25,10 +30,11 @@ class AssetUsageCatchUpHookFactory implements CatchUpHookFactoryInterface
     ) {
     }
 
-    public function build(ContentRepository $contentRepository): AssetUsageCatchUpHook
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): AssetUsageCatchUpHook
     {
         return new AssetUsageCatchUpHook(
-            $contentRepository,
+            $contentRepositoryId,
+            $projectionState,
             $this->assetUsageIndexingService
         );
     }

--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\Neos\FrontendRouting\CatchUpHook;
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
@@ -28,7 +27,7 @@ final class RouterCacheHook implements CatchUpHookInterface
     private array $tagsToFlush = [];
 
     public function __construct(
-        private readonly ContentRepository $contentRepository,
+        private readonly DocumentUriPathFinder $documentUriPathFinder,
         private readonly RouterCachingService $routerCachingService,
     ) {
     }
@@ -85,7 +84,7 @@ final class RouterCacheHook implements CatchUpHookInterface
 
             $this->collectTagsToFlush($node);
 
-            $descendantsOfNode = $this->getState()->getDescendantsOfNode($node);
+            $descendantsOfNode = $this->documentUriPathFinder->getDescendantsOfNode($node);
             array_map($this->collectTagsToFlush(...), iterator_to_array($descendantsOfNode));
         }
     }
@@ -105,7 +104,7 @@ final class RouterCacheHook implements CatchUpHookInterface
 
             $this->collectTagsToFlush($node);
 
-            $descendantsOfNode = $this->getState()->getDescendantsOfNode($node);
+            $descendantsOfNode = $this->documentUriPathFinder->getDescendantsOfNode($node);
             array_map($this->collectTagsToFlush(...), iterator_to_array($descendantsOfNode));
         }
     }
@@ -130,7 +129,7 @@ final class RouterCacheHook implements CatchUpHookInterface
 
             $this->collectTagsToFlush($node);
 
-            $descendantsOfNode = $this->getState()->getDescendantsOfNode($node);
+            $descendantsOfNode = $this->documentUriPathFinder->getDescendantsOfNode($node);
             array_map($this->collectTagsToFlush(...), iterator_to_array($descendantsOfNode));
         }
     }
@@ -153,7 +152,7 @@ final class RouterCacheHook implements CatchUpHookInterface
 
             $this->collectTagsToFlush($node);
 
-            $descendantsOfNode = $this->getState()->getDescendantsOfNode($node);
+            $descendantsOfNode = $this->documentUriPathFinder->getDescendantsOfNode($node);
             array_map($this->collectTagsToFlush(...), iterator_to_array($descendantsOfNode));
         }
     }
@@ -173,15 +172,10 @@ final class RouterCacheHook implements CatchUpHookInterface
         $this->tagsToFlush = [];
     }
 
-    private function getState(): DocumentUriPathFinder
-    {
-        return $this->contentRepository->projectionState(DocumentUriPathFinder::class);
-    }
-
     private function findDocumentNodeInfoByIdAndDimensionSpacePoint(NodeAggregateId $nodeAggregateId, DimensionSpacePoint $dimensionSpacePoint): ?DocumentNodeInfo
     {
         try {
-            return $this->getState()->getByIdAndDimensionSpacePointHash(
+            return $this->documentUriPathFinder->getByIdAndDimensionSpacePointHash(
                 $nodeAggregateId,
                 $dimensionSpacePoint->hash
             );

--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Neos\Neos\FrontendRouting\CatchUpHook;
 
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Neos\FrontendRouting\Projection\DocumentUriPathFinder;
 
@@ -21,10 +20,10 @@ final class RouterCacheHookFactory implements CatchUpHookFactoryInterface
     ) {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
+    public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface
     {
         return new RouterCacheHook(
-            $projectionState,
+            $dependencies->projectionState,
             $this->routerCachingService
         );
     }

--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHookFactory.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Neos\Neos\FrontendRouting\CatchUpHook;
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHookInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
-use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
+use Neos\Neos\FrontendRouting\Projection\DocumentUriPathFinder;
 
+/**
+ * @implements CatchUpHookFactoryInterface<DocumentUriPathFinder>
+ */
 final class RouterCacheHookFactory implements CatchUpHookFactoryInterface
 {
     public function __construct(
@@ -17,10 +21,10 @@ final class RouterCacheHookFactory implements CatchUpHookFactoryInterface
     ) {
     }
 
-    public function build(ContentRepository $contentRepository): CatchUpHookInterface
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): CatchUpHookInterface
     {
         return new RouterCacheHook(
-            $contentRepository,
+            $projectionState,
             $this->routerCachingService
         );
     }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
@@ -14,9 +14,14 @@ namespace Neos\Neos\Fusion\Cache;
  * source code.
  */
 
-use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
+/**
+ * @implements CatchUpHookFactoryInterface<ContentGraphReadModelInterface>
+ */
 class GraphProjectorCatchUpHookForCacheFlushingFactory implements CatchUpHookFactoryInterface
 {
     public function __construct(
@@ -24,10 +29,11 @@ class GraphProjectorCatchUpHookForCacheFlushingFactory implements CatchUpHookFac
     ) {
     }
 
-    public function build(ContentRepository $contentRepository): GraphProjectorCatchUpHookForCacheFlushing
+    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): GraphProjectorCatchUpHookForCacheFlushing
     {
         return new GraphProjectorCatchUpHookForCacheFlushing(
-            $contentRepository,
+            $contentRepositoryId,
+            $projectionState,
             $this->contentCacheFlusher
         );
     }

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushingFactory.php
@@ -14,10 +14,9 @@ namespace Neos\Neos\Fusion\Cache;
  * source code.
  */
 
+use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\CatchUpHookFactoryInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
-use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 
 /**
  * @implements CatchUpHookFactoryInterface<ContentGraphReadModelInterface>
@@ -29,11 +28,11 @@ class GraphProjectorCatchUpHookForCacheFlushingFactory implements CatchUpHookFac
     ) {
     }
 
-    public function build(ContentRepositoryId $contentRepositoryId, ProjectionStateInterface $projectionState): GraphProjectorCatchUpHookForCacheFlushing
+    public function build(CatchUpHookFactoryDependencies $dependencies): GraphProjectorCatchUpHookForCacheFlushing
     {
         return new GraphProjectorCatchUpHookForCacheFlushing(
-            $contentRepositoryId,
-            $projectionState,
+            $dependencies->contentRepositoryId,
+            $dependencies->projectionState,
             $this->contentCacheFlusher
         );
     }


### PR DESCRIPTION
With this change - repeating history - will a catchup not have access to the full content repository, as it would allow full recursion via handle and accessing other projections state is not safe as the other projection might not be behind - the order is undefined.

Also this will make it possible to catchup projections from outside of the cr instance which is absolutely required for: https://github.com/neos/neos-development-collection/pull/5321

It seems that once upon a time, the old catchups did only have access to their projection state, but that was reverted with the change https://github.com/neos/neos-development-collection/commit/51b6d6ef1ddf29ea6631e2de119f8d8ffe896712#diff-315ddb033d1c40e107cbd08614930fa10d499a08afdc583dbb74949e3a3b2458L7 as we introduced support for multiple content repositories and thus cache flushing needed to be adjusted. 

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
