### PR TITLE
BUGFIX: Change base workspace

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
@@ -75,7 +75,15 @@ Feature: Change base workspace constraints
 
     Then the last command should have thrown an exception of type "WorkspaceIsNotEmptyException"
 
-  Scenario: Changing the base workspace does not work if the new base if a base of the current (cyclic)
+  Scenario: Changing the base workspace does not work if the new base is the current workspace (cyclic)
+    When the command ChangeBaseWorkspace is executed with payload and exceptions are caught:
+      | Key                | Value                        |
+      | workspaceName      | "user-test"                  |
+      | baseWorkspaceName  | "user-test"                  |
+
+    Then the last command should have thrown an exception of type "BaseWorkspaceEqualsWorkspaceException"
+
+  Scenario: Changing the base workspace does not work if the new base is a base of the current (cyclic)
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                           |
       | workspaceName      | "shared-branched"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
@@ -1,0 +1,94 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Change base workspace constraints
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content':
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        child1:
+          type: 'Neos.ContentRepository.Testing:Content'
+        child2:
+          type: 'Neos.ContentRepository.Testing:Content'
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                  |
+      | workspaceName      | "shared"               |
+      | baseWorkspaceName  | "live"                 |
+      | newContentStreamId | "shared-cs-identifier" |
+
+  Scenario: Changing the base workspace is not allowed if there are pending changes
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "user-test"                              |
+      | nodeAggregateId           | "holy-nody"                              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node in shared"}           |
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to node user-cs-identifier;holy-nody;{}
+
+    When the command ChangeBaseWorkspace is executed with payload and exceptions are caught:
+      | Key                | Value                        |
+      | workspaceName      | "user-test"                  |
+      | baseWorkspaceName  | "shared"                     |
+      | newContentStreamId | "user-rebased-cs-identifier" |
+
+    Then the last command should have thrown an exception of type "WorkspaceIsNotEmptyException"
+
+  Scenario: Changing the base workspace does not work if the new base if a base of the current (cyclic)
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                           |
+      | workspaceName      | "shared-branched"               |
+      | baseWorkspaceName  | "shared"                        |
+      | newContentStreamId | "shared-branched-cs-identifier" |
+
+    When the command ChangeBaseWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value             |
+      | workspaceName     | "shared"          |
+      | baseWorkspaceName | "shared-branched" |
+
+    Then the last command should have thrown an exception of type "CircularRelationBetweenWorkspacesException"
+
+  Scenario: Changing the base workspace does not work if the new base complexly cyclic
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                    |
+      | workspaceName      | "shared-a"               |
+      | baseWorkspaceName  | "shared"                 |
+      | newContentStreamId | "shared-a-cs-identifier" |
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                     |
+      | workspaceName      | "shared-a1"               |
+      | baseWorkspaceName  | "shared"                  |
+      | newContentStreamId | "shared-a1-cs-identifier" |
+    When the command ChangeBaseWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value             |
+      | workspaceName     | "shared"          |
+      | baseWorkspaceName | "shared-a1" |
+    Then the last command should have thrown an exception of type "CircularRelationBetweenWorkspacesException"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
@@ -41,6 +41,19 @@ Feature: Change base workspace constraints
       | baseWorkspaceName  | "live"                 |
       | newContentStreamId | "shared-cs-identifier" |
 
+  Scenario: Changing the base workspace is not allowed for root workspaces
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value                 |
+      | workspaceName      | "groot"               |
+      | newContentStreamId | "cs-groot-identifier" |
+
+    When the command ChangeBaseWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value   |
+      | workspaceName     | "live"  |
+      | baseWorkspaceName | "groot" |
+
+    Then the last command should have thrown an exception of type "WorkspaceHasNoBaseWorkspaceName"
+
   Scenario: Changing the base workspace is not allowed if there are pending changes
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                    |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -1,0 +1,93 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Change base workspace works :D what else
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content':
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        child1:
+          type: 'Neos.ContentRepository.Testing:Content'
+        child2:
+          type: 'Neos.ContentRepository.Testing:Content'
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "live"                                   |
+      | nodeAggregateId           | "nody-mc-nodeface"                       |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "Original text"}                |
+
+    # Create user workspace
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+  Scenario: Change base workspace is a no-op if the base already matches
+    When the command ChangeBaseWorkspace is executed with payload:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+      | baseWorkspaceName | "live"      |
+
+    Then I expect exactly 1 event to be published on stream "Workspace:user-test"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                  | Expected                      |
+      | workspaceName        | "user-test"                   |
+      | baseWorkspaceName    | "live"                        |
+      | newContentStreamId   | "user-cs-identifier"          |
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+
+  Scenario: Change base workspace is a no-op if the base already matches but the workspace is outdated
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "live"                                   |
+      | nodeAggregateId           | "holy-nody"                       |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node in live"}                |
+
+    Then workspaces user-test has status OUTDATED
+
+    When the command ChangeBaseWorkspace is executed with payload:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+      | baseWorkspaceName | "live"      |
+
+    Then workspaces user-test has status OUTDATED
+
+    Then I expect exactly 1 event to be published on stream "Workspace:user-test"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                  | Expected                      |
+      | workspaceName        | "user-test"                   |
+      | baseWorkspaceName    | "live"                        |
+      | newContentStreamId   | "user-cs-identifier"          |
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to no node
+
+    Given I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to node cs-identifier;holy-nody;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -37,12 +37,17 @@ Feature: Change base workspace works :D what else
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | initialPropertyValues     | {"text": "Original text"}                |
 
