### PR TITLE
TASK: Introduce `ContentRepository::getNodeType` to simplify 80% use

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -25,7 +25,9 @@ use Neos\ContentRepository\Core\EventStore\EventPersister;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryFactory;
+use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\CatchUp;
 use Neos\ContentRepository\Core\Projection\CatchUpOptions;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
@@ -284,6 +286,14 @@ final class ContentRepository
     public function findContentStreams(): ContentStreams
     {
         return $this->contentGraphReadModel->findContentStreams();
+    }
+
+    /**
+     * Returns the specified node type (which could be abstract)
+     */
+    public function getNodeType(string|NodeTypeName $nodeTypeName): ?NodeType
+    {
+        return $this->nodeTypeManager->getNodeType($nodeTypeName);
     }
 
     public function getNodeTypeManager(): NodeTypeManager

--- a/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
+++ b/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/PropertyOperation.php
@@ -97,9 +97,8 @@ class PropertyOperation extends AbstractOperation
         }
 
         $contentRepository = $this->contentRepositoryRegistry->get($element->contentRepositoryId);
-        $nodeTypeManager = $contentRepository->getNodeTypeManager();
 
-        if ($nodeTypeManager->getNodeType($element->nodeTypeName)?->hasReference($propertyName)) {
+        if ($contentRepository->getNodeType($element->nodeTypeName)?->hasReference($propertyName)) {
             // legacy access layer for references
             $subgraph = $this->contentRepositoryRegistry->subgraphForNode($element);
             $references = $subgraph->findReferences(
@@ -107,7 +106,7 @@ class PropertyOperation extends AbstractOperation
                 FindReferencesFilter::create(referenceName: $propertyName)
             )->getNodes();
 
-            $maxItems = $nodeTypeManager->getNodeType($element->nodeTypeName)->getReferences()[$propertyName]['constraints']['maxItems'] ?? null;
+            $maxItems = $contentRepository->getNodeType($element->nodeTypeName)->getReferences()[$propertyName]['constraints']['maxItems'] ?? null;
             if ($maxItems === 1) {
                 // legacy layer references with only one item like the previous `type: reference`
                 // (the node type transforms that to constraints.maxItems = 1)

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
@@ -99,7 +99,7 @@ final class ContentCommandController extends CommandController
 
         foreach ($childNodes as $childNode) {
             if ($childNode->classification->isRegular()) {
-                $childNodeType = $contentRepository->getNodeTypeManager()->getNodeType($childNode->nodeTypeName);
+                $childNodeType = $contentRepository->getNodeType($childNode->nodeTypeName);
                 if ($childNodeType?->isOfType('Neos.Neos:Document')) {
                     $this->output("%s- %s\n", [
                         str_repeat('  ', $level),

--- a/Neos.ContentRepositoryRegistry/Classes/Command/NodeTypesCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/NodeTypesCommandController.php
@@ -40,9 +40,9 @@ class NodeTypesCommandController extends CommandController
     public function showCommand(string $nodeTypeName, string $path = '', int $level = 0, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $nodeTypeManager = $this->contentRepositoryRegistry->get($contentRepositoryId)->getNodeTypeManager();
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
-        $nodeType = $nodeTypeManager->getNodeType($nodeTypeName);
+        $nodeType = $contentRepository->getNodeType($nodeTypeName);
         if (!$nodeType) {
             $this->outputLine('<error>NodeType "%s" was not found!</error>', [$nodeTypeName]);
             $this->quit();

--- a/Neos.Media.Browser/Classes/Controller/UsageController.php
+++ b/Neos.Media.Browser/Classes/Controller/UsageController.php
@@ -101,7 +101,7 @@ class UsageController extends ActionController
             $nodeAggregate = $contentRepository->getContentGraph($usage->getWorkspaceName())->findNodeAggregateById(
                 $usage->getNodeAggregateId()
             );
-            $nodeType = $nodeAggregate ? $contentRepository->getNodeTypeManager()->getNodeType($nodeAggregate->nodeTypeName) : null;
+            $nodeType = $nodeAggregate ? $contentRepository->getNodeType($nodeAggregate->nodeTypeName) : null;
 
             $workspacePermissions = $this->workspaceService->getWorkspacePermissionsForUser(
                 $currentContentRepositoryId,

--- a/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
+++ b/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
@@ -57,7 +57,7 @@ class AssetUsageIndexingService
     {
         $workspaceBases = $this->getWorkspaceBasesAndWorkspace($contentRepositoryId, $node->workspaceName);
         $workspaceDependents = $this->getWorkspaceDependents($contentRepositoryId, $node->workspaceName);
-        $nodeType = $this->contentRepositoryRegistry->get($contentRepositoryId)->getNodeTypeManager()->getNodeType($node->nodeTypeName);
+        $nodeType = $this->contentRepositoryRegistry->get($contentRepositoryId)->getNodeType($node->nodeTypeName);
 
         if ($nodeType === null) {
             return;

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -322,7 +322,6 @@ class NodesController extends ActionController
         ContentRepository $contentRepository
     ): void {
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
-        $nodeTypeManager = $contentRepository->getNodeTypeManager();
         $nodeAggregate = $contentGraph->findNodeAggregateById($identifier);
 
         if ($nodeAggregate && $nodeAggregate->coveredDimensionSpacePoints->count() > 0) {
@@ -333,7 +332,7 @@ class NodesController extends ActionController
             // materialized recursively upwards in the rootline. To find the node path for the given identifier,
             // we just use the first result. This is a safe assumption at least for "Document" nodes (aggregate=true),
             // because they are always moved in-sync.
-            if ($nodeTypeManager->getNodeType($nodeAggregate->nodeTypeName)?->isAggregate()) {
+            if ($contentRepository->getNodeType($nodeAggregate->nodeTypeName)?->isAggregate()) {
                 // TODO: we would need the SourceDimensions parameter (as in Create()) to ensure the correct
                 // rootline is traversed. Here, we, as a workaround, simply use the 1st aggregate for now.
 

--- a/Neos.Neos/Classes/Domain/NodeLabel/DelegatingNodeLabelRenderer.php
+++ b/Neos.Neos/Classes/Domain/NodeLabel/DelegatingNodeLabelRenderer.php
@@ -25,9 +25,9 @@ final readonly class DelegatingNodeLabelRenderer implements NodeLabelGeneratorIn
 
     public function getLabel(Node $node): string
     {
-        $nodeTypeManager = $this->contentRepositoryRegistry->get($node->contentRepositoryId)->getNodeTypeManager();
-        $nodeType = $nodeTypeManager->getNodeType($node->nodeTypeName)
-            ?? $nodeTypeManager->getNodeType(NodeTypeNameFactory::forFallback());
+        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
+        $nodeType = $contentRepository->getNodeType($node->nodeTypeName)
+            ?? $contentRepository->getNodeType(NodeTypeNameFactory::forFallback());
         $generator = $this->getDelegatedGenerator($nodeType);
         if ($generator instanceof DelegatingNodeLabelRenderer) {
             throw new \RuntimeException(

--- a/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
@@ -304,8 +304,7 @@ final class WorkspacePublishingService
         }
 
         if (
-            !$contentRepository->getNodeTypeManager()
-                ->getNodeType($nodeAggregate->nodeTypeName)
+            !$contentRepository->getNodeType($nodeAggregate->nodeTypeName)
                 ?->isOfType($nodeTypeName)
         ) {
             throw new \RuntimeException(

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -170,7 +170,7 @@ class ContentCacheFlusher
         $tagsToFlush = [];
 
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($nodeTypeName);
+        $nodeType = $contentRepository->getNodeType($nodeTypeName);
         if ($nodeType) {
             $nodeTypesNamesToFlush = $this->getAllImplementedNodeTypeNames($nodeType);
         } else {

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -86,8 +86,7 @@ class NodeHelper implements ProtectedContextAwareInterface
     public function nodeType(Node $node): ?NodeType
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
-        return $contentRepository->getNodeTypeManager()
-            ->getNodeType($node->nodeTypeName);
+        return $contentRepository->getNodeType($node->nodeTypeName);
     }
 
     /**
@@ -97,8 +96,7 @@ class NodeHelper implements ProtectedContextAwareInterface
     public function isOfType(Node $node, string $nodeType): bool
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
-        return (bool)$contentRepository->getNodeTypeManager()
-            ->getNodeType($node->nodeTypeName)?->isOfType($nodeType);
+        return (bool)$contentRepository->getNodeType($node->nodeTypeName)?->isOfType($nodeType);
     }
 
     public function isDisabled(Node $node): bool

--- a/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
+++ b/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
@@ -30,10 +30,10 @@ trait NodeTypeWithFallbackProvider
      */
     protected function getNodeType(Node $node): NodeType
     {
-        $nodeTypeManager = $this->contentRepositoryRegistry->get($node->contentRepositoryId)->getNodeTypeManager();
+        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
 
-        return $nodeTypeManager->getNodeType($node->nodeTypeName)
-            ?? $nodeTypeManager->getNodeType(NodeTypeNameFactory::forFallback())
+        return $contentRepository->getNodeType($node->nodeTypeName)
+            ?? $contentRepository->getNodeType(NodeTypeNameFactory::forFallback())
             ?? throw new NodeTypeNotFound(sprintf('Fallback NodeType not found while attempting to get NodeType "%s".', $node->nodeTypeName->value), 1710789992);
     }
 }

--- a/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
+++ b/Neos.Neos/Classes/Utility/NodeTypeWithFallbackProvider.php
@@ -17,7 +17,7 @@ use Neos\Neos\Domain\Service\NodeTypeNameFactory;
  * This is only a temporary drop-in replacement as the automatic fallback handling
  * of the NodeTypeManager was removed and Node::getNodeType was also removed.
  *
- * Its preferred to use the nullable {@see NodeTypeManager::getNodeType()} instead, and for cases where
+ * Its preferred to use the nullable {@see NodeTypeManager::getNodeType()}, aliased {@see ContentRepository::getNodeType()} instead, and for cases where
  * the Fallback NodeType is really required use {@see NodeTypeNameFactory::forFallback()}.
  *
  * @property ContentRepositoryRegistry $contentRepositoryRegistry


### PR DESCRIPTION
`$contentRepository->getNodeTypeManager()->getNodeType()` will be aliased as `$contentRepository->getNodeType()` to make the 90% usecase easy ... basically the same we are doing for `getContentSubgraph()` and `findWorkspaceByName()`

that way we probably dont need a higher level utility as fetching the cr would be just enough see https://github.com/neos/neos-development-collection/issues/5065

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
