### PR TITLE
TASK: Use dedicated `testing` cr instead of `default` for behat

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
@@ -15,8 +15,8 @@ Feature: Run projection integrity violation detection regarding root connection
         'Neos.ContentRepository:Root': true
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
@@ -11,8 +11,8 @@ Feature: Run integrity violation detection regarding hierarchy relations and nod
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
@@ -11,8 +11,8 @@ Feature: Run integrity violation detection regarding parent relations
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -14,8 +14,8 @@ Feature: Run integrity violation detection regarding reference relations
         referenceProperty:
           type: reference
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
@@ -11,8 +11,8 @@ Feature: Run integrity violation detection regarding sibling sorting
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
@@ -11,8 +11,8 @@ Feature: Run integrity violation detection regarding subtree tag inheritance
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
@@ -11,8 +11,8 @@ Feature: Run projection integrity violation detection regarding naming of tether
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
@@ -13,8 +13,8 @@ Feature: Sibling positions are properly resolved
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Configuration/Testing/Behat/Settings.ContentRepositoryRegistry.yaml
+++ b/Neos.ContentRepository.BehavioralTests/Configuration/Testing/Behat/Settings.ContentRepositoryRegistry.yaml
@@ -1,7 +1,8 @@
 Neos:
   ContentRepositoryRegistry:
-    presets:
-      default:
+    contentRepositories:
+      testing:
+        preset: default
         userIdProvider:
           factoryObjectName: 'Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\FakeUserIdProviderFactory'
         clock:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
@@ -17,8 +17,8 @@ Feature: Create a root node aggregate
       superTypes:
         'Neos.ContentRepository:Root': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Create a root node aggregate
         'Neos.ContentRepository:Root': true
     'Neos.ContentRepository.Testing:NonRoot': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -29,8 +29,8 @@ Feature: Create a root node aggregate with tethered children
         child-node:
           type: 'Neos.ContentRepository.Testing:SubNode'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -31,8 +31,8 @@ Feature: Create a root node aggregate with tethered children
         child-node:
           type: 'Neos.ContentRepository.Testing:SubNode'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
@@ -16,8 +16,8 @@ Feature: Create a root node aggregate
       superTypes:
         'Neos.ContentRepository:Root': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -28,8 +28,8 @@ Feature: Create node aggregate with node
     'Neos.ContentRepository.Testing:AbstractNode':
       abstract: true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
@@ -30,8 +30,8 @@ Feature: Create node aggregate with node
     'Neos.ContentRepository.Testing:AbstractNode':
       abstract: true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -102,7 +102,7 @@ Feature: Create node aggregate with node
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
       | originDimensionSpacePoint | {"example":"source"}                  |
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:LeafNode': {}
     'Neos.ContentRepository.Testing:Node':

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -21,8 +21,8 @@ Feature: Create node aggregate with node
         nullText:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -188,8 +188,8 @@ Feature: Create node aggregate with node
     """yaml
     'Neos.ContentRepository.Testing:NodeWithoutTetheredChildNodes': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -266,8 +266,8 @@ Feature: Create node aggregate with node
           defaultValue: 'my default'
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -445,8 +445,8 @@ Feature: Create node aggregate with node
           # transliterated invalidcharactors
           type: 'Neos.ContentRepository.Testing:SubNode'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -20,8 +20,8 @@ Feature: Create node aggregate with node
         nullText:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -45,8 +45,8 @@ Feature: Create a node aggregate with complex default values
           type: DateTimeImmutable
           defaultValue: 'not a date'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -30,8 +30,8 @@ Feature: Create node aggregate with node
 
     'Neos.ContentRepository.Testing:UglyNode': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
@@ -16,8 +16,8 @@ Feature: Create node variant
           type: 'Neos.ContentRepository.Testing:Tethered'
     'Neos.ContentRepository.Testing:Tethered': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -20,8 +20,8 @@ Feature: Create node specialization
     'Neos.ContentRepository.Testing:TetheredLeaf': []
     'Neos.ContentRepository.Testing:LeafDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -20,8 +20,8 @@ Feature: Create node generalization
           type: 'Neos.ContentRepository.Testing:TetheredDocument'
     'Neos.ContentRepository.Testing:DocumentWithoutTetheredChildren': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -20,8 +20,8 @@ Feature: Create node peer variant
           type: 'Neos.ContentRepository.Testing:TetheredDocument'
     'Neos.ContentRepository.Testing:DocumentWithoutTetheredChildren': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
@@ -16,8 +16,8 @@ Feature: Set node properties: Constraint checks
         postalAddress:
           type: 'Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -54,8 +54,8 @@ Feature: Set properties
             price: 13.37
             priceCurrency: 'EUR'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
@@ -27,8 +27,8 @@ Feature: Set node properties with different scopes
           scope: nodeAggregate
           defaultValue: 'My string'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
@@ -36,8 +36,8 @@ Feature: Constraint checks on SetNodeReferences
             postalAddress:
               type: 'Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
@@ -41,8 +41,8 @@ Feature: Node References without Dimensions
             postalAddress:
               type: 'Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
@@ -20,8 +20,8 @@ Feature: Node References with Dimensions
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
@@ -34,8 +34,8 @@ Feature: Set node properties with different scopes
           type: references
           scope: specializations
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
@@ -20,8 +20,8 @@ Feature: Node References with Dimensions
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -13,8 +13,8 @@ Feature: Constraint checks on node aggregate disabling
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -14,8 +14,8 @@ Feature: Disable a node aggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -16,8 +16,8 @@ Feature: Disable a node aggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
@@ -13,8 +13,8 @@ Feature: Enable a node aggregate
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -14,8 +14,8 @@ Feature: Enable a node aggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -16,8 +16,8 @@ Feature: Enable a node aggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -12,8 +12,8 @@ Feature: Creation of nodes underneath disabled nodes
     """yaml
     'Neos.ContentRepository.Testing:Document': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -14,8 +14,8 @@ Feature: Creation of nodes underneath disabled nodes
     """yaml
     'Neos.ContentRepository.Testing:Document': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -12,8 +12,8 @@ Feature: Variation of hidden nodes
     """yaml
     'Neos.ContentRepository.Testing:Document': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