-    # Create user workspace
     And the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
       | baseWorkspaceName  | "live"               |
       | newContentStreamId | "user-cs-identifier" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                  |
+      | workspaceName      | "shared"               |
+      | baseWorkspaceName  | "live"                 |
+      | newContentStreamId | "shared-cs-identifier" |
 
   Scenario: Change base workspace is a no-op if the base already matches
     When the command ChangeBaseWorkspace is executed with payload:
@@ -93,12 +98,6 @@ Feature: Change base workspace works :D what else
     Then I expect node aggregate identifier "holy-nody" to lead to node cs-identifier;holy-nody;{}
 
   Scenario: Change base workspace if user has no changes and is up to date with new base
-    And the command CreateWorkspace is executed with payload:
-      | Key                | Value                  |
-      | workspaceName      | "shared"               |
-      | baseWorkspaceName  | "live"                 |
-      | newContentStreamId | "shared-cs-identifier" |
-
     When the command ChangeBaseWorkspace is executed with payload:
       | Key                | Value                        |
       | workspaceName      | "user-test"                  |
@@ -112,12 +111,6 @@ Feature: Change base workspace works :D what else
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-rebased-cs-identifier;nody-mc-nodeface;{}
 
   Scenario: Change base workspace if user has no changes and is not up to date with new base
-    And the command CreateWorkspace is executed with payload:
-      | Key                | Value                  |
-      | workspaceName      | "shared"               |
-      | baseWorkspaceName  | "live"                 |
-      | newContentStreamId | "shared-cs-identifier" |
-
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                    |
       | workspaceName             | "shared"                                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -91,3 +91,55 @@ Feature: Change base workspace works :D what else
 
     Given I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "holy-nody" to lead to node cs-identifier;holy-nody;{}
+
+  Scenario: Change base workspace if user has no changes and is up to date with new base
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                  |
+      | workspaceName      | "shared"               |
+      | baseWorkspaceName  | "live"                 |
+      | newContentStreamId | "shared-cs-identifier" |
+
+    When the command ChangeBaseWorkspace is executed with payload:
+      | Key                | Value                        |
+      | workspaceName      | "user-test"                  |
+      | baseWorkspaceName  | "shared"                     |
+      | newContentStreamId | "user-rebased-cs-identifier" |
+
+    Then workspaces user-test has status UP_TO_DATE
+
+    Given I am in workspace "user-test" and dimension space point {}
+    # todo no fork needed?
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-rebased-cs-identifier;nody-mc-nodeface;{}
+
+  Scenario: Change base workspace if user has no changes and is not up to date with new base
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                  |
+      | workspaceName      | "shared"               |
+      | baseWorkspaceName  | "live"                 |
+      | newContentStreamId | "shared-cs-identifier" |
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "shared"                                 |
+      | nodeAggregateId           | "holy-nody"                              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node in shared"}           |
+
+    Given I am in workspace "shared" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to node shared-cs-identifier;holy-nody;{}
+
+    When the command ChangeBaseWorkspace is executed with payload:
+      | Key                | Value                        |
+      | workspaceName      | "user-test"                  |
+      | baseWorkspaceName  | "shared"                     |
+      | newContentStreamId | "user-rebased-cs-identifier" |
+
+    Then workspaces user-test has status UP_TO_DATE
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to node user-rebased-cs-identifier;holy-nody;{}
+    And I expect this node to have the following properties:
+      | Key  | Value                |
+      | text | "New node in shared" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -29,21 +29,18 @@ Feature: Workspace rebasing - conflicting changes
       | nodeTypeName    | "Neos.ContentRepository:Root" |
 
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId  | nodeTypeName                           | parentNodeAggregateId  | nodeName |
-      | nody-mc-nodeface | Neos.ContentRepository.Testing:Content | lady-eleonode-rootford | child    |
+      | nodeAggregateId  | nodeTypeName                           | parentNodeAggregateId  |
+      | nody-mc-nodeface | Neos.ContentRepository.Testing:Content | lady-eleonode-rootford |
+      | sir-nodebelig    | Neos.ContentRepository.Testing:Content | lady-eleonode-rootford |
+      | nobody-node      | Neos.ContentRepository.Testing:Content | lady-eleonode-rootford |
 
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                |
       | nodeAggregateId           | "nody-mc-nodeface"   |
       | originDimensionSpacePoint | {}                   |
       | propertyValues            | {"text": "Original"} |
