### PR TITLE
FEATURE: Introduce `Workspace::hasPublishableChanges`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -159,7 +159,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         $queryBuilder = $this->dbal->createQueryBuilder();
 
         return $queryBuilder
-            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.sourceContentStreamVersion = scs.version as upToDateWithBase')
+            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.sourceContentStreamVersion = scs.version as upToDateWithBase, cs.publishableEvents as publishableEventsOnStream')
             ->from($this->tableNames->workspace(), 'ws')
             ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');
@@ -188,11 +188,12 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
             $baseWorkspaceName,
             ContentStreamId::fromString($row['currentContentStreamId']),
             $status,
+            $baseWorkspaceName === null ? 0 : $row['publishableEventsOnStream'],
         );
     }
 
     /**
-     * @param array<string, mixed> $row todo fetch source content stream version and use for publishing as expected version
+     * @param array<string, mixed> $row
      */
     private static function contentStreamFromDatabaseRow(array $row): ContentStream
     {

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -159,7 +159,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         $queryBuilder = $this->dbal->createQueryBuilder();
 
         return $queryBuilder
-            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.sourceContentStreamVersion = scs.version as upToDateWithBase, cs.publishableEvents as publishableEventsOnStream')
+            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.sourceContentStreamVersion = scs.version as upToDateWithBase, cs.dirty as workspaceHasChanges')
             ->from($this->tableNames->workspace(), 'ws')
             ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');
@@ -188,7 +188,9 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
             $baseWorkspaceName,
             ContentStreamId::fromString($row['currentContentStreamId']),
             $status,
-            $baseWorkspaceName === null ? 0 : $row['publishableEventsOnStream'],
+            $baseWorkspaceName === null
+                ? false
+                : (bool)$row['workspaceHasChanges'],
         );
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -159,7 +159,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         $queryBuilder = $this->dbal->createQueryBuilder();
 
         return $queryBuilder
-            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.sourceContentStreamVersion = scs.version as upToDateWithBase, cs.dirty as workspaceHasChanges')
+            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion = scs.version as upToDateWithBase')
             ->from($this->tableNames->workspace(), 'ws')
             ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');
@@ -190,7 +190,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
             $status,
             $baseWorkspaceName === null
                 ? false
-                : (bool)$row['workspaceHasChanges'],
+                : (bool)$row['hasChanges'],
         );
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -24,6 +24,7 @@ use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\InitiatingEventMetadata;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
+use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasClosed;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasReopened;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
@@ -236,8 +237,16 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             WorkspaceWasRemoved::class => $this->whenWorkspaceWasRemoved($event),
             default => $event instanceof EmbedsContentStreamId || throw new \InvalidArgumentException(sprintf('Unsupported event %s', get_debug_type($event))),
         };
-        if ($event instanceof EmbedsContentStreamId && ContentStreamEventStreamName::isContentStreamStreamName($eventEnvelope->streamName)) {
-            $this->updateContentStreamVersion($event, $eventEnvelope->version);
+        if (
+            $event instanceof EmbedsContentStreamId
+            && ContentStreamEventStreamName::isContentStreamStreamName($eventEnvelope->streamName)
+            && !(
+                // special case as we dont need to update anything. The handling above takes care of setting the version to 0
+                $event instanceof ContentStreamWasForked
+                || $event instanceof ContentStreamWasCreated
+            )
+        ) {
+            $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version, $event instanceof PublishableToWorkspaceInterface);
         }
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -237,7 +237,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             default => $event instanceof EmbedsContentStreamId || throw new \InvalidArgumentException(sprintf('Unsupported event %s', get_debug_type($event))),
         };
         if ($event instanceof EmbedsContentStreamId && ContentStreamEventStreamName::isContentStreamStreamName($eventEnvelope->streamName)) {
-            $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version);
+            $this->updateContentStreamVersion($event, $eventEnvelope->version);
         }
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -130,7 +130,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             DbalSchemaFactory::columnForContentStreamId('sourceContentStreamId')->setNotnull(false),
             (new Column('sourceContentStreamVersion', Type::getType(Types::INTEGER)))->setNotnull(false),
             (new Column('closed', Type::getType(Types::BOOLEAN)))->setNotnull(true),