@@ -17,8 +17,8 @@ Feature: Remove NodeAggregate
         tethered:
           type: 'Neos.ContentRepository.Testing:Tethered'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -14,8 +14,8 @@ Feature: Remove NodeAggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -16,8 +16,8 @@ Feature: Remove NodeAggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -21,8 +21,8 @@ Feature: Recreate a node variant
           type: 'Neos.ContentRepository.Testing:TetheredDocument'
     'Neos.ContentRepository.Testing:DocumentWithoutTetheredChildren': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -21,8 +21,8 @@ Feature: Create node specialization
     'Neos.ContentRepository.Testing:TetheredLeaf': []
     'Neos.ContentRepository.Testing:LeafDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -22,8 +22,8 @@ Feature: Create node specialization
     'Neos.ContentRepository.Testing:TetheredLeaf': []
     'Neos.ContentRepository.Testing:LeafDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
@@ -28,8 +28,8 @@ Feature: Move node to a new parent / within the current parent before a sibling 
               '*': true
               'Neos.ContentRepository.Testing:Content': false
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -175,7 +175,7 @@ Feature: Move node to a new parent / within the current parent before a sibling 
     Then the last command should have thrown an exception of type "NodeNameIsAlreadyCovered"
 
   Scenario: Using the scatter (or really any) strategy, try to move a node to a parent that reserves the name for a tethered child
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     'Neos.ContentRepository.Testing:Content':

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
@@ -16,8 +16,8 @@ Feature: Move a node with content dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -16,8 +16,8 @@ Feature: Move a node with content dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
@@ -13,8 +13,8 @@ Feature: Move a node with content dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -19,8 +19,8 @@ Feature: Move a node aggregate into and out of a tagged parent
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
@@ -9,8 +9,8 @@ Feature: Additional constraint checks after move node capabilities are introduce
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Move a node without content dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
@@ -17,8 +17,8 @@ Feature: Change node name
         tethered:
           type: 'Neos.ContentRepository.Testing:Content'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -101,7 +101,7 @@ Feature: Change node name
     Then the last command should have thrown an exception of type "NodeNameIsAlreadyCovered"
 
   Scenario: Try to rename a node aggregate using a name of a not yet existent, tethered child
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Content': []
     'Neos.ContentRepository.Testing:Document':

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -15,8 +15,8 @@ Feature: Change node aggregate name
         tethered:
           type: 'Neos.ContentRepository.Testing:Node'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
@@ -51,8 +51,8 @@ Feature: Change node aggregate type - basic error cases
           type: string
           defaultValue: 'otherText'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
@@ -89,8 +89,8 @@ Feature: Change node aggregate type - behavior of DELETE strategy
           'Neos.ContentRepository.Testing:ChildOfNodeTypeA': false
           'Neos.ContentRepository.Testing:ChildOfNodeTypeB': false
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -101,8 +101,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
           type: string
           defaultValue: 'commonDefaultTextB'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
@@ -17,8 +17,8 @@ Feature: ForkContentStream Without Dimensions
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -14,8 +14,8 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -17,8 +17,8 @@ Feature: ForkContentStream Without Dimensions
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -19,8 +19,8 @@ Feature: On forking a content stream, node references should be copied as well.
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddDimensionShineThrough.feature
@@ -29,8 +29,8 @@ Feature: Add Dimension Specialization
           type: string
     'Neos.ContentRepository.Testing:OtherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -52,7 +52,7 @@ Feature: Add Dimension Specialization
   Scenario: Success Case - simple
     # we change the dimension configuration
     ########################
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, ch | ch->de->mul     |
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
@@ -145,7 +145,7 @@ Feature: Add Dimension Specialization
     When VisibilityConstraints are set to "frontend"
 
     # we change the dimension configuration
-    When I change the content dimensions in content repository "default" to:
+    When I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, ch | ch->de->mul     |
 
@@ -181,7 +181,7 @@ Feature: Add Dimension Specialization
 
   Scenario: Error case - there's already an edge in the target dimension
     # we change the dimension configuration
-    When I change the content dimensions in content repository "default" to:
+    When I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations |
       | language   | mul, de, ch, en | ch->de->mul     |
 
@@ -221,7 +221,7 @@ Feature: Add Dimension Specialization
 
 
   Scenario: Error case - the target dimension is not a specialization of the source dimension (1)
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values       | Generalizations |
       | language   | mul, de, foo | de->mul         |
 
