### PR TITLE
FEATURE: Decentral subscription store

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -75,7 +75,7 @@ final class ContentRepositoryFactory
         Serializer $propertySerializer,
         private readonly AuthProviderFactoryInterface $authProviderFactory,
         private readonly ClockInterface $clock,
-        SubscriptionStoreInterface $subscriptionStore,
+        SubscriptionStoreInterface $contentGraphSubscriptionStore,
         ContentGraphProjectionFactoryInterface $contentGraphProjectionFactory,
         private readonly CatchUpHookFactoryInterface|null $contentGraphCatchUpHookFactory,
         private readonly CommandHooksFactory $commandHooksFactory,
@@ -106,14 +106,15 @@ final class ContentRepositoryFactory
         }
         $this->additionalProjectionStates = ProjectionStates::fromArray($additionalProjectionStates);
         $this->contentGraphProjection = $contentGraphProjectionFactory->build($this->subscriberFactoryDependencies);
-        $subscribers[] = $this->buildContentGraphSubscriber();
-        $this->subscriptionEngine = new SubscriptionEngine($this->eventStore, $subscriptionStore, Subscribers::fromArray($subscribers), $eventNormalizer, $logger);
+        $subscribers[] = $this->buildContentGraphSubscriber($contentGraphSubscriptionStore);
+        $this->subscriptionEngine = new SubscriptionEngine($this->eventStore, Subscribers::fromArray($subscribers), $eventNormalizer, $logger);
     }
 