-            (new Column('dirty', Type::getType(Types::BOOLEAN)))->setNotnull(true),
+            (new Column('hasChanges', Type::getType(Types::BOOLEAN)))->setNotnull(true),
         ]);
 
         return $contentStreamTable->setPrimaryKey(['id']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -129,8 +129,8 @@ class DoctrineDbalContentGraphSchemaBuilder
             (new Column('version', Type::getType(Types::INTEGER)))->setNotnull(true),
             DbalSchemaFactory::columnForContentStreamId('sourceContentStreamId')->setNotnull(false),
             (new Column('sourceContentStreamVersion', Type::getType(Types::INTEGER)))->setNotnull(false),
-            (new Column('closed', Type::getType(Types::BOOLEAN)))->setDefault(false)->setNotnull(true),
-            (new Column('publishableEvents', Type::getType(Types::INTEGER)))->setNotnull(true),
+            (new Column('closed', Type::getType(Types::BOOLEAN)))->setNotnull(true),
+            (new Column('dirty', Type::getType(Types::BOOLEAN)))->setNotnull(true),
         ]);
 
         return $contentStreamTable->setPrimaryKey(['id']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -130,6 +130,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             DbalSchemaFactory::columnForContentStreamId('sourceContentStreamId')->setNotnull(false),
             (new Column('sourceContentStreamVersion', Type::getType(Types::INTEGER)))->setNotnull(false),
             (new Column('closed', Type::getType(Types::BOOLEAN)))->setDefault(false)->setNotnull(true),
+            (new Column('publishableEvents', Type::getType(Types::INTEGER)))->setNotnull(true),
         ]);
 
         return $contentStreamTable->setPrimaryKey(['id']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
@@ -22,7 +22,7 @@ trait ContentStream
             'sourceContentStreamId' => $sourceContentStreamId?->value,
             'sourceContentStreamVersion' => $sourceVersion?->value,
             'closed' => 0,
-            'dirty' => 0
+            'hasChanges' => 0
         ]);
     }
 
@@ -57,7 +57,7 @@ trait ContentStream
             'version' => $version->value,
         ];
         if ($markAsDirty) {
-            $updatePayload['dirty'] = 1;
+            $updatePayload['hasChanges'] = 1;
         }
         $this->dbal->update($this->tableNames->contentStream(), $updatePayload, [
             'id' => $contentStreamId->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
-use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
-use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\Model\Event\Version;
 
@@ -54,18 +51,16 @@ trait ContentStream
         ]);
     }
 