@@ -240,7 +240,7 @@ Feature: Add Dimension Specialization
 
 
   Scenario: Error case - the target dimension is not a specialization of the source dimension (2)
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values       | Generalizations   |
       | language   | mul, de, foo | de->mul, foo->mul |
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Add New Property
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
@@ -20,8 +20,8 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Change Property
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Filter - Node Name
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
@@ -15,8 +15,8 @@ Feature: Filter - Property not empty
           type: string
     """
 
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Filter - Property Value
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/MoveDimensionSpacePoint.feature
@@ -27,8 +27,8 @@ Feature: Move dimension space point
     'Neos.ContentRepository.Testing:Document': []
     'Neos.ContentRepository.Testing:OtherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -49,7 +49,7 @@ Feature: Move dimension space point
 
   Scenario: Success Case - simple
     # we change the dimension configuration
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values     | Generalizations |
       | language   | mul, de_DE | de_DE->mul      |
 
@@ -97,7 +97,7 @@ Feature: Move dimension space point
     When VisibilityConstraints are set to "frontend"
 
     # we change the dimension configuration
-    When I change the content dimensions in content repository "default" to:
+    When I change the content dimensions in content repository "testing" to:
       | Identifier | Values     | Generalizations |
       | language   | mul, de_DE | de_DE->mul      |
 
@@ -132,7 +132,7 @@ Feature: Move dimension space point
 
   Scenario: Error case - there's already an edge in the target dimension
     # we change the dimension configuration
-    When I change the content dimensions in content repository "default" to:
+    When I change the content dimensions in content repository "testing" to:
       | Identifier | Values  | Generalizations |
       | language   | mul, ch | ch->mul         |
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
@@ -16,8 +16,8 @@ Feature: Adjust node types with a node migration
     'Neos.ContentRepository.Testing:Document': []
     'Neos.ContentRepository.Testing:OtherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Success Case
     ########################
@@ -44,7 +44,7 @@ Feature: Adjust node types with a node migration
     # Actual Test
     ########################
     # we remove the Document node type (which still exists in the CR)
-    When I change the node types in content repository "default" to:
+    When I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       constraints:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Adjust node types with a node migration
     'Neos.ContentRepository.Testing:Document': []
     'Neos.ContentRepository.Testing:OtherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Success case
     ########################
@@ -42,7 +42,7 @@ Feature: Adjust node types with a node migration
     # Actual Test
     ########################
     # we remove the Document node type (which still exists in the CR)
-    And I change the node types in content repository "default" to:
+    And I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       constraints:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/PublishingOnSuccess_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/PublishingOnSuccess_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Publishing on Success
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
@@ -17,8 +17,8 @@ Feature: Remove Nodes
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Remove Property
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
@@ -17,8 +17,8 @@ Feature: Rename Node Aggregate
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Rename Property
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -37,7 +37,7 @@ Feature: Rename Property
 
 
   Scenario: Fixed newValue
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       constraints:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
@@ -14,8 +14,8 @@ Feature: Strip Tags on Property
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
@@ -21,8 +21,8 @@ Feature: Update root node aggregate dimensions
     'Neos.ContentRepository.Testing:Document': []
     'Neos.ContentRepository.Testing:OtherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -35,7 +35,7 @@ Feature: Update root node aggregate dimensions
 
   Scenario: Run migration after adding a new dimension value
     # we change the dimension configuration
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values              | Generalizations      |
       | language   | mul, de, en, ch, fr | ch->de->mul, en->mul |
 
@@ -67,7 +67,7 @@ Feature: Update root node aggregate dimensions
 
   Scenario: Run migration after removing a new dimension value
     # we change the dimension configuration
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, ch | ch->de->mul     |
 
@@ -99,7 +99,7 @@ Feature: Update root node aggregate dimensions
 
   Scenario: Run migration after renaming a new dimension value
     # we change the dimension configuration
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de_DE, en, ch | ch->de_DE->mul, en->mul |
 
@@ -131,7 +131,7 @@ Feature: Update root node aggregate dimensions
 
   Scenario: Without migration, creating new nodeaggregates in new dimensionspacepoint will fail
     # we change the dimension configuration
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values              | Generalizations      |
       | language   | mul, de, en, ch, fr | ch->de->mul, en->mul |
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeCopying/CopyNode_NoDimensions.feature
@@ -9,8 +9,8 @@ Feature: Copy nodes (without dimensions)
       references:
         ref: []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
@@ -10,8 +10,8 @@ Feature: Node Property Conversion
         dateProperty:
           type: DateTime
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -14,8 +14,8 @@ Feature: Disable a node aggregate
         references:
           type: references
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -11,8 +11,8 @@ Feature: Remove NodeAggregate
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -41,8 +41,8 @@ Feature: Find and count nodes using the findAncestorNodes, countAncestorNodes an
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -55,8 +55,8 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -41,8 +41,8 @@ Feature: Find nodes using the findClosestNode query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
@@ -43,8 +43,8 @@ Feature: Find nodes using the countNodes query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -55,8 +55,8 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -54,8 +54,8 @@ Feature: Find nodes using the findNodeById query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
@@ -57,8 +57,8 @@ Feature: Find nodes using the findNodeByPath query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
@@ -54,8 +54,8 @@ Feature: Find nodes using the findNodeByPath query with node name as path argume
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -54,8 +54,8 @@ Feature: Find nodes using the findParentNodes query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
@@ -14,8 +14,8 @@ Feature: Find root nodes by type
       superTypes:
         'Neos.ContentRepository:Root': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -43,8 +43,8 @@ Feature: Find nodes using the findSubtree query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
@@ -64,8 +64,8 @@ Feature: Find and count references and their target nodes using the findReferenc
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -44,8 +44,8 @@ Feature: Find nodes using the retrieveNodePath query
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
@@ -54,8 +54,8 @@ Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedi
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -56,8 +56,8 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       superTypes:
         'Neos.ContentRepository.Testing:AbstractPage': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value     |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
@@ -11,8 +11,8 @@ Feature: Run projection integrity violation detection to find nodes that do not 
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
@@ -11,8 +11,8 @@ Feature: Create an intact content graph and run integrity violation detection
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
@@ -11,8 +11,8 @@ Feature: Create two nodes with the same node aggregate identifier in the same su
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
@@ -11,8 +11,8 @@ Feature: Run projection integrity violation detection regarding node aggregate c
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
@@ -13,8 +13,8 @@ Feature: Run projection integrity violation detection regarding node aggregate t
     'Neos.ContentRepository.Testing:DocumentA': []
     'Neos.ContentRepository.Testing:DocumentB': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -11,8 +11,8 @@ Feature: Run integrity violation detection regarding reference relations
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
@@ -10,8 +10,8 @@ Feature: Update Root Node aggregate dimensions
     And using the following node types:
     """yaml
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -70,7 +70,7 @@ Feature: Update Root Node aggregate dimensions
 
 
   Scenario: Adding a dimension and updating the root node works
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, en |                 |
 