-    And the command CreateWorkspace is executed with payload:
-      | Key                | Value                |
-      | workspaceName      | "user-test"          |
-      | baseWorkspaceName  | "live"               |
-      | newContentStreamId | "user-cs-identifier" |
 
-  Scenario: Conflicting changes lead to OUTDATED which can be recovered from via forced rebase
+  Scenario: Conflicting changes lead to WorkspaceRebaseFailed exception which can be recovered from via forced rebase
 
     When the command CreateWorkspace is executed with payload:
       | Key                | Value              |
@@ -96,6 +93,17 @@ Feature: Workspace rebasing - conflicting changes
     Then workspaces live,user-ws-one have status UP_TO_DATE
     Then workspace user-ws-two has status OUTDATED
 
+    # Rebase without force fails
+    When the command RebaseWorkspace is executed with payload and exceptions are caught:
+      | Key                         | Value                 |
+      | workspaceName               | "user-ws-two"         |
+      | rebasedContentStreamId      | "user-cs-two-rebased" |
+    Then I expect the content stream "user-cs-two" to exist
+    Then I expect the content stream "user-cs-two-rebased" to not exist
+    Then the last command should have thrown the WorkspaceRebaseFailed exception with:
+      | SequenceNumber | Command                     | Exception                          |
+      | 13             | SetSerializedNodeProperties | NodeAggregateCurrentlyDoesNotExist |
+
     When the command RebaseWorkspace is executed with payload:
       | Key                         | Value                 |
       | workspaceName               | "user-ws-two"         |
@@ -103,4 +111,80 @@ Feature: Workspace rebasing - conflicting changes
       | rebaseErrorHandlingStrategy | "force"               |
 
     Then workspaces live,user-ws-one,user-ws-two have status UP_TO_DATE
