### PR TITLE
TASK: Use individual transactions in subscription engine and use session lock via `GET_LOCK`

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/AbstractSubscriptionEngineTestCase.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/AbstractSubscriptionEngineTestCase.php
@@ -44,6 +44,8 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class AbstractSubscriptionEngineTestCase extends TestCase // we don't use Flows functional test case as it would reset the database afterwards
 {
+    protected static ContentRepositoryId $contentRepositoryId;
+
     protected ContentRepository $contentRepository;
 
     protected SubscriptionEngine $subscriptionEngine;
@@ -56,13 +58,16 @@ abstract class AbstractSubscriptionEngineTestCase extends TestCase // we don't u
 
     protected CatchUpHookInterface&MockObject $catchupHookForFakeProjection;
 
+    public static function setUpBeforeClass(): void
+    {
+        static::$contentRepositoryId = ContentRepositoryId::fromString('t_subscription');
+    }
+
     public function setUp(): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString('t_subscription');
-
         $this->resetDatabase(
             $this->getObject(Connection::class),
-            $contentRepositoryId,
+            self::$contentRepositoryId,
             keepSchema: true
         );
 
@@ -75,10 +80,12 @@ abstract class AbstractSubscriptionEngineTestCase extends TestCase // we don't u
             $this->fakeProjection
         );
 
-        $this->secondFakeProjection = new DebugEventProjection(
-            sprintf('cr_%s_debug_projection', $contentRepositoryId->value),
-            $this->getObject(Connection::class)
-        );
+        if (!isset($this->secondFakeProjection)) {
+            $this->secondFakeProjection = new DebugEventProjection(
+                sprintf('cr_%s_debug_projection', self::$contentRepositoryId->value),
+                $this->getObject(Connection::class)
+            );
+        }
 
         FakeProjectionFactory::setProjection(
             'second',
@@ -95,9 +102,9 @@ abstract class AbstractSubscriptionEngineTestCase extends TestCase // we don't u
         FakeNodeTypeManagerFactory::setConfiguration([]);
         FakeContentDimensionSourceFactory::setWithoutDimensions();
 
-        $this->getObject(ContentRepositoryRegistry::class)->resetFactoryInstance($contentRepositoryId);
+        $this->getObject(ContentRepositoryRegistry::class)->resetFactoryInstance(self::$contentRepositoryId);
 
-        $this->setupContentRepositoryDependencies($contentRepositoryId);
+        $this->setupContentRepositoryDependencies(self::$contentRepositoryId);
     }
 
     final protected function setupContentRepositoryDependencies(ContentRepositoryId $contentRepositoryId)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ExternalProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ExternalProjectionErrorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+