@@ -132,7 +132,7 @@ Feature: Update Root Node aggregate dimensions
 
 
   Scenario: Adding a dimension updating the root node, removing dimension, updating the root node, works (dimension gone again)
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values      | Generalizations |
       | language   | mul, de, en |                 |
     And the command UpdateRootNodeAggregateDimensions is executed with payload:
@@ -145,7 +145,7 @@ Feature: Update Root Node aggregate dimensions
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
 
     # again, remove "en"
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values   | Generalizations |
       | language   | mul, de, |                 |
     And the command UpdateRootNodeAggregateDimensions is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
@@ -16,8 +16,8 @@ Feature: Dimension mismatch
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -37,7 +37,7 @@ Feature: Dimension mismatch
       | originDimensionSpacePoint | {"language": "en"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                  |
 
-    When I change the content dimensions in content repository "default" to:
+    When I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de | en->de          |
     Then I expect the following structure adjustments for type "Neos.ContentRepository.Testing:Document":

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
@@ -22,8 +22,8 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
 
     'Neos.ContentRepository.Testing:SubDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -65,7 +65,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
     ########################
     # Actual Test
     ########################
-    When I change the node types in content repository "default" to:
+    When I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       constraints:
@@ -110,8 +110,8 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
 
     'Neos.ContentRepository.Testing:SubDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -154,7 +154,7 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
     # Actual Test
     ########################
 
-    When I change the node types in content repository "default" to:
+    When I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       childNodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
@@ -22,8 +22,8 @@ Feature: Remove disallowed Child Nodes and grandchild nodes
 
     'Neos.ContentRepository.Testing:AnotherDocument': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
@@ -16,8 +16,8 @@ Feature: Properties
           type: string
           defaultValue: "Foo"
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -42,7 +42,7 @@ Feature: Properties
       | myProp | "Foo" |
 
   Scenario: The property is removed
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
@@ -57,7 +57,7 @@ Feature: Properties
     And I expect this node to have no properties
 
   Scenario: a new property default value is set
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       properties:
@@ -82,7 +82,7 @@ Feature: Properties
       | otherProp | "foo" |
 
   Scenario: a new property default value is not set if the value already contains the empty string
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       properties:
@@ -101,7 +101,7 @@ Feature: Properties
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: a broken property (which cannot be deserialized) is detected and removed
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       properties:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -28,8 +28,8 @@ Feature: Tethered Nodes integrity violations
           type: 'Neos.ContentRepository.Testing:TetheredLeaf'
     'Neos.ContentRepository.Testing:TetheredLeaf': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -82,7 +82,7 @@ Feature: Tethered Nodes integrity violations
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: Adjusting the schema adding a new tethered node leads to a MissingTetheredNode integrity violation
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       childNodes:
@@ -114,7 +114,7 @@ Feature: Tethered Nodes integrity violations
       | TETHERED_NODE_MISSING | lady-eleonode-rootford |
 
   Scenario: Adding missing tethered nodes resolves the corresponding integrity violations
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root':
       childNodes:
@@ -154,7 +154,7 @@ Feature: Tethered Nodes integrity violations
       | foo | "my default applied" |
 
   Scenario: Adding the same
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       childNodes:
@@ -178,7 +178,7 @@ Feature: Tethered Nodes integrity violations
     Then I expect exactly 8 events to be published on stream "ContentStream:cs-identifier"
 
   Scenario: Adjusting the schema removing a tethered node leads to a DisallowedTetheredNode integrity violation (which can be fixed)
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository:Root': []
     'Neos.ContentRepository.Testing:Document': []
@@ -208,7 +208,7 @@ Feature: Tethered Nodes integrity violations
     And  I expect path "tethered-node" to lead to no node
 
   Scenario: Adjusting the schema changing the type of a tethered node leads to a InvalidTetheredNodeType integrity violation
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       childNodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
@@ -17,8 +17,8 @@ Feature: Tethered Nodes Reordering Structure changes
           type: 'Neos.ContentRepository.Testing:Tethered'
     'Neos.ContentRepository.Testing:Tethered': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -47,7 +47,7 @@ Feature: Tethered Nodes Reordering Structure changes
       | cs-identifier;third-tethered-node-agg;{} |
 
   Scenario: re-ordering the tethered child nodes brings up wrongly sorted tethered nodes
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     'Neos.ContentRepository.Testing:Document':
       childNodes:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
@@ -9,8 +9,8 @@ Feature: Unknown node types
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -35,7 +35,7 @@ Feature: Unknown node types
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
   Scenario: When removing "Neos.ContentRepository.Testing:Document", we find a missing node type.
-    Given I change the node types in content repository "default" to:
+    Given I change the node types in content repository "testing" to:
     """yaml
     """
     Then I expect the following structure adjustments for type "Neos.ContentRepository.Testing:Document":

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -13,8 +13,8 @@ Feature: Tag subtree with dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -11,8 +11,8 @@ Feature: Tag subtree without dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
@@ -23,8 +23,8 @@ Feature: Workspace discarding - complex chained functionality
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
@@ -23,8 +23,8 @@ Feature: Discard individual nodes (basics)
         image:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
@@ -16,8 +16,8 @@ Feature: Change base workspace constraints
         child2:
           type: 'Neos.ContentRepository.Testing:Content'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -16,8 +16,8 @@ Feature: Change base workspace works :D what else
         child2:
           type: 'Neos.ContentRepository.Testing:Content'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -13,8 +13,8 @@ Feature: Rebasing with no conflict
         child2:
           type: 'Neos.ContentRepository.Testing:Content'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
@@ -27,8 +27,8 @@ Feature: Rebasing auto-created nodes works
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -16,8 +16,8 @@ Feature: Workspace rebasing - conflicting changes
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
@@ -16,8 +16,8 @@ Feature: Workspace based content publishing
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
@@ -23,8 +23,8 @@ Feature: Workspace publication - complex chained functionality
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
@@ -18,8 +18,8 @@ Feature: Individual node publication
         child2:
           type: 'Neos.ContentRepository.Testing:Content'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
@@ -23,8 +23,8 @@ Feature: Publishing individual nodes (basics)
         image:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -32,8 +32,8 @@ Feature: Publishing hide/show scenario of nodes
         image:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -16,8 +16,8 @@ Feature: Publishing moved nodes without dimensions
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
@@ -16,8 +16,8 @@ Feature: Workspace discarding - basic functionality
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
@@ -10,8 +10,8 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -7,8 +7,8 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     And using the following node types:
     """yaml
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
@@ -12,8 +12,8 @@ Feature: Single Node operations on live workspace
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/WorkspaceState.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/WorkspaceState.feature
@@ -12,8 +12,8 @@ Feature: Workspace status
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/Export/Export.feature
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/Export/Export.feature
@@ -9,8 +9,8 @@ Feature: As a user of the CR I want to export the event stream
     """yaml
     'Neos.ContentRepository.Testing:Document': []
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/Import/Import.feature
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/Import/Import.feature
@@ -9,8 +9,8 @@ Feature: As a user of the CR I want to export the event stream
       superTypes:
         Neos.Neos:Site: true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Import the event stream into a specific content stream
     Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-identifier"

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Assets.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Assets.feature
@@ -21,8 +21,8 @@ Feature: Export of used Assets, Image Variants and Persistent Resources
         'assets':
           type: 'array<Neos\Media\Domain\Model\Asset>'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the following PersistentResources exist
       | identifier | filename       | collectionName | mediaType       |
       | resource1  | Some-File1.jpg | persistent     | image/jpeg      |

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Basic.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Basic.feature
@@ -14,8 +14,8 @@ Feature: Simple migrations without content dimensions
           type: string
           defaultValue: 'My default text'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Single homepage node with one property
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Errors.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Errors.feature
@@ -21,11 +21,11 @@ Feature: Exceptional cases during migrations
       superTypes:
         'Neos.Neos:Site': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Node variant with different type
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values     | Generalizations |
       | language   | en      | en, de, ch | ch->de          |
     When I have the following node data rows:
@@ -74,7 +74,7 @@ Feature: Exceptional cases during migrations
 
 
   Scenario: Invalid dimension configuration (unknown value)
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values     | Generalizations |
       | language   | en      | en, de, ch | ch->de          |
     When I have the following node data rows:
@@ -108,7 +108,7 @@ Feature: Exceptional cases during migrations
     """
 
   Scenario: Node variants with the same dimension
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values     | Generalizations |
       | language   | en      | en, de, ch | ch->de          |
     When I have the following node data rows:
@@ -124,7 +124,7 @@ Feature: Exceptional cases during migrations
     """
 
   Scenario: Duplicate nodes
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values     | Generalizations |
       | language   | en      | en, de, ch | ch->de          |
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
@@ -22,8 +22,8 @@ Feature: Simple migrations without content dimensions for hidden state migration
           defaultValue: 'My default text'
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: A node with a "hidden" property true must get disabled
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
@@ -15,8 +15,8 @@ Feature: Simple migrations without content dimensions for hidden state migration
           defaultValue: 'My default text'
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: A node with a "hidden" property true must get disabled
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/References.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/References.feature
@@ -23,8 +23,8 @@ Feature: Migrations that contain nodes with "reference" or "references propertie
         'text':
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Two nodes with references
     When I have the following node data rows:
@@ -47,7 +47,7 @@ Feature: Migrations that contain nodes with "reference" or "references propertie
 
 
   Scenario: Node with references in one dimension
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values     | Generalizations |
       | language   | en      | en, de, ch | ch->de          |
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
@@ -13,8 +13,8 @@ Feature: Migrating nodes with content dimensions
         'Neos.Neos:Site': true
     'Some.Package:Thing': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Node specialization variants are prioritized over peer variants
     When I have the following node data rows:
@@ -47,7 +47,7 @@ Feature: Migrating nodes with content dimensions
       | NodeGeneralizationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "ch"}, "generalizationOrigin": {"language": "de"}, "variantSucceedingSiblings": [{"dimensionSpacePoint":{"language": "de"},"nodeAggregateId":null}]}                                                                                                                            |
 
   Scenario: Node variant with a subset of the original dimension space points (NodeSpecializationVariantWasCreated covers languages "de" _and_ "ch")
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Default | Values          | Generalizations |
       | language   | mul     | mul, en, de, ch | ch->de->mul     |
     When I have the following node data rows:

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Create node aggregate with node without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Create node aggregate with node with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
@@ -17,8 +17,8 @@ Feature: Create node generalization variant
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -17,8 +17,8 @@ Feature: Create node specialization variant
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
@@ -17,8 +17,8 @@ Feature: Create node peer variant with internal workspace between live and user 
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/04-CreateNodePeerVariant.feature
@@ -17,8 +17,8 @@ Feature: Create node peer variant
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Create node aggregate with node without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Create node aggregate with node with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/04-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/04-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Remove node aggregate with node without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
@@ -17,8 +17,8 @@ Feature: Move DimensionSpacePoints
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -76,7 +76,7 @@ Feature: Move DimensionSpacePoints
 
 
   Scenario: Rename a dimension value in live workspace
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations    |
       | language   | de_DE,gsw,fr,en | gsw->de_DE->en, fr |
 