-    And I expect a node identified by user-cs-two-rebased;noderus-secundus;{} to exist in the content graph
+
+    Then I expect the content stream "user-cs-two" to not exist
+    Then I expect the content stream "user-cs-two-rebased" to exist
+
+    When I am in workspace "user-ws-two" and dimension space point {}
+    Then I expect node aggregate identifier "noderus-secundus" to lead to node user-cs-two-rebased;noderus-secundus;{}
+
+  Scenario: Not conflicting changes are preserved on force rebase
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-ws"            |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value           |
+      | workspaceName                | "live"          |
+      | nodeAggregateId              | "sir-nodebelig" |
+      | coveredDimensionSpacePoint   | {}              |
+      | nodeVariantSelectionStrategy | "allVariants"   |
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | workspaceName                | "live"        |
+      | nodeAggregateId              | "nobody-node" |
+      | coveredDimensionSpacePoint   | {}            |
+      | nodeVariantSelectionStrategy | "allVariants" |
+
+    And the command SetNodeProperties is executed with payload:
+      | Key                       | Value                     |
+      | workspaceName             | "user-ws"                 |
+      | nodeAggregateId           | "sir-nodebelig"           |
+      | originDimensionSpacePoint | {}                        |
+      | propertyValues            | {"text": "Modified text"} |
+
+    # change that is rebaseable
+    And the command SetNodeProperties is executed with payload:
+      | Key                       | Value                               |
+      | workspaceName             | "user-ws"                           |
+      | nodeAggregateId           | "nody-mc-nodeface"                  |
+      | originDimensionSpacePoint | {}                                  |
+      | propertyValues            | {"text": "Rebaseable change in ws"} |
+
+    And the command SetNodeProperties is executed with payload:
+      | Key                       | Value                     |
+      | workspaceName             | "user-ws"                 |
+      | nodeAggregateId           | "nobody-node"             |
+      | originDimensionSpacePoint | {}                        |
+      | propertyValues            | {"text": "Modified text"} |
+
+    # Rebase without force fails
+    When the command RebaseWorkspace is executed with payload and exceptions are caught:
+      | Key                | Value                        |
+      | workspaceName      | "user-ws"                    |
+      | newContentStreamId | "user-cs-identifier-rebased" |
+    Then I expect the content stream "user-cs-identifier" to exist
+    Then I expect the content stream "user-cs-identifier-rebased" to not exist
+    Then the last command should have thrown the WorkspaceRebaseFailed exception with:
+      | SequenceNumber | Command                     | Exception                          |
+      | 12             | SetSerializedNodeProperties | NodeAggregateCurrentlyDoesNotExist |
+      | 14             | SetSerializedNodeProperties | NodeAggregateCurrentlyDoesNotExist |
+
+    When the command RebaseWorkspace is executed with payload:
+      | Key                         | Value                        |
+      | workspaceName               | "user-ws"                    |
+      | rebasedContentStreamId      | "user-cs-identifier-rebased" |
+      | rebaseErrorHandlingStrategy | "force"                      |
+
+    Then I expect the content stream "user-cs-identifier" to not exist
+    Then I expect the content stream "user-cs-identifier-rebased" to exist
+
+    When I am in workspace "user-ws" and dimension space point {}
+    Then I expect node aggregate identifier "sir-nodebelig" to lead to no node
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-rebased;nody-mc-nodeface;{}
+    And I expect this node to have the following properties:
+      | Key  | Value                     |
+      | text | "Rebaseable change in ws" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
@@ -36,11 +36,11 @@ Feature: Workspace publication - complex chained functionality
       | nodeTypeName    | "Neos.ContentRepository:Root" |
 
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | tetheredDescendantNodeAggregateIds | properties                |
-      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | {"tethered": "nodewyn-tetherton"}  |                           |
-      | sir-nodebelig          | Neos.ContentRepository.Testing:Content  | lady-eleonode-rootford |                                  |                           |
-      | nobody-node          | Neos.ContentRepository.Testing:Content  | lady-eleonode-rootford |                                  |                           |
-      | nody-mc-nodeface       | Neos.ContentRepository.Testing:Content  | nodewyn-tetherton      |                                  |  |
+      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | tetheredDescendantNodeAggregateIds | properties |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | {"tethered": "nodewyn-tetherton"}  |            |
+      | sir-nodebelig          | Neos.ContentRepository.Testing:Content  | lady-eleonode-rootford |                                    |            |
+      | nobody-node            | Neos.ContentRepository.Testing:Content  | lady-eleonode-rootford |                                    |            |
+      | nody-mc-nodeface       | Neos.ContentRepository.Testing:Content  | nodewyn-tetherton      |                                    |            |
 
     And the command CreateWorkspace is executed with payload:
       | Key                | Value        |

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -732,14 +732,14 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
         $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        if ($workspace->baseWorkspaceName->equals($command->baseWorkspaceName)) {
+        $currentBaseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+
+        if ($currentBaseWorkspace->workspaceName->equals($command->baseWorkspaceName)) {
             // no-op
             return;
         }
 
         $this->requireEmptyWorkspace($workspace);
-        $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
-
         $newBaseWorkspace = $this->requireWorkspace($command->baseWorkspaceName, $commandHandlingDependencies);
 
         $this->requireNonCircularRelationBetweenWorkspaces($workspace, $newBaseWorkspace, $commandHandlingDependencies);

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -732,6 +732,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
         $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        if ($workspace->baseWorkspaceName->equals($command->baseWorkspaceName)) {
+            // no-op
+            return;
+        }
+
         $this->requireEmptyWorkspace($workspace);
         $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -739,13 +739,14 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $this->requireEmptyWorkspace($workspace);
         $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
-        $this->requireNonCircularRelationBetweenWorkspaces($workspace, $baseWorkspace, $commandHandlingDependencies);
+        $newBaseWorkspace = $this->requireWorkspace($command->baseWorkspaceName, $commandHandlingDependencies);
+
+        $this->requireNonCircularRelationBetweenWorkspaces($workspace, $newBaseWorkspace, $commandHandlingDependencies);
 
         yield $this->forkContentStream(
             $command->newContentStreamId,
-            $baseWorkspace->currentContentStreamId,
+            $newBaseWorkspace->currentContentStreamId,
             $commandHandlingDependencies
         );
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Command/ChangeBaseWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Command/ChangeBaseWorkspace.php
@@ -35,4 +35,15 @@ final readonly class ChangeBaseWorkspace implements CommandInterface
     {
         return new self($workspaceName, $baseWorkspaceName, ContentStreamId::create());
     }
+
+    /**
+     * During the publish process, we create a new content stream.
+     *
+     * This method adds its ID, so that the command
+     * can run fully deterministic - we need this for the test cases.
+     */
+    public function withNewContentStreamId(ContentStreamId $newContentStreamId): self
+    {
+        return new self($this->workspaceName, $this->baseWorkspaceName, $newContentStreamId);
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Command/PublishIndividualNodesFromWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Command/PublishIndividualNodesFromWorkspace.php
@@ -52,9 +52,9 @@ final readonly class PublishIndividualNodesFromWorkspace implements CommandInter
     }
 
     /**
-     * See the description of {@see self::withContentStreamIdForMatchingPart()}.
+     * The id of the new content stream that will contain all remaining events
      *
-     * This property adds the ID of the second content stream, so that the command
+     * This method adds its ID, so that the command
      * can run fully deterministic - we need this for the test cases.
      */
     public function withContentStreamIdForRemainingPart(ContentStreamId $contentStreamIdForRemainingPart): self

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Features;
 
 use Behat\Gherkin\Node\TableNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\ChangeBaseWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishIndividualNodesFromWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Dto\NodeIdsToPublishOrDiscard;
@@ -92,6 +93,34 @@ trait WorkspacePublishing
     {
         try {
             $this->theCommandPublishWorkspaceIsExecuted($payloadTable);
+        } catch (\Exception $exception) {
+            $this->lastCommandException = $exception;
+        }
+    }
+
+    /**
+     * @Given /^the command ChangeBaseWorkspace is executed with payload:$/
+     * @throws \Exception
+     */
+    public function theCommandChangeBaseWorkspaceIsExecuted(TableNode $payloadTable): void
+    {
+        $commandArguments = $this->readPayloadTable($payloadTable);
+        $command = ChangeBaseWorkspace::create(
+            array_key_exists('workspaceName', $commandArguments)
+                ? WorkspaceName::fromString($commandArguments['workspaceName'])
+                : $this->currentWorkspaceName,
+            WorkspaceName::fromString($commandArguments['baseWorkspaceName']),
+        );
+        $this->currentContentRepository->handle($command);
+    }
+
+    /**
+     * @Given /^the command ChangeBaseWorkspace is executed with payload and exceptions are caught:$/
+     */
+    public function theCommandChangeBaseWorkspaceIsExecutedAndExceptionsAreCaught(TableNode $payloadTable): void
+    {
+        try {
+            $this->theCommandChangeBaseWorkspaceIsExecuted($payloadTable);
         } catch (\Exception $exception) {
             $this->lastCommandException = $exception;
         }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/WorkspacePublishing.php
@@ -111,6 +111,9 @@ trait WorkspacePublishing
                 : $this->currentWorkspaceName,
             WorkspaceName::fromString($commandArguments['baseWorkspaceName']),
         );
+        if (array_key_exists('newContentStreamId', $commandArguments)) {
+            $command = $command->withNewContentStreamId(ContentStreamId::fromString($commandArguments['newContentStreamId']));
+        }
         $this->currentContentRepository->handle($command);
     }
 


### PR DESCRIPTION
While writing tests for the completely untested `ChangeBaseWorkspace` command (which is used by the Neos UI to switch between workspaces), i noticed an accidental regression due to unfortunate naming of the variable

ChangeBaseWorkspace changed previously to the _old_ base and not to the  _new_:

https://github.com/neos/neos-development-collection/commit/7d691d85394c9819b64996c51cc208f321603212#diff-3e5de1a138586c8c85cdd71ed1a765ecc0ba0d79ab2579a6000475d427cefda2R843-R848


The symptoms are:
- the "actual" source of the workspace is the previous one, so one doesnt see changes made in the shared workspace
- if the shared workspace is edited, no sync button is shown (as the status cannot be calculated correctly)

After publishing, discard, or rebase everything will be in order again, as we use the `baseWorkspaceName` as new base then properly and the hick-up is gone.

I dont think we need a further migration.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