-    private function buildContentGraphSubscriber(): ProjectionSubscriber
+    private function buildContentGraphSubscriber(SubscriptionStoreInterface $subscriptionStore): ProjectionSubscriber
     {
         return new ProjectionSubscriber(
             SubscriptionId::fromString('contentGraph'),
+            $subscriptionStore,
             $this->contentGraphProjection,
             $this->contentGraphCatchUpHookFactory?->build(CatchUpHookFactoryDependencies::create(
                 $this->contentRepositoryId,

--- a/Neos.ContentRepository.Core/Classes/Factory/ProjectionSubscriberFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ProjectionSubscriberFactory.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookFactoryInterfa
 use Neos\ContentRepository\Core\Projection\ProjectionFactoryInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\Subscription\Store\SubscriptionStoreInterface;
 use Neos\ContentRepository\Core\Subscription\Subscriber\ProjectionSubscriber;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 
@@ -34,6 +35,7 @@ final readonly class ProjectionSubscriberFactory
      */
     public function __construct(
         private SubscriptionId $subscriptionId,
+        private SubscriptionStoreInterface $subscriptionStore,
         private ProjectionFactoryInterface $projectionFactory,
         private ?CatchUpHookFactoryInterface $catchUpHookFactory,
         private array $projectionFactoryOptions,
@@ -53,6 +55,7 @@ final readonly class ProjectionSubscriberFactory
 
         return new ProjectionSubscriber(
             $this->subscriptionId,
+            $this->subscriptionStore,
             $projection,
             $catchUpHook,
         );

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -19,7 +19,6 @@ use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Psr\Log\LoggerInterface;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\Store\SubscriptionCriteria;
-use Neos\ContentRepository\Core\Subscription\Store\SubscriptionStoreInterface;
 use Neos\ContentRepository\Core\Subscription\Subscriber\Subscribers;
 use Neos\ContentRepository\Core\Subscription\Subscription;
 use Neos\ContentRepository\Core\Subscription\Subscriptions;
@@ -30,16 +29,14 @@ use Neos\ContentRepository\Core\Subscription\Subscriptions;
 final class SubscriptionEngine
 {
     private bool $processing = false;
-    private readonly SubscriptionManager $subscriptionManager;
+    private SubscriptionManager $subscriptionManager; // todo inline!!
 
     public function __construct(
         private readonly EventStoreInterface $eventStore,
-        private readonly SubscriptionStoreInterface $subscriptionStore,
         private readonly Subscribers $subscribers,
         private readonly EventNormalizer $eventNormalizer,
         private readonly LoggerInterface|null $logger = null,
     ) {
-        $this->subscriptionManager = new SubscriptionManager($this->subscriptionStore);
     }
 
     public function setup(SubscriptionEngineCriteria|null $criteria = null): Result
@@ -48,27 +45,34 @@ final class SubscriptionEngine
 
         $this->logger?->info('Subscription Engine: Start to setup.');
 
-        $this->subscriptionStore->setup();
-        $this->discoverNewSubscriptions();
-        $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::fromArray([
-            SubscriptionStatus::NEW,
-            SubscriptionStatus::BOOTING,
-            SubscriptionStatus::ACTIVE,
-            SubscriptionStatus::DETACHED,
-            SubscriptionStatus::ERROR,
-        ])));
-        if ($subscriptions->isEmpty()) {
-            $this->logger?->info('Subscription Engine: No subscriptions found.'); // todo not happy? Because there must be at least the content graph?!!
-            return Result::success();
-        }
+        $subscriberGroups = $this->subscribers->groupByStore();
         $errors = [];
-        foreach ($subscriptions as $subscription) {
-            $error = $this->setupSubscription($subscription);
-            if ($error !== null) {
-                $errors[] = $error;
+        foreach ($subscriberGroups as [$store]) {
+            $store->setup();
+
+            $this->subscriptionManager = new SubscriptionManager($store); // todo hack
+            $this->discoverNewSubscriptions();
+
+            $subscriptions = $store->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::fromArray([
+                SubscriptionStatus::NEW,
+                SubscriptionStatus::BOOTING,
+                SubscriptionStatus::ACTIVE,
+                SubscriptionStatus::DETACHED,
+                SubscriptionStatus::ERROR,
+            ])));
+            if ($subscriptions->isEmpty()) {
+                $this->logger?->info('Subscription Engine: No subscriptions found.'); // todo not happy? Because there must be at least the content graph?!!
+                return Result::success();
             }
+            foreach ($subscriptions as $subscription) {
+                $error = $this->setupSubscription($subscription);
+                if ($error !== null) {
+                    $errors[] = $error;
+                }
+            }
+            $this->subscriptionManager->flush();
         }
-        $this->subscriptionManager->flush();
+
         return $errors === [] ? Result::success() : Result::failed(Errors::fromArray($errors));
     }
 
@@ -87,41 +91,50 @@ final class SubscriptionEngine
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
 
         $this->logger?->info('Subscription Engine: Start to reset.');
-        $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::any()));
-        if ($subscriptions->isEmpty()) {
-            $this->logger?->info('Subscription Engine: No subscriptions to reset.');
-            return Result::success();
-        }
+
+        $subscriberGroups = $this->subscribers->groupByStore();
         $errors = [];
-        foreach ($subscriptions as $subscription) {
-            $error = $this->resetSubscription($subscription);
-            if ($error !== null) {
-                $errors[] = $error;
+        foreach ($subscriberGroups as [$store]) {
+            $subscriptions = $store->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::any()));
+            $this->subscriptionManager = new SubscriptionManager($store);
+            if ($subscriptions->isEmpty()) {
+                $this->logger?->info('Subscription Engine: No subscriptions to reset.');
+                return Result::success();
             }
+            foreach ($subscriptions as $subscription) {
+                $error = $this->resetSubscription($subscription);
+                if ($error !== null) {
+                    $errors[] = $error;
+                }
+            }
+            $this->subscriptionManager->flush();
         }
-        $this->subscriptionManager->flush();
         return $errors === [] ? Result::success() : Result::failed(Errors::fromArray($errors));
     }
 
     public function subscriptionStatuses(SubscriptionCriteria|null $criteria = null): SubscriptionAndProjectionStatuses
     {
+        $subscriberGroups = $this->subscribers->groupByStore();
         $statuses = [];
-        try {
-            $subscriptions = $this->subscriptionStore->findByCriteria($criteria ?? SubscriptionCriteria::noConstraints());
-        } catch (TableNotFoundException) {
-            // the schema is not setup - thus there are no subscribers
-            return SubscriptionAndProjectionStatuses::createEmpty();
+        foreach ($subscriberGroups as [$store]) {
+            try {
+                $subscriptions = $store->findByCriteria($criteria ?? SubscriptionCriteria::noConstraints());
+            } catch (TableNotFoundException) {
+                // the schema is not setup - thus there are no subscribers
+                continue;
+            }
+            foreach ($subscriptions as $subscription) {
+                $subscriber = $this->subscribers->contain($subscription->id) ? $this->subscribers->get($subscription->id) : null;
+                $statuses[] = SubscriptionAndProjectionStatus::create(
+                    subscriptionId: $subscription->id,
+                    subscriptionStatus: $subscription->status,
+                    subscriptionPosition: $subscription->position,
+                    subscriptionError: $subscription->error,
+                    projectionStatus: $subscriber?->projection->status(),
+                );
+            }
         }
-        foreach ($subscriptions as $subscription) {
-            $subscriber = $this->subscribers->contain($subscription->id) ? $this->subscribers->get($subscription->id) : null;
-            $statuses[] = SubscriptionAndProjectionStatus::create(
-                subscriptionId: $subscription->id,
-                subscriptionStatus: $subscription->status,
-                subscriptionPosition: $subscription->position,
-                subscriptionError: $subscription->error,
-                projectionStatus: $subscriber?->projection->status(),
-            );
-        }
+
         return SubscriptionAndProjectionStatuses::fromArray($statuses);
     }
 
@@ -240,101 +253,112 @@ final class SubscriptionEngine
     {
         $this->logger?->info(sprintf('Subscription Engine: Start catching up subscriptions in state "%s".', $subscriptionStatus->value));
 
-        return $this->subscriptionManager->findForAndUpdate(
+        $subscriberGroups = $this->subscribers->groupByStore();
+
+        // todo merge results
+        $returnResult = null;
+
+        foreach ($subscriberGroups as [$store, $subscribers]) {
+            // todo do not global override manager!
+            $this->subscriptionManager = new SubscriptionManager($store);
+            $returnResult = $this->subscriptionManager->findForAndUpdate(
             SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, $subscriptionStatus),
-            function (Subscriptions $subscriptions) use ($subscriptionStatus, $progressClosure) {
-                foreach ($subscriptions as $subscription) {
-                    if (!$this->subscribers->contain($subscription->id)) {
-                        // mark detached subscriptions as we cannot handle them and exclude them from catchup
-                        $subscription->set(
-                            status: SubscriptionStatus::DETACHED,
-                        );
-                        $this->subscriptionManager->update($subscription);
-                        $this->logger?->info(sprintf('Subscription Engine: Subscriber for "%s" not found and has been marked as detached.', $subscription->id->value));
-                        $subscriptions = $subscriptions->without($subscription->id);
-                    }
-                }
-                if ($subscriptions->isEmpty()) {
-                    $this->logger?->info(sprintf('Subscription Engine: No subscriptions in state "%s". Finishing catch up', $subscriptionStatus->value));
-
-                    return ProcessedResult::success(0);
-                }
-                foreach ($subscriptions as $subscription) {
-                    try {
-                        $this->subscribers->get($subscription->id)->onBeforeCatchUp($subscription->status);
-                    } catch (\Throwable $e) {
-                        // analog to onAfterCatchUp, we tolerate no exceptions here and consider it a critical developer error.
-                        $message = sprintf('Subscriber "%s" failed onBeforeCatchUp: %s', $subscription->id->value, $e->getMessage());
-                        $this->logger?->critical($message);
-                        throw new CatchUpFailed($message, 1732374000, $e);
-                    }
-                }
-                $startSequenceNumber = $subscriptions->lowestPosition()?->next() ?? SequenceNumber::none();
-                $this->logger?->debug(sprintf('Subscription Engine: Event stream is processed from position %s.', $startSequenceNumber->value));
-
-                /** @var list<Error> $errors */
-                $errors = [];
-                $numberOfProcessedEvents = 0;
-                try {
-                    $eventStream = $this->eventStore->load(VirtualStreamName::all())->withMinimumSequenceNumber($startSequenceNumber);
-                    foreach ($eventStream as $eventEnvelope) {
-                        $sequenceNumber = $eventEnvelope->sequenceNumber;
-                        if ($numberOfProcessedEvents > 0) {
-                            $this->logger?->debug(sprintf('Subscription Engine: Current event stream position: %s', $sequenceNumber->value));
-                        }
-                        if ($progressClosure !== null) {
-                            $progressClosure($eventEnvelope);
-                        }
-                        $domainEvent = $this->eventNormalizer->denormalize($eventEnvelope->event);
-                        foreach ($subscriptions as $subscription) {
-                            if ($subscription->status !== $subscriptionStatus) {
-                                continue;
-                            }
-                            if ($subscription->position->value >= $sequenceNumber->value) {
-                                $this->logger?->debug(sprintf('Subscription Engine: Subscription "%s" is farther than the current position (%d >= %d), continue catch up.', $subscription->id->value, $subscription->position->value, $sequenceNumber->value));
-                                continue;
-                            }
-                            $this->subscriptionStore->createSavepoint();
-                            $error = $this->handleEvent($eventEnvelope, $domainEvent, $subscription);
-                            if (!$error) {
-                                $this->subscriptionStore->releaseSavepoint();
-                                continue;
-                            }
-                            $this->subscriptionStore->rollbackSavepoint();
-                            $errors[] = $error;
-                        }
-                        $numberOfProcessedEvents++;
-                    }
-                } finally {
+                function (Subscriptions $subscriptions) use ($subscriptionStatus, $progressClosure, $store, $subscribers) {
                     foreach ($subscriptions as $subscription) {
-                        $this->subscriptionManager->update($subscription);
+                        // TODO we cannot mark a subscriber as detached, if it belongs to another store and no one else is using that store anymore. Then it will just be ACTIVE and never found, not even by status
+                        if (!$subscribers->contain($subscription->id)) {
+                            // mark detached subscriptions as we cannot handle them and exclude them from catchup
+                            $subscription->set(
+                                status: SubscriptionStatus::DETACHED,
+                            );
+                            $this->subscriptionManager->update($subscription);
+                            $this->logger?->info(sprintf('Subscription Engine: Subscriber for "%s" not found and has been marked as detached.', $subscription->id->value));
+                            $subscriptions = $subscriptions->without($subscription->id);
+                        }
                     }
-                }
-                foreach ($subscriptions as $subscription) {
-                    try {
-                        $this->subscribers->get($subscription->id)->onAfterCatchUp();
-                    } catch (\Throwable $e) {
-                        // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
-                        $message = sprintf('Subscriber "%s" failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
-                        $this->logger?->critical($message);
-                        throw new CatchUpFailed($message, 1732374000, $e);
-                    }
-                    if ($subscription->status !== $subscriptionStatus) {
-                        continue;
-                    }
+                    if ($subscriptions->isEmpty()) {
+                        $this->logger?->info(sprintf('Subscription Engine: No subscriptions in state "%s". Finishing catch up', $subscriptionStatus->value));
 
-                    if ($subscription->status !== SubscriptionStatus::ACTIVE) {
-                        $subscription->set(
-                            status: SubscriptionStatus::ACTIVE,
-                        );
-                        $this->subscriptionManager->update($subscription);
-                        $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active after booting.', $subscription->id->value));
+                        return ProcessedResult::success(0);
                     }
+                    foreach ($subscriptions as $subscription) {
+                        try {
+                            $subscribers->get($subscription->id)->onBeforeCatchUp($subscription->status);
+                        } catch (\Throwable $e) {
+                            // analog to onAfterCatchUp, we tolerate no exceptions here and consider it a critical developer error.
+                            $message = sprintf('Subscriber "%s" failed onBeforeCatchUp: %s', $subscription->id->value, $e->getMessage());
+                            $this->logger?->critical($message);
+                            throw new CatchUpFailed($message, 1732374000, $e);
+                        }
+                    }
+                    $startSequenceNumber = $subscriptions->lowestPosition()?->next() ?? SequenceNumber::none();
+                    $this->logger?->debug(sprintf('Subscription Engine: Event stream is processed from position %s.', $startSequenceNumber->value));
+
+                    /** @var list<Error> $errors */
+                    $errors = [];
+                    $numberOfProcessedEvents = 0;
+                    try {
+                        $eventStream = $this->eventStore->load(VirtualStreamName::all())->withMinimumSequenceNumber($startSequenceNumber);
+                        foreach ($eventStream as $eventEnvelope) {
+                            $sequenceNumber = $eventEnvelope->sequenceNumber;
+                            if ($numberOfProcessedEvents > 0) {
+                                $this->logger?->debug(sprintf('Subscription Engine: Current event stream position: %s', $sequenceNumber->value));
+                            }
+                            if ($progressClosure !== null) {
+                                $progressClosure($eventEnvelope);
+                            }
+                            $domainEvent = $this->eventNormalizer->denormalize($eventEnvelope->event);
+                            foreach ($subscriptions as $subscription) {
+                                if ($subscription->status !== $subscriptionStatus) {
+                                    continue;
+                                }
+                                if ($subscription->position->value >= $sequenceNumber->value) {
+                                    $this->logger?->debug(sprintf('Subscription Engine: Subscription "%s" is farther than the current position (%d >= %d), continue catch up.', $subscription->id->value, $subscription->position->value, $sequenceNumber->value));
+                                    continue;
+                                }
+                                $store->createSavepoint();
+                                $error = $this->handleEvent($eventEnvelope, $domainEvent, $subscription);
+                                if (!$error) {
+                                    $store->releaseSavepoint();
+                                    continue;
+                                }
+                                $store->rollbackSavepoint();
+                                $errors[] = $error;
+                            }
+                            $numberOfProcessedEvents++;
+                        }
+                    } finally {
+                        foreach ($subscriptions as $subscription) {
+                            $this->subscriptionManager->update($subscription);
+                        }
+                    }
+                    foreach ($subscriptions as $subscription) {
+                        try {
+                            $subscribers->get($subscription->id)->onAfterCatchUp();
+                        } catch (\Throwable $e) {
+                            // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
+                            $message = sprintf('Subscriber "%s" failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
+                            $this->logger?->critical($message);
+                            throw new CatchUpFailed($message, 1732374000, $e);
+                        }
+                        if ($subscription->status !== $subscriptionStatus) {
+                            continue;
+                        }
+
+                        if ($subscription->status !== SubscriptionStatus::ACTIVE) {
+                            $subscription->set(
+                                status: SubscriptionStatus::ACTIVE,
+                            );
+                            $this->subscriptionManager->update($subscription);
+                            $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active after booting.', $subscription->id->value));
+                        }
+                    }
+                    $this->logger?->info(sprintf('Subscription Engine: Finish catch up. %d processed events %d errors.', $numberOfProcessedEvents, count($errors)));
+                    return $errors === [] ? ProcessedResult::success($numberOfProcessedEvents) : ProcessedResult::failed($numberOfProcessedEvents, Errors::fromArray($errors));
                 }
-                $this->logger?->info(sprintf('Subscription Engine: Finish catch up. %d processed events %d errors.', $numberOfProcessedEvents, count($errors)));
-                return $errors === [] ? ProcessedResult::success($numberOfProcessedEvents) : ProcessedResult::failed($numberOfProcessedEvents, Errors::fromArray($errors));
-            }
-        );
+            );
+        }
+        return $returnResult ?? ProcessedResult::success(0);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
@@ -32,4 +32,6 @@ interface SubscriptionStoreInterface
     public function releaseSavepoint(): void;
 
     public function rollbackSavepoint(): void;
+
+    public function getId(): string;
 }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/ProjectionSubscriber.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/ProjectionSubscriber.php
@@ -8,6 +8,7 @@ use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\Subscription\Store\SubscriptionStoreInterface;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\EventStore\Model\EventEnvelope;
@@ -22,8 +23,9 @@ final class ProjectionSubscriber
      */
     public function __construct(
         public readonly SubscriptionId $id,
+        public readonly SubscriptionStoreInterface $store,
         public readonly ProjectionInterface $projection,
-        private readonly ?CatchUpHookInterface $catchUpHook
+        private readonly ?CatchUpHookInterface $catchUpHook,
     ) {
     }
 

--- a/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/Subscribers.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/Subscribers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Subscription\Subscriber;
 
+use Neos\ContentRepository\Core\Subscription\Store\SubscriptionStoreInterface;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 
 /**
@@ -69,6 +70,23 @@ final class Subscribers implements \IteratorAggregate, \Countable, \JsonSerializ
     public function count(): int
     {
         return count($this->subscribersById);
+    }
+
+    /**
+     * @return iterable<array{SubscriptionStoreInterface, self}>
+     */
+    public function groupByStore(): iterable
+    {
+        $byStore = [];
+
+        foreach ($this->subscribersById as $subscriber) {
+            $byStore[$subscriber->store->getId()][] = $subscriber;
+        }
+
+        foreach ($byStore as $subscribers) {
+            $store = reset($subscribers)->store;
+            yield [$store, self::fromArray($subscribers)];
+        }
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -198,11 +198,12 @@ final class ContentRepositoryRegistry
                 $this->buildPropertySerializer($contentRepositoryId, $contentRepositorySettings),
                 $this->buildAuthProviderFactory($contentRepositoryId, $contentRepositorySettings),
                 $clock,
-                $this->buildSubscriptionStore($contentRepositoryId, $clock, $contentRepositorySettings),
+                // todo if the contentGraphProjection factory uses different database, we need to use another $subscriptionStore here! Configure it per projection???
+                $subscriptionStore = $this->buildSubscriptionStore($contentRepositoryId, $clock, $contentRepositorySettings),
                 $this->buildContentGraphProjectionFactory($contentRepositoryId, $contentRepositorySettings),
                 $contentGraphCatchUpHookFactory,
                 $this->buildCommandHooksFactory($contentRepositoryId, $contentRepositorySettings),
-                $this->buildAdditionalSubscribersFactories($contentRepositoryId, $contentRepositorySettings),
+                $this->buildAdditionalSubscribersFactories($contentRepositoryId, $contentRepositorySettings, $subscriptionStore),
                 $this->logger,
             );
         } catch (\Exception $exception) {
@@ -330,7 +331,7 @@ final class ContentRepositoryRegistry
     }
 
     /** @param array<string, mixed> $contentRepositorySettings */
-    private function buildAdditionalSubscribersFactories(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings): ContentRepositorySubscriberFactories
+    private function buildAdditionalSubscribersFactories(ContentRepositoryId $contentRepositoryId, array $contentRepositorySettings, SubscriptionStoreInterface $subscriptionStore): ContentRepositorySubscriberFactories
     {
         if (!is_array($contentRepositorySettings['projections'] ?? [])) {
             throw InvalidConfigurationException::fromMessage('Content repository "%s" expects projections configured as array.', $contentRepositoryId->value);
@@ -351,6 +352,7 @@ final class ContentRepositoryRegistry
             }
             $projectionSubscriberFactories[$projectionName] = new ProjectionSubscriberFactory(
                 SubscriptionId::fromString($projectionName),
+                $subscriptionStore, // todo if projection factory uses different database, we need to use another $subscriptionStore here!
                 $projectionFactory,
                 $this->buildCatchUpHookFactory($contentRepositoryId, $projectionName, $projectionOptions),
                 $projectionOptions['options'] ?? [],

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
@@ -175,4 +175,9 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
     {
         $this->dbal->rollbackSavepoint('SUBSCRIBER');
     }
+
+    public function getId(): string
+    {
+        return spl_object_hash($this->dbal);
+    }
 }


### PR DESCRIPTION
Allows to run projections in a different database WITH their store to ensure exactly once delivery and that on critical error (memory error) the transaction is not committet and that the projection in the other db is not already ahead.

TODO, allow to use actually wire it together via cr registry, That one projection runs in one database WITH its subscription store.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

see https://github.com/neos/neos-development-collection/pull/5321#issuecomment-2495670705

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