@@ -101,7 +101,7 @@ Feature: Move DimensionSpacePoints
 
 
   Scenario: Rename a dimension value in user workspace
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations    |
       | language   | de_DE,gsw,fr,en | gsw->de_DE->en, fr |
 
@@ -126,7 +126,7 @@ Feature: Move DimensionSpacePoints
 
 
   Scenario: Adding a dimension in live workspace
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values       | Generalizations |
       | language   | de,gsw,fr,en | gsw->de->en, fr |
       | market     | DE, FR       | DE, FR          |
@@ -157,7 +157,7 @@ Feature: Move DimensionSpacePoints
 
 
   Scenario: Adding a dimension in user workspace
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values       | Generalizations |
       | language   | de,gsw,fr,en | gsw->de->en, fr |
       | market     | DE, FR       | DE, FR          |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Build index for existing nodes without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
@@ -18,8 +18,8 @@ Feature: Build index for existing nodes with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Publish nodes without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Publish nodes with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Publish nodes partially without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Publish nodes partially with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature:  Discard workspace without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Discard workspace with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -15,8 +15,8 @@ Feature: Publish nodes partially without dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
@@ -17,8 +17,8 @@ Feature: Publish nodes partially with dimensions
         assets:
           type: array<Neos\Media\Domain\Model\Asset>
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Assets.feature
@@ -34,8 +34,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
           type: string
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When an asset exists with id "an-asset-to-change"
@@ -79,7 +79,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on asset changes
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/ConvertUris.feature
@@ -23,8 +23,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
         'Neos.Neos:Document': true
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -56,7 +56,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on DynamicNodeTag 
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/Nodes.feature
@@ -25,8 +25,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -53,7 +53,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInOtherWorkspace.feature
@@ -25,8 +25,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -59,7 +59,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing on node and nodety
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -40,8 +40,8 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
         text:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "editor"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -74,7 +74,7 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