+final class ExternalProjectionErrorTest extends AbstractSubscriptionEngineTestCase
+{
+    use ProjectionRollbackTestTrait;
+
+    static Connection $secondConnection;
+
+    /** @before */
+    public function injectExternalFakeProjection(): void
+    {
+        $entityManager = $this->getObject(EntityManagerInterface::class);
+
+        if (!isset(self::$secondConnection)) {
+            self::$secondConnection = DriverManager::getConnection(
+                $entityManager->getConnection()->getParams(),
+                $entityManager->getConfiguration(),
+                $entityManager->getEventManager()
+            );
+        }
+
+        $this->secondFakeProjection = new DebugEventProjection(
+            sprintf('cr_%s_debug_projection', self::$contentRepositoryId->value),
+            self::$secondConnection
+        );
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -13,7 +13,6 @@ use Neos\ContentRepository\Core\Subscription\Engine\Error;
 use Neos\ContentRepository\Core\Subscription\Engine\Errors;
 use Neos\ContentRepository\Core\Subscription\Engine\ProcessedResult;
 use Neos\ContentRepository\Core\Subscription\Engine\Result;
-use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
 use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionError;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
@@ -23,12 +22,15 @@ use Neos\EventStore\Model\EventEnvelope;
 
 final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
 {
+    use ProjectionRollbackTestTrait;
+
     /** @test */
     public function projectionWithError()
     {
         $this->eventStore->setup();
         $this->fakeProjection->expects(self::once())->method('setUp');
-        $this->subscriptionEngine->setup();
+        $result = $this->subscriptionEngine->setup();
+        self::assertNull($result->errors);
         $this->fakeProjection->expects(self::any())->method('status')->willReturn(ProjectionStatus::ok());
         $result = $this->subscriptionEngine->boot();
         self::assertEquals(ProcessedResult::success(0), $result);
@@ -84,8 +86,10 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
         $this->fakeProjection->expects(self::any())->method('status')->willReturn(ProjectionStatus::ok());
         $this->fakeProjection->expects(self::once())->method('resetState');
         $this->fakeProjection->expects(self::exactly(2))->method('apply');
-        $this->subscriptionEngine->setup();
-        $this->subscriptionEngine->boot();
+        $result = $this->subscriptionEngine->setup();
+        self::assertNull($result->errors);
+        $result = $this->subscriptionEngine->boot();
+        self::assertNull($result->errors);
 
         // commit an event
         $this->commitExampleContentStreamEvent();
@@ -218,133 +222,6 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
                 setupStatus: ProjectionStatus::ok(),
             ),
             $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
-        );
-    }
-
-    /** @test */
-    public function projectionIsRolledBackAfterError()
-    {
-        $this->eventStore->setup();
-        $this->fakeProjection->expects(self::once())->method('setUp');
-        $this->fakeProjection->expects(self::once())->method('apply');
-        $result = $this->subscriptionEngine->setup();
-        self::assertNull($result->errors);
-        $result = $this->subscriptionEngine->boot();
-        self::assertNull($result->errors);
-
-        // commit an event
-        $this->commitExampleContentStreamEvent();
-
-        $exception = new \RuntimeException('This projection is kaputt.');
-
-        $this->secondFakeProjection->injectSaboteur(fn () => throw $exception);
-
-        $expectedFailure = ProjectionSubscriptionStatus::create(
-            subscriptionId: SubscriptionId::fromString('Vendor.Package:SecondFakeProjection'),
-            subscriptionStatus: SubscriptionStatus::ERROR,
-            subscriptionPosition: SequenceNumber::none(),
-            subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception),
-            setupStatus: ProjectionStatus::ok(),
-        );
-
-        self::assertEmpty(
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
-        );
-
-        $result = $this->subscriptionEngine->catchUpActive();
-        self::assertSame($result->errors?->first()->message, 'This projection is kaputt.');
-
-        self::assertEquals(
-            $expectedFailure,
-            $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
-        );
-
-        // should be empty as we need an exact once delivery
-        self::assertEmpty(
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
-        );
-
-        //
-        // fix projection and catchup
-        //
-
-        $this->secondFakeProjection->killSaboteur();
-
-        // reactivate and catchup
-        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:SecondFakeProjection')]));
-        self::assertNull($result->errors);
-
-        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
-        self::assertEquals(
-            [SequenceNumber::fromInteger(1)],
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
-        );
-    }
-
-    /** @test */
-    public function projectionIsRolledBackAfterErrorButKeepsSuccessFullEvents()
-    {
-        $this->eventStore->setup();
-        $this->fakeProjection->expects(self::once())->method('setUp');
-        $this->fakeProjection->expects(self::exactly(2))->method('apply');
-        $this->subscriptionEngine->setup();
-        $this->subscriptionEngine->boot();
-
-        // commit two events
-        $this->commitExampleContentStreamEvent();
-        $this->commitExampleContentStreamEvent();
-
-        $exception = new \RuntimeException('Event 2 is kaputt.');
-
-        // fail at the second event
-        $this->secondFakeProjection->injectSaboteur(
-            fn (EventEnvelope $eventEnvelope) =>
-            $eventEnvelope->sequenceNumber->value === 2
-                ? throw $exception
-                : null
-        );
-
-        self::assertEmpty(
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
-        );
-
-        $result = $this->subscriptionEngine->catchUpActive();
-        self::assertTrue($result->hasFailed());
-
-        $expectedFailure = ProjectionSubscriptionStatus::create(
-            subscriptionId: SubscriptionId::fromString('Vendor.Package:SecondFakeProjection'),
-            subscriptionStatus: SubscriptionStatus::ERROR,
-            subscriptionPosition: SequenceNumber::fromInteger(1),
-            subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception),
-            setupStatus: ProjectionStatus::ok(),
-        );
-
-        self::assertEquals(
-            $expectedFailure,
-            $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
-        );
-
-        // the first successful event is applied and committet:
-        self::assertEquals(
-            [SequenceNumber::fromInteger(1)],
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
-        );
-
-        //
-        // fix projection and catchup
-        //
-
-        $this->secondFakeProjection->killSaboteur();
-
-        // catchup after fix
-        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:SecondFakeProjection')]));
-        self::assertNull($result->errors);
-
-        // subscriptionError is reset, and the position is advanced if there were events
-        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(2));
-        self::assertEquals(
-            [SequenceNumber::fromInteger(1), SequenceNumber::fromInteger(2)],
-            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
         );
     }
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionRollbackTestTrait.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionRollbackTestTrait.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription;
+
+use Neos\ContentRepository\Core\Projection\ProjectionStatus;
+use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
+use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
+use Neos\ContentRepository\Core\Subscription\SubscriptionError;
+use Neos\ContentRepository\Core\Subscription\SubscriptionId;
+use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use Neos\EventStore\Model\EventEnvelope;
+
+trait ProjectionRollbackTestTrait
+{
+    /** @test */
+    public function projectionIsRolledBackAfterError()
+    {
+        $this->eventStore->setup();
+        $this->fakeProjection->expects(self::once())->method('setUp');
+        $this->fakeProjection->expects(self::once())->method('apply');
+        $result = $this->subscriptionEngine->setup();
+        self::assertNull($result->errors);
+        $result = $this->subscriptionEngine->boot();
+        self::assertNull($result->errors);
+
+        // commit an event
+        $this->commitExampleContentStreamEvent();
+
+        $exception = new \RuntimeException('This projection is kaputt.');
+
+        $this->secondFakeProjection->injectSaboteur(fn () => throw $exception);
+
+        $expectedFailure = ProjectionSubscriptionStatus::create(
+            subscriptionId: SubscriptionId::fromString('Vendor.Package:SecondFakeProjection'),
+            subscriptionStatus: SubscriptionStatus::ERROR,
+            subscriptionPosition: SequenceNumber::none(),
+            subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception),
+            setupStatus: ProjectionStatus::ok(),
+        );
+
+        self::assertEmpty(
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+
+        $result = $this->subscriptionEngine->catchUpActive();
+        self::assertSame($result->errors?->first()->message, 'This projection is kaputt.');
+
+        self::assertEquals(
+            $expectedFailure,
+            $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
+        );
+
+        // should be empty as we need an exact once delivery
+        self::assertEmpty(
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+
+        //
+        // fix projection and catchup
+        //
+
+        $this->secondFakeProjection->killSaboteur();
+
+        // reactivate and catchup
+        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:SecondFakeProjection')]));
+        self::assertNull($result->errors);
+
+        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+        self::assertEquals(
+            [SequenceNumber::fromInteger(1)],
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+    }
+
+    /** @test */
+    public function projectionIsRolledBackAfterErrorButKeepsSuccessFullEvents()
+    {
+        $this->eventStore->setup();
+        $this->fakeProjection->expects(self::once())->method('setUp');
+        $this->fakeProjection->expects(self::exactly(2))->method('apply');
+        $this->subscriptionEngine->setup();
+        $this->subscriptionEngine->boot();
+
+        // commit two events
+        $this->commitExampleContentStreamEvent();
+        $this->commitExampleContentStreamEvent();
+
+        $exception = new \RuntimeException('Event 2 is kaputt.');
+
+        // fail at the second event
+        $this->secondFakeProjection->injectSaboteur(
+            fn (EventEnvelope $eventEnvelope) =>
+            $eventEnvelope->sequenceNumber->value === 2
+                ? throw $exception
+                : null
+        );
+
+        self::assertEmpty(
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+
+        $result = $this->subscriptionEngine->catchUpActive();
+        self::assertTrue($result->hasFailed());
+
+        $expectedFailure = ProjectionSubscriptionStatus::create(
+            subscriptionId: SubscriptionId::fromString('Vendor.Package:SecondFakeProjection'),
+            subscriptionStatus: SubscriptionStatus::ERROR,
+            subscriptionPosition: SequenceNumber::fromInteger(1),
+            subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception),
+            setupStatus: ProjectionStatus::ok(),
+        );
+
+        self::assertEquals(
+            $expectedFailure,
+            $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
+        );
+
+        // the first successful event is applied and committet:
+        self::assertEquals(
+            [SequenceNumber::fromInteger(1)],
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+
+        //
+        // fix projection and catchup
+        //
+
+        $this->secondFakeProjection->killSaboteur();
+
+        // catchup after fix
+        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:SecondFakeProjection')]));
+        self::assertNull($result->errors);
+
+        // subscriptionError is reset, and the position is advanced if there were events
+        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(2));
+        self::assertEquals(
+            [SequenceNumber::fromInteger(1), SequenceNumber::fromInteger(2)],
+            $this->secondFakeProjection->getState()->findAppliedSequenceNumbers()
+        );
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWritingInWorkspaces/ParallelWritingInWorkspacesTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWritingInWorkspaces/ParallelWritingInWorkspacesTest.php
@@ -38,10 +38,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use PHPUnit\Framework\Assert;
 
 /**
- * This tests ensures that the subscribers are updated without any locking problems:
- *
- *     Exception in subscriber "contentGraph" while catching up:
- *     An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction.
+ * This tests ensures that the subscribers are updated without any locking problems (and to test via {@see DebugEventProjection} that locking is used at all!)
  *
  * To test that we utilise two processes committing and catching up to a lot of events.
  * The is archived by creating nodes in a loop which have tethered nodes as this will lead to a lot of events being emitted in a fast way.
@@ -57,6 +54,9 @@ class ParallelWritingInWorkspacesTest extends AbstractParallelTestCase
 
     public function setUp(): void
     {
+        // todo assert that debug projection got events but no dubs!
+        $this->markTestSkipped('todo fix that processes WAIT instead of shoot each other!!! https://github.com/neos/neos-development-collection/pull/5376');
+
         parent::setUp();
         $this->log('------ process started ------');
 

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/ProjectionTransactionTrait.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/ProjectionTransactionTrait.php
@@ -14,11 +14,11 @@ trait ProjectionTransactionTrait
 {
     /**
      * DBAL default implementation for {@see ProjectionInterface::transactional()}
+     * @param \Closure(): void $closure
      */
     public function transactional(\Closure $closure): void
     {
         if ($this->dbal->isTransactionActive() === false) {
-            /** @phpstan-ignore argument.templateType */
             $this->dbal->transactional($closure);
             return;
         }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookInterface.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Projection\CatchUpHook;
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
+use Neos\ContentRepository\Core\Projection\ProjectionInterface;
+use Neos\ContentRepository\Core\Subscription\Exception\CatchUpFailed;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\EventStore\Model\EventEnvelope;
 
@@ -21,25 +22,34 @@ interface CatchUpHookInterface
 {
     /**
      * This hook is called at the beginning of a catch-up run;
-     * AFTER the Database Lock is acquired ({@see SubscriptionEngine::catchUpActive()}).
+     * AFTER the Database Lock is acquired, BEFORE any projection was opened.
+     *
+     * Its important that no errors are thrown, as they will cause the catchup to directly halt with a {@see CatchUpFailed} exception.
      */
     public function onBeforeCatchUp(SubscriptionStatus $subscriptionStatus): void;
 
     /**
      * This hook is called for every event during the catchup process, **before** the projection
-     * is updated. Thus, this hook runs AFTER the database lock is acquired.
+     * is updated but in the same transaction: {@see ProjectionInterface::transactional()}.
+     *
+     * Any errors will cause the transaction being rolled back, and the projection goes into {@see SubscriptionStatus::ERROR} state.
      */
     public function onBeforeEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void;
 
     /**
      * This hook is called for every event during the catchup process, **after** the projection
-     * is updated. Thus, this hook runs AFTER the database lock is acquired.
+     * is updated but in the same transaction: {@see ProjectionInterface::transactional()}.
+     *
+     * Any errors will cause the transaction being rolled back, and the projection goes into {@see SubscriptionStatus::ERROR} state.
      */
     public function onAfterEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void;
 
     /**
      * This hook is called at the END of a catch-up run
-     * BEFORE the Database Lock is released ({@see SubscriptionEngine::catchUpActive()}).
+     * BEFORE the Database Lock is released, but AFTER the transaction is commited.
+     *
+     * Its important that no errors are thrown, as they will cause the catchup to directly halt with a {@see CatchUpFailed} exception.
+     * The projections and their new position will already be persisted and there is no rollback.
      */
     public function onAfterCatchUp(): void;
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionInterface.php
@@ -32,8 +32,8 @@ interface ProjectionInterface
 
     /**
      * Must invoke the closure which will update the catchup hooks and {@see apply}.
-     * Additionally, to guarantee exactly once delivery and also to behave correct during exceptions (even fatal ones),
-     * a database transaction should be started, or if a transaction is already active on the same connection save points
+     * Additionally, to guarantee exactly once delivery and also to behave correct during exceptions (even if php crashes),
+     * a database transaction must be started, or if a transaction is already active on the same connection save points
      * must be used and rolled back on error.
      *
      * @param-immediately-invoked-callable $closure

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -349,7 +349,7 @@ final class SubscriptionEngine
                     $this->logger?->debug(sprintf('Subscription Engine: Subscription "%s" is farther than the current position (%d >= %d), continue catch up.', $subscription->id->value, $subscription->position->value, $sequenceNumber->value));
                     continue;
                 }
-                $this->subscriptionStore->transactional(function () use ($eventEnvelope, $domainEvent, $subscription, $numberOfProcessedEvents, &$subscriptionsToCatchup, &$errors, &$highestSequenceNumberForSubscriber) {
+                $error = $this->subscriptionStore->transactional(function () use ($eventEnvelope, $domainEvent, $subscription, $numberOfProcessedEvents, &$subscriptionsToCatchup, &$highestSequenceNumberForSubscriber) {
                     $error = $this->handleEvent($eventEnvelope, $domainEvent, $subscription->id);
                     if ($error !== null) {
                         // ERROR Case:
@@ -366,18 +366,7 @@ final class SubscriptionEngine
                                 $error->throwable
                             ),
                         );
-                        // 3.) invoke onAfterCatchUp, as onBeforeCatchUp was invoked already and to be consistent we want to "shutdown" this catchup iteration event though we know it failed
-                        // todo put the ERROR $subscriptionStatus into the after hook, so it can properly be reacted upon
-                        try {
-                            $this->subscribers->get($subscription->id)->onAfterCatchUp();
-                        } catch (\Throwable $e) {
-                            // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
-                            $message = sprintf('Subscriber "%s" had an error and also failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
-                            $this->logger?->critical($message);
-                            throw new CatchUpFailed($message, 1732733740, $e);
-                        }
-                        $errors[] = $error;
-                        return;
+                        return $error;
                     }
 
                     $highestSequenceNumberForSubscriber[$subscription->id->value] = $eventEnvelope->sequenceNumber;
@@ -393,8 +382,21 @@ final class SubscriptionEngine
                     if ($numberOfProcessedEvents === 0 && $subscription->status !== SubscriptionStatus::ACTIVE) {
                         $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active from %s.', $subscription->id->value, $subscription->status->name));
                     }
+                    return null;
                 });
-
+                if ($error !== null) {
+                    $errors[] = $error;
+                    // 3.) invoke onAfterCatchUp, as onBeforeCatchUp was invoked already and to be consistent we want to "shutdown" this catchup iteration event though we know it failed
+                    // todo put the ERROR $subscriptionStatus into the after hook, so it can properly be reacted upon
+                    try {
+                        $this->subscribers->get($subscription->id)->onAfterCatchUp();
+                    } catch (\Throwable $e) {
+                        // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
+                        $message = sprintf('Subscriber "%s" had an error and also failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
+                        $this->logger?->critical($message);
+                        throw new CatchUpFailed($message, 1732733740, $e);
+                    }
+                }
             }
             $numberOfProcessedEvents++;
         }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -58,7 +58,7 @@ final class SubscriptionEngine
 
         $this->subscriptionStore->setup();
         $this->discoverNewSubscriptions();
-        $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::fromArray([
+        $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::fromArray([
             SubscriptionStatus::NEW,
             SubscriptionStatus::BOOTING,
             SubscriptionStatus::ACTIVE
@@ -80,45 +80,45 @@ final class SubscriptionEngine
     public function boot(SubscriptionEngineCriteria|null $criteria = null, \Closure $progressCallback = null): ProcessedResult
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
-        return $this->processExclusively(fn () => $this->subscriptionStore->transactional(
+        return $this->processExclusively(
             function () use ($criteria, $progressCallback) {
                 $this->logger?->info('Subscription Engine: Start catching up subscriptions in state "BOOTING".');
-                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteriaForUpdate(
+                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteria(
                     SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatus::BOOTING)
                 );
                 return $this->catchUpSubscriptions($subscriptionsToCatchup, $progressCallback);
-            })
+            }
         );
     }
 
     public function catchUpActive(SubscriptionEngineCriteria|null $criteria = null, \Closure $progressCallback = null): ProcessedResult
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
-        return $this->processExclusively(fn () => $this->subscriptionStore->transactional(
+        return $this->processExclusively(
             function () use ($criteria, $progressCallback) {
                 $this->logger?->info('Subscription Engine: Start catching up subscriptions in state "ACTIVE".');
-                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteriaForUpdate(
+                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteria(
                     SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatus::ACTIVE)
                 );
                 return $this->catchUpSubscriptions($subscriptionsToCatchup, $progressCallback);
-            })
+            }
         );
     }
 
     public function reactivate(SubscriptionEngineCriteria|null $criteria = null, \Closure $progressCallback = null): ProcessedResult
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
-        return $this->processExclusively(fn () => $this->subscriptionStore->transactional(
+        return $this->processExclusively(
             function () use ($criteria, $progressCallback) {
                 $this->logger?->info('Subscription Engine: Start catching up subscriptions in state "ACTIVE".');
-                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteriaForUpdate(
+                $subscriptionsToCatchup = $this->subscriptionStore->findByCriteria(
                     SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::fromArray([
                         SubscriptionStatus::ERROR,
                         SubscriptionStatus::DETACHED,
                     ]))
                 );
                 return $this->catchUpSubscriptions($subscriptionsToCatchup, $progressCallback);
-            })
+            }
         );
     }
 
@@ -127,7 +127,7 @@ final class SubscriptionEngine
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
 
         $this->logger?->info('Subscription Engine: Start to reset.');
-        $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::any()));
+        $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::forEngineCriteriaAndStatus($criteria, SubscriptionStatusFilter::any()));
         if ($subscriptions->isEmpty()) {
             $this->logger?->info('Subscription Engine: No subscriptions to reset.');
             return Result::success();
@@ -146,7 +146,7 @@ final class SubscriptionEngine
     {
         $statuses = [];
         try {
-            $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate(SubscriptionCriteria::create(ids: $criteria?->ids));
+            $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::create(ids: $criteria?->ids));
         } catch (TableNotFoundException) {
             // the schema is not setup - thus there are no subscribers
             return SubscriptionStatusCollection::createEmpty();
@@ -210,7 +210,7 @@ final class SubscriptionEngine
      */
     private function discoverNewSubscriptions(): void
     {
-        $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate(SubscriptionCriteria::noConstraints());
+        $subscriptions = $this->subscriptionStore->findByCriteria(SubscriptionCriteria::noConstraints());
         foreach ($this->subscribers as $subscriber) {
             if ($subscriptions->contain($subscriber->id)) {
                 continue;
@@ -296,6 +296,16 @@ final class SubscriptionEngine
 
     private function catchUpSubscriptions(Subscriptions $subscriptionsToCatchup, \Closure $progressClosure = null): ProcessedResult
     {
+
+        // problems:
+        // one the onBeforeCatchUp / onAfterCatchUp hooks will be more difficult and less obvious to invoke
+        // we cannot detach old subscriptions as we loop over the subscribers
+        // we have to fetch the subscriber and then skip its posisiont if its ahead
+        // we cannot abort easily if there ar no matching subscribers?
+        // if abortsCatchupAndRollBack fails we cannot abort transaction!!! -> but this is also a problem if we 'd start batching again....
+        // for batches before and after????
+
+
         foreach ($subscriptionsToCatchup as $subscription) {
             if (!$this->subscribers->contain($subscription->id)) {
                 // mark detached subscriptions as we cannot handle them and exclude them from catchup
@@ -349,39 +359,67 @@ final class SubscriptionEngine
                     $this->logger?->debug(sprintf('Subscription Engine: Subscription "%s" is farther than the current position (%d >= %d), continue catch up.', $subscription->id->value, $subscription->position->value, $sequenceNumber->value));
                     continue;
                 }
-                $error = $this->handleEvent($eventEnvelope, $domainEvent, $subscription->id);
-                if ($error !== null) {
-                    // ERROR Case:
-                    // 1.) for the leftover events we are not including this failed subscription for catchup
-                    $subscriptionsToCatchup = $subscriptionsToCatchup->without($subscription->id);
-                    // 2.) update the subscription error state on either its unchanged or new position (if some events worked)
+                $this->subscriptionStore->transactional(function () use ($eventEnvelope, $domainEvent, $subscription, $numberOfProcessedEvents, &$subscriptionsToCatchup, &$errors, &$highestSequenceNumberForSubscriber) {
+                    $error = $this->handleEvent($eventEnvelope, $domainEvent, $subscription->id);
+                    if ($error !== null) {
+                        // ERROR Case:
+                        // 1.) for the leftover events we are not including this failed subscription for catchup
+                        $subscriptionsToCatchup = $subscriptionsToCatchup->without($subscription->id);
+                        // 2.) update the subscription error state on either its unchanged or new position (if some events worked)
+                        $this->subscriptionStore->update(
+                            $subscription->id,
+                            status: SubscriptionStatus::ERROR,
+                            // todo rather use previous position:
+                            position: $highestSequenceNumberForSubscriber[$subscription->id->value] ?? $subscription->position,
+                            subscriptionError: SubscriptionError::fromPreviousStatusAndException(
+                                $subscription->status,
+                                $error->throwable
+                            ),
+                        );
+                        // 3.) invoke onAfterCatchUp, as onBeforeCatchUp was invoked already and to be consistent we want to "shutdown" this catchup iteration event though we know it failed
+                        // todo put the ERROR $subscriptionStatus into the after hook, so it can properly be reacted upon
+                        try {
+                            $this->subscribers->get($subscription->id)->onAfterCatchUp();
+                        } catch (\Throwable $e) {
+                            // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
+                            $message = sprintf('Subscriber "%s" had an error and also failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
+                            $this->logger?->critical($message);
+                            throw new CatchUpFailed($message, 1732733740, $e);
+                        }
+                        $errors[] = $error;
+                        return;
+                    }
+
+                    $highestSequenceNumberForSubscriber[$subscription->id->value] = $eventEnvelope->sequenceNumber;
+
+                    // after catchup mark all subscriptions as active, so they are triggered automatically now.
+                    // The position will be set to the one the subscriber handled last, or if no events were in the stream, and we booted we keep the persisted position
                     $this->subscriptionStore->update(
                         $subscription->id,
-                        status: SubscriptionStatus::ERROR,
-                        position: $highestSequenceNumberForSubscriber[$subscription->id->value] ?? $subscription->position,
-                        subscriptionError: SubscriptionError::fromPreviousStatusAndException(
-                            $subscription->status,
-                            $error->throwable
-                        ),
+                        status: SubscriptionStatus::ACTIVE,
+                        position: $eventEnvelope->sequenceNumber,
+                        subscriptionError: null,
                     );
-                    // 3.) invoke onAfterCatchUp, as onBeforeCatchUp was invoked already and to be consistent we want to "shutdown" this catchup iteration event though we know it failed
-                    // todo put the ERROR $subscriptionStatus into the after hook, so it can properly be reacted upon
-                    try {
-                        $this->subscribers->get($subscription->id)->onAfterCatchUp();
-                    } catch (\Throwable $e) {
-                        // analog to onBeforeCatchUp, we tolerate no exceptions here and consider it a critical developer error.
-                        $message = sprintf('Subscriber "%s" had an error and also failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
-                        $this->logger?->critical($message);
-                        throw new CatchUpFailed($message, 1732733740, $e);
+                    if ($numberOfProcessedEvents === 0 && $subscription->status !== SubscriptionStatus::ACTIVE) {
+                        $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active from %s.', $subscription->id->value, $subscription->status->name));
                     }
-                    $errors[] = $error;
-                    continue;
-                }
-                // HAPPY Case:
-                $highestSequenceNumberForSubscriber[$subscription->id->value] = $eventEnvelope->sequenceNumber;
+                });
+
             }
             $numberOfProcessedEvents++;
         }
+        foreach ($subscriptionsToCatchup as $subscription) {
+            if ($numberOfProcessedEvents === 0 && $subscription->status !== SubscriptionStatus::ACTIVE) {
+                $this->subscriptionStore->update(
+                    $subscription->id,
+                    status: SubscriptionStatus::ACTIVE,
+                    position: $subscription->position,
+                    subscriptionError: null,
+                );
+                $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active from %s.', $subscription->id->value, $subscription->status->name));
+            }
+        }
+
         foreach ($subscriptionsToCatchup as $subscription) {
             try {
                 $this->subscribers->get($subscription->id)->onAfterCatchUp();
@@ -390,17 +428,6 @@ final class SubscriptionEngine
                 $message = sprintf('Subscriber "%s" failed onAfterCatchUp: %s', $subscription->id->value, $e->getMessage());
                 $this->logger?->critical($message);
                 throw new CatchUpFailed($message, 1732374000, $e);
-            }
-            // after catchup mark all subscriptions as active, so they are triggered automatically now.
-            // The position will be set to the one the subscriber handled last, or if no events were in the stream, and we booted we keep the persisted position
-            $this->subscriptionStore->update(
-                $subscription->id,
-                status: SubscriptionStatus::ACTIVE,
-                position: $highestSequenceNumberForSubscriber[$subscription->id->value] ?? $subscription->position,
-                subscriptionError: null,
-            );
-            if ($subscription->status !== SubscriptionStatus::ACTIVE) {
-                $this->logger?->info(sprintf('Subscription Engine: Subscription "%s" has been set to active after booting.', $subscription->id->value));
             }
         }
         $this->logger?->info(sprintf('Subscription Engine: Finish catch up. %d processed events %d errors.', $numberOfProcessedEvents, count($errors)));
@@ -418,9 +445,11 @@ final class SubscriptionEngine
             throw new SubscriptionEngineAlreadyProcessingException('Subscription engine is already processing', 1732714075);
         }
         $this->processing = true;
+        $this->subscriptionStore->acquireLock();
         try {
             return $closure();
         } finally {
+            $this->subscriptionStore->releaseLock();
             $this->processing = false;
         }
     }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -436,8 +436,11 @@ final class SubscriptionEngine
         if ($this->processing) {
             throw new SubscriptionEngineAlreadyProcessingException('Subscription engine is already processing', 1732714075);
         }
+        $acquiredLock = $this->subscriptionStore->acquireLock();
+        if ($acquiredLock === false) {
+            throw new \RuntimeException('Failed to acquire lock for subscriptions.', 1733135506);
+        }
         $this->processing = true;
-        $this->subscriptionStore->acquireLock();
         try {
             return $closure();
         } finally {

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -296,16 +296,6 @@ final class SubscriptionEngine
 
     private function catchUpSubscriptions(Subscriptions $subscriptionsToCatchup, \Closure $progressClosure = null): ProcessedResult
     {
-
-        // problems:
-        // one the onBeforeCatchUp / onAfterCatchUp hooks will be more difficult and less obvious to invoke
-        // we cannot detach old subscriptions as we loop over the subscribers
-        // we have to fetch the subscriber and then skip its posisiont if its ahead
-        // we cannot abort easily if there ar no matching subscribers?
-        // if abortsCatchupAndRollBack fails we cannot abort transaction!!! -> but this is also a problem if we 'd start batching again....
-        // for batches before and after????
-
-
         foreach ($subscriptionsToCatchup as $subscription) {
             if (!$this->subscribers->contain($subscription->id)) {
                 // mark detached subscriptions as we cannot handle them and exclude them from catchup

--- a/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
@@ -29,7 +29,10 @@ interface SubscriptionStoreInterface
         SubscriptionError|null $subscriptionError,
     ): void;
 
-    public function acquireLock(): void;
+    /**
+     * @return bool if the lock could be acquired or if a parallel process has it
+     */
+    public function acquireLock(): bool;
 
     public function releaseLock(): void;
 

--- a/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionStoreInterface.php
@@ -18,7 +18,7 @@ interface SubscriptionStoreInterface
 {
     public function setup(): void;
 
-    public function findByCriteriaForUpdate(SubscriptionCriteria $criteria): Subscriptions;
+    public function findByCriteria(SubscriptionCriteria $criteria): Subscriptions;
 
     public function add(Subscription $subscription): void;
 
@@ -28,6 +28,10 @@ interface SubscriptionStoreInterface
         SequenceNumber $position,
         SubscriptionError|null $subscriptionError,
     ): void;
+
+    public function acquireLock(): void;
+
+    public function releaseLock(): void;
 
     /**
      * @template T

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
@@ -166,22 +166,28 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
         );
     }
 
-    public function acquireLock(): void
+    public function acquireLock(): bool
     {
         // todo fully implement https://github.com/patchlevel/event-sourcing/blob/caaf54fcf32c0e42b1036a5c7ff77c1a37af0105/src/Store/DoctrineDbalStore.php#L456
         // todo check if 16 chars (crID) is a good lock value?
         $result = $this->dbal->fetchOne(sprintf('SELECT GET_LOCK("%s", %d)', $this->contentRepositoryId->value, 0));
-        if ($result !== 1) {
-            throw new \RuntimeException('Failed to acquire lock for subscriptions.', 1733135506);
-        }
+        // https://dev.mysql.com/doc/refman/8.4/en/locking-functions.html#function_get-lock
+        return match ($result) {
+            0 => false,
+            1 => true,
+            null => throw new \RuntimeException(sprintf('Database error while acquiring lock "%s" for subscriptions.', $this->contentRepositoryId->value), 1733135506)
+        };
     }
 
     public function releaseLock(): void
     {
         $result = $this->dbal->fetchOne(sprintf('SELECT RELEASE_LOCK("%s")', $this->contentRepositoryId->value));
-        if ($result !== 1) {
-            throw new \RuntimeException('Failed to release lock for subscriptions.', 1733135506);
-        }
+        // https://dev.mysql.com/doc/refman/8.4/en/locking-functions.html#function_release-lock
+        match ($result) {
+            0 => throw new \RuntimeException(sprintf('The lock "%s" was not established by this thread (in which case the lock is not released', $this->contentRepositoryId->value), 1733142649),
+            1 => null,
+            null => throw new \RuntimeException(sprintf('The lock "%s" does not exist if it was never obtained or if it has previously been released.', $this->contentRepositoryId->value), 1733142651)
+        };
     }
 
     public function transactional(\Closure $closure): mixed

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Neos\ContentRepository\Core\Infrastructure\DbalSchemaDiff;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Subscription\Store\SubscriptionCriteria;
 use Neos\ContentRepository\Core\Subscription\Store\SubscriptionStoreInterface;
 use Neos\ContentRepository\Core\Subscription\Subscription;
@@ -31,7 +32,8 @@ use Neos\Flow\Annotations as Flow;
 final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
 {
     public function __construct(
-        private string $tableName,
+        private readonly ContentRepositoryId $contentRepositoryId,
+        private readonly string $tableName,
         private readonly Connection $dbal,
         private readonly ClockInterface $clock,
     ) {
@@ -167,17 +169,18 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
     public function acquireLock(): void
     {
         // todo fully implement https://github.com/patchlevel/event-sourcing/blob/caaf54fcf32c0e42b1036a5c7ff77c1a37af0105/src/Store/DoctrineDbalStore.php#L456
-        $result = $this->dbal->fetchOne(sprintf('SELECT GET_LOCK("%s", %d)', 'default', 0));
+        // todo check if 16 chars (crID) is a good lock value?
+        $result = $this->dbal->fetchOne(sprintf('SELECT GET_LOCK("%s", %d)', $this->contentRepositoryId->value, 0));
         if ($result !== 1) {
-            throw new \RuntimeException('failed to acquire lock');
+            throw new \RuntimeException('Failed to acquire lock for subscriptions.', 1733135506);
         }
     }
 
     public function releaseLock(): void
     {
-        $result = $this->dbal->fetchOne(sprintf('SELECT RELEASE_LOCK("%s")', 'default'));
+        $result = $this->dbal->fetchOne(sprintf('SELECT RELEASE_LOCK("%s")', $this->contentRepositoryId->value));
         if ($result !== 1) {
-            throw new \RuntimeException('failed to release lock');
+            throw new \RuntimeException('Failed to release lock for subscriptions.', 1733135506);
         }
     }
 

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
@@ -64,13 +64,12 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
         }
     }
 
-    public function findByCriteriaForUpdate(SubscriptionCriteria $criteria): Subscriptions
+    public function findByCriteria(SubscriptionCriteria $criteria): Subscriptions
     {
         $queryBuilder = $this->dbal->createQueryBuilder()
             ->select('*')
             ->from($this->tableName)
             ->orderBy('id');
-        $queryBuilder->forUpdate();
         if ($criteria->ids !== null) {
             $queryBuilder->andWhere('id IN (:ids)')
                 ->setParameter(
@@ -163,6 +162,23 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
             $subscriptionError,
             $lastSavedAt,
         );
+    }
+
+    public function acquireLock(): void
+    {
+        // todo fully implement https://github.com/patchlevel/event-sourcing/blob/caaf54fcf32c0e42b1036a5c7ff77c1a37af0105/src/Store/DoctrineDbalStore.php#L456
+        $result = $this->dbal->fetchOne(sprintf('SELECT GET_LOCK("%s", %d)', 'default', 0));
+        if ($result !== 1) {
+            throw new \RuntimeException('failed to acquire lock');
+        }
+    }
+
+    public function releaseLock(): void
+    {
+        $result = $this->dbal->fetchOne(sprintf('SELECT RELEASE_LOCK("%s")', 'default'));
+        if ($result !== 1) {
+            throw new \RuntimeException('failed to release lock');
+        }
     }
 
     public function transactional(\Closure $closure): mixed

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/SubscriptionStoreFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/SubscriptionStoreFactory.php
@@ -22,6 +22,11 @@ final readonly class SubscriptionStoreFactory implements SubscriptionStoreFactor
     /** @param array<string, mixed> $options */
     public function build(ContentRepositoryId $contentRepositoryId, ClockInterface $clock, array $options): SubscriptionStoreInterface
     {
-        return new DoctrineSubscriptionStore(sprintf('cr_%s_subscriptions', $contentRepositoryId->value), $this->connection, $clock);
+        return new DoctrineSubscriptionStore(
+            $contentRepositoryId,
+            sprintf('cr_%s_subscriptions', $contentRepositoryId->value),
+            $this->connection,
+            $clock
+        );
     }
 }


### PR DESCRIPTION
Adjustments for https://github.com/neos/neos-development-collection/pull/5321

**1.) Introduce dedicated locking and use small transactions**
    
using many small transactions has two advantages:
- on a replay with many events, we dont build up a huge transaction that the database has to possible extract into files at some point. Otherwise, we would need to introduce batching and need to require the for update lock
- to ensure integrity - that the projection got exactly that many events how it is in the subscription store - each applied event per projection has its own transaction. If something goes really wrong (php crashes) the transaction will not be committed. This is important for the case of using a different connection or a different database for a projection, as otherwise a crash of another projection would lead to a external projection being up-to-date while the subscription update is fully rolled back.

later we can introduce a concept of batching possibly - even though it must be patched per subscriber and not mixed to ensure integrity in fatal errors.

**2.) Ensure `onAfterCatchUp` is always executed _after_ the projection is persisted. Even in error case.**

**3.) Deactivate `ParallelWritingInWorkspacesTest` test for now**

we will implement a proper wait mechanism later -> see https://github.com/neos/neos-development-collection/pull/5376
Previously that test worked in the subscription branch as we used a FOR UPDATE lock which waits by default instead of using NOWAIT.

To not put the load on the database in `GET_LOCK` we call it with no wait (0 timeout)

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