-    private function updateContentStreamVersion(EventInterface&EmbedsContentStreamId $event, Version $version): void
+    private function updateContentStreamVersion(ContentStreamId $contentStreamId, Version $version, bool $markAsDirty): void
     {
-        // todo make fork content stream `EmbedsContentStreamId` but then just ignore it here because we set the version already
-        $isPublishableEvent = $event instanceof PublishableToWorkspaceInterface;
         $updatePayload = [
             'version' => $version->value,
         ];
-        if ($isPublishableEvent) {
+        if ($markAsDirty) {
             $updatePayload['dirty'] = 1;
         }
         $this->dbal->update($this->tableNames->contentStream(), $updatePayload, [
-            'id' => $event->getContentStreamId()->value,
+            'id' => $contentStreamId->value,
         ]);
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
@@ -177,10 +177,7 @@ Feature: Workspace based content publishing
 
     # the user and live workspace are unchanged
     Then I expect exactly 1 event to be published on stream "Workspace:user-test"
-    Then I expect exactly 3 event to be published on stream "ContentStream:user-cs-identifier"
-    And event at index 2 is of type "ContentStreamWasReopened" with payload:
-      | Key                  | Expected                 |
-      | contentStreamId      | "user-cs-identifier"     |
+    Then I expect exactly 1 event to be published on stream "ContentStream:user-cs-identifier"
 
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
 

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/PublishableToWorkspaceInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/PublishableToWorkspaceInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\Common;
 
+use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -26,7 +27,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  *
  * @internal used internally for the publishing mechanism of workspaces
  */
-interface PublishableToWorkspaceInterface
+interface PublishableToWorkspaceInterface extends EventInterface
 {
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self;
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Event/ContentStreamWasForked.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Event/ContentStreamWasForked.php
@@ -15,13 +15,14 @@ namespace Neos\ContentRepository\Core\Feature\ContentStreamForking\Event;
  */
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\Model\Event\Version;
 
 /**
  * @api events are the persistence-API of the content repository
  */
-final readonly class ContentStreamWasForked implements EventInterface
+final readonly class ContentStreamWasForked implements EventInterface, EmbedsContentStreamId
 {
     public function __construct(
         /**
@@ -31,6 +32,11 @@ final readonly class ContentStreamWasForked implements EventInterface
         public ContentStreamId $sourceContentStreamId,
         public Version $versionOfSourceContentStream,
     ) {
+    }
+
+    public function getContentStreamId(): ContentStreamId
+    {
+        return $this->newContentStreamId;
     }
 
     public static function fromArray(array $values): self

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
@@ -32,12 +32,9 @@ final readonly class Workspace
         public ?WorkspaceName $baseWorkspaceName,
         public ContentStreamId $currentContentStreamId,
         public WorkspaceStatus $status,
-        private int $countOfPublishableChanges
+        private bool $hasPublishableChanges
     ) {
-        if ($this->countOfPublishableChanges < 0) {
-            throw new \InvalidArgumentException('The number of changes must be greater than 0', 1730371545);
-        }
-        if ($this->isRootWorkspace() && $this->countOfPublishableChanges !== 0) {
+        if ($this->isRootWorkspace() && $this->hasPublishableChanges) {
             throw new \InvalidArgumentException('Root workspaces cannot have changes', 1730371566);
         }
     }
@@ -50,19 +47,17 @@ final readonly class Workspace
         ?WorkspaceName $baseWorkspaceName,
         ContentStreamId $currentContentStreamId,
         WorkspaceStatus $status,
-        int $countOfPublishableChanges
+        bool $hasPublishableChanges
     ): self {
-        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status, $countOfPublishableChanges);
+        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status, $hasPublishableChanges);
     }
 
+    /**
+     * Indicates if the workspace contains changed to be published
+     */
     public function hasPublishableChanges(): bool
     {
-        return $this->countOfPublishableChanges !== 0;
-    }
-
-    public function countPublishableChanges(): int
-    {
-        return $this->countOfPublishableChanges;
+        return $this->hasPublishableChanges;
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
@@ -32,7 +32,14 @@ final readonly class Workspace
         public ?WorkspaceName $baseWorkspaceName,
         public ContentStreamId $currentContentStreamId,
         public WorkspaceStatus $status,
+        private int $countOfPublishableChanges
     ) {
+        if ($this->countOfPublishableChanges < 0) {
+            throw new \InvalidArgumentException('The number of changes must be greater than 0', 1730371545);
+        }
+        if ($this->isRootWorkspace() && $this->countOfPublishableChanges !== 0) {
+            throw new \InvalidArgumentException('Root workspaces cannot have changes', 1730371566);
+        }
     }
 
     /**
@@ -43,8 +50,19 @@ final readonly class Workspace
         ?WorkspaceName $baseWorkspaceName,
         ContentStreamId $currentContentStreamId,
         WorkspaceStatus $status,
+        int $countOfPublishableChanges
     ): self {
-        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status);
+        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status, $countOfPublishableChanges);
+    }
+
+    public function hasPublishableChanges(): bool
+    {
+        return $this->countOfPublishableChanges !== 0;
+    }
+
+    public function countPublishableChanges(): int
+    {
+        return $this->countOfPublishableChanges;
     }
 
     /**

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php
@@ -16,7 +16,6 @@ use Neos\ContentRepository\NodeMigration\Command\ExecuteMigration;
 use Neos\ContentRepository\NodeMigration\Filter\FiltersFactory;
 use Neos\ContentRepository\NodeMigration\Filter\InvalidMigrationFilterSpecified;
 use Neos\ContentRepository\NodeMigration\Transformation\TransformationsFactory;
-use Neos\Neos\PendingChangesProjection\ChangeFinder;
 
 /**
  * Node Migrations are manually written adjustments to the Node tree;
@@ -68,7 +67,7 @@ readonly class NodeMigrationService implements ContentRepositoryServiceInterface
 
         $targetWorkspaceWasCreated = false;
         if ($targetWorkspace = $this->contentRepository->findWorkspaceByName($command->targetWorkspaceName)) {
-            if (!$this->workspaceIsEmpty($targetWorkspace)) {
+            if ($targetWorkspace->hasPublishableChanges()) {
                 throw new MigrationException(sprintf('Target workspace "%s" already exists an is not empty. Please clear the workspace before.', $targetWorkspace->workspaceName->value));
             }
 
@@ -195,13 +194,5 @@ readonly class NodeMigrationService implements ContentRepositoryServiceInterface
                 }
             }
         }
-    }
-
-    private function workspaceIsEmpty(Workspace $workspace): bool
-    {
-        // todo introduce Workspace::hasPendingChanges
-        return $this->contentRepository
-                ->projectionState(ChangeFinder::class)
-                ->countByContentStreamId($workspace->currentContentStreamId) === 0;
     }
 }

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -398,13 +398,15 @@ class WorkspaceCommandController extends CommandController
 
         if ($crWorkspace->hasPublishableChanges()) {
             if ($force === false) {
+                try {
+                    $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
+                } catch (\Exception) {
+                    $nodesCount = 'NAN';
+                }
                 $this->outputLine(
-                    'Did not delete workspace "%s" because it contains %d publishable changes.'
-                        . ' Use --force to delete it nevertheless.',
-                    [
-                        $crWorkspace->countPublishableChanges(),
-                        $workspaceName->value
-                    ]
+                    'Did not delete workspace "%s" because it contains %s unpublished node(s).'
+                    . ' Use --force to delete it nevertheless.',
+                    [$workspaceName->value, $nodesCount]
                 );
                 $this->quit(5);
             }

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -396,20 +396,15 @@ class WorkspaceCommandController extends CommandController
             $this->quit(3);
         }
 
-
-        try {
-            $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
-        } catch (\Exception $exception) {
-            $this->outputLine('Could not fetch unpublished nodes for workspace %s, nothing was deleted. %s', [$workspaceName->value, $exception->getMessage()]);
-            $this->quit(4);
-        }
-
-        if ($nodesCount > 0) {
+        if ($crWorkspace->hasPublishableChanges()) {
             if ($force === false) {
                 $this->outputLine(
-                    'Did not delete workspace "%s" because it contains %s unpublished node(s).'
+                    'Did not delete workspace "%s" because it contains %d publishable changes.'
                         . ' Use --force to delete it nevertheless.',
-                    [$workspaceName->value, $nodesCount]
+                    [
+                        $crWorkspace->countPublishableChanges(),
+                        $workspaceName->value
+                    ]
                 );
                 $this->quit(5);
             }

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -398,17 +398,13 @@ class WorkspaceCommandController extends CommandController
 
         if ($crWorkspace->hasPublishableChanges()) {
             if ($force === false) {
-                try {
-                    $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
-                } catch (\Exception) {
-                    $nodesCount = 'NAN';
-                }
+                $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
                 $this->outputLine(
                     'Did not delete workspace "%s" because it contains %s unpublished node(s).'
                     . ' Use --force to delete it nevertheless.',
                     [$workspaceName->value, $nodesCount]
                 );
-                $this->quit(5);
+                $this->quit(4);
             }
             $this->workspacePublishingService->discardAllWorkspaceChanges($contentRepositoryId, $workspaceName);
         }

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -373,30 +373,13 @@ class WorkspaceController extends AbstractModuleController
             $this->redirect('index');
         }
 
-        $nodesCount = 0;
-
-        try {
-            $nodesCount = $contentRepository->projectionState(ChangeFinder::class)
-                ->countByContentStreamId(
-                    $workspace->currentContentStreamId
-                );
-        } catch (\Exception $exception) {
-            $message = $this->translator->translateById(
-                'workspaces.notDeletedErrorWhileFetchingUnpublishedNodes',
-                [$workspaceMetadata->title->value],
-                null,
-                null,
-                'Main',
-                'Neos.Workspace.Ui'
-            ) ?: 'workspaces.notDeletedErrorWhileFetchingUnpublishedNodes';
-            $this->addFlashMessage($message, '', Message::SEVERITY_WARNING);
-            $this->redirect('index');
-        }
-        if ($nodesCount > 0) {
+        if ($workspace->hasPublishableChanges()) {
+            // todo indicate to the user that theses changes ARE NOT change projection changes
+            $changesCount = $workspace->countPublishableChanges();
             $message = $this->translator->translateById(
                 'workspaces.workspaceCannotBeDeletedBecauseOfUnpublishedNodes',
-                [$workspaceMetadata->title->value, $nodesCount],
-                $nodesCount,
+                [$workspaceMetadata->title->value, $changesCount],
+                $changesCount,
                 null,
                 'Main',
                 'Neos.Workspace.Ui'

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -27,11 +27,11 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodes
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
-use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Diff\Diff;
@@ -374,12 +374,15 @@ class WorkspaceController extends AbstractModuleController
         }
 
         if ($workspace->hasPublishableChanges()) {
-            // todo indicate to the user that theses changes ARE NOT change projection changes
-            $changesCount = $workspace->countPublishableChanges();
+            try {
+                $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
+            } catch (\Exception) {
+                $nodesCount = null;
+            }
             $message = $this->translator->translateById(
                 'workspaces.workspaceCannotBeDeletedBecauseOfUnpublishedNodes',
-                [$workspaceMetadata->title->value, $changesCount],
-                $changesCount,
+                [$workspaceMetadata->title->value, $nodesCount ?? 'NAN'],
+                $nodesCount,
                 null,
                 'Main',
                 'Neos.Workspace.Ui'

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -374,14 +374,10 @@ class WorkspaceController extends AbstractModuleController
         }
 
         if ($workspace->hasPublishableChanges()) {
-            try {
-                $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
-            } catch (\Exception) {
-                $nodesCount = null;
-            }
+            $nodesCount = $this->workspacePublishingService->countPendingWorkspaceChanges($contentRepositoryId, $workspaceName);
             $message = $this->translator->translateById(
                 'workspaces.workspaceCannotBeDeletedBecauseOfUnpublishedNodes',
-                [$workspaceMetadata->title->value, $nodesCount ?? 'NAN'],
+                [$workspaceMetadata->title->value, $nodesCount],
                 $nodesCount,
                 null,
                 'Main',

--- a/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
@@ -168,9 +168,6 @@
       <trans-unit id="workspaces.workspaceCannotBeDeletedBecauseOfDependencies">
         <source>Workspace "{0}" cannot be deleted because the following workspaces are based on it: {1}</source>
       </trans-unit>
-      <trans-unit id="workspaces.notDeletedErrorWhileFetchingUnpublishedNodes">
-        <source>An error occurred while fetching unpublished nodes from workspace "{0}", nothing was deleted.</source>
-      </trans-unit>
       <trans-unit id="workspaces.cantEditBecauseWorkspaceContainsChanges">
         <source>Your personal workspace contains changes, please publish or discard them first.</source>
       </trans-unit>


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Introduces `Workspace::hasPublishableChanges` which will be used for following cases:
- to make `Discard` a noop (instead of looking into the event stream)
- to make `ChangeBaseWorkspace` fail if the workspace has changes (instead of looking into the event stream)
- to make `DeleteWorkspace` fail if the workspace has changes (future pr)
- for node migrations as it should be standalone package and NOT use the change finder ([link](https://github.com/neos/neos-development-collection/blob/97a3588560cd6b0c33c414a70eb7a849b0c226b4/Neos.ContentRepository.NodeMigration/src/NodeMigrationService.php#L200))

Also its good to have some rudimentary changes concept already low level which will hopefully improved at somepoint in Neos X by diffing two content graphs or something.

Note also that the `hasPublishableChanges` will also return true for the case a NodeMigration was run on the workspace and created events like `DimensionShineThroughWasAdded` which are in fact publish able (which is NOT detected via the change projection !!!).

## Implementation:

We decided for a simple `hasChanges` boolean flag on the content stream for now which will be set if there is at least one event that is considered a change: `PublishableToWorkspaceInterface`.
Technically an increment to count the events that are `PublishableToWorkspaceInterface` could also work but as there is no grouping of events per node aggregate id it would be hard to reason about the number and its meaning (it would be completely different to the change projections count)

We leverage the `PublishableToWorkspaceInterface` to ignore events like forking, closing and reopening, as they are not published to another stream. 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