@@ -295,4 +295,4 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     """
     <div class="neos-contentcollection">secondRender[Text Node at the start of the document]secondRender[Text Node in the middle of the document]secondRender[Text Node at the end of the document]</div>
     """
-    
+

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/WorkspaceService.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/WorkspaceService.feature
@@ -7,8 +7,8 @@ Feature: Neos WorkspaceService related features
     """yaml
     'Neos.ContentRepository:Root': {}
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the following Neos users exist:
       | Id      | Username | First name | Last name | Roles                                            |
       | janedoe | jane.doe | Jane       | Doe       | Neos.Neos:Administrator                          |
@@ -94,7 +94,7 @@ Feature: Neos WorkspaceService related features
 
   Scenario: Assign role to non-existing workspace
     When the role COLLABORATOR is assigned to workspace "some-workspace" for group "Neos.Neos:AbstractEditor"
-    Then an exception 'Failed to find workspace with name "some-workspace" for content repository "default"' should be thrown
+    Then an exception 'Failed to find workspace with name "some-workspace" for content repository "testing"' should be thrown
 
   Scenario: Assign group role to root workspace
     Given the root workspace "some-root-workspace" is created
@@ -107,7 +107,7 @@ Feature: Neos WorkspaceService related features
     Given the root workspace "some-root-workspace" is created
     When the role COLLABORATOR is assigned to workspace "some-root-workspace" for group "Neos.Neos:AbstractEditor"
     And the role MANAGER is assigned to workspace "some-root-workspace" for group "Neos.Neos:AbstractEditor"
-    Then an exception 'Failed to assign role for workspace "some-root-workspace" to subject "Neos.Neos:AbstractEditor" (Content Repository "default"): There is already a role assigned for that user/group, please unassign that first' should be thrown
+    Then an exception 'Failed to assign role for workspace "some-root-workspace" to subject "Neos.Neos:AbstractEditor" (Content Repository "testing"): There is already a role assigned for that user/group, please unassign that first' should be thrown
 
   Scenario: Assign user role to root workspace
     Given the root workspace "some-root-workspace" is created
@@ -120,16 +120,16 @@ Feature: Neos WorkspaceService related features
     Given the root workspace "some-root-workspace" is created
     When the role COLLABORATOR is assigned to workspace "some-root-workspace" for user "some-user-id"
     And the role MANAGER is assigned to workspace "some-root-workspace" for user "some-user-id"
-    Then an exception 'Failed to assign role for workspace "some-root-workspace" to subject "some-user-id" (Content Repository "default"): There is already a role assigned for that user/group, please unassign that first' should be thrown
+    Then an exception 'Failed to assign role for workspace "some-root-workspace" to subject "some-user-id" (Content Repository "testing"): There is already a role assigned for that user/group, please unassign that first' should be thrown
 
   Scenario: Unassign role from non-existing workspace
     When the role for group "Neos.Neos:AbstractEditor" is unassigned from workspace "some-workspace"
-    Then an exception 'Failed to find workspace with name "some-workspace" for content repository "default"' should be thrown
+    Then an exception 'Failed to find workspace with name "some-workspace" for content repository "testing"' should be thrown
 
   Scenario: Unassign role from workspace that has not been assigned before
     Given the root workspace "some-root-workspace" is created
     When the role for group "Neos.Neos:AbstractEditor" is unassigned from workspace "some-root-workspace"
-    Then an exception 'Failed to unassign role for subject "Neos.Neos:AbstractEditor" from workspace "some-root-workspace" (Content Repository "default"): No role assignment exists for this user/group' should be thrown
+    Then an exception 'Failed to unassign role for subject "Neos.Neos:AbstractEditor" from workspace "some-root-workspace" (Content Repository "testing"): No role assignment exists for this user/group' should be thrown
 
   Scenario: Assign two roles, then unassign one
     Given the root workspace "some-root-workspace" is created

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
@@ -23,8 +23,8 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
         uriPathSegment:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -58,7 +58,7 @@ Feature: Basic routing functionality (match & resolve document nodes in one dime
       Neos:
         sites:
           'node1':
-            preset: 'default'
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/NoopResolver.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/NoopResolver.feature
@@ -6,14 +6,14 @@ Feature: NoopResolver does nothing (boilerplate testcase)
     And using the following node types:
     """yaml
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: Match homepage URL
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
@@ -24,7 +24,7 @@ Feature: NoopResolver does nothing (boilerplate testcase)
     When I am on URL "/foo"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/UriPathResolver.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/UriPathResolver.feature
