### PR TITLE
BUGFIX: Behat: Reset `lastCommandException` once asserted

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -53,6 +53,7 @@ Feature: Constraint checks on node aggregate disabling
       | nodeAggregateId              | "i-do-not-exist" |
       | nodeVariantSelectionStrategy | "allVariants"    |
       | tag                          | "disabled"       |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist"
 
   Scenario: Try to disable an already disabled node aggregate
     Given the command DisableNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -344,6 +344,21 @@ trait GenericCommandExecutionAndEventPublication
         }
 
         Assert::assertSame($payloadTable->getHash(), $actualComparableHash);
+        $this->lastCommandException = null;
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function ensureNoUnhandledCommandExceptions(): void
+    {
+        if ($this->lastCommandException !== null) {
+            Assert::fail(sprintf(
+                'Last command did throw with exception which was not asserted: %s: %s',
+                $this->lastCommandException::class,
+                $this->lastCommandException->getMessage()
+            ));
+        }
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -350,13 +350,15 @@ trait GenericCommandExecutionAndEventPublication
     /**
      * @AfterScenario
      */
-    public function ensureNoUnhandledCommandExceptions(): void
+    public function ensureNoUnhandledCommandExceptions(\Behat\Behat\Hook\Scope\AfterScenarioScope $event): void
     {
         if ($this->lastCommandException !== null) {
             Assert::fail(sprintf(
-                'Last command did throw with exception which was not asserted: %s: %s',
+                'Last command did throw with exception which was not asserted: %s: "%s" in %s:%s',
                 $this->lastCommandException::class,
-                $this->lastCommandException->getMessage()
+                $this->lastCommandException->getMessage(),
+                $event->getFeature()->getFile(),
+                $event->getScenario()->getLine(),
             ));
         }
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -321,6 +321,7 @@ trait GenericCommandExecutionAndEventPublication
                 $this->lastCommandException->getMessage()
             ));
         }
+        $this->lastCommandException = null;
     }
 
     /**


### PR DESCRIPTION
Without this fix it was not possible to expect multiple exceptions in a single step or, worse, it led to false positives:

```gherkin
  Scenario:
    When doing something
    Then the last command should have thrown an exception of type "Foo"

    When doing something else
    Then the last command should have thrown an exception of type "Bar"
```

The 2nd time would succeed even if the previous interaction did not lead to an exception