@@ -31,15 +31,15 @@ Feature: UriPathResolver works as expected
     And using the following node types:
     """yaml
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
   Scenario: No dimension
     When I am on URL "/"
 
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -47,14 +47,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{}' and the remaining URI Path should be "/"
 
   Scenario: One dimension; with non-empty default value; /
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -72,14 +72,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{}' and the remaining URI Path should be "/"
 
   Scenario: One dimension; with non-empty default value; /deu
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/deu"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -95,14 +95,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "de"}' and the remaining URI Path should be "/"
 
   Scenario: One dimension; with non-empty default value; /deu/test
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/deu/test"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -118,14 +118,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "de"}' and the remaining URI Path should be "/test"
 
   Scenario: One dimension; with empty default value; /
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -141,14 +141,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "de"}' and the remaining URI Path should be "/"
 
   Scenario: One dimension; with empty default value; /test
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/test"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -164,14 +164,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "de"}' and the remaining URI Path should be "/test"
 
   Scenario: One dimension; with empty default value; /uk
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/uk"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -187,14 +187,14 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "en"}' and the remaining URI Path should be "/"
 
   Scenario: One dimension; with empty default value; /uk/test
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/uk/test"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -210,7 +210,7 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "en"}' and the remaining URI Path should be "/test"
 
   Scenario: Multiple dimensions; with non-empty default value; /
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -218,7 +218,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -240,7 +240,7 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{}' and the remaining URI Path should be "/"
 
   Scenario: Multiple dimensions; with non-empty default value; /uk_si
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -248,7 +248,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "/uk_si"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -270,7 +270,7 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "en", "target_group": "simple"}' and the remaining URI Path should be "/"
 
   Scenario: Multiple dimensions; with non-empty default value; /uk_si/test
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -278,7 +278,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "/uk_si/test"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -298,7 +298,7 @@ Feature: UriPathResolver works as expected
     Then the resolved dimension should be '{"language": "en", "target_group": "simple"}' and the remaining URI Path should be "/test"
 
   Scenario Outline: Multiple dimensions; with empty default value
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -306,7 +306,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "<inputUri>"
     And I invoke the Dimension Resolver from site configuration:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -339,7 +339,7 @@ Feature: UriPathResolver works as expected
     # TODO /uk_ do NOT RESOLVE
 
   Scenario: Error: two uri path segment identifiers mapping to different dimensions
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -347,7 +347,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -362,7 +362,7 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: two uri path segment identifiers mapping to different dimensions
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier   | Values         | Generalizations |
       | target_group | normal, simple |                 |
       | language     | en, de         |                 |
@@ -370,7 +370,7 @@ Feature: UriPathResolver works as expected
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -390,14 +390,14 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: non-existing dimension name
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -409,14 +409,14 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: non-existing dimension value
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -430,14 +430,14 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: / in dimensionValueMapping
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -452,14 +452,14 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: / as separator
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory
@@ -475,14 +475,14 @@ Feature: UriPathResolver works as expected
     Then the last command should have thrown an exception of type "UriPathResolverConfigurationException"
 
   Scenario: Error: separator in dimensionValueMapping
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values | Generalizations |
       | language   | en, de |                 |
 
     When I am on URL "/"
     And I invoke the Dimension Resolver from site configuration and exceptions are caught:
     """yaml
-    contentRepository: default
+    contentRepository: testing
     contentDimensions:
       resolver:
         factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
@@ -35,8 +35,8 @@ Feature: Routing functionality with multiple content dimensions
       superTypes:
         'Neos.Neos:Test.Routing.Page': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     And the command CreateRootWorkspace is executed with payload:
@@ -70,7 +70,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               defaultDimensionSpacePoint:
@@ -108,7 +108,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               defaultDimensionSpacePoint:
@@ -158,7 +158,7 @@ Feature: Routing functionality with multiple content dimensions
     And the node "carl-destinode" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"de"}' should resolve to URL "/de/nody/karl-de"
 
   Scenario: Move Dimension, then resolving should still work
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values         | Generalizations |
       | market     | DE, CH         | CH->DE          |
       | language   | en, de_DE, gsw | gsw->de_DE->en  |
@@ -168,7 +168,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:
@@ -226,7 +226,7 @@ Feature: Routing functionality with multiple content dimensions
     Then the matched node should be "carl-destinode" in content stream "cs-identifier" and dimension '{"market":"DE", "language":"de"}'
 
   Scenario: Add Dimension shine through, then resolving should still work
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations         |
       | market     | DE, CH          | CH->DE                  |
       | language   | en, de, gsw, at | gsw->de->en, at->de->en |
@@ -236,7 +236,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:
@@ -291,7 +291,7 @@ Feature: Routing functionality with multiple content dimensions
 
   Scenario: Create new Dimension value and adjust root node, then root node resolving should still work.
     # new "fr" language
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations |
       | market     | DE, CH          | CH->DE          |
       | language   | en, de, gsw, fr | gsw->de->en     |
@@ -301,7 +301,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:
@@ -347,7 +347,7 @@ Feature: Routing functionality with multiple content dimensions
 
   Scenario: Create new Dimension value and adjust root node, then root node resolving should still work.
     # new "fr" language
-    Given I change the content dimensions in content repository "default" to:
+    Given I change the content dimensions in content repository "testing" to:
       | Identifier | Values          | Generalizations |
       | market     | DE, CH          | CH->DE          |
       | language   | en, de, gsw, fr | gsw->de->en     |
@@ -357,7 +357,7 @@ Feature: Routing functionality with multiple content dimensions
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -23,8 +23,8 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
         uriPathSegment:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -59,7 +59,7 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
@@ -32,8 +32,8 @@ Feature: Low level tests covering the inner behavior of the routing projection
       superTypes:
         'Neos.Neos:Test.Routing.Page': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
@@ -32,8 +32,8 @@ Feature: Linking between multiple websites
       superTypes:
         'Neos.Neos:Test.Routing.Page': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -65,13 +65,13 @@ Feature: Linking between multiple websites
       Neos:
         sites:
           'site-1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
           'site-2':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeAggregateTypeChangeEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeAggregateTypeChangeEdgeCases.feature
@@ -19,8 +19,8 @@ Feature: Test cases for node aggregate type change edge cases
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
@@ -18,8 +18,8 @@ Feature: Test cases for node creation edge cases
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -18,8 +18,8 @@ Feature: Test cases for node variation edge cases
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -117,8 +117,8 @@ Feature: Test cases for node variation edge cases
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
@@ -207,8 +207,8 @@ Feature: Test cases for node variation edge cases
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
@@ -18,8 +18,8 @@ Feature: Test cases for partial publish to live and uri path generation
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
@@ -23,8 +23,8 @@ Feature: Route cache invalidation
         uriPathSegment:
           type: string
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -57,7 +57,7 @@ Feature: Route cache invalidation
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
@@ -40,8 +40,8 @@ Feature: Routing behavior of shortcut nodes
       superTypes:
         'Neos.Neos:Test.Routing.Page': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -87,7 +87,7 @@ Feature: Routing behavior of shortcut nodes
       Neos:
         sites:
           'node1':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
@@ -22,8 +22,8 @@ Feature: Tests for site node child documents. These are special in that they hav
         notFound:
           type: 'Neos.Neos:Document'
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -46,7 +46,7 @@ Feature: Tests for site node child documents. These are special in that they hav
       Neos:
         sites:
           'site':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -16,8 +16,8 @@ Feature: Basic routing functionality (match & resolve nodes with unknown types)
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCase.feature
@@ -25,8 +25,8 @@ Feature: Tests for the "Neos.Neos:ContentCase" Fusion prototype
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -49,7 +49,7 @@ Feature: Tests for the "Neos.Neos:ContentCase" Fusion prototype
       Neos:
         sites:
           'a':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCollection.feature
@@ -33,8 +33,8 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
       superTypes:
         'Neos.Neos:Content': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -56,7 +56,7 @@ Feature: Tests for the "Neos.Neos:ContentCollection" Fusion prototype
       Neos:
         sites:
           'a':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -22,8 +22,8 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -46,7 +46,7 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
       Neos:
         sites:
           'a':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -38,8 +38,8 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
         'Neos.Neos:Content': true
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -84,7 +84,7 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
       Neos:
         sites:
           '*':
-            contentRepository: default
+            contentRepository: testing
             contentDimensions:
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
@@ -466,7 +466,7 @@ Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
     }
     """
     # if the node type config is empty, the label rendering should still work
-    When I change the node types in content repository "default" to:
+    When I change the node types in content repository "testing" to:
     """yaml
     """
     When I execute the following Fusion code:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -38,8 +38,8 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
         'Neos.Neos:Content': true
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And I am user identified by "initiating-user-identifier"
 
     When the command CreateRootWorkspace is executed with payload:
@@ -71,7 +71,7 @@ Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
       Neos:
         sites:
           'a':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/NodeUri.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/NodeUri.feature
@@ -22,8 +22,8 @@ Feature: Tests for the "Neos.Neos:NodeUri" Fusion prototype
       superTypes:
         'Neos.Neos:Document': true
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
 
     When the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -45,7 +45,7 @@ Feature: Tests for the "Neos.Neos:NodeUri" Fusion prototype
       Neos:
         sites:
           'a':
-            preset: default
+            contentRepository: testing
             uriPathSuffix: ''
             contentDimensions:
               resolver:

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -25,8 +25,8 @@ Feature: Simple handling of nodes with exceeded enableAfter and disableAfter dat
         'Neos.TimeableNodeVisibility:Timeable': true
 
     """
-    And using identifier "default", I define a content repository
-    And I am in content repository "default"
+    And using identifier "testing", I define a content repository
+    And I am in content repository "testing"
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |


### PR DESCRIPTION
IDK, i did this change yesterday evening because i was deep in this rabbit hole and did not stop :D

The idea was that for the core behavioural test we do technically do not need to run the catchup hooks etc as this is neos part to test. And it slows down the whole test suite see issue: https://github.com/neos/neos-development-collection/issues/4878

That would also us to get rid of the doctrine:migrate hack here: https://github.com/neos/neos-development-collection/pull/5258#discussion_r1782535368


But to be true, having the catchup always run on standby did help us in the past. Not because they did assert anything special but to assert they do not throw an exception. And all the testcases in Neos.Neos are not as complex at what the core has to offer for say special Node move strategies :)


For now as quick tip regarding performance:
I always run the tests with catchup hooks disabled: https://github.com/neos/neos-development-collection/pull/4904

----

but maybe we could indeed do this change sometime and continue to run the tests on `default` nightly or something :)

there is one logic error i made: The Neos.Neos tests still have to work on `default` because the catchup hooks need to be there.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
